### PR TITLE
feat(subject-details): add sub-subject counter to details header (expanded + compact)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -38,15 +38,15 @@ export function createProjectSubjectsDetailsRenderer(config) {
       buildExpandedBottomHtml(currentSelection) {
         const item = currentSelection.item;
         if (currentSelection.type === "sujet") {
-          return statePill(getEffectiveSujetStatus(item.id), {
+          return `${statePill(getEffectiveSujetStatus(item.id), {
             reviewState: getEntityReviewMeta("sujet", item.id).review_state,
             entityType: "sujet"
-          });
+          })}${problemsCountsHtml(item, { entityType: "sujet" })}`;
         }
         return `${statePill(getEffectiveSituationStatus(item.id), {
           reviewState: getEntityReviewMeta("situation", item.id).review_state,
           entityType: "situation"
-        })}${problemsCountsHtml(item)}`;
+        })}${problemsCountsHtml(item, { entityType: "situation" })}`;
       },
       buildCompactConfig(currentSelection, { titleTextHtml }) {
         const item = currentSelection.item;
@@ -59,7 +59,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
               entityType: "sujet"
             }),
             topHtml: titleTextHtml,
-            bottomHtml: ""
+            bottomHtml: `${problemsCountsHtml(item, { entityType: "sujet" })}`
           };
         }
         return {
@@ -70,7 +70,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
             entityType: "situation"
           }),
           topHtml: titleTextHtml,
-          bottomHtml: `${problemsCountsHtml(item)}`
+          bottomHtml: `${problemsCountsHtml(item, { entityType: "situation" })}`
         };
       }
     });

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -702,11 +702,16 @@ function problemsCountsIconHtml(closedCount, totalCount) {
   return renderProblemsCountsIconHtml(closedCount, totalCount);
 }
 
-function problemsCountsHtml(situation) {
-  const linkedSubjects = getSituationSubjects(situation);
+function problemsCountsHtml(item, options = {}) {
+  const entityType = String(options.entityType || "situation").toLowerCase();
+  const linkedSubjects = entityType === "sujet"
+    ? getChildSubjectList(item)
+    : getSituationSubjects(item);
   const totalSubjects = linkedSubjects.length;
-  const closedSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() !== "open").length;
-  return `<div class="subissues-counts subissues-counts--problems">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} sur ${totalSubjects}</span></div>`;
+  const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
+  const closedSubjects = Math.max(0, totalSubjects - openSubjects);
+  const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
+  return `<div class="subissues-counts subissues-counts--problems" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} / ${totalSubjects}</span></div>`;
 }
 
 /* =========================================================

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2337,7 +2337,7 @@ body.is-resizing{
 .details-title--compact .details-title-compact--inline .details-title-text{min-width:0;}
 .details-title--compact .details-title-compact-top{display:flex;align-items:baseline;gap:0px 4px;min-width:0;flex-wrap:wrap;}
 .details-title--compact .details-title-compact-bottom{display:flex;align-items:center;gap:8px;min-width:0;height:16px;}
-.details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;}
+.details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;font-size:12px;line-height:16px;gap:4px;background:transparent;}
 .details-title--compact .details-title-compact-bottom .verdict-bar{flex:0 1 auto;}
 .details-title--compact .gh-state{font-size:14px;line-height:21px;padding:3px 10px;height:32px;}
 .details-title--compact .details-title-row{align-items:flex-start;}
@@ -2353,7 +2353,21 @@ body.is-resizing{
 
 .details-title--expanded .details-title-text{font-size:32px;font-weight:400;line-height:43px;color:#fff;}
 .details-title--expanded .gh-state{font-size:14px;line-height:21px;padding:3px 10px;}
-.details-title--expanded .subissues-counts--problems{line-height:21px;padding:0px 12px;margin:0px;height:29px;min-width:auto;}
+.details-title--expanded .subissues-counts--problems{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  margin:0px;
+  min-width:auto;
+  height:32px;
+  padding:3px 10px;
+  border-radius:999px;
+  border:1px solid var(--border2);
+  background:rgba(22,27,34,.35);
+  font-size:14px;
+  line-height:21px;
+  font-weight:400;
+}
 .details-title--expanded .subissues-counts--verdicts{margin-left:8px;}
 
 /* Expanded title layout: 2 lines */


### PR DESCRIPTION
### Motivation
- Provide a sub-subject counter in the subject details header so users see quick open/total counts in both expanded and compact header states.
- Reuse the existing shared subissues rendering so situations and sujets follow the same visual/API contract.

### Description
- Add the shared counter into the details title pipeline by updating `renderDetailsTitleWrapHtml` in `apps/web/js/views/project-subjects/project-subjects-details-renderer.js` to include `problemsCountsHtml` for both expanded and compact layouts.
- Make `problemsCountsHtml` accept `item` and an `options` object with `entityType` and compute `open / total` and `closed` from either `getChildSubjectList` (for `sujet`) or `getSituationSubjects` (for `situation`) in `apps/web/js/views/project-subjects/project-subjects-view.js` and return accessible markup with an `aria-label`.
- Adjust header styles in `apps/web/style.css` so the expanded header shows a pill-like bordered badge (matching the open/closed badge language) and the compact header shows a smaller borderless inline counter.
- Keep the shared ring icon rendering via `renderProblemsCountsIconHtml` and update the displayed text format to `open / total`.

### Testing
- Ran `node --test apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs` and all tests passed (5 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2b5e634c8329a1fbf1f93301cdc0)