### PR TITLE
Handle Supabase avatar URLs (signed/public) and expose avatar_storage_path for collaborators

### DIFF
--- a/apps/web/js/services/avatar-url.js
+++ b/apps/web/js/services/avatar-url.js
@@ -19,6 +19,48 @@ function looksLikeDirectAvatarUrl(value = "") {
     || candidate.startsWith("assets/");
 }
 
+function buildUrl(value = "") {
+  const candidate = safeString(value);
+  if (!candidate) return null;
+  try {
+    return new URL(candidate, window.location.origin || "http://localhost");
+  } catch {
+    return null;
+  }
+}
+
+function extractStoragePathFromSupabaseUrl(value = "") {
+  const url = buildUrl(value);
+  if (!url) return "";
+  const path = safeString(url.pathname || "");
+  if (!path) return "";
+
+  const directMatch = path.match(/\/storage\/v1\/object\/(?:public|sign)\/avatars\/(.+)$/i);
+  if (directMatch?.[1]) return safeString(decodeURIComponent(directMatch[1]));
+
+  const encodedMatch = path.match(/\/storage\/v1\/object\/sign\/avatars\/(.+)$/i);
+  if (encodedMatch?.[1]) return safeString(decodeURIComponent(encodedMatch[1]));
+
+  return "";
+}
+
+function isLikelyExpiringSignedAvatarUrl(value = "") {
+  const url = buildUrl(value);
+  if (!url) return false;
+  const path = safeString(url.pathname || "").toLowerCase();
+  if (!/\/storage\/v1\/object\/sign\/avatars\//.test(path)) return false;
+  return url.searchParams.has("token") || url.searchParams.has("expires") || url.searchParams.has("t");
+}
+
+function buildPublicAvatarUrl(storagePath = "", fallback = DEFAULT_AVATAR_URL) {
+  const normalizedPath = safeString(storagePath);
+  if (!normalizedPath) return safeString(fallback) || DEFAULT_AVATAR_URL;
+  const { data } = supabase.storage
+    .from(AVATARS_BUCKET)
+    .getPublicUrl(normalizedPath);
+  return safeString(data?.publicUrl) || safeString(fallback) || DEFAULT_AVATAR_URL;
+}
+
 export async function createAvatarSignedUrl(storagePath = "", fallback = DEFAULT_AVATAR_URL) {
   const normalizedPath = safeString(storagePath);
   if (!normalizedPath) return safeString(fallback) || DEFAULT_AVATAR_URL;
@@ -38,14 +80,18 @@ export async function resolveAvatarUrl({
   fallback = DEFAULT_AVATAR_URL
 } = {}) {
   const directAvatarUrl = safeString(avatarUrl || avatar);
-  if (directAvatarUrl && looksLikeDirectAvatarUrl(directAvatarUrl)) return directAvatarUrl;
+  const storagePathFromDirectUrl = extractStoragePathFromSupabaseUrl(directAvatarUrl);
 
-  const storagePath = safeString(avatarStoragePath || directAvatarUrl);
+  if (directAvatarUrl && looksLikeDirectAvatarUrl(directAvatarUrl) && !isLikelyExpiringSignedAvatarUrl(directAvatarUrl)) {
+    return directAvatarUrl;
+  }
+
+  const storagePath = safeString(avatarStoragePath || storagePathFromDirectUrl || directAvatarUrl);
   if (!storagePath) return safeString(fallback) || DEFAULT_AVATAR_URL;
 
   try {
     return await createAvatarSignedUrl(storagePath, fallback);
   } catch {
-    return safeString(fallback) || DEFAULT_AVATAR_URL;
+    return buildPublicAvatarUrl(storagePath, fallback);
   }
 }

--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -1371,10 +1371,11 @@ async function mapProjectCollaboratorRow(row = {}) {
   const lot = row.project_lot || {};
   const lotCatalog = lot.lot_catalog || {};
   const linkedUserId = safeString(row.linked_user_id || row.collaborator_user_id || row.user_id || "");
+  const avatarStoragePath = safeString(profile.avatar_storage_path || row.avatar_storage_path || "");
   const avatarUrl = await resolveAvatarUrl({
     avatarUrl: safeString(profile.avatar_url || row.avatar_url || ""),
     avatar: safeString(profile.avatar || ""),
-    avatarStoragePath: safeString(profile.avatar_storage_path || row.avatar_storage_path || ""),
+    avatarStoragePath,
     fallback: ""
   });
 
@@ -1397,6 +1398,7 @@ async function mapProjectCollaboratorRow(row = {}) {
     addedAt: row.created_at || null,
     removedAt: row.removed_at || null,
     company: safeString(profile.company || row.company || ""),
+    avatarStoragePath,
     avatarUrl,
     sourceType: safeString(row.source_type || (linkedUserId ? "mdall_user" : "directory_person")) || "directory_person"
   };

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1153,6 +1153,7 @@ function getActiveProjectCollaborators() {
       roleGroupCode: String(collaborator?.roleGroupCode || "").trim().toLowerCase(),
       roleGroupLabel: firstNonEmpty(collaborator?.roleGroupLabel, ""),
       email: firstNonEmpty(collaborator?.email, ""),
+      avatarStoragePath: firstNonEmpty(collaborator?.avatarStoragePath, ""),
       avatarUrl: firstNonEmpty(collaborator?.avatarUrl, collaborator?.avatar, "")
     }))
     .filter((collaborator) => !!collaborator.id);

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -641,10 +641,13 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
   align-items:center;
   flex:0 0 auto;
   color:var(--muted);
+  fill:var(--muted);
 }
 .subject-meta-collapsible-toggle__chevron .octicon-chevron-up,
-.subject-meta-collapsible-toggle__chevron .octicon-chevron-down{
+.subject-meta-collapsible-toggle__chevron .octicon-chevron-down,
+.subject-meta-collapsible-toggle__chevron svg{
   color:var(--muted);
+  fill:var(--muted);
 }
 
 .subject-meta-parent-card{

--- a/supabase/migrations/202605030020_project_collaborators_view_avatar_storage_path.sql
+++ b/supabase/migrations/202605030020_project_collaborators_view_avatar_storage_path.sql
@@ -1,0 +1,37 @@
+-- Expose avatar storage path in collaborators view so UI can resolve assignee avatars reliably.
+
+drop view if exists public.project_collaborators_view;
+
+create view public.project_collaborators_view as
+select
+  pc.id,
+  pc.project_id,
+  pc.person_id,
+  pc.collaborator_user_id,
+  dp.linked_user_id,
+  pc.project_lot_id,
+  pc.collaborator_email,
+  pc.invited_by_user_id,
+  pc.status,
+  pc.created_at,
+  pc.updated_at,
+  pc.removed_at,
+  coalesce(nullif(btrim(dp.first_name), ''), nullif(btrim(up.first_name), ''), '') as first_name,
+  coalesce(nullif(btrim(dp.last_name), ''), nullif(btrim(up.last_name), ''), '') as last_name,
+  trim(concat_ws(' ', coalesce(nullif(btrim(dp.first_name), ''), nullif(btrim(up.first_name), ''), ''), coalesce(nullif(btrim(dp.last_name), ''), nullif(btrim(up.last_name), ''), ''))) as full_name,
+  coalesce(nullif(btrim(dp.email), ''), nullif(btrim(up.public_email), ''), nullif(btrim(pc.collaborator_email), '')) as email,
+  coalesce(nullif(btrim(dp.company), ''), nullif(btrim(up.company), ''), '') as company,
+  nullif(btrim(up.avatar_storage_path), '') as avatar_storage_path,
+  case when coalesce(dp.linked_user_id, pc.collaborator_user_id) is not null then 'mdall_user' else 'directory_person' end as source_type,
+  lc.id as lot_catalog_id,
+  lc.group_code as role_group_code,
+  lc.group_label as role_group_label,
+  lc.code as role_code,
+  lc.label as role_label
+from public.project_collaborators pc
+join public.directory_people dp on dp.id = pc.person_id
+left join public.user_public_profiles up on up.user_id = coalesce(dp.linked_user_id, pc.collaborator_user_id)
+left join public.project_lots pl on pl.id = pc.project_lot_id
+left join public.lot_catalog lc on lc.id = pl.lot_catalog_id;
+
+grant select on public.project_collaborators_view to anon, authenticated;


### PR DESCRIPTION
### Motivation

- Ensure avatar URLs coming from Supabase storage are resolved reliably whether they are direct, signed (and possibly expiring), or stored as a storage path, and avoid leaking expiring signed URLs to the UI.
- Fall back to a public URL when creating a signed URL fails so avatars remain visible.
- Surface the `avatar_storage_path` from the backend collaborators view and propagate it through the frontend so the UI can resolve avatars deterministically.
- Add a minor CSS fix to ensure SVG chevrons inherit the muted color.

### Description

- Added URL handling helpers in `apps/web/js/services/avatar-url.js`: `buildUrl`, `extractStoragePathFromSupabaseUrl`, `isLikelyExpiringSignedAvatarUrl`, and `buildPublicAvatarUrl`, and updated `resolveAvatarUrl` to prefer non-expiring direct URLs, extract storage paths from Supabase URLs, request a signed URL, and fall back to a public URL on error.
- Kept `createAvatarSignedUrl` unchanged but updated callers to use the new fallback behavior.
- Updated `apps/web/js/services/project-supabase-sync.js` to capture and propagate `avatarStoragePath` from profile data and pass it to `resolveAvatarUrl` so collaborator records include the storage path.
- Updated `apps/web/js/views/project-subjects/project-subjects-view.js` to include `avatarStoragePath` when returning active collaborators.
- Added a new SQL migration `supabase/migrations/202605030020_project_collaborators_view_avatar_storage_path.sql` to expose `avatar_storage_path` in `public.project_collaborators_view` and grant select to `anon` and `authenticated` roles.
- Touched `apps/web/style.css` to add `fill: var(--muted)` for chevrons and SVG so icons render with the muted color.

### Testing

- Ran the existing JavaScript test suite with `npm test` and the linter with `npm run lint`, and both completed successfully in local/CI runs.
- Verified the frontend build step with `npm run build` completed without errors in CI.
- No new automated tests were added for these changes; the migration SQL is included for CI DB migrations to apply during deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5efee9f08329a6110382eabdfe97)