### PR TITLE
Refonte du menu Relations : sélection du sujet parent et service Supabase dédié

### DIFF
--- a/apps/web/js/services/subject-parent-relation-service.js
+++ b/apps/web/js/services/subject-parent-relation-service.js
@@ -1,0 +1,100 @@
+import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+
+const SUPABASE_URL = getSupabaseUrl();
+
+function normalizeId(value) {
+  const normalized = String(value || "").trim();
+  return normalized || "";
+}
+
+function getSubjectsByIdMap(rawSubjectsResult) {
+  return rawSubjectsResult?.subjectsById && typeof rawSubjectsResult.subjectsById === "object"
+    ? rawSubjectsResult.subjectsById
+    : {};
+}
+
+function ensureNoParentCycle({ subjectId, parentSubjectId, subjectsById }) {
+  if (!parentSubjectId) return;
+  if (subjectId === parentSubjectId) {
+    throw new Error("Un sujet ne peut pas être son propre parent.");
+  }
+
+  const visited = new Set([subjectId]);
+  let cursorId = parentSubjectId;
+  while (cursorId) {
+    if (visited.has(cursorId)) {
+      throw new Error("Relation invalide : boucle détectée dans la hiérarchie des sujets.");
+    }
+    visited.add(cursorId);
+    const cursor = subjectsById[cursorId];
+    if (!cursor) break;
+    cursorId = normalizeId(cursor.parent_subject_id || cursor.parentSubjectId || cursor.raw?.parent_subject_id);
+  }
+}
+
+function assertParentCandidateExists(parentSubjectId, subjectsById) {
+  if (!parentSubjectId) return;
+  if (!subjectsById[parentSubjectId]) {
+    throw new Error("Le sujet parent sélectionné est introuvable.");
+  }
+}
+
+function assertSameProject(subject, parentSubject) {
+  if (!subject || !parentSubject) return;
+  const subjectProjectId = normalizeId(subject.project_id || subject.projectId || subject.raw?.project_id);
+  const parentProjectId = normalizeId(parentSubject.project_id || parentSubject.projectId || parentSubject.raw?.project_id);
+  if (subjectProjectId && parentProjectId && subjectProjectId !== parentProjectId) {
+    throw new Error("Le sujet parent doit appartenir au même projet.");
+  }
+}
+
+export async function setSubjectParentRelationInSupabase({ subjectId, parentSubjectId = null, rawSubjectsResult = null } = {}) {
+  const normalizedSubjectId = normalizeId(subjectId);
+  const normalizedParentSubjectId = normalizeId(parentSubjectId);
+  if (!normalizedSubjectId) {
+    throw new Error("subjectId est requis.");
+  }
+
+  const subjectsById = getSubjectsByIdMap(rawSubjectsResult);
+  const subject = subjectsById[normalizedSubjectId];
+  if (!subject) {
+    throw new Error("Le sujet à mettre à jour est introuvable.");
+  }
+
+  assertParentCandidateExists(normalizedParentSubjectId, subjectsById);
+  ensureNoParentCycle({
+    subjectId: normalizedSubjectId,
+    parentSubjectId: normalizedParentSubjectId || "",
+    subjectsById
+  });
+  if (normalizedParentSubjectId) {
+    assertSameProject(subject, subjectsById[normalizedParentSubjectId]);
+  }
+
+  const headers = await buildSupabaseAuthHeaders({
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    Prefer: "return=representation"
+  });
+
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/subjects?id=eq.${encodeURIComponent(normalizedSubjectId)}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({
+      parent_subject_id: normalizedParentSubjectId || null
+    })
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Mise à jour du sujet parent impossible (${res.status}) : ${text}`);
+  }
+
+  const rows = await res.json().catch(() => []);
+  const updatedRow = (Array.isArray(rows) ? rows[0] : rows) || null;
+  return {
+    subjectId: normalizedSubjectId,
+    parentSubjectId: normalizeId(updatedRow?.parent_subject_id),
+    updatedRow
+  };
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -16,6 +16,7 @@ import {
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
+import { setSubjectParentRelationInSupabase } from "../services/subject-parent-relation-service.js";
 import {
   bindProjectSituationsRunbar,
   syncProjectSituationsRunbar
@@ -334,6 +335,7 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getToggleSubjectSituation: () => toggleSubjectSituation,
   getToggleSubjectLabel: () => toggleSubjectLabel,
   getToggleSubjectAssignee: () => toggleSubjectAssignee,
+  getSetSubjectParent: () => setSubjectParent,
   syncDescriptionEditorDraft,
   startDescriptionEdit,
   clearDescriptionEditState,
@@ -542,6 +544,11 @@ const projectSubjectsActions = createProjectSubjectsActions({
   replaceSubjectAssigneesInSupabase: (...args) => replaceSubjectAssigneesInSupabase(...args),
   addSubjectToObjectiveInSupabase: (...args) => addSubjectToObjectiveInSupabase(...args),
   removeSubjectFromObjectiveInSupabase: (...args) => removeSubjectFromObjectiveInSupabase(...args),
+  setSubjectParentInSupabase: (subjectId, parentSubjectId) => setSubjectParentRelationInSupabase({
+    subjectId,
+    parentSubjectId,
+    rawSubjectsResult: store.projectSubjectsView?.rawSubjectsResult || null
+  }),
   rerenderPanels: (...args) => projectSubjectsView.rerenderPanels(...args)
 });
 
@@ -551,6 +558,7 @@ const {
   setSubjectSituationIds,
   toggleSubjectAssignee,
   toggleSubjectSituation,
+  setSubjectParent,
   setSubjectLabels,
   toggleSubjectLabel,
   toggleSubjectObjective,

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -43,6 +43,7 @@ export function createProjectSubjectsActions(config) {
     replaceSubjectAssigneesInSupabase,
     addSubjectToObjectiveInSupabase,
     removeSubjectFromObjectiveInSupabase,
+    setSubjectParentInSupabase,
     rerenderPanels
   } = config;
 
@@ -227,6 +228,51 @@ export function createProjectSubjectsActions(config) {
       raw.relationOptionsById = raw.relationOptionsById && typeof raw.relationOptionsById === "object" ? raw.relationOptionsById : {};
       raw.situationsById[situationKey] = situation;
       raw.relationOptionsById[situationKey] = situation;
+    }
+  }
+
+  function syncSubjectParentMap(subjectId, parentSubjectId) {
+    const raw = store.projectSubjectsView?.rawSubjectsResult;
+    if (!raw || typeof raw !== "object") return;
+    const subjectKey = String(subjectId || "");
+    if (!subjectKey) return;
+    const parentKey = String(parentSubjectId || "").trim();
+    raw.subjectsById = raw.subjectsById && typeof raw.subjectsById === "object" ? raw.subjectsById : {};
+    if (!raw.subjectsById[subjectKey]) return;
+    raw.subjectsById[subjectKey].parent_subject_id = parentKey || null;
+    if (raw.subjectsById[subjectKey].raw && typeof raw.subjectsById[subjectKey].raw === "object") {
+      raw.subjectsById[subjectKey].raw.parent_subject_id = parentKey || null;
+    }
+  }
+
+  async function setSubjectParent(subjectId, parentSubjectId, options = {}) {
+    const subjectKey = String(subjectId || "").trim();
+    if (!subjectKey) return false;
+    const nextParentKey = String(parentSubjectId || "").trim();
+    const subject = getNestedSujet(subjectKey);
+    if (!subject) return false;
+    const previousParent = String(subject.parent_subject_id || subject.parentSubjectId || subject.raw?.parent_subject_id || "").trim();
+    if (previousParent === nextParentKey) return true;
+
+    syncSubjectParentMap(subjectKey, nextParentKey);
+
+    if (!options.skipRerender) {
+      if (options.root) rerenderScope(options.root);
+      else rerenderPanels();
+    }
+
+    try {
+      await setSubjectParentInSupabase(subjectKey, nextParentKey || null);
+      return true;
+    } catch (error) {
+      syncSubjectParentMap(subjectKey, previousParent || null);
+      if (!options.skipRerender) {
+        if (options.root) rerenderScope(options.root);
+        else rerenderPanels();
+      }
+      console.warn("setSubjectParent failed", error);
+      showError(`Mise à jour du sujet parent impossible : ${String(error?.message || error || "Erreur inconnue")}`);
+      return false;
     }
   }
 
@@ -799,6 +845,7 @@ export function createProjectSubjectsActions(config) {
     setSubjectAssigneeIds,
     toggleSubjectAssignee,
     toggleSubjectSituation,
+    setSubjectParent,
     setSubjectLabels,
     toggleSubjectLabel,
     toggleSubjectObjective,

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -19,6 +19,7 @@ export function createProjectSubjectsEvents(config) {
     getToggleSubjectSituation,
     getToggleSubjectLabel,
     getToggleSubjectAssignee,
+    getSetSubjectParent,
     syncDescriptionEditorDraft,
     startDescriptionEdit,
     clearDescriptionEditState,
@@ -177,6 +178,7 @@ export function createProjectSubjectsEvents(config) {
     const toggleSubjectSituation = getToggleSubjectSituation?.();
     const toggleSubjectLabel = getToggleSubjectLabel?.();
     const toggleSubjectAssignee = getToggleSubjectAssignee?.();
+    const setSubjectParent = getSetSubjectParent?.();
 
     dropdownHost.querySelectorAll("[data-subject-kanban-search]").forEach((input) => {
       input.addEventListener("input", () => {
@@ -253,6 +255,11 @@ export function createProjectSubjectsEvents(config) {
           const activeKey = String(getSubjectsViewState().subjectMetaDropdown.activeKey || "");
           if (!activeKey) return;
           event.preventDefault();
+          if (field === "relations" && String(getSubjectsViewState().subjectMetaDropdown?.relationsView || "") === "parent") {
+            if (typeof setSubjectParent !== "function") return;
+            await applyNonDestructiveMetaToggle(root, field, () => setSubjectParent(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+            return;
+          }
           if (field === "objectives") {
             await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectObjective(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
             return;
@@ -313,6 +320,58 @@ export function createProjectSubjectsEvents(config) {
         if (subjectSelection?.type !== "sujet") return;
         const assigneeId = String(btn.dataset.subjectAssigneeToggle || "");
         await applyNonDestructiveMetaToggle(root, "assignees", () => toggleSubjectAssignee(subjectSelection.item.id, assigneeId, { root, skipRerender: true }));
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-parent-entry]").forEach((btn) => {
+      btn.onclick = async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type !== "sujet") return;
+        if (typeof setSubjectParent !== "function") return;
+        const parentSubjectId = String(btn.dataset.subjectRelationsParentEntry || "");
+        await applyNonDestructiveMetaToggle(root, "relations", () => setSubjectParent(subjectSelection.item.id, parentSubjectId, { root, skipRerender: true }));
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-remove-parent]").forEach((btn) => {
+      btn.onclick = async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type !== "sujet") return;
+        if (typeof setSubjectParent !== "function") return;
+        await applyNonDestructiveMetaToggle(root, "relations", () => setSubjectParent(subjectSelection.item.id, "", { root, skipRerender: true }));
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-open-parent]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.relationsView = "parent";
+        dropdown.query = "";
+        dropdown.activeKey = "";
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type === "sujet") {
+          const entries = getSubjectMetaMenuEntries(subjectSelection.item, "relations");
+          dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
+        }
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-back]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.relationsView = "menu";
+        dropdown.query = "";
+        dropdown.activeKey = "";
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
       };
     });
 
@@ -448,6 +507,7 @@ export function createProjectSubjectsEvents(config) {
         } else {
           dropdownController().closeKanban();
           dropdownController().openMeta({ field, showClosedSituations: false });
+          dropdown.relationsView = field === "relations" ? "menu" : "";
           const entries = scopedSelection?.type === "sujet" ? getSubjectMetaMenuEntries(scopedSelection.item, field) : [];
           const selectedObjectiveKey = field === "objectives" && scopedSelection?.type === "sujet"
             ? String(getSubjectSidebarMeta(scopedSelection.item.id).objectiveIds[0] || "")

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -133,10 +133,12 @@ export function createProjectSubjectsState({ store }) {
         field: null,
         query: "",
         activeKey: "",
-        showClosedSituations: false
+        showClosedSituations: false,
+        relationsView: "menu"
       };
     }
     if (typeof v.subjectMetaDropdown.showClosedSituations !== "boolean") v.subjectMetaDropdown.showClosedSituations = false;
+    if (typeof v.subjectMetaDropdown.relationsView !== "string") v.subjectMetaDropdown.relationsView = "menu";
     if (!v.subjectKanbanDropdown || typeof v.subjectKanbanDropdown !== "object") {
       v.subjectKanbanDropdown = {
         subjectId: "",
@@ -180,7 +182,8 @@ export function createProjectSubjectsState({ store }) {
       field: null,
       query: "",
       activeKey: "",
-      showClosedSituations: false
+      showClosedSituations: false,
+      relationsView: "menu"
     };
     v.labelsSortMenuOpen = false;
     v.labelsRowMenuOpen = "";

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1298,6 +1298,36 @@ function renderSubjectMetaFieldValue(subject, field) {
   return renderSubjectMetaButtonValue("Aucune donnée");
 }
 
+function getSubjectLastActivityTimestamp(subject = {}) {
+  const updatedAt = firstNonEmpty(
+    getEntityDescriptionState("sujet", subject.id)?.updated_at,
+    subject.updated_at,
+    subject.raw?.updated_at,
+    subject.created_at,
+    subject.raw?.created_at
+  );
+  const ts = Date.parse(updatedAt || "");
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function getRelationParentSuggestions(subject, query = "") {
+  const currentSubjectId = String(subject?.id || "");
+  const normalizedQuery = String(query || "").trim().toLowerCase();
+  const map = store.projectSubjectsView?.rawSubjectsResult?.subjectsById || {};
+  const candidates = Object.values(map)
+    .filter((item) => {
+      const itemId = String(item?.id || "");
+      if (!itemId || itemId === currentSubjectId) return false;
+      return matchSearch([item?.title, item?.id], normalizedQuery);
+    })
+    .sort((left, right) => {
+      const tsDiff = getSubjectLastActivityTimestamp(right) - getSubjectLastActivityTimestamp(left);
+      if (tsDiff !== 0) return tsDiff;
+      return String(firstNonEmpty(left?.title, left?.id, "")).localeCompare(String(firstNonEmpty(right?.title, right?.id, "")), "fr");
+    });
+  return candidates.slice(0, 13);
+}
+
 function buildSubjectMetaMenuItems(subject, field) {
   const dropdownState = getSubjectsViewState().subjectMetaDropdown || {};
   const query = String(dropdownState.query || "").trim().toLowerCase();
@@ -1429,6 +1459,52 @@ function buildSubjectMetaMenuItems(subject, field) {
     };
   }
 
+  if (field === "relations" && String(dropdownState.relationsView || "menu") === "parent") {
+    const selectedParent = getSubjectParentSubject(subject.id);
+    const selectedParentId = String(selectedParent?.id || "");
+    const suggestions = getRelationParentSuggestions(subject, query);
+    const suggestionItems = suggestions
+      .filter((item) => String(item?.id || "") !== selectedParentId)
+      .map((candidate) => ({
+        key: String(candidate.id || ""),
+        isActive: String(dropdownState.activeKey || "") === String(candidate.id || ""),
+        isSelected: false,
+        iconHtml: `
+          <span class="select-menu__situation-iconset" aria-hidden="true">
+            <span class="select-menu__checkbox">${svgIcon("check", { className: "octicon octicon-check" })}</span>
+            <span class="select-menu__situation-icon">${issueIcon(getEffectiveSujetStatus(candidate.id))}</span>
+          </span>
+        `,
+        title: firstNonEmpty(candidate.title, candidate.id, "Sujet"),
+        metaHtml: escapeHtml(getEntityDisplayRef("sujet", candidate.id)),
+        dataAttrs: { "subject-relations-parent-entry": String(candidate.id || "") }
+      }));
+
+    const selectedItem = selectedParent
+      ? {
+        key: selectedParentId,
+        isActive: String(dropdownState.activeKey || "") === selectedParentId,
+        isSelected: true,
+        iconHtml: `
+          <span class="select-menu__situation-iconset" aria-hidden="true">
+            <span class="select-menu__checkbox is-checked">${svgIcon("check", { className: "octicon octicon-check" })}</span>
+            <span class="select-menu__situation-icon">${issueIcon(getEffectiveSujetStatus(selectedParent.id))}</span>
+          </span>
+        `,
+        title: firstNonEmpty(selectedParent.title, selectedParent.id, "Sujet parent"),
+        metaHtml: escapeHtml(getEntityDisplayRef("sujet", selectedParent.id)),
+        dataAttrs: { "subject-relations-parent-entry": selectedParentId }
+      }
+      : null;
+
+    return {
+      selectedItem,
+      suggestionItems,
+      items: [selectedItem, ...suggestionItems].filter(Boolean),
+      emptyHint: query ? "Aucun résultat pour cette recherche." : "Aucun sujet suggéré."
+    };
+  }
+
   const emptyHintMap = {
     assignees: "Aucun assigné pour le moment.",
     labels: "Aucun label pour le moment.",
@@ -1470,25 +1546,68 @@ function renderSubjectMetaDropdown(subject, field) {
   }
 
   if (field === "relations") {
-    const relationItems = [
-      "Modifier ou supprimer le sujet parent",
-      "Ajouter ou modifier « Bloqué par »",
-      "Ajouter ou modifier « Bloquant »"
-    ];
+    const relationsView = String(dropdownState.relationsView || "menu");
+    if (relationsView === "parent") {
+      const { selectedItem, suggestionItems, emptyHint } = buildSubjectMetaMenuItems(subject, field);
+      return `
+        <div class="subject-meta-dropdown gh-menu gh-menu--open" role="dialog">
+          <button type="button" class="subject-meta-relations-back" data-subject-relations-back>
+            <span class="subject-meta-relations-back__icon">${svgIcon("arrow-left", { className: "octicon octicon-arrow-left" })}</span>
+            <span class="subject-meta-relations-back__label">Gérer les relations</span>
+          </button>
+          <div class="subject-meta-dropdown__search">
+            <span class="subject-meta-dropdown__search-icon" aria-hidden="true">${svgIcon("search", { className: "octicon octicon-search" })}</span>
+            <input type="search" class="subject-meta-dropdown__search-input" data-subject-meta-search="${escapeHtml(field)}" value="${escapeHtml(query)}" placeholder="Rechercher un sujet parent" autocomplete="off">
+          </div>
+          <div class="subject-meta-dropdown__body">
+            ${selectedItem ? renderSelectMenuSection({ title: "Sélectionné", items: [selectedItem] }) : `
+              <div class="select-menu__section">
+                <button type="button" class="select-menu__item subject-meta-relations-menu__item" data-subject-relations-remove-parent>
+                  <span class="select-menu__item-mainrow">
+                    <span class="select-menu__item-content">
+                      <span class="select-menu__item-title">Aucun sujet parent</span>
+                      <span class="select-menu__item-meta">Retirer la relation existante</span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            `}
+            ${renderSelectMenuSection({
+              title: "Suggestions",
+              items: suggestionItems,
+              emptyTitle: "Aucune suggestion",
+              emptyHint
+            })}
+          </div>
+        </div>
+      `;
+    }
+
     return `
       <div class="subject-meta-dropdown gh-menu gh-menu--open" role="dialog">
-        <div class="subject-meta-dropdown__title">Gérer les relations</div>
         <div class="subject-meta-dropdown__body">
           <div class="select-menu__section">
-            ${relationItems.map((title) => `
-              <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem">
-                <span class="select-menu__item-mainrow">
-                  <span class="select-menu__item-content">
-                    <span class="select-menu__item-title">${escapeHtml(title)}</span>
-                  </span>
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-subject-relations-open-parent>
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Modifier ou supprimer le sujet parent</span>
                 </span>
-              </button>
-            `).join("")}
+              </span>
+            </button>
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Ajouter ou modifier « Bloqué par »</span>
+                </span>
+              </span>
+            </button>
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Ajouter ou modifier « Bloquant »</span>
+                </span>
+              </span>
+            </button>
           </div>
         </div>
       </div>

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -114,6 +114,7 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.field = null;
   dropdown.query = "";
   dropdown.activeKey = "";
+  dropdown.relationsView = "menu";
 }
 
 export function closeKanbanSelectDropdown(getViewState) {
@@ -134,6 +135,7 @@ export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "
   dropdown.query = String(query || "");
   dropdown.activeKey = String(activeKey || "");
   dropdown.showClosedSituations = !!showClosedSituations;
+  dropdown.relationsView = field === "relations" ? "menu" : "";
 }
 
 export function openKanbanSelectDropdown(getViewState, { subjectId = "", situationId = "", activeKey = "", query = "" } = {}) {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -710,6 +710,30 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
   width:100%;
 }
 
+.subject-meta-relations-back{
+  width:100%;
+  display:flex;
+  align-items:center;
+  gap:8px;
+  padding:12px 16px 10px;
+  border:0;
+  border-bottom:1px solid var(--border);
+  background:transparent;
+  color:var(--text);
+  text-align:left;
+  cursor:pointer;
+}
+
+.subject-meta-relations-back__icon{
+  display:inline-flex;
+  color:var(--muted);
+}
+
+.subject-meta-relations-back__label{
+  font-size:14px;
+  font-weight:600;
+}
+
 .subject-meta-field__chip{
   display:flex;
   align-items:center;


### PR DESCRIPTION
### Motivation
- Simplifier et fiabiliser le flux "Relations" dans le détail d'un sujet en proposant un sous-écran dédié pour modifier/supprimer le sujet parent, en n'autorisant qu'un seul parent et en persistant la modification de façon robuste dans Supabase.
- Mettre en place une logique métier centralisée et testable (service) pour éviter les bricolages côté UI et prévenir les erreurs (cycles, parent introuvable, projet différent, etc.).

### Description
- Ajout d'un nouveau service `apps/web/js/services/subject-parent-relation-service.js` exposant `setSubjectParentRelationInSupabase` qui effectue les validations (id présent, existence du parent, même projet, détection de boucle) puis un `PATCH` sur `subjects.parent_subject_id` avec `Prefer: return=representation` et gestion d'erreurs explicites.
- Refonte du dropdown `Relations` : suppression du titre/divider sur l'écran principal et ajout d'un sous-écran accessible via "Modifier ou supprimer le sujet parent" contenant un bouton retour (flèche gauche + « Gérer les relations »), un champ de recherche, une section "Sélectionné" (si parent existant) et une section "Suggestions" (limitée aux 13 sujets ayant eu l'activité la plus récente). (modifications principales dans `project-subjects-view.js`).
- Ajout d'une action métier `setSubjectParent` dans `project-subjects-actions.js` qui fait une mise à jour optimiste du store local, appelle le service Supabase et fait rollback + message d'erreur en cas d'échec.
- Raccordement des événements UI dans `project-subjects-events.js` pour : ouvrir la vue parent, revenir au menu, sélectionner un parent, supprimer le parent, et gérer la touche `Enter` dans la vue parent; extension de l'état dropdown avec `relationsView` dans `project-subjects-state.js` et synchronisation dans le contrôleur `select-dropdown-controller.js`; ajout de styles pour le header retour dans `apps/web/style.css`.

### Testing
- Vérification syntaxique JavaScript avec la commande `node --check` sur les fichiers modifiés (`apps/web/js/services/subject-parent-relation-service.js`, `apps/web/js/views/project-subjects/*.js`, `apps/web/js/views/ui/select-dropdown-controller.js`) et l'ensemble des contrôles s'est terminé sans erreur (passé).
- Aucune autre suite de tests automatisés (unit/integration) n'a été exécutée dans cet environnement lors de cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df75741acc8329aa93e0c1dda97ba6)