### PR TITLE
Respect compact normal details head when opening drilldown (CSS var + JS offset + tests)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const stylePath = path.resolve(__dirname, "../../../style.css");
+const styleCss = fs.readFileSync(stylePath, "utf8");
+
+test("le head compact normal du sujet reste en full-bleed viewport", () => {
+  assert.match(
+    styleCss,
+    /#situationsDetailsTitle\.details-head--compact\s*\{[^}]*width:\s*100vw;[^}]*margin-left:\s*calc\(50%\s*-\s*50vw\);[^}]*margin-right:\s*calc\(50%\s*-\s*50vw\);/m
+  );
+});
+
+test("le drilldown est ancré avec un offset CSS dédié", () => {
+  assert.match(
+    styleCss,
+    /#drilldownPanel\s*\{\s*top:\s*var\(--subject-drilldown-top-offset,\s*0px\);\s*\}/m
+  );
+});

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -7,6 +7,14 @@ export function normalizeNormalDetailsCompactSnapshot(snapshot) {
   };
 }
 
+export function computeDrilldownTopOffset(snapshot, normalDetailsHeadBottom = 0) {
+  const normalizedSnapshot = normalizeNormalDetailsCompactSnapshot(snapshot);
+  if (!normalizedSnapshot.compact) return 0;
+  const safeHeadBottom = Number(normalDetailsHeadBottom || 0);
+  if (!Number.isFinite(safeHeadBottom)) return 0;
+  return Math.max(0, Math.round(safeHeadBottom));
+}
+
 function getScrollableElementScrollState(element) {
   if (!element) return null;
   return {
@@ -40,6 +48,21 @@ export function createProjectSubjectDrilldownController(config) {
   } = config;
 
   let lockedWindowScrollY = 0;
+
+  function readNormalDetailsHeadBottom() {
+    const normalDetailsHead = document.getElementById("situationsDetailsTitle");
+    if (!normalDetailsHead) return 0;
+    const rect = normalDetailsHead.getBoundingClientRect?.();
+    return Number(rect?.bottom || 0);
+  }
+
+  function applyDrilldownViewportOffset(snapshot) {
+    const panel = document.getElementById("drilldownPanel");
+    if (!panel) return;
+    const topOffset = computeDrilldownTopOffset(snapshot, readNormalDetailsHeadBottom());
+    panel.style.setProperty("--subject-drilldown-top-offset", `${topOffset}px`);
+    panel.classList.toggle("drilldown--offset-from-normal-compact", topOffset > 0);
+  }
 
   function getNormalDetailsCompactSnapshot() {
     const normalDetailsChrome = document.getElementById("situationsDetailsChrome");
@@ -93,6 +116,12 @@ export function createProjectSubjectDrilldownController(config) {
     bindOverlayChromeDismiss(panel, {
       onClose: closeDrilldown
     });
+
+    window.addEventListener("resize", () => {
+      if (!store.situationsView?.drilldown?.isOpen) return;
+      const viewState = ensureViewUiState();
+      applyDrilldownViewportOffset(viewState.drilldown?.normalDetailsCompactSnapshot);
+    });
   }
 
   function updateDrilldownPanel() {
@@ -127,12 +156,14 @@ export function createProjectSubjectDrilldownController(config) {
     wireDetailsInteractive(body);
     bindDetailsScroll(document);
     applyNormalDetailsCompactSnapshot(viewState.drilldown?.normalDetailsCompactSnapshot);
+    applyDrilldownViewportOffset(viewState.drilldown?.normalDetailsCompactSnapshot);
     restoreScrollableElementScrollState(shell, shellScrollState);
     shell.__syncCondensedTitle?.();
     requestAnimationFrame(() => {
       const currentShell = document.querySelector("#drilldownPanel .drilldown__inner");
       restoreScrollableElementScrollState(currentShell, shellScrollState);
       applyNormalDetailsCompactSnapshot(viewState.drilldown?.normalDetailsCompactSnapshot);
+      applyDrilldownViewportOffset(viewState.drilldown?.normalDetailsCompactSnapshot);
       currentShell?.__syncCondensedTitle?.();
     });
   }
@@ -179,6 +210,7 @@ export function createProjectSubjectDrilldownController(config) {
     ensureDrilldownDom();
     closeGlobalNav();
     viewState.drilldown.normalDetailsCompactSnapshot = getNormalDetailsCompactSnapshot();
+    applyDrilldownViewportOffset(viewState.drilldown.normalDetailsCompactSnapshot);
     viewState.drilldown.isOpen = true;
     if (store.situationsView?.drilldown && typeof store.situationsView.drilldown === "object") {
       store.situationsView.drilldown.isOpen = true;
@@ -198,6 +230,10 @@ export function createProjectSubjectDrilldownController(config) {
     }
     const panel = document.getElementById("drilldownPanel");
     panel?.classList.remove("drilldown--situation-kanban");
+    if (panel) {
+      panel.style.setProperty("--subject-drilldown-top-offset", "0px");
+      panel.classList.remove("drilldown--offset-from-normal-compact");
+    }
     setOverlayChromeOpenState(panel, false);
     syncWindowScrollLock(false);
     document.__syncCondensedTitle?.();

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normalizeNormalDetailsCompactSnapshot } from './project-subject-drilldown.js';
+import { computeDrilldownTopOffset, normalizeNormalDetailsCompactSnapshot } from './project-subject-drilldown.js';
 
 test('normalizeNormalDetailsCompactSnapshot conserve expanded explicite', () => {
   const snapshot = normalizeNormalDetailsCompactSnapshot({ compact: true, expanded: false });
@@ -15,4 +15,13 @@ test('normalizeNormalDetailsCompactSnapshot fallback expanded=!compact', () => {
 
   const expandedSnapshot = normalizeNormalDetailsCompactSnapshot({ compact: false });
   assert.deepEqual(expandedSnapshot, { compact: false, expanded: true });
+});
+
+test('computeDrilldownTopOffset retourne 0 si le head normal n’est pas compact', () => {
+  assert.equal(computeDrilldownTopOffset({ compact: false }, 146.8), 0);
+});
+
+test('computeDrilldownTopOffset arrondit et borne la valeur en mode compact', () => {
+  assert.equal(computeDrilldownTopOffset({ compact: true }, 146.8), 147);
+  assert.equal(computeDrilldownTopOffset({ compact: true }, -12), 0);
 });

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -1099,12 +1099,9 @@ body.modal-open {
 /* ===== Details head state classes (for clean CSS cascade) =====
    JS toggles these classes on .gh-panel__head--tight and .modal__head.
    You can override/extend these rules as needed. */
-.gh-panel__head--tight.details-head--compact, 
-.modal__head.details-head--compact, 
-.drilldown__head.details-head--compact, 
-.overlay-chrome__head
-/* FIX: full-width compact subject header */
-.details-head--compact {
+.gh-panel__head--tight.details-head--compact,
+.modal__head.details-head--compact,
+.overlay-chrome__head .details-head--compact {
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
@@ -2525,7 +2522,7 @@ body.is-resizing{
 /* ===== Drilldown slide-in panel ===== */
 .drilldown__inner {
   width:min(720px, 92vw);
-  height:100vh;
+  height:100%;
   border-left:1px solid var(--border);
   transform:translateX(100%);
   transition:transform 180ms ease;
@@ -3333,6 +3330,9 @@ body.route--project #situationsDetailsTitle.details-head--compact{
   position:sticky;
   top:var(--app-top);
   z-index:calc(var(--z-header) - 1);
+  width:100vw;
+  margin-left:calc(50% - 50vw);
+  margin-right:calc(50% - 50vw);
   background: var(--bg) !important;
   border-bottom:1px solid var(--border);
   backdrop-filter:blur(8px);
@@ -3347,6 +3347,10 @@ body.route--project.project-shell-compact.project-subject-details-top-compact #g
 body.route--project.project-shell-compact.project-subject-details-top-compact #situationsDetailsTitle.details-head--compact{
   top:0;
   z-index:calc(var(--z-header) + 1);
+}
+
+#drilldownPanel{
+  top:var(--subject-drilldown-top-offset, 0px);
 }
 
 .project-tabs{transition:opacity .12s ease, visibility .12s ease;}


### PR DESCRIPTION
### Motivation

- Ensure the drilldown slide-in panel is visually aligned under the normal details header when that header is in compact, full-bleed mode. 
- Provide a robust, numeric top offset computed from the normal details head geometry so the drilldown doesn't overlap the header. 
- Make the behavior testable and maintainable via a dedicated CSS variable and unit tests.

### Description

- Add `computeDrilldownTopOffset`, `readNormalDetailsHeadBottom`, and `applyDrilldownViewportOffset` to compute and apply a clamped integer top offset when the normal details head is compact. 
- Set a CSS custom property `--subject-drilldown-top-offset` on `#drilldownPanel` and toggle the `drilldown--offset-from-normal-compact` class when an offset is active. 
- Wire the offset application on open/close, during panel updates, and on window `resize`, and reset the variable when closing the drilldown. 
- Update `style.css` to enforce full-bleed compact details header rules, add `#drilldownPanel { top: var(--subject-drilldown-top-offset, 0px); }`, and adjust `.drilldown__inner` height to `100%`. 
- Add a style test `project-subject-drilldown-style.test.mjs` and extend `project-subject-drilldown.test.mjs` with unit tests for `computeDrilldownTopOffset`.

### Testing

- Added unit tests for `normalizeNormalDetailsCompactSnapshot` and `computeDrilldownTopOffset` and a CSS presence test for the compact header and drilldown offset variable. 
- Ran the node test suite with `node --test` covering both the logic and style assertions. 
- All added automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de324d9464832988831ee0cee8bcdf)