### PR TITLE
Centralize subject assignee resolution and harden rendering to fix disappearing assignees

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -3,6 +3,7 @@ import { buildSubjectHierarchyIndexes } from "./subject-hierarchy.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./project-situations-supabase.js";
 import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
@@ -817,9 +818,7 @@ export async function removeLabelFromSubject(subjectId, labelId) {
 export async function replaceSubjectAssignees(subjectId, personIds = []) {
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
-  const uniquePersonIds = [...new Set((Array.isArray(personIds) ? personIds : [])
-    .map((value) => normalizeUuid(value))
-    .filter(Boolean))];
+  const uniquePersonIds = [...new Set(normalizeAssigneeIds(personIds).map((value) => normalizeUuid(value)).filter(Boolean))];
   const projectId = await fetchSubjectProjectId(normalizedSubjectId);
 
   const deleteUrl = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);

--- a/apps/web/js/services/subject-assignees-service.js
+++ b/apps/web/js/services/subject-assignees-service.js
@@ -1,0 +1,35 @@
+function normalizeAssigneeId(value) {
+  return String(value || "").trim();
+}
+
+export function normalizeAssigneeIds(values) {
+  return [...new Set((Array.isArray(values) ? values : []).map((value) => normalizeAssigneeId(value)).filter(Boolean))];
+}
+
+export function resolveSubjectAssigneeIds({
+  subjectMetaAssignees,
+  assigneeMap,
+  subjectId,
+  subject
+} = {}) {
+  const normalizedSubjectId = String(subjectId || "").trim();
+  const map = assigneeMap && typeof assigneeMap === "object" ? assigneeMap : {};
+
+  if (Array.isArray(subjectMetaAssignees)) {
+    return normalizeAssigneeIds(subjectMetaAssignees);
+  }
+
+  const mapped = normalizeAssigneeIds(map[normalizedSubjectId]);
+  if (mapped.length) return mapped;
+
+  return normalizeAssigneeIds([
+    subject?.assignee_person_id,
+    subject?.raw?.assignee_person_id
+  ]);
+}
+
+export function findCollaboratorByAssigneeId(collaboratorsById, assigneeId) {
+  const key = normalizeAssigneeId(assigneeId);
+  if (!key || !(collaboratorsById instanceof Map)) return null;
+  return collaboratorsById.get(key) || null;
+}

--- a/apps/web/js/services/subject-assignees-service.test.mjs
+++ b/apps/web/js/services/subject-assignees-service.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  normalizeAssigneeIds,
+  resolveSubjectAssigneeIds,
+  findCollaboratorByAssigneeId
+} from "./subject-assignees-service.js";
+
+test("normalizeAssigneeIds déduplique et nettoie les identifiants", () => {
+  assert.deepEqual(
+    normalizeAssigneeIds(["  abc ", "", null, "abc", " def "]),
+    ["abc", "def"]
+  );
+});
+
+test("resolveSubjectAssigneeIds priorise la méta si présente, même vide", () => {
+  assert.deepEqual(
+    resolveSubjectAssigneeIds({
+      subjectMetaAssignees: [],
+      assigneeMap: { "s1": ["p1"] },
+      subjectId: "s1",
+      subject: { assignee_person_id: "p2" }
+    }),
+    []
+  );
+});
+
+test("resolveSubjectAssigneeIds retombe sur la map puis sur le primaire du sujet", () => {
+  assert.deepEqual(
+    resolveSubjectAssigneeIds({
+      subjectMetaAssignees: undefined,
+      assigneeMap: { "s1": ["p1", "p2"] },
+      subjectId: "s1",
+      subject: { assignee_person_id: "p3" }
+    }),
+    ["p1", "p2"]
+  );
+
+  assert.deepEqual(
+    resolveSubjectAssigneeIds({
+      subjectMetaAssignees: undefined,
+      assigneeMap: {},
+      subjectId: "s1",
+      subject: { assignee_person_id: "p3" }
+    }),
+    ["p3"]
+  );
+});
+
+test("findCollaboratorByAssigneeId lit une clé nettoyée", () => {
+  const byId = new Map([["p1", { id: "p1", name: "Alice" }]]);
+  assert.deepEqual(findCollaboratorByAssigneeId(byId, " p1 "), { id: "p1", name: "Alice" });
+  assert.equal(findCollaboratorByAssigneeId(byId, "p2"), null);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -1,3 +1,5 @@
+import { normalizeAssigneeIds } from "../../services/subject-assignees-service.js";
+
 export function createProjectSubjectsActions(config) {
   const {
     store,
@@ -127,7 +129,7 @@ export function createProjectSubjectsActions(config) {
   }
 
   function normalizeSubjectAssigneeIds(assigneeIds) {
-    return [...new Set((Array.isArray(assigneeIds) ? assigneeIds : []).map((value) => String(value || "").trim()).filter(Boolean))];
+    return normalizeAssigneeIds(assigneeIds);
   }
 
   function setSubjectAssigneeIds(subjectId, assigneeIds) {

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2,6 +2,11 @@ import { getDisplayAuthorName, getAuthorIdentity } from "../ui/author-identity.j
 import { renderProblemsCountsIconHtml } from "../ui/subissues-counts.js";
 import { formatObjectiveDueDateLabel } from "./project-subject-milestones.js";
 import {
+  findCollaboratorByAssigneeId,
+  normalizeAssigneeIds,
+  resolveSubjectAssigneeIds
+} from "../../services/subject-assignees-service.js";
+import {
   createSelectDropdownController,
   ensureSelectDropdownHost,
   getSubjectSelectDropdownScopeRoot,
@@ -663,16 +668,15 @@ function getSubjectSidebarMeta(subjectId) {
   const assigneePersonIdsBySubjectId = rawResult?.assigneePersonIdsBySubjectId && typeof rawResult.assigneePersonIdsBySubjectId === "object"
     ? rawResult.assigneePersonIdsBySubjectId
     : {};
-  const derivedAssignees = (Array.isArray(subjectMeta.assignees) && subjectMeta.assignees.length)
-    ? subjectMeta.assignees
-    : (
-      Array.isArray(assigneePersonIdsBySubjectId[normalizedSubjectId]) && assigneePersonIdsBySubjectId[normalizedSubjectId].length
-        ? assigneePersonIdsBySubjectId[normalizedSubjectId]
-        : [String(subject?.assignee_person_id || subject?.raw?.assignee_person_id || "")].filter(Boolean)
-    );
+  const derivedAssignees = resolveSubjectAssigneeIds({
+    subjectMetaAssignees: subjectMeta.assignees,
+    assigneeMap: assigneePersonIdsBySubjectId,
+    subjectId: normalizedSubjectId,
+    subject
+  });
 
   return {
-    assignees: derivedAssignees.map((value) => String(value || "")).filter(Boolean),
+    assignees: normalizeAssigneeIds(derivedAssignees),
     labels: derivedLabels,
     objectiveIds,
     situationIds: derivedSituationIds,
@@ -1184,8 +1188,17 @@ function renderSubjectAssigneesValue(subjectId) {
   const assigneeIds = getSubjectSidebarMeta(subjectId).assignees;
   const collaborators = getActiveProjectCollaborators();
   const collaboratorsById = new Map(collaborators.map((collaborator) => [collaborator.id, collaborator]));
-  const selected = assigneeIds
-    .map((assigneeId) => collaboratorsById.get(String(assigneeId || "")))
+  const selected = normalizeAssigneeIds(assigneeIds)
+    .map((assigneeId) => findCollaboratorByAssigneeId(collaboratorsById, assigneeId) || {
+      id: assigneeId,
+      userId: "",
+      name: `Collaborateur ${assigneeId.slice(0, 8)}`,
+      role: "Collaborateur",
+      roleGroupCode: "",
+      roleGroupLabel: "",
+      email: "",
+      avatarUrl: ""
+    })
     .filter(Boolean);
 
   if (!selected.length) {


### PR DESCRIPTION
### Motivation
- Assignés ajoutés dans le détail d'un sujet pouvaient disparaître après navigation en arrière à cause d'une normalisation/résolution d'IDs dispersée et inconsistante entre UI et persistance.

### Description
- Ajout d'un service dédié `subject-assignees-service` exposant `normalizeAssigneeIds`, `resolveSubjectAssigneeIds` et `findCollaboratorByAssigneeId` pour centraliser la logique d'IDs d'assignés et l'ordre de résolution (meta → map → assignee principal). 
- Le rendu du panneau détail utilise désormais `resolveSubjectAssigneeIds` et `normalizeAssigneeIds` et fournit un fallback d'affichage déterministe quand le collaborateur n'est pas encore hydraté pour éviter la disparition visuelle des assignés. 
- Les actions de sujets réutilisent la normalisation centralisée pour les toggles d'assignés afin d'éliminer la duplication et les divergences de format. 
- La fonction de persistance Supabase `replaceSubjectAssignees` normalise/dédouble les IDs via le service avant d'écrire en base, et des tests unitaires ont été ajoutés pour verrouiller ces règles. 

### Testing
- Ajout de `apps/web/js/services/subject-assignees-service.test.mjs` couvrant normalisation, résolution et lookup; tous les tests unitaires lancés ont réussi. 
- Commande de test exécutée: `node --test apps/web/js/services/subject-assignees-service.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs` et résultat: 10 tests passés, 0 échoués.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5c6944108329ac35e3ab6592b4fd)