### PR TITLE
Fix self-assignment when current user is not a project collaborator

### DIFF
--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -1513,6 +1513,31 @@ async function ensureDirectoryPerson({ personId = "", email = "", firstName = ""
   };
 }
 
+export async function resolveCurrentUserDirectoryPersonId(options = {}) {
+  const {
+    email = "",
+    firstName = "",
+    lastName = "",
+    company = ""
+  } = options || {};
+
+  const currentUser = await getCurrentUser().catch(() => null);
+  const resolvedEmail = safeString(email || currentUser?.email || "").toLowerCase();
+  if (!resolvedEmail || !isValidEmailAddress(resolvedEmail)) {
+    return "";
+  }
+
+  const person = await ensureDirectoryPerson({
+    email: resolvedEmail,
+    userId: safeString(currentUser?.id || ""),
+    firstName: safeString(firstName || currentUser?.user_metadata?.first_name || ""),
+    lastName: safeString(lastName || currentUser?.user_metadata?.last_name || ""),
+    company: safeString(company)
+  });
+
+  return safeString(person?.id || "");
+}
+
 export async function addProjectCollaboratorToSupabase({ personId = "", userId = "", email = "", firstName = "", lastName = "", company = "", projectLotId = "", status = "Actif" } = {}) {
   const backendProjectId = await resolveCurrentBackendProjectId();
   const lotId = safeString(projectLotId);

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -78,7 +78,11 @@ import {
   toSharedDateInputValue
 } from "./ui/shared-date-picker.js";
 import { getSelectionDocumentRefs } from "../services/project-document-selectors.js";
-import { persistSubjectIssueActionToSupabase, syncProjectCollaboratorsFromSupabase } from "../services/project-supabase-sync.js";
+import {
+  persistSubjectIssueActionToSupabase,
+  resolveCurrentUserDirectoryPersonId,
+  syncProjectCollaboratorsFromSupabase
+} from "../services/project-supabase-sync.js";
 import {
   getSituationsTableGridTemplate,
   renderFlatSujetRow,
@@ -360,7 +364,13 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getProjectSubjectMilestones: () => projectSubjectMilestones,
   getProjectSubjectLabels: () => projectSubjectLabels,
   renderSubjectMetaFieldValue: (...args) => projectSubjectsView.renderSubjectMetaFieldValue(...args),
-  getSubjectsCurrentRoot: () => subjectsCurrentRoot
+  getSubjectsCurrentRoot: () => subjectsCurrentRoot,
+  resolveCurrentUserAssigneeId: () => resolveCurrentUserDirectoryPersonId({
+    email: store.user?.email || "",
+    firstName: store.user?.firstName || "",
+    lastName: store.user?.lastName || "",
+    company: store.user?.publicProfile?.company || ""
+  })
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -47,7 +47,8 @@ export function createProjectSubjectsEvents(config) {
     bindOverlayChromeDismiss,
     bindOverlayChromeCompact,
     getProjectSubjectMilestones,
-    renderSubjectMetaFieldValue
+    renderSubjectMetaFieldValue,
+    resolveCurrentUserAssigneeId
   } = config;
 
   let detachDropdownDocumentEvents = null;
@@ -74,11 +75,16 @@ export function createProjectSubjectsEvents(config) {
     detachDropdownDocumentEvents = null;
   }
 
-  function resolveSelfCollaboratorAssigneeId() {
+  async function resolveSelfCollaboratorAssigneeId() {
     const currentUserId = String(store.user?.id || "").trim();
     const currentEmail = String(store.user?.email || "").trim().toLowerCase();
     const collaborators = Array.isArray(store.projectForm?.collaborators) ? store.projectForm.collaborators : [];
-    if (!collaborators.length) return "";
+    if (!collaborators.length) {
+      if (typeof resolveCurrentUserAssigneeId === "function") {
+        return String(await resolveCurrentUserAssigneeId() || "");
+      }
+      return "";
+    }
 
     const collaboratorByUserId = collaborators.find((collaborator) => {
       const collaboratorUserId = String(collaborator?.userId || collaborator?.linkedUserId || "").trim();
@@ -91,6 +97,10 @@ export function createProjectSubjectsEvents(config) {
       return collaboratorEmail && currentEmail && collaboratorEmail === currentEmail;
     });
     if (collaboratorByEmail) return String(collaboratorByEmail?.personId || collaboratorByEmail?.id || "");
+
+    if (typeof resolveCurrentUserAssigneeId === "function") {
+      return String(await resolveCurrentUserAssigneeId() || "");
+    }
 
     return "";
   }
@@ -596,7 +606,7 @@ export function createProjectSubjectsEvents(config) {
         event.stopPropagation();
         const selection = getScopedSelection(root);
         if (selection?.type !== "sujet") return;
-        const selfAssigneeId = resolveSelfCollaboratorAssigneeId();
+        const selfAssigneeId = await resolveSelfCollaboratorAssigneeId();
         if (!selfAssigneeId) {
           showError("Votre profil n'est pas présent dans la liste des collaborateurs du projet.");
           return;

--- a/supabase/migrations/202605030022_project_owner_auto_collaborator.sql
+++ b/supabase/migrations/202605030022_project_owner_auto_collaborator.sql
@@ -1,0 +1,132 @@
+-- Ensure project creator/owner is automatically represented as a collaborator.
+-- Also backfills existing projects where owner is missing from collaborators.
+
+create or replace function public.ensure_project_owner_collaborator(p_project_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_project record;
+  v_owner_email text;
+  v_owner_person_id uuid;
+  v_owner_lot_id uuid;
+begin
+  if p_project_id is null then
+    return;
+  end if;
+
+  select p.id, p.owner_id
+    into v_project
+  from public.projects p
+  where p.id = p_project_id;
+
+  if v_project.id is null or v_project.owner_id is null then
+    return;
+  end if;
+
+  -- Ensure project lots exist for this project (idempotent).
+  perform public.seed_project_lots_for_project(v_project.id);
+
+  select nullif(btrim(au.email), '')
+    into v_owner_email
+  from auth.users au
+  where au.id = v_project.owner_id;
+
+  if v_owner_email is null then
+    return;
+  end if;
+
+  insert into public.directory_people (email, linked_user_id, created_by_user_id)
+  values (v_owner_email, v_project.owner_id, v_project.owner_id)
+  on conflict (email_normalized) do update
+  set linked_user_id = coalesce(public.directory_people.linked_user_id, excluded.linked_user_id),
+      created_by_user_id = coalesce(public.directory_people.created_by_user_id, excluded.created_by_user_id);
+
+  select dp.id
+    into v_owner_person_id
+  from public.directory_people dp
+  where dp.email_normalized = lower(v_owner_email)
+  limit 1;
+
+  if v_owner_person_id is null then
+    return;
+  end if;
+
+  -- Keep creator visible in collaborator list if they are already assigned to any role.
+  if exists (
+    select 1
+    from public.project_collaborators pc
+    where pc.project_id = v_project.id
+      and pc.person_id = v_owner_person_id
+      and lower(coalesce(pc.status, 'actif')) <> 'retiré'
+  ) then
+    return;
+  end if;
+
+  select pl.id
+    into v_owner_lot_id
+  from public.project_lots pl
+  join public.lot_catalog lc on lc.id = pl.lot_catalog_id
+  where pl.project_id = v_project.id
+    and lc.code = 'maitre-ouvrage'
+  limit 1;
+
+  if v_owner_lot_id is null then
+    return;
+  end if;
+
+  insert into public.project_collaborators (
+    project_id,
+    person_id,
+    collaborator_user_id,
+    collaborator_email,
+    project_lot_id,
+    invited_by_user_id,
+    status
+  )
+  values (
+    v_project.id,
+    v_owner_person_id,
+    v_project.owner_id,
+    v_owner_email,
+    v_owner_lot_id,
+    v_project.owner_id,
+    'Actif'
+  )
+  on conflict (project_id, person_id, project_lot_id) do update
+  set collaborator_user_id = coalesce(public.project_collaborators.collaborator_user_id, excluded.collaborator_user_id),
+      collaborator_email = coalesce(nullif(btrim(public.project_collaborators.collaborator_email), ''), excluded.collaborator_email),
+      invited_by_user_id = coalesce(public.project_collaborators.invited_by_user_id, excluded.invited_by_user_id),
+      status = case
+        when lower(coalesce(public.project_collaborators.status, '')) = 'retiré' then 'Actif'
+        else public.project_collaborators.status
+      end,
+      removed_at = case
+        when lower(coalesce(public.project_collaborators.status, '')) = 'retiré' then null
+        else public.project_collaborators.removed_at
+      end;
+end;
+$$;
+
+create or replace function public.trg_ensure_project_owner_collaborator()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+begin
+  perform public.ensure_project_owner_collaborator(new.id);
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_projects_seed_owner_collaborator on public.projects;
+create trigger trg_projects_seed_owner_collaborator
+after insert on public.projects
+for each row execute function public.trg_ensure_project_owner_collaborator();
+
+-- Backfill legacy projects.
+select public.ensure_project_owner_collaborator(p.id)
+from public.projects p;


### PR DESCRIPTION
### Motivation
- The "Assigner à moi-même" button failed with an error when the connected user (often the project creator) was not present in `projectForm.collaborators`, preventing quick self-assignment. 

### Description
- Add `resolveCurrentUserDirectoryPersonId` in `apps/web/js/services/project-supabase-sync.js` to resolve (or create) the current user's `directory_people` person id via email/userId. 
- Export and wire that helper into the subjects view by passing `resolveCurrentUserAssigneeId` from `apps/web/js/views/project-subjects.js` to the events layer. 
- Make `resolveSelfCollaboratorAssigneeId` asynchronous in `apps/web/js/views/project-subjects/project-subjects-events.js` and use the new helper as a fallback when `projectForm.collaborators` is empty or does not contain the current user, then `await` the result before attempting to toggle assignee. 

### Testing
- Ran syntax/type checks with `node --check apps/web/js/services/project-supabase-sync.js`, `node --check apps/web/js/views/project-subjects.js`, and `node --check apps/web/js/views/project-subjects/project-subjects-events.js`, all of which completed successfully. 
- No automated browser/integration tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df65c8cb4c8329a42b92178267578e)