### PR TITLE
Add parent-subject card and improve sub-issues UI (chevrons, counts, drilldown)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -38,15 +38,15 @@ export function createProjectSubjectsDetailsRenderer(config) {
       buildExpandedBottomHtml(currentSelection) {
         const item = currentSelection.item;
         if (currentSelection.type === "sujet") {
-          return statePill(getEffectiveSujetStatus(item.id), {
+          return `${statePill(getEffectiveSujetStatus(item.id), {
             reviewState: getEntityReviewMeta("sujet", item.id).review_state,
             entityType: "sujet"
-          });
+          })}${problemsCountsHtml(item, { entityType: "sujet" })}`;
         }
         return `${statePill(getEffectiveSituationStatus(item.id), {
           reviewState: getEntityReviewMeta("situation", item.id).review_state,
           entityType: "situation"
-        })}${problemsCountsHtml(item)}`;
+        })}${problemsCountsHtml(item, { entityType: "situation" })}`;
       },
       buildCompactConfig(currentSelection, { titleTextHtml }) {
         const item = currentSelection.item;
@@ -59,7 +59,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
               entityType: "sujet"
             }),
             topHtml: titleTextHtml,
-            bottomHtml: ""
+            bottomHtml: `${problemsCountsHtml(item, { entityType: "sujet" })}`
           };
         }
         return {
@@ -70,7 +70,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
             entityType: "situation"
           }),
           topHtml: titleTextHtml,
-          bottomHtml: `${problemsCountsHtml(item)}`
+          bottomHtml: `${problemsCountsHtml(item, { entityType: "situation" })}`
         };
       }
     });

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -973,6 +973,17 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
 
+      const parentSubjectCard = event.target.closest("[data-parent-subject-id]");
+      if (parentSubjectCard) {
+        event.preventDefault();
+        event.stopPropagation();
+        const parentSubjectId = String(parentSubjectCard.dataset.parentSubjectId || "");
+        if (parentSubjectId) {
+          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(parentSubjectId);
+        }
+        return;
+      }
+
       const titleTrigger = event.target.closest(".js-row-title-trigger");
       if (titleTrigger) {
         event.preventDefault();

--- a/apps/web/js/views/project-subjects/project-subjects-selection.js
+++ b/apps/web/js/views/project-subjects/project-subjects-selection.js
@@ -108,6 +108,7 @@ export function createProjectSubjectsSelection({
     }
     setActiveSelection({ selectedSituationId: situation?.id || null, selectedSubjectId: sujet.id });
     if (situation?.id) viewState.expandedSituations.add(situation.id);
+    viewState.rightSubissuesOpen = true;
     viewState.showTableOnly = false;
     viewState.detailsModalOpen = false;
     syncLegacySituationsView({

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -149,7 +149,11 @@ function statePill(status = "open", options = {}) {
 
 function chevron(isOpen, isVisible = true) {
   if (!isVisible) return "";
-  return `<span class="chev">${isOpen ? "▾" : "▸"}</span>`;
+  return `
+    <span class="subject-meta-collapsible-toggle__chevron" aria-hidden="true">
+      ${svgIcon(isOpen ? "chevron-up" : "chevron-down", { className: isOpen ? "octicon octicon-chevron-up" : "octicon octicon-chevron-down" })}
+    </span>
+  `;
 }
 
 function entityLinkHtml(type, id, text) {
@@ -702,11 +706,25 @@ function problemsCountsIconHtml(closedCount, totalCount) {
   return renderProblemsCountsIconHtml(closedCount, totalCount);
 }
 
-function problemsCountsHtml(situation) {
-  const linkedSubjects = getSituationSubjects(situation);
+function problemsCountsHtml(item, options = {}) {
+  const entityType = String(options.entityType || "situation").toLowerCase();
+  const linkedSubjects = entityType === "sujet"
+    ? getChildSubjectList(item)
+    : getSituationSubjects(item);
   const totalSubjects = linkedSubjects.length;
-  const closedSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() !== "open").length;
-  return `<div class="subissues-counts subissues-counts--problems">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} sur ${totalSubjects}</span></div>`;
+  const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
+  const closedSubjects = Math.max(0, totalSubjects - openSubjects);
+  const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
+  return `<div class="subissues-counts subissues-counts--problems" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} / ${totalSubjects}</span></div>`;
+}
+
+function subissuesHeadCountsHtml(subjects = []) {
+  const linkedSubjects = Array.isArray(subjects) ? subjects : [];
+  const totalSubjects = linkedSubjects.length;
+  const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
+  const closedSubjects = Math.max(0, totalSubjects - openSubjects);
+  const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
+  return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} sur ${totalSubjects}</span></div>`;
 }
 
 /* =========================================================
@@ -1069,11 +1087,59 @@ function renderSubjectObjectivesValue(subjectId) {
   `;
 }
 
+function getSubjectParentSubject(subjectId) {
+  const subject = getNestedSujet(subjectId);
+  if (!subject) return null;
+  const parentSubjectId = firstNonEmpty(
+    subject.parent_subject_id,
+    subject.parentSubjectId,
+    subject.raw?.parent_subject_id
+  );
+  if (!parentSubjectId) return null;
+  return getNestedSujet(parentSubjectId);
+}
+
+function renderSubjectParentCard(subjectId) {
+  const parentSubject = getSubjectParentSubject(subjectId);
+  if (!parentSubject) return renderSubjectMetaButtonValue("Aucun sujet parent");
+
+  const parentStatus = getEffectiveSujetStatus(parentSubject.id);
+  const parentChildren = getChildSubjectList(parentSubject);
+  const displayRef = getEntityDisplayRef("sujet", parentSubject.id);
+  const author = getDisplayAuthorName(firstNonEmpty(
+    getEntityDescriptionState("sujet", parentSubject.id)?.author,
+    parentSubject?.agent,
+    parentSubject?.raw?.agent,
+    "system"
+  ), {
+    agent: firstNonEmpty(
+      getEntityDescriptionState("sujet", parentSubject.id)?.agent,
+      parentSubject?.agent,
+      parentSubject?.raw?.agent,
+      "system"
+    ),
+    fallback: "System"
+  });
+
+  return `
+    <button type="button" class="subject-meta-parent-card" data-parent-subject-id="${escapeHtml(parentSubject.id)}">
+      <span class="subject-meta-parent-card__label">Sujet parent</span>
+      <span class="subject-meta-parent-card__head">
+        <span class="subject-meta-parent-card__icon">${issueIcon(parentStatus)}</span>
+        <span class="subject-meta-parent-card__title">${escapeHtml(firstNonEmpty(parentSubject.title, parentSubject.id, "Sujet parent"))}</span>
+        <span class="subject-meta-parent-card__count">${subissuesHeadCountsHtml(parentChildren)}</span>
+      </span>
+      <span class="subject-meta-parent-card__meta">${escapeHtml(author)} ${escapeHtml(displayRef)}</span>
+    </button>
+  `;
+}
+
 function renderSubjectMetaFieldValue(subject, field) {
   if (!subject || String(subject.type || "") === "") return "";
   if (field === "labels") return renderSubjectLabelsValue(subject.id);
   if (field === "situations") return renderSubjectSituationsValue(subject.id);
   if (field === "objectives") return renderSubjectObjectivesValue(subject.id);
+  if (field === "relations") return renderSubjectParentCard(subject.id);
   return renderSubjectMetaButtonValue("Aucune donnée");
 }
 
@@ -1174,6 +1240,32 @@ function buildSubjectMetaMenuItems(subject, field) {
 function renderSubjectMetaDropdown(subject, field) {
   const dropdownState = getSubjectsViewState().subjectMetaDropdown || {};
   const query = String(dropdownState.query || "");
+
+  if (field === "relations") {
+    const relationItems = [
+      "Modifier ou supprimer le sujet parent",
+      "Ajouter ou modifier « Bloqué par »",
+      "Ajouter ou modifier « Bloquant »"
+    ];
+    return `
+      <div class="subject-meta-dropdown gh-menu gh-menu--open" role="dialog">
+        <div class="subject-meta-dropdown__title">Gérer les relations</div>
+        <div class="subject-meta-dropdown__body">
+          <div class="select-menu__section">
+            ${relationItems.map((title) => `
+              <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem">
+                <span class="select-menu__item-mainrow">
+                  <span class="select-menu__item-content">
+                    <span class="select-menu__item-title">${escapeHtml(title)}</span>
+                  </span>
+                </span>
+              </button>
+            `).join("")}
+          </div>
+        </div>
+      </div>
+    `;
+  }
 
   if (field === "objectives") {
     const { openItems, closedItems } = buildSubjectMetaMenuItems(subject, field);
@@ -1304,7 +1396,7 @@ function renderSubjectMetaControls(subject) {
       ${renderSubjectMetaField({
         field: "relations",
         label: "Relations",
-        valueHtml: renderSubjectMetaButtonValue(summarizeSubjectMetaValue(meta.relations, "Aucune relation"))
+        valueHtml: renderSubjectParentCard(subject.id)
       })}
     </div>
   `;
@@ -1317,6 +1409,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
   const rows = childSubjects.map((childSujet) => `
       <div class="issue-row issue-row--pb click ${sujetRowClass}" data-sujet-id="${escapeHtml(childSujet.id)}">
         <div class="cell cell-theme cell-theme--full lvl0">
+          ${issueIcon(getEffectiveSujetStatus(childSujet.id))}
           <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(childSujet.title, childSujet.id, ""))}</span>
         </div>
       </div>
@@ -1329,10 +1422,10 @@ function renderSubIssuesForSujet(sujet, options = {}) {
 
   return renderSubIssuesPanel({
     title: "Sous-sujets",
-    leftMetaHtml: `<div class="subissues-counts subissues-counts--total"><span class="mono">${childSubjects.length}</span></div>`,
+    leftMetaHtml: subissuesHeadCountsHtml(childSubjects),
     rightMetaHtml: "",
     bodyHtml: body,
-    isOpen: !!store.situationsView.rightSubissuesOpen
+    isOpen: store.situationsView.rightSubissuesOpen !== false
   });
 }
 
@@ -1365,6 +1458,7 @@ function renderSubIssuesForSituation(situation, options = {}) {
         rows.push(`
           <div class="issue-row issue-row--pb click ${sujetRowClass}" data-sujet-id="${escapeHtml(childSujet.id)}">
             <div class="cell cell-theme cell-theme--full lvl1">
+              ${issueIcon(getEffectiveSujetStatus(childSujet.id))}
               <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(childSujet.title, childSujet.id, ""))}</span>
             </div>
           </div>
@@ -1373,7 +1467,6 @@ function renderSubIssuesForSituation(situation, options = {}) {
     }
   }
 
-  const stats = situationVerdictStats(situation);
   const body = renderSubIssuesTable({
     rowsHtml: rows.join(""),
     emptyTitle: "Aucun sujet"

--- a/apps/web/js/views/ui/issues-table.js
+++ b/apps/web/js/views/ui/issues-table.js
@@ -66,11 +66,18 @@ export function renderSubIssuesPanel({
   bodyHtml = "",
   isOpen = false
 } = {}) {
+  const chevronIcon = `
+    <span class="subject-meta-collapsible-toggle__chevron" aria-hidden="true">
+      <svg class="${isOpen ? "octicon octicon-chevron-up" : "octicon octicon-chevron-down"}" viewBox="0 0 16 16" width="16" height="16" role="img">
+        <use href="assets/icons.svg#${isOpen ? "chevron-up" : "chevron-down"}" xlink:href="assets/icons.svg#${isOpen ? "chevron-up" : "chevron-down"}"></use>
+      </svg>
+    </span>
+  `;
   return `
     <div class="details-subissues">
       <div class="subissues-head click" data-action="toggle-subissues">
         <div class="subissues-head-left">
-          <span class="chev">${isOpen ? "▾" : "▸"}</span>
+          ${chevronIcon}
           <span class="subissues-title">${escapeHtml(title || "")}</span>
           ${leftMetaHtml || ""}
         </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -642,6 +642,71 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
   flex:0 0 auto;
   color:var(--muted);
 }
+.subject-meta-collapsible-toggle__chevron .octicon-chevron-up,
+.subject-meta-collapsible-toggle__chevron .octicon-chevron-down{
+  color:var(--muted);
+}
+
+.subject-meta-parent-card{
+  width:100%;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  border:1px solid var(--border);
+  border-radius:8px;
+  background:rgba(13,17,23,.32);
+  color:var(--text);
+  text-align:left;
+  padding:10px;
+  cursor:pointer;
+}
+.subject-meta-parent-card:hover,
+.subject-meta-parent-card:focus-visible{
+  background:rgba(56,139,253,.08);
+  border-color:rgba(88,166,255,.45);
+  outline:none;
+}
+.subject-meta-parent-card__label{
+  font-size:11px;
+  font-weight:600;
+  color:var(--muted);
+}
+.subject-meta-parent-card__head{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  min-width:0;
+}
+.subject-meta-parent-card__icon{
+  display:inline-flex;
+  align-items:center;
+  flex:0 0 auto;
+}
+.subject-meta-parent-card__title{
+  min-width:0;
+  font-size:13px;
+  line-height:18px;
+  font-weight:600;
+  color:var(--text);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.subject-meta-parent-card__count{
+  margin-left:auto;
+  flex:0 0 auto;
+}
+.subject-meta-parent-card__count .subissues-counts{
+  margin-left:0;
+}
+.subject-meta-parent-card__meta{
+  font-size:12px;
+  color:var(--muted);
+}
+
+.subject-meta-relations-menu__item{
+  width:100%;
+}
 
 .subject-meta-field__chip{
   display:flex;
@@ -2267,11 +2332,27 @@ body.is-resizing{
 
 /* ===== Right panel: Sub-issues table (below description) ===== */
 .details-subissues{margin-left:52px;width:calc(100% - 52px);margin-bottom:8px;margin-top:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden;container-type:inline-size;}
-.subissues-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;background: var(--headbgtight);border-bottom: solid 1px var(--border2);}
+.subissues-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;background: transparent;border-bottom: solid 1px var(--border2);}
 .subissues-head-left{display:flex;align-items:center;gap:10px;min-width:0;}
 .subissues-head-right{display:flex;align-items:center;gap:8px;flex:0 0 auto;min-width:0;}
 .subissues-title{font-size:13px;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .subissues-counts{display:inline-flex;align-items:center;gap:2px;margin-left:6px;padding:2px 6px;border:1px solid var(--border2);border-radius:999px;background:rgba(22,27,34,.35);color:var(--muted);font-size:12px;line-height:1;}
+.subissues-counts--head{
+  gap:4px;
+  margin-left:0;
+  min-height:20px;
+  height:20px;
+  padding:0 8px;
+  line-height:20px;
+  border-radius:999px;
+}
+.subissues-counts--head > span:last-child{
+  line-height:20px;
+}
+.subissues-counts--head .subissues-problems-icon{
+  width:16px;
+  height:16px;
+}
 .subissues-body{padding:0;}
 .subissues-table{border:none;border-radius:0;}
 .subissues-table .issues-table__head{border-bottom:1px solid var(--border2);}
@@ -2337,7 +2418,7 @@ body.is-resizing{
 .details-title--compact .details-title-compact--inline .details-title-text{min-width:0;}
 .details-title--compact .details-title-compact-top{display:flex;align-items:baseline;gap:0px 4px;min-width:0;flex-wrap:wrap;}
 .details-title--compact .details-title-compact-bottom{display:flex;align-items:center;gap:8px;min-width:0;height:16px;}
-.details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;}
+.details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;font-size:12px;line-height:16px;gap:4px;background:transparent;}
 .details-title--compact .details-title-compact-bottom .verdict-bar{flex:0 1 auto;}
 .details-title--compact .gh-state{font-size:14px;line-height:21px;padding:3px 10px;height:32px;}
 .details-title--compact .details-title-row{align-items:flex-start;}
@@ -2353,7 +2434,21 @@ body.is-resizing{
 
 .details-title--expanded .details-title-text{font-size:32px;font-weight:400;line-height:43px;color:#fff;}
 .details-title--expanded .gh-state{font-size:14px;line-height:21px;padding:3px 10px;}
-.details-title--expanded .subissues-counts--problems{line-height:21px;padding:0px 12px;margin:0px;height:29px;min-width:auto;}
+.details-title--expanded .subissues-counts--problems{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  margin:0px;
+  min-width:auto;
+  height:32px;
+  padding:3px 10px;
+  border-radius:999px;
+  border:1px solid var(--border2);
+  background:rgba(22,27,34,.35);
+  font-size:14px;
+  line-height:21px;
+  font-weight:400;
+}
 .details-title--expanded .subissues-counts--verdicts{margin-left:8px;}
 
 /* Expanded title layout: 2 lines */


### PR DESCRIPTION
### Motivation
- Surface parent-subject relations in the subject meta area and make sub-issues UI clearer and more accessible. 
- Replace text chevrons with proper SVG icons and improve the sub-issues counts display and aria labeling to convey open/closed counts. 
- Allow drilling down into a parent subject from the details meta card and ensure the right-hand sub-issues panel opens when selecting a subject.

### Description
- Added a parent-subject card component and rendering: implemented `getSubjectParentSubject`, `renderSubjectParentCard`, and integrated it as the `relations` meta field in `renderSubjectMetaFieldValue` and `renderSubjectMetaControls` in `project-subjects-view.js`.
- Reworked sub-issues counts and labels: changed `problemsCountsHtml` signature to `problemsCountsHtml(item, options)` and added `subissuesHeadCountsHtml` to produce head-style counts with an accessible `aria-label` and `open/total` display.
- Replaced plain-text chevrons with SVG icon markup in `chevron()` and `renderSubIssuesPanel`, and added related styles in `style.css` for the toggle and parent card visuals.
- Improved sub-issues list rendering by showing issue icons for child rows and using the new head counts in `renderSubIssuesForSujet` and `renderSubIssuesForSituation`.
- Added click handling to open a parent subject drilldown: new handler for elements with `data-parent-subject-id` in `project-subjects-events.js` calling `openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel`.
- Ensure selecting a subject opens the right sub-issues panel by setting `viewState.rightSubissuesOpen = true` in `project-subjects-selection.js`.
- CSS updates in `style.css` to style the parent card, chevrons, and sub-issues head/count variants.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2b5e634c8329a1fbf1f93301cdc0)