### PR TITLE
Fix self-assignment when current user is not a project collaborator

### DIFF
--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -1513,6 +1513,31 @@ async function ensureDirectoryPerson({ personId = "", email = "", firstName = ""
   };
 }
 
+export async function resolveCurrentUserDirectoryPersonId(options = {}) {
+  const {
+    email = "",
+    firstName = "",
+    lastName = "",
+    company = ""
+  } = options || {};
+
+  const currentUser = await getCurrentUser().catch(() => null);
+  const resolvedEmail = safeString(email || currentUser?.email || "").toLowerCase();
+  if (!resolvedEmail || !isValidEmailAddress(resolvedEmail)) {
+    return "";
+  }
+
+  const person = await ensureDirectoryPerson({
+    email: resolvedEmail,
+    userId: safeString(currentUser?.id || ""),
+    firstName: safeString(firstName || currentUser?.user_metadata?.first_name || ""),
+    lastName: safeString(lastName || currentUser?.user_metadata?.last_name || ""),
+    company: safeString(company)
+  });
+
+  return safeString(person?.id || "");
+}
+
 export async function addProjectCollaboratorToSupabase({ personId = "", userId = "", email = "", firstName = "", lastName = "", company = "", projectLotId = "", status = "Actif" } = {}) {
   const backendProjectId = await resolveCurrentBackendProjectId();
   const lotId = safeString(projectLotId);

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -78,7 +78,11 @@ import {
   toSharedDateInputValue
 } from "./ui/shared-date-picker.js";
 import { getSelectionDocumentRefs } from "../services/project-document-selectors.js";
-import { persistSubjectIssueActionToSupabase, syncProjectCollaboratorsFromSupabase } from "../services/project-supabase-sync.js";
+import {
+  persistSubjectIssueActionToSupabase,
+  resolveCurrentUserDirectoryPersonId,
+  syncProjectCollaboratorsFromSupabase
+} from "../services/project-supabase-sync.js";
 import {
   getSituationsTableGridTemplate,
   renderFlatSujetRow,
@@ -360,7 +364,13 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getProjectSubjectMilestones: () => projectSubjectMilestones,
   getProjectSubjectLabels: () => projectSubjectLabels,
   renderSubjectMetaFieldValue: (...args) => projectSubjectsView.renderSubjectMetaFieldValue(...args),
-  getSubjectsCurrentRoot: () => subjectsCurrentRoot
+  getSubjectsCurrentRoot: () => subjectsCurrentRoot,
+  resolveCurrentUserAssigneeId: () => resolveCurrentUserDirectoryPersonId({
+    email: store.user?.email || "",
+    firstName: store.user?.firstName || "",
+    lastName: store.user?.lastName || "",
+    company: store.user?.publicProfile?.company || ""
+  })
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -47,7 +47,8 @@ export function createProjectSubjectsEvents(config) {
     bindOverlayChromeDismiss,
     bindOverlayChromeCompact,
     getProjectSubjectMilestones,
-    renderSubjectMetaFieldValue
+    renderSubjectMetaFieldValue,
+    resolveCurrentUserAssigneeId
   } = config;
 
   let detachDropdownDocumentEvents = null;
@@ -74,11 +75,16 @@ export function createProjectSubjectsEvents(config) {
     detachDropdownDocumentEvents = null;
   }
 
-  function resolveSelfCollaboratorAssigneeId() {
+  async function resolveSelfCollaboratorAssigneeId() {
     const currentUserId = String(store.user?.id || "").trim();
     const currentEmail = String(store.user?.email || "").trim().toLowerCase();
     const collaborators = Array.isArray(store.projectForm?.collaborators) ? store.projectForm.collaborators : [];
-    if (!collaborators.length) return "";
+    if (!collaborators.length) {
+      if (typeof resolveCurrentUserAssigneeId === "function") {
+        return String(await resolveCurrentUserAssigneeId() || "");
+      }
+      return "";
+    }
 
     const collaboratorByUserId = collaborators.find((collaborator) => {
       const collaboratorUserId = String(collaborator?.userId || collaborator?.linkedUserId || "").trim();
@@ -91,6 +97,10 @@ export function createProjectSubjectsEvents(config) {
       return collaboratorEmail && currentEmail && collaboratorEmail === currentEmail;
     });
     if (collaboratorByEmail) return String(collaboratorByEmail?.personId || collaboratorByEmail?.id || "");
+
+    if (typeof resolveCurrentUserAssigneeId === "function") {
+      return String(await resolveCurrentUserAssigneeId() || "");
+    }
 
     return "";
   }
@@ -596,7 +606,7 @@ export function createProjectSubjectsEvents(config) {
         event.stopPropagation();
         const selection = getScopedSelection(root);
         if (selection?.type !== "sujet") return;
-        const selfAssigneeId = resolveSelfCollaboratorAssigneeId();
+        const selfAssigneeId = await resolveSelfCollaboratorAssigneeId();
         if (!selfAssigneeId) {
           showError("Votre profil n'est pas présent dans la liste des collaborateurs du projet.");
           return;


### PR DESCRIPTION
### Motivation
- The "Assigner à moi-même" button failed with an error when the connected user (often the project creator) was not present in `projectForm.collaborators`, preventing quick self-assignment. 

### Description
- Add `resolveCurrentUserDirectoryPersonId` in `apps/web/js/services/project-supabase-sync.js` to resolve (or create) the current user's `directory_people` person id via email/userId. 
- Export and wire that helper into the subjects view by passing `resolveCurrentUserAssigneeId` from `apps/web/js/views/project-subjects.js` to the events layer. 
- Make `resolveSelfCollaboratorAssigneeId` asynchronous in `apps/web/js/views/project-subjects/project-subjects-events.js` and use the new helper as a fallback when `projectForm.collaborators` is empty or does not contain the current user, then `await` the result before attempting to toggle assignee. 

### Testing
- Ran syntax/type checks with `node --check apps/web/js/services/project-supabase-sync.js`, `node --check apps/web/js/views/project-subjects.js`, and `node --check apps/web/js/views/project-subjects/project-subjects-events.js`, all of which completed successfully. 
- No automated browser/integration tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df65c8cb4c8329a42b92178267578e)