### PR TITLE
Use dedicated native drag preview elements for subissue DnD and update related logic/tests

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -35,6 +35,10 @@
   </div>
 </div>
 
+<div id="nativeDragPreviewRoot" aria-hidden="true">
+  <div id="nativeDragPreviewCard"></div>
+</div>
+
 <script>
  window.MDALL_CONFIG = window.MDALL_CONFIG || {};
  window.MDALL_CONFIG.googleMapsEmbedApiKey = window.MDALL_CONFIG.googleMapsEmbedApiKey || "AIzaSyCdKMqBvnO7h9cC7otxgOOFJpzn1Gl5hyM";

--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -10,6 +10,8 @@ const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
 const eventsSource = fs.readFileSync(eventsPath, "utf8");
 const stylePath = path.resolve(__dirname, "../../../style.css");
 const styleSource = fs.readFileSync(stylePath, "utf8");
+const indexPath = path.resolve(__dirname, "../../../index.html");
+const indexSource = fs.readFileSync(indexPath, "utf8");
 
 test("wireDetailsInteractive récupère reorderSubjectChildren pour le DnD des sous-sujets", () => {
   assert.match(
@@ -31,16 +33,31 @@ test("le dragstart de sous-sujet est contrôlé par l'état dragFromHandle", () 
 test("le dragstart est armé par pointerdown sur le handle et utilise un drag preview dédié", () => {
   assert.match(eventsSource, /row\.dataset\.subissueDragFromHandle = event\.target\?\.closest\?\.\("\[data-subissue-drag-handle\]"\) \? "true" : "false";/);
   assert.match(eventsSource, /if \(!dragFromHandle\) \{/);
-  assert.match(eventsSource, /dragPreviewNode = row\.cloneNode\(true\);/);
-  assert.match(eventsSource, /dragPreviewNode\.classList\.remove\("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after"\);/);
-  assert.match(eventsSource, /dragPreviewNode\.classList\.add\("subissue-drag-preview"\);/);
+  assert.match(eventsSource, /const getNativeSubissueDragPreviewNodes = \(\) => \{/);
+  assert.match(eventsSource, /const mountSubissueDragPreview = \(\{ row, rowRect, rowStyles, issuesCols, childSubjectId \}\) => \{/);
+  assert.match(eventsSource, /const previewRoot = document\.getElementById\("nativeDragPreviewRoot"\);/);
+  assert.match(eventsSource, /const previewCard = document\.getElementById\("nativeDragPreviewCard"\);/);
+  assert.match(eventsSource, /previewRoot\.classList\.add\("is-active"\);/);
+  assert.match(eventsSource, /previewCard\.textContent = previewTitle;/);
   assert.match(eventsSource, /const issuesCols = String\(rowStyles\.getPropertyValue\("--issues-cols"\) \|\| ""\)\.trim\(\);/);
-  assert.match(eventsSource, /if \(issuesCols\) dragPreviewNode\.style\.setProperty\("--issues-cols", issuesCols\);/);
-  assert.match(eventsSource, /dragPreviewNode\.style\.gridTemplateColumns = rowStyles\.gridTemplateColumns;/);
-  assert.match(eventsSource, /dragPreviewNode\.style\.backgroundColor = "var\(--bbg, var\(--bg, #0d1117\)\)";/);
-  assert.match(eventsSource, /dragPreviewNode\.style\.border = "solid 1px var\(--border, rgba\(139,148,158,.35\)\)";/);
-  assert.match(eventsSource, /dragPreviewNode\.style\.borderRadius = "var\(--radius\)";/);
-  assert.match(eventsSource, /event\.dataTransfer\.setDragImage\(dragPreviewNode, offsetX, offsetY\);/);
+  assert.match(eventsSource, /if \(issuesCols\) previewCard\.style\.setProperty\("--issues-cols", issuesCols\);/);
+  assert.match(eventsSource, /const resolveCssCustomProp = \(styles, name, fallback = ""\) => \{/);
+  assert.match(eventsSource, /const previewBackgroundColor = resolveCssCustomProp\(rowStyles, "--bbg", resolveCssCustomProp\(rowStyles, "--bg", "#0d1117"\)\);/);
+  assert.match(eventsSource, /const previewBorderColor = resolveCssCustomProp\(rowStyles, "--border", "rgba\(139,148,158,.35\)"\);/);
+  assert.match(eventsSource, /const previewBorderRadius = resolveCssCustomProp\(rowStyles, "--radius", "6px"\);/);
+  assert.match(eventsSource, /previewCard\.style\.gridTemplateColumns = rowStyles\.gridTemplateColumns;/);
+  assert.match(eventsSource, /previewCard\.style\.backgroundColor = previewBackgroundColor;/);
+  assert.match(eventsSource, /previewCard\.style\.borderStyle = "solid";/);
+  assert.match(eventsSource, /previewCard\.style\.borderWidth = "1px";/);
+  assert.match(eventsSource, /previewCard\.style\.borderColor = previewBorderColor;/);
+  assert.match(eventsSource, /previewCard\.style\.borderRadius = previewBorderRadius;/);
+  assert.match(eventsSource, /previewCard\.style\.boxShadow = "0 14px 36px rgba\(1,4,9,.55\), 0 0 0 1px rgba\(1,4,9,.35\)";/);
+  assert.match(eventsSource, /borderStyle: previewCard\.style\.borderStyle,/);
+  assert.match(eventsSource, /borderWidth: previewCard\.style\.borderWidth,/);
+  assert.match(eventsSource, /borderColor: previewCard\.style\.borderColor,/);
+  assert.match(eventsSource, /boxShadow: previewCard\.style\.boxShadow,/);
+  assert.match(eventsSource, /event\.dataTransfer\.setDragImage\(dragPreviewNode \|\| row, offsetX, offsetY\);/);
+  assert.match(eventsSource, /previewCard\.removeAttribute\("style"\);/);
   assert.match(eventsSource, /row\.classList\.add\("is-subissue-dragging", "is-subissue-drag-gap"\);/);
 });
 
@@ -51,8 +68,14 @@ test("le handle n'est visible qu'au survol/focus et le gap de drag affiche les t
   assert.match(styleSource, /\.subissues-sortable-row\.is-subissue-drag-gap::before,[\s\S]*\.subissues-sortable-row\.is-subissue-drag-gap::after/);
   assert.match(styleSource, /\.subissues-sortable-row\.is-subissue-drag-gap::before\{top:0;\}/);
   assert.match(styleSource, /\.subissues-sortable-row\.is-subissue-drag-gap::after\{bottom:0;\}/);
-  assert.match(styleSource, /\.subissue-drag-preview\{[\s\S]*background-color:var\(--bbg, var\(--bg, #0d1117\)\);[\s\S]*border:solid 1px var\(--border, rgba\(139,148,158,.35\)\);[\s\S]*border-radius:var\(--radius\);[\s\S]*opacity:1 !important;/);
-  assert.match(styleSource, /\.subissue-drag-preview > \*\{[\s\S]*visibility:visible !important;/);
+  assert.match(styleSource, /#nativeDragPreviewRoot\{[\s\S]*position:fixed;[\s\S]*pointer-events:none;/);
+  assert.match(styleSource, /#nativeDragPreviewRoot\.is-active\{[\s\S]*display:block;/);
+  assert.match(styleSource, /#nativeDragPreviewCard\{[\s\S]*text-overflow:ellipsis;[\s\S]*opacity:1;/);
+});
+
+test("le root de drag preview natif est déclaré dans index.html", () => {
+  assert.match(indexSource, /<div id="nativeDragPreviewRoot" aria-hidden="true">/);
+  assert.match(indexSource, /<div id="nativeDragPreviewCard"><\/div>/);
 });
 
 test("le dragover réordonne en direct avec animation FLIP pour faire la place d'une ligne", () => {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -628,8 +628,13 @@ export function createProjectSubjectsEvents(config) {
       let dragPreviewNode = null;
 
       const clearDragPreview = () => {
-        if (dragPreviewNode?.parentNode) {
-          dragPreviewNode.parentNode.removeChild(dragPreviewNode);
+        const previewRoot = document.getElementById("nativeDragPreviewRoot");
+        const previewCard = document.getElementById("nativeDragPreviewCard");
+        if (previewRoot) previewRoot.classList.remove("is-active");
+        if (previewCard) {
+          previewCard.textContent = "";
+          previewCard.removeAttribute("data-child-subject-id");
+          previewCard.removeAttribute("style");
         }
         dragPreviewNode = null;
       };
@@ -638,6 +643,75 @@ export function createProjectSubjectsEvents(config) {
         sortableRows.forEach((row) => {
           row.classList.remove("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after");
         });
+      };
+
+      const resolveCssCustomProp = (styles, name, fallback = "") => {
+        const rawName = String(name || "").trim();
+        if (!styles || !rawName.startsWith("--")) return String(fallback || "");
+        const resolved = String(styles.getPropertyValue(rawName) || "").trim();
+        if (resolved) return resolved;
+        return String(fallback || "");
+      };
+
+      const getNativeSubissueDragPreviewNodes = () => {
+        const previewRoot = document.getElementById("nativeDragPreviewRoot");
+        const previewCard = document.getElementById("nativeDragPreviewCard");
+        if (!previewRoot || !previewCard) return { previewRoot: null, previewCard: null };
+        return { previewRoot, previewCard };
+      };
+
+      const mountSubissueDragPreview = ({ row, rowRect, rowStyles, issuesCols, childSubjectId }) => {
+        const { previewRoot, previewCard } = getNativeSubissueDragPreviewNodes();
+        if (!previewRoot || !previewCard) return null;
+
+        const previewBackgroundColor = resolveCssCustomProp(rowStyles, "--bbg", resolveCssCustomProp(rowStyles, "--bg", "#0d1117"));
+        const previewBorderColor = resolveCssCustomProp(rowStyles, "--border", "rgba(139,148,158,.35)");
+        const previewBorderRadius = resolveCssCustomProp(rowStyles, "--radius", "6px");
+        const previewTitle = String(
+          row.querySelector(".js-row-title-trigger")?.textContent
+          || row.querySelector("[data-subissue-title]")?.textContent
+          || row.textContent
+          || ""
+        ).replace(/\s+/g, " ").trim();
+
+        previewRoot.classList.add("is-active");
+        previewCard.setAttribute("data-child-subject-id", childSubjectId);
+        previewCard.textContent = previewTitle;
+        previewCard.style.width = `${Math.max(1, Math.round(rowRect.width))}px`;
+        if (issuesCols) previewCard.style.setProperty("--issues-cols", issuesCols);
+        previewCard.style.display = "grid";
+        previewCard.style.gridTemplateColumns = rowStyles.gridTemplateColumns;
+        previewCard.style.padding = rowStyles.padding;
+        previewCard.style.opacity = "1";
+        previewCard.style.backgroundColor = previewBackgroundColor;
+        previewCard.style.borderStyle = "solid";
+        previewCard.style.borderWidth = "1px";
+        previewCard.style.borderColor = previewBorderColor;
+        previewCard.style.borderRadius = previewBorderRadius;
+        previewCard.style.boxShadow = "0 14px 36px rgba(1,4,9,.55), 0 0 0 1px rgba(1,4,9,.35)";
+
+        debugSubissuesDnd("dragstart-preview", {
+          rowRect: {
+            width: rowRect.width,
+            height: rowRect.height
+          },
+          issuesCols,
+          rowGridTemplateColumns: rowStyles.gridTemplateColumns,
+          previewInline: {
+            width: previewCard.style.width,
+            display: previewCard.style.display,
+            gridTemplateColumns: previewCard.style.gridTemplateColumns,
+            backgroundColor: previewCard.style.backgroundColor,
+            borderStyle: previewCard.style.borderStyle,
+            borderWidth: previewCard.style.borderWidth,
+            borderColor: previewCard.style.borderColor,
+            borderRadius: previewCard.style.borderRadius,
+            boxShadow: previewCard.style.boxShadow,
+            opacity: previewCard.style.opacity
+          }
+        });
+
+        return previewCard;
       };
 
       const animateSubissueRowReflow = (container, mutateDom) => {
@@ -683,56 +757,26 @@ export function createProjectSubjectsEvents(config) {
             event.preventDefault();
             return;
           }
-          row.classList.add("is-subissue-dragging", "is-subissue-drag-gap");
           event.dataTransfer?.setData("text/plain", childSubjectId);
           if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
 
           const rowRect = row.getBoundingClientRect();
           const rowStyles = window.getComputedStyle(row);
           const issuesCols = String(rowStyles.getPropertyValue("--issues-cols") || "").trim();
-          dragPreviewNode = row.cloneNode(true);
-          dragPreviewNode.classList.remove("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after");
-          dragPreviewNode.classList.add("subissue-drag-preview");
-          dragPreviewNode.style.width = `${Math.max(1, Math.round(rowRect.width))}px`;
-          if (issuesCols) dragPreviewNode.style.setProperty("--issues-cols", issuesCols);
-          dragPreviewNode.style.display = rowStyles.display;
-          dragPreviewNode.style.gridTemplateColumns = rowStyles.gridTemplateColumns;
-          dragPreviewNode.style.padding = rowStyles.padding;
-          dragPreviewNode.style.opacity = "1";
-          dragPreviewNode.style.backgroundColor = "var(--bg)";
-          dragPreviewNode.style.border = "solid 1px var(--border)";
-          dragPreviewNode.style.borderRadius = "var(--radius)";
-          dragPreviewNode.style.position = "fixed";
-          dragPreviewNode.style.top = "0";
-          dragPreviewNode.style.left = "0";
-          dragPreviewNode.style.transform = "translate(-200vw, -200vh)";
-          dragPreviewNode.style.zIndex = "-1";
-          dragPreviewNode.style.pointerEvents = "none";
-          dragPreviewNode.setAttribute("aria-hidden", "true");
-          document.body.appendChild(dragPreviewNode);
-          debugSubissuesDnd("dragstart-preview", {
-            rowRect: {
-              width: rowRect.width,
-              height: rowRect.height
-            },
+          dragPreviewNode = mountSubissueDragPreview({
+            row,
+            rowRect,
+            rowStyles,
             issuesCols,
-            rowGridTemplateColumns: rowStyles.gridTemplateColumns,
-            previewInline: {
-              width: dragPreviewNode.style.width,
-              display: dragPreviewNode.style.display,
-              gridTemplateColumns: dragPreviewNode.style.gridTemplateColumns,
-              backgroundColor: dragPreviewNode.style.backgroundColor,
-              border: dragPreviewNode.style.border,
-              borderRadius: dragPreviewNode.style.borderRadius,
-              opacity: dragPreviewNode.style.opacity
-            }
+            childSubjectId
           });
           if (event.dataTransfer) {
             const offsetX = Math.max(0, Math.round(event.clientX - rowRect.left));
             const offsetY = Math.max(0, Math.round(event.clientY - rowRect.top));
-            event.dataTransfer.setDragImage(dragPreviewNode, offsetX, offsetY);
-            debugSubissuesDnd("dragstart-setDragImage", { offsetX, offsetY });
+            event.dataTransfer.setDragImage(dragPreviewNode || row, offsetX, offsetY);
+            debugSubissuesDnd("dragstart-setDragImage", { offsetX, offsetY, hasNativePreview: !!dragPreviewNode });
           }
+          row.classList.add("is-subissue-dragging", "is-subissue-drag-gap");
         });
 
         row.addEventListener("dragover", (event) => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2731,26 +2731,24 @@ body.is-resizing{
   transform:translateY(-8px);
 }
 
-.subissue-drag-preview{
-  background-color:var(--bbg, var(--bg));
-  border:solid 1px var(--border);
-  border-radius:var(--radius);
-  box-shadow:0 10px 30px rgba(0,0,0,.34), 0 1px 0 rgba(255,255,255,.06) inset;
-  opacity:1 !important;
+#nativeDragPreviewRoot{
+  position:fixed;
+  top:0;
+  left:0;
+  z-index:-1;
+  display:none;
+  pointer-events:none;
 }
-.subissue-drag-preview > *{
-  visibility:visible !important;
+#nativeDragPreviewRoot.is-active{
+  display:block;
 }
-
-.subissue-drag-preview{
-  background-color:var(--bbg, var(--bg, #0d1117));
-  border:solid 1px var(--border, rgba(139,148,158,.35));
-  border-radius:var(--radius);
-  box-shadow:0 10px 30px rgba(0,0,0,.34), 0 1px 0 rgba(255,255,255,.06) inset;
-  opacity:1 !important;
-}
-.subissue-drag-preview > *{
-  visibility:visible !important;
+#nativeDragPreviewCard{
+  color:var(--text);
+  font:500 13px/1.4 var(--font);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  opacity:1;
 }
 
 


### PR DESCRIPTION
### Motivation
- Replace ad-hoc cloned-node drag preview with a dedicated native preview root/card to avoid DOM insertion hacks and better control native `setDragImage` styling and behavior.

### Description
- Add `#nativeDragPreviewRoot` and `#nativeDragPreviewCard` markup to `apps/web/index.html` for native drag previews.
- Replace cloning logic with `getNativeSubissueDragPreviewNodes`, `mountSubissueDragPreview`, and `resolveCssCustomProp` helpers in `project-subjects-events.js`, and update `clearDragPreview` to reset the native preview.
- Adjust dragstart logic to mount the native preview, use `event.dataTransfer.setDragImage(dragPreviewNode || row, ...)`, and move the `.is-subissue-dragging` class addition to after `setDragImage` to avoid interfering with the preview measurement.
- Replace `.subissue-drag-preview` CSS with styles for `#nativeDragPreviewRoot` and `#nativeDragPreviewCard` in `style.css`.
- Update `project-subjects-events-subissues-dnd.test.mjs` to assert the new functions, CSS selectors, and presence of the new HTML preview root/card, and to load `index.html` for validation.

### Testing
- Ran the updated unit test file `apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` which performs pattern-matching assertions against `project-subjects-events.js`, `style.css`, and `index.html`; all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbff22a54832981c733d445b43d6a)