### PR TITLE
Fix duplicate subject-parent service import in project subjects view

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -16,11 +16,6 @@ import {
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
-import { setSubjectParentRelationInSupabase } from "../services/subject-parent-relation-service.js";
-import {
-  setSubjectParentRelationInSupabase,
-  reorderSubjectChildrenInSupabase as reorderSubjectChildrenInSupabaseService
-} from "../services/subject-parent-relation-service.js";
 import {
   setSubjectParentRelationInSupabase as setSubjectParentRelationInSupabaseService,
   reorderSubjectChildrenInSupabase as reorderSubjectChildrenInSupabaseService

--- a/apps/web/js/views/project-subjects/project-subjects-imports.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-imports.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const viewPath = path.resolve(__dirname, "../project-subjects.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+
+const subjectParentServiceImportPattern = /from\s+"\.\.\/services\/subject-parent-relation-service\.js";/g;
+
+test("project-subjects importe le service parent/enfant une seule fois", () => {
+  const imports = viewSource.match(subjectParentServiceImportPattern) ?? [];
+  assert.equal(imports.length, 1);
+});
+
+test("project-subjects utilise les alias de service attendus", () => {
+  assert.match(viewSource, /setSubjectParentRelationInSupabase\s+as\s+setSubjectParentRelationInSupabaseService/);
+  assert.match(viewSource, /reorderSubjectChildrenInSupabase\s+as\s+reorderSubjectChildrenInSupabaseService/);
+});


### PR DESCRIPTION
### Motivation
- The view `apps/web/js/views/project-subjects.js` caused a browser runtime `Identifier ... has already been declared` error due to duplicate imports of the same service module. 
- The intent is to remove the redundant import while keeping the single aliased import used by the view code to avoid re-declaration.

### Description
- Removed duplicate imports from `apps/web/js/views/project-subjects.js` and kept a single aliased import from `../services/subject-parent-relation-service.js` used by the view. 
- Added a non-regression unit test `apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` that verifies there is exactly one import from the service and that the expected aliases (`...Service`) are present. 
- Change is minimal and scoped to the import section and the new test file to preserve a clean diff and avoid touching unrelated code. 
- Noted that the test is static source validation and does not exercise runtime/browser integration.

### Testing
- Ran the test suite with `node --test` including the new test: `node --test apps/web/js/services/subject-assignees-service.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` and all tests passed. 
- The new test `apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` succeeded and confirms the single import and expected aliases. 
- Remaining fragility: the added test is a static source check and does not guarantee that unrelated runtime issues in the browser are covered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa16e53a88329a4351f75d743e62b)