### PR TITLE
Fix chevron fill and harden assignee avatar URL resolution

### DIFF
--- a/apps/web/js/services/avatar-url.js
+++ b/apps/web/js/services/avatar-url.js
@@ -19,6 +19,48 @@ function looksLikeDirectAvatarUrl(value = "") {
     || candidate.startsWith("assets/");
 }
 
+function buildUrl(value = "") {
+  const candidate = safeString(value);
+  if (!candidate) return null;
+  try {
+    return new URL(candidate, window.location.origin || "http://localhost");
+  } catch {
+    return null;
+  }
+}
+
+function extractStoragePathFromSupabaseUrl(value = "") {
+  const url = buildUrl(value);
+  if (!url) return "";
+  const path = safeString(url.pathname || "");
+  if (!path) return "";
+
+  const directMatch = path.match(/\/storage\/v1\/object\/(?:public|sign)\/avatars\/(.+)$/i);
+  if (directMatch?.[1]) return safeString(decodeURIComponent(directMatch[1]));
+
+  const encodedMatch = path.match(/\/storage\/v1\/object\/sign\/avatars\/(.+)$/i);
+  if (encodedMatch?.[1]) return safeString(decodeURIComponent(encodedMatch[1]));
+
+  return "";
+}
+
+function isLikelyExpiringSignedAvatarUrl(value = "") {
+  const url = buildUrl(value);
+  if (!url) return false;
+  const path = safeString(url.pathname || "").toLowerCase();
+  if (!/\/storage\/v1\/object\/sign\/avatars\//.test(path)) return false;
+  return url.searchParams.has("token") || url.searchParams.has("expires") || url.searchParams.has("t");
+}
+
+function buildPublicAvatarUrl(storagePath = "", fallback = DEFAULT_AVATAR_URL) {
+  const normalizedPath = safeString(storagePath);
+  if (!normalizedPath) return safeString(fallback) || DEFAULT_AVATAR_URL;
+  const { data } = supabase.storage
+    .from(AVATARS_BUCKET)
+    .getPublicUrl(normalizedPath);
+  return safeString(data?.publicUrl) || safeString(fallback) || DEFAULT_AVATAR_URL;
+}
+
 export async function createAvatarSignedUrl(storagePath = "", fallback = DEFAULT_AVATAR_URL) {
   const normalizedPath = safeString(storagePath);
   if (!normalizedPath) return safeString(fallback) || DEFAULT_AVATAR_URL;
@@ -38,14 +80,18 @@ export async function resolveAvatarUrl({
   fallback = DEFAULT_AVATAR_URL
 } = {}) {
   const directAvatarUrl = safeString(avatarUrl || avatar);
-  if (directAvatarUrl && looksLikeDirectAvatarUrl(directAvatarUrl)) return directAvatarUrl;
+  const storagePathFromDirectUrl = extractStoragePathFromSupabaseUrl(directAvatarUrl);
 
-  const storagePath = safeString(avatarStoragePath || directAvatarUrl);
+  if (directAvatarUrl && looksLikeDirectAvatarUrl(directAvatarUrl) && !isLikelyExpiringSignedAvatarUrl(directAvatarUrl)) {
+    return directAvatarUrl;
+  }
+
+  const storagePath = safeString(avatarStoragePath || storagePathFromDirectUrl || directAvatarUrl);
   if (!storagePath) return safeString(fallback) || DEFAULT_AVATAR_URL;
 
   try {
     return await createAvatarSignedUrl(storagePath, fallback);
   } catch {
-    return safeString(fallback) || DEFAULT_AVATAR_URL;
+    return buildPublicAvatarUrl(storagePath, fallback);
   }
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -641,10 +641,13 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
   align-items:center;
   flex:0 0 auto;
   color:var(--muted);
+  fill:var(--muted);
 }
 .subject-meta-collapsible-toggle__chevron .octicon-chevron-up,
-.subject-meta-collapsible-toggle__chevron .octicon-chevron-down{
+.subject-meta-collapsible-toggle__chevron .octicon-chevron-down,
+.subject-meta-collapsible-toggle__chevron svg{
   color:var(--muted);
+  fill:var(--muted);
 }
 
 .subject-meta-parent-card{


### PR DESCRIPTION
### Motivation
- Garantir le rendu visuel des chevrons de collapse lorsque l'icône utilise `fill` au lieu de `currentColor` pour que l'UI affiche correctement la couleur `--muted`.
- Fiabiliser l'affichage des images de profil des collaborateurs qui pouvaient disparaître si une URL signée Supabase expirait ou n'était pas correctement résolue.

### Description
- Ajout de `fill: var(--muted)` sur la classe `subject-meta-collapsible-toggle__chevron` et propagation du `fill` aux sélecteurs SVG/icônes dans `apps/web/style.css` pour forcer un rendu cohérent des chevrons.
- Renforcement du service d'avatar `apps/web/js/services/avatar-url.js` avec plusieurs ajouts techniques : `buildUrl`, `extractStoragePathFromSupabaseUrl`, `isLikelyExpiringSignedAvatarUrl` et `buildPublicAvatarUrl` pour analyser les URLs existantes et extraire un `storage path` Supabase quand c'est possible.
- Changement de logique dans `resolveAvatarUrl` pour retourner immédiatement une URL directe uniquement si elle n'est pas une URL signée susceptible d'expirer, et sinon tenter de régénérer une signed URL via `createAvatarSignedUrl` puis, en cas d'échec, retomber sur l'URL publique construite avec `getPublicUrl`.
- Fallbacks améliorés : on ne renvoie plus aveuglément le `fallback` quand la génération d'URL signée échoue, on tente plutôt une URL publique basée sur le chemin de stockage extrait.

### Testing
- Exécution des tests unitaires de service : `node --test apps/web/js/services/subject-assignees-service.test.mjs` — tous les tests ont réussi (4/4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5efee9f08329a6110382eabdfe97)