### PR TITLE
Fix compact drilldown header width alignment

### DIFF
--- a/apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const stylePath = path.resolve(__dirname, "../../../style.css");
+const styleCss = fs.readFileSync(stylePath, "utf8");
+
+test("drilldown compact header keeps container width", () => {
+  assert.match(
+    styleCss,
+    /\.drilldown__head\.details-head--compact\s*\{\s*width:\s*100%;\s*margin-left:\s*0;\s*margin-right:\s*0;\s*\}/m
+  );
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -1110,6 +1110,13 @@ body.modal-open {
   margin-right: calc(50% - 50vw);
 }
 
+/* Keep drilldown compact header aligned to drilldown container width. */
+.drilldown__head.details-head--compact {
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
+}
+
 
 #project-content.gh-page{
   position:static;


### PR DESCRIPTION
### Motivation
- Le header compact du drilldown (`div.drilldown__head.details-head--compact`) était étiré en `100vw` au lieu d’être calé sur la largeur du container du drilldown, provoquant un décalage visuel en mode compact.
- L’intention est de corriger ce comportement sans toucher au reste du style global ni ajouter de refactor inutile.

### Description
- Ajout d’une surcharge CSS ciblée dans `apps/web/style.css` pour ` .drilldown__head.details-head--compact` qui définit `width: 100%` et `margin-left/right: 0` afin de l’aligner sur le container du drilldown.
- La règle globale `.details-head--compact { width: 100vw; ... }` est laissée en place et la nouvelle règle agit comme override ciblé et minimal.
- Ajout d’un test unitaire `apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs` qui vérifie la présence exacte de la règle CSS attendue dans `apps/web/style.css`.

### Testing
- Exécution des tests unitaires avec `node --test apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs` a passé avec succès (3 tests, 0 échecs).
- Aucun autre test automatisé du dépôt n’a été modifié ou exécuté dans ce changement.
- Point fragile : la correction est volontairement minimale et dépend de l’ordre de cascade CSS et de la spécificité actuelle; si une règle plus spécifique est ajoutée ailleurs, l’override pourrait nécessiter un ajustement ultérieur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de324d9464832988831ee0cee8bcdf)