### PR TITLE
Corrige le remplacement d'un objectif sélectionné dans le dropdown « Objectifs »

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -335,12 +335,13 @@ export function createProjectSubjectsActions(config) {
       ? meta.objectiveIds.map((id) => String(id || "")).filter(Boolean)
       : [];
     const wasLinked = previousIds.includes(objectiveKey);
-    const nextIds = wasLinked
-      ? previousIds.filter((id) => id !== objectiveKey)
-      : [...previousIds, objectiveKey];
+    const nextIds = wasLinked ? [] : [objectiveKey];
+    const removedObjectiveIds = previousIds.filter((id) => !nextIds.includes(id));
+    const addedObjectiveIds = nextIds.filter((id) => !previousIds.includes(id));
 
     setSubjectObjectiveIds(subjectKey, nextIds);
-    syncSubjectObjectiveMaps(subjectKey, objectiveKey, !wasLinked);
+    removedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, false));
+    addedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, true));
 
     if (!options.skipRerender) {
       if (options.root) rerenderScope(options.root);
@@ -348,12 +349,17 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      if (wasLinked) await removeSubjectFromObjectiveInSupabase(objectiveKey, subjectKey);
-      else await addSubjectToObjectiveInSupabase(objectiveKey, subjectKey);
+      for (const removedId of removedObjectiveIds) {
+        await removeSubjectFromObjectiveInSupabase(removedId, subjectKey);
+      }
+      for (const addedId of addedObjectiveIds) {
+        await addSubjectToObjectiveInSupabase(addedId, subjectKey);
+      }
       return true;
     } catch (error) {
       setSubjectObjectiveIds(subjectKey, previousIds);
-      syncSubjectObjectiveMaps(subjectKey, objectiveKey, wasLinked);
+      removedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, true));
+      addedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, false));
       if (!options.skipRerender) {
         if (options.root) rerenderScope(options.root);
         else rerenderPanels();


### PR DESCRIPTION
### Motivation
- Diagnostic : la meta `objectiveIds` est normalisée en mono-valeur (`[normalized[0]]`), donc l'ancien comportement qui ajoutait un nouvel id laissait l'ancien id en position 0 et empêchait le remplacement visible de l'objectif.
- Contrainte respectée : modification minimale et ciblée pour corriger le comportement sans toucher à la normalisation globale des données.

### Description
- Modifié `toggleSubjectObjective` dans `apps/web/js/views/project-subjects/project-subjects-actions.js` pour forcer le comportement mono-objectif (`nextIds = wasLinked ? [] : [objectiveKey]`).
- Calcul explicite des ids à retirer et à ajouter (`removedObjectiveIds`, `addedObjectiveIds`) et mise à jour cohérente des maps locales via `syncSubjectObjectiveMaps` pour chaque suppression/ajout.
- Synchronisation côté Supabase mise en séquence : suppression(s) puis ajout(s), avec rollback complet des maps et de l'état local en cas d'erreur réseau.
- Fichier modifié : `apps/web/js/views/project-subjects/project-subjects-actions.js` (changement limité et diff propre).

### Testing
- Vérification syntaxique exécutée avec `node --check apps/web/js/views/project-subjects/project-subjects-actions.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de26a6916083299913f46cd77c71fc)