### PR TITLE
Consolidate subject-parent-relation imports and guard DnD reorder handler; add tests

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -16,11 +16,6 @@ import {
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
-import { setSubjectParentRelationInSupabase } from "../services/subject-parent-relation-service.js";
-import {
-  setSubjectParentRelationInSupabase,
-  reorderSubjectChildrenInSupabase as reorderSubjectChildrenInSupabaseService
-} from "../services/subject-parent-relation-service.js";
 import {
   setSubjectParentRelationInSupabase as setSubjectParentRelationInSupabaseService,
   reorderSubjectChildrenInSupabase as reorderSubjectChildrenInSupabaseService

--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+
+test("wireDetailsInteractive récupère reorderSubjectChildren pour le DnD des sous-sujets", () => {
+  assert.match(
+    eventsSource,
+    /function wireDetailsInteractive\(root\)[\s\S]*?const reorderSubjectChildren = getReorderSubjectChildren\?\.\(\);/
+  );
+});
+
+test("le handler drop protège l'appel reorderSubjectChildren", () => {
+  assert.match(eventsSource, /typeof reorderSubjectChildren !== "function"/);
+  assert.match(eventsSource, /await reorderSubjectChildren\(parentSubjectId, orderedChildIds, \{ root, skipRerender: false \}\);/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -496,6 +496,7 @@ export function createProjectSubjectsEvents(config) {
     const toggleSubjectLabel = getToggleSubjectLabel?.();
     const toggleSubjectAssignee = getToggleSubjectAssignee?.();
     const applyIssueStatusAction = getApplyIssueStatusAction?.();
+    const reorderSubjectChildren = getReorderSubjectChildren?.();
 
     root.querySelectorAll("[data-subject-meta-trigger]").forEach((btn) => {
       btn.onclick = async (event) => {

--- a/apps/web/js/views/project-subjects/project-subjects-imports.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-imports.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const viewPath = path.resolve(__dirname, "../project-subjects.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+
+const subjectParentServiceImportPattern = /from\s+"\.\.\/services\/subject-parent-relation-service\.js";/g;
+
+test("project-subjects importe le service parent/enfant une seule fois", () => {
+  const imports = viewSource.match(subjectParentServiceImportPattern) ?? [];
+  assert.equal(imports.length, 1);
+});
+
+test("project-subjects utilise les alias de service attendus", () => {
+  assert.match(viewSource, /setSubjectParentRelationInSupabase\s+as\s+setSubjectParentRelationInSupabaseService/);
+  assert.match(viewSource, /reorderSubjectChildrenInSupabase\s+as\s+reorderSubjectChildrenInSupabaseService/);
+});


### PR DESCRIPTION
### Motivation

- Remove duplicate imports and standardize the aliasing of the subject parent/child service to avoid ambiguous references and accidental double-imports.
- Make the sub-issues drag-and-drop handler robust by retrieving and guarding the `reorderSubjectChildren` callback before calling it.

### Description

- Consolidated imports from `../services/subject-parent-relation-service.js` in `apps/web/js/views/project-subjects.js` into a single import and aliased them as `setSubjectParentRelationInSupabaseService` and `reorderSubjectChildrenInSupabaseService`.
- Added a defensive retrieval of `reorderSubjectChildren` in `wireDetailsInteractive` inside `apps/web/js/views/project-subjects/project-subjects-events.js` using `getReorderSubjectChildren?.()` so the DnD handler can check its type before invoking it.
- Added two unit tests: `project-subjects-imports.test.mjs` that asserts the subject-parent service is imported only once and that the expected aliases are used, and `project-subjects-events-subissues-dnd.test.mjs` that asserts the events file wires and protects the `reorderSubjectChildren` call for sub-issues DnD.

### Testing

- Ran the repository test suite with the new tests included via `node --test`, which executed `project-subjects-imports.test.mjs` and `project-subjects-events-subissues-dnd.test.mjs`, and the tests passed.
- Existing automated tests covering project subjects were also executed and showed no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa16e53a88329a4351f75d743e62b)