### PR TITLE
Fix normal details head state when opening drilldown

### DIFF
--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -1,3 +1,12 @@
+export function normalizeNormalDetailsCompactSnapshot(snapshot) {
+  const compact = !!snapshot?.compact;
+  const hasExpanded = typeof snapshot?.expanded === "boolean";
+  return {
+    compact,
+    expanded: hasExpanded ? snapshot.expanded : !compact
+  };
+}
+
 function getScrollableElementScrollState(element) {
   if (!element) return null;
   return {
@@ -39,7 +48,8 @@ export function createProjectSubjectDrilldownController(config) {
     return {
       compact: normalDetailsChrome.classList.contains("overlay-chrome--compact")
         || normalDetailsHead.classList.contains("details-head--compact")
-        || document.body.classList.contains("project-subject-details-top-compact")
+        || document.body.classList.contains("project-subject-details-top-compact"),
+      expanded: normalDetailsHead.classList.contains("details-head--expanded")
     };
   }
 
@@ -48,11 +58,11 @@ export function createProjectSubjectDrilldownController(config) {
     const normalDetailsChrome = document.getElementById("situationsDetailsChrome");
     const normalDetailsHead = document.getElementById("situationsDetailsTitle");
     if (!normalDetailsChrome || !normalDetailsHead) return;
-    const compact = !!snapshot.compact;
-    normalDetailsChrome.classList.toggle("overlay-chrome--compact", compact);
-    normalDetailsHead.classList.toggle("details-head--compact", compact);
-    normalDetailsHead.classList.toggle("details-head--expanded", !compact);
-    document.body.classList.toggle("project-subject-details-top-compact", compact);
+    const normalizedSnapshot = normalizeNormalDetailsCompactSnapshot(snapshot);
+    normalDetailsChrome.classList.toggle("overlay-chrome--compact", normalizedSnapshot.compact);
+    normalDetailsHead.classList.toggle("details-head--compact", normalizedSnapshot.compact);
+    normalDetailsHead.classList.toggle("details-head--expanded", normalizedSnapshot.expanded);
+    document.body.classList.toggle("project-subject-details-top-compact", normalizedSnapshot.compact);
   }
 
   function ensureDrilldownDom() {

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeNormalDetailsCompactSnapshot } from './project-subject-drilldown.js';
+
+test('normalizeNormalDetailsCompactSnapshot conserve expanded explicite', () => {
+  const snapshot = normalizeNormalDetailsCompactSnapshot({ compact: true, expanded: false });
+  assert.equal(snapshot.compact, true);
+  assert.equal(snapshot.expanded, false);
+});
+
+test('normalizeNormalDetailsCompactSnapshot fallback expanded=!compact', () => {
+  const compactSnapshot = normalizeNormalDetailsCompactSnapshot({ compact: true });
+  assert.deepEqual(compactSnapshot, { compact: true, expanded: false });
+
+  const expandedSnapshot = normalizeNormalDetailsCompactSnapshot({ compact: false });
+  assert.deepEqual(expandedSnapshot, { compact: false, expanded: true });
+});


### PR DESCRIPTION
### Motivation
- When opening the drilldown the normal-details head lost its `expanded` state (it was being forced to `!compact`), so the UI changed unexpectedly when drilling down; the goal is to preserve the head state when taking/restoring the snapshot.
- Make a minimal, targeted change only where snapshotting/restoring happens to keep the diff small and behavior predictable.

### Description
- Add a normalization helper `normalizeNormalDetailsCompactSnapshot(snapshot)` that returns both `compact` and `expanded` flags and preserves an explicit `expanded` value instead of forcing `expanded = !compact`.
- Capture and restore the `expanded` class alongside `compact` when taking/applying the normal-details snapshot in `createProjectSubjectDrilldownController` (`apps/web/js/views/project-subjects/project-subject-drilldown.js`).
- Keep changes localized to snapshot capture/restore logic and avoid touching scroll/listener logic to limit risk.
- Add a unit test file `apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs` that verifies explicit `expanded` is preserved and the fallback rule `expanded = !compact` when `expanded` is absent.

### Testing
- Ran the unit tests with `node --test --experimental-default-type=module apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs`, which ran 2 tests and both passed.
- No other automated test framework was present/modified in the repository, and no additional test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2e6729b08329ac2af92775e33b27)