### PR TITLE
Improve sub-issues UI: chevrons, counts, icons, and open-right-panel by default

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -38,15 +38,15 @@ export function createProjectSubjectsDetailsRenderer(config) {
       buildExpandedBottomHtml(currentSelection) {
         const item = currentSelection.item;
         if (currentSelection.type === "sujet") {
-          return statePill(getEffectiveSujetStatus(item.id), {
+          return `${statePill(getEffectiveSujetStatus(item.id), {
             reviewState: getEntityReviewMeta("sujet", item.id).review_state,
             entityType: "sujet"
-          });
+          })}${problemsCountsHtml(item, { entityType: "sujet" })}`;
         }
         return `${statePill(getEffectiveSituationStatus(item.id), {
           reviewState: getEntityReviewMeta("situation", item.id).review_state,
           entityType: "situation"
-        })}${problemsCountsHtml(item)}`;
+        })}${problemsCountsHtml(item, { entityType: "situation" })}`;
       },
       buildCompactConfig(currentSelection, { titleTextHtml }) {
         const item = currentSelection.item;
@@ -59,7 +59,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
               entityType: "sujet"
             }),
             topHtml: titleTextHtml,
-            bottomHtml: ""
+            bottomHtml: `${problemsCountsHtml(item, { entityType: "sujet" })}`
           };
         }
         return {
@@ -70,7 +70,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
             entityType: "situation"
           }),
           topHtml: titleTextHtml,
-          bottomHtml: `${problemsCountsHtml(item)}`
+          bottomHtml: `${problemsCountsHtml(item, { entityType: "situation" })}`
         };
       }
     });

--- a/apps/web/js/views/project-subjects/project-subjects-selection.js
+++ b/apps/web/js/views/project-subjects/project-subjects-selection.js
@@ -108,6 +108,7 @@ export function createProjectSubjectsSelection({
     }
     setActiveSelection({ selectedSituationId: situation?.id || null, selectedSubjectId: sujet.id });
     if (situation?.id) viewState.expandedSituations.add(situation.id);
+    viewState.rightSubissuesOpen = true;
     viewState.showTableOnly = false;
     viewState.detailsModalOpen = false;
     syncLegacySituationsView({

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -149,7 +149,11 @@ function statePill(status = "open", options = {}) {
 
 function chevron(isOpen, isVisible = true) {
   if (!isVisible) return "";
-  return `<span class="chev">${isOpen ? "▾" : "▸"}</span>`;
+  return `
+    <span class="subject-meta-collapsible-toggle__chevron" aria-hidden="true">
+      ${svgIcon(isOpen ? "chevron-up" : "chevron-down", { className: isOpen ? "octicon octicon-chevron-up" : "octicon octicon-chevron-down" })}
+    </span>
+  `;
 }
 
 function entityLinkHtml(type, id, text) {
@@ -702,11 +706,25 @@ function problemsCountsIconHtml(closedCount, totalCount) {
   return renderProblemsCountsIconHtml(closedCount, totalCount);
 }
 
-function problemsCountsHtml(situation) {
-  const linkedSubjects = getSituationSubjects(situation);
+function problemsCountsHtml(item, options = {}) {
+  const entityType = String(options.entityType || "situation").toLowerCase();
+  const linkedSubjects = entityType === "sujet"
+    ? getChildSubjectList(item)
+    : getSituationSubjects(item);
   const totalSubjects = linkedSubjects.length;
-  const closedSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() !== "open").length;
-  return `<div class="subissues-counts subissues-counts--problems">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} sur ${totalSubjects}</span></div>`;
+  const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
+  const closedSubjects = Math.max(0, totalSubjects - openSubjects);
+  const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
+  return `<div class="subissues-counts subissues-counts--problems" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} / ${totalSubjects}</span></div>`;
+}
+
+function subissuesHeadCountsHtml(subjects = []) {
+  const linkedSubjects = Array.isArray(subjects) ? subjects : [];
+  const totalSubjects = linkedSubjects.length;
+  const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
+  const closedSubjects = Math.max(0, totalSubjects - openSubjects);
+  const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
+  return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} sur ${totalSubjects}</span></div>`;
 }
 
 /* =========================================================
@@ -1317,6 +1335,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
   const rows = childSubjects.map((childSujet) => `
       <div class="issue-row issue-row--pb click ${sujetRowClass}" data-sujet-id="${escapeHtml(childSujet.id)}">
         <div class="cell cell-theme cell-theme--full lvl0">
+          ${issueIcon(getEffectiveSujetStatus(childSujet.id))}
           <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(childSujet.title, childSujet.id, ""))}</span>
         </div>
       </div>
@@ -1329,10 +1348,10 @@ function renderSubIssuesForSujet(sujet, options = {}) {
 
   return renderSubIssuesPanel({
     title: "Sous-sujets",
-    leftMetaHtml: `<div class="subissues-counts subissues-counts--total"><span class="mono">${childSubjects.length}</span></div>`,
+    leftMetaHtml: subissuesHeadCountsHtml(childSubjects),
     rightMetaHtml: "",
     bodyHtml: body,
-    isOpen: !!store.situationsView.rightSubissuesOpen
+    isOpen: store.situationsView.rightSubissuesOpen !== false
   });
 }
 
@@ -1365,6 +1384,7 @@ function renderSubIssuesForSituation(situation, options = {}) {
         rows.push(`
           <div class="issue-row issue-row--pb click ${sujetRowClass}" data-sujet-id="${escapeHtml(childSujet.id)}">
             <div class="cell cell-theme cell-theme--full lvl1">
+              ${issueIcon(getEffectiveSujetStatus(childSujet.id))}
               <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(childSujet.title, childSujet.id, ""))}</span>
             </div>
           </div>
@@ -1373,7 +1393,6 @@ function renderSubIssuesForSituation(situation, options = {}) {
     }
   }
 
-  const stats = situationVerdictStats(situation);
   const body = renderSubIssuesTable({
     rowsHtml: rows.join(""),
     emptyTitle: "Aucun sujet"

--- a/apps/web/js/views/ui/issues-table.js
+++ b/apps/web/js/views/ui/issues-table.js
@@ -66,11 +66,18 @@ export function renderSubIssuesPanel({
   bodyHtml = "",
   isOpen = false
 } = {}) {
+  const chevronIcon = `
+    <span class="subject-meta-collapsible-toggle__chevron" aria-hidden="true">
+      <svg class="${isOpen ? "octicon octicon-chevron-up" : "octicon octicon-chevron-down"}" viewBox="0 0 16 16" width="16" height="16" role="img">
+        <use href="assets/icons.svg#${isOpen ? "chevron-up" : "chevron-down"}" xlink:href="assets/icons.svg#${isOpen ? "chevron-up" : "chevron-down"}"></use>
+      </svg>
+    </span>
+  `;
   return `
     <div class="details-subissues">
       <div class="subissues-head click" data-action="toggle-subissues">
         <div class="subissues-head-left">
-          <span class="chev">${isOpen ? "▾" : "▸"}</span>
+          ${chevronIcon}
           <span class="subissues-title">${escapeHtml(title || "")}</span>
           ${leftMetaHtml || ""}
         </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2267,11 +2267,27 @@ body.is-resizing{
 
 /* ===== Right panel: Sub-issues table (below description) ===== */
 .details-subissues{margin-left:52px;width:calc(100% - 52px);margin-bottom:8px;margin-top:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden;container-type:inline-size;}
-.subissues-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;background: var(--headbgtight);border-bottom: solid 1px var(--border2);}
+.subissues-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;background: transparent;border-bottom: solid 1px var(--border2);}
 .subissues-head-left{display:flex;align-items:center;gap:10px;min-width:0;}
 .subissues-head-right{display:flex;align-items:center;gap:8px;flex:0 0 auto;min-width:0;}
 .subissues-title{font-size:13px;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .subissues-counts{display:inline-flex;align-items:center;gap:2px;margin-left:6px;padding:2px 6px;border:1px solid var(--border2);border-radius:999px;background:rgba(22,27,34,.35);color:var(--muted);font-size:12px;line-height:1;}
+.subissues-counts--head{
+  gap:4px;
+  margin-left:0;
+  min-height:20px;
+  height:20px;
+  padding:0 8px;
+  line-height:20px;
+  border-radius:999px;
+}
+.subissues-counts--head > span:last-child{
+  line-height:20px;
+}
+.subissues-counts--head .subissues-problems-icon{
+  width:16px;
+  height:16px;
+}
 .subissues-body{padding:0;}
 .subissues-table{border:none;border-radius:0;}
 .subissues-table .issues-table__head{border-bottom:1px solid var(--border2);}
@@ -2337,7 +2353,7 @@ body.is-resizing{
 .details-title--compact .details-title-compact--inline .details-title-text{min-width:0;}
 .details-title--compact .details-title-compact-top{display:flex;align-items:baseline;gap:0px 4px;min-width:0;flex-wrap:wrap;}
 .details-title--compact .details-title-compact-bottom{display:flex;align-items:center;gap:8px;min-width:0;height:16px;}
-.details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;}
+.details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;font-size:12px;line-height:16px;gap:4px;background:transparent;}
 .details-title--compact .details-title-compact-bottom .verdict-bar{flex:0 1 auto;}
 .details-title--compact .gh-state{font-size:14px;line-height:21px;padding:3px 10px;height:32px;}
 .details-title--compact .details-title-row{align-items:flex-start;}
@@ -2353,7 +2369,21 @@ body.is-resizing{
 
 .details-title--expanded .details-title-text{font-size:32px;font-weight:400;line-height:43px;color:#fff;}
 .details-title--expanded .gh-state{font-size:14px;line-height:21px;padding:3px 10px;}
-.details-title--expanded .subissues-counts--problems{line-height:21px;padding:0px 12px;margin:0px;height:29px;min-width:auto;}
+.details-title--expanded .subissues-counts--problems{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  margin:0px;
+  min-width:auto;
+  height:32px;
+  padding:3px 10px;
+  border-radius:999px;
+  border:1px solid var(--border2);
+  background:rgba(22,27,34,.35);
+  font-size:14px;
+  line-height:21px;
+  font-weight:400;
+}
 .details-title--expanded .subissues-counts--verdicts{margin-left:8px;}
 
 /* Expanded title layout: 2 lines */


### PR DESCRIPTION
### Motivation
- Make the sub-issues UI clearer and more accessible by replacing text chevrons with SVG icons, surface per-item issue icons, and show open/total counts with accessible labels.
- Ensure the right-hand sub-issues panel opens when a subject is selected for a smoother navigation flow.

### Description
- Replace simple text chevrons with SVG chevron icons and consistent markup in `issues-table.js` and `project-subjects-view.js` so toggles use the same icon HTML and classes.
- Change `problemsCountsHtml` signature in `project-subjects-view.js` to accept an `item` and `options.entityType`, compute open/closed/total counts, render an accessible `aria-label`, and switch displayed text to `open / total`; add `subissuesHeadCountsHtml` for head badges.
- Add per-subject `issueIcon` rendering in subject list rows for both sujet children and situation lists in `project-subjects-view.js` and adjust panel open state logic to treat `rightSubissuesOpen` explicitly (not `!!` coercion).
- Default open the right sub-issues panel when selecting a subject by setting `viewState.rightSubissuesOpen = true` in `project-subjects-selection.js`.
- Update `project-subjects-details-renderer.js` calls to `problemsCountsHtml` to pass the appropriate `entityType` argument for sujets and situations.
- Add CSS updates in `style.css` to style the new chevrons, head badge variant (`.subissues-counts--head`), layout tweaks for transparent head background, and polish subissues count visuals.

### Testing
- Ran linting (`yarn lint`) and the frontend test suite (`yarn test`) locally; both succeeded. 
- Ran a local frontend build (`yarn build`) and verified the right-hand sub-issues panel opens on subject selection and that chevrons, icons and counts render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2b5e634c8329a1fbf1f93301cdc0)