### PR TITLE
Améliore l’affichage et les actions des sous-sujets dans le détail d’un sujet

### DIFF
--- a/apps/web/assets/icons.svg
+++ b/apps/web/assets/icons.svg
@@ -221,9 +221,15 @@
   <symbol id="chevron-down" viewBox="0 0 16 16">
     <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
   </symbol>
+  <symbol id="chevron-right" viewBox="0 0 12 12">
+    <path d="M4.7 10c-.2 0-.4-.1-.5-.2-.3-.3-.3-.8 0-1.1L6.9 6 4.2 3.3c-.3-.3-.3-.8 0-1.1.3-.3.8-.3 1.1 0l3.3 3.2c.3.3.3.8 0 1.1L5.3 9.7c-.2.2-.4.3-.6.3Z"></path>
+  </symbol>
 
   <symbol id="chevron-up" viewBox="0 0 16 16">
     <path d="M3.22 10.53a.749.749 0 0 1 0-1.06l4.25-4.25a.749.749 0 0 1 1.06 0l4.25 4.25a.749.749 0 1 1-1.06 1.06L8 6.811 4.28 10.53a.749.749 0 0 1-1.06 0Z"></path>
+  </symbol>
+  <symbol id="circle" viewBox="0 0 24 24">
+    <path d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9.5A9.5 9.5 0 0 0 2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5Z"></path>
   </symbol>
 
     <symbol id="pencil" viewBox="0 0 16 16">

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -618,6 +618,53 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    const setSubjectParent = getSetSubjectParent?.();
+    const subissuesExpandedSet = (() => {
+      const uiState = getSubjectsViewState();
+      if (!(uiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
+        uiState.rightSubissuesExpandedSubjectIds = new Set(Array.isArray(uiState.rightSubissuesExpandedSubjectIds) ? uiState.rightSubissuesExpandedSubjectIds : []);
+      }
+      if (typeof uiState.rightSubissueMenuOpenId !== "string") uiState.rightSubissueMenuOpenId = "";
+      return uiState.rightSubissuesExpandedSubjectIds;
+    })();
+
+    root.querySelectorAll("[data-subissue-tree-toggle]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectId = String(btn.dataset.subissueTreeToggle || "");
+        if (!subjectId) return;
+        if (subissuesExpandedSet.has(subjectId)) subissuesExpandedSet.delete(subjectId);
+        else subissuesExpandedSet.add(subjectId);
+        rerenderPanels();
+      };
+    });
+
+    root.querySelectorAll("[data-subissue-actions-trigger]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectId = String(btn.dataset.subissueActionsTrigger || "");
+        const uiState = getSubjectsViewState();
+        uiState.rightSubissueMenuOpenId = String(uiState.rightSubissueMenuOpenId || "") === subjectId ? "" : subjectId;
+        rerenderPanels();
+      };
+    });
+
+    root.querySelectorAll("[data-subissue-remove-parent]").forEach((btn) => {
+      btn.onclick = async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectId = String(btn.dataset.subissueRemoveParent || "");
+        if (!subjectId || typeof setSubjectParent !== "function") return;
+        await setSubjectParent(subjectId, "", { root, skipRerender: false });
+        const uiState = getSubjectsViewState();
+        uiState.rightSubissueMenuOpenId = "";
+        subissuesExpandedSet.delete(subjectId);
+        rerenderPanels();
+      };
+    });
+
     const sortableRows = Array.from(root.querySelectorAll("[data-subissue-sortable-row='true']"));
     if (sortableRows.length) {
       debugSubissuesDnd("debug-enabled", {
@@ -870,6 +917,11 @@ export function createProjectSubjectsEvents(config) {
             event.preventDefault();
             return;
           }
+          if (subissuesExpandedSet.has(childSubjectId)) {
+            subissuesExpandedSet.delete(childSubjectId);
+          }
+          const uiState = getSubjectsViewState();
+          uiState.rightSubissueMenuOpenId = "";
           event.dataTransfer?.setData("text/plain", childSubjectId);
           if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
 

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -33,6 +33,10 @@ export function createProjectSubjectsState({ store }) {
     }
     v.expandedSujets = v.expandedSubjectIds;
     if (typeof v.rightSubissuesOpen !== "boolean") v.rightSubissuesOpen = true;
+    if (!(v.rightSubissuesExpandedSubjectIds instanceof Set)) {
+      v.rightSubissuesExpandedSubjectIds = new Set(Array.isArray(v.rightSubissuesExpandedSubjectIds) ? v.rightSubissuesExpandedSubjectIds : []);
+    }
+    if (typeof v.rightSubissueMenuOpenId !== "string") v.rightSubissueMenuOpenId = "";
     if (typeof v.commentPreviewMode !== "boolean") v.commentPreviewMode = false;
     if (typeof v.helpMode !== "boolean") v.helpMode = false;
     if (typeof v.showTableOnly !== "boolean") v.showTableOnly = true;
@@ -197,6 +201,7 @@ export function createProjectSubjectsState({ store }) {
       query: "",
       activeKey: ""
     };
+    v.rightSubissueMenuOpenId = "";
     return v;
   }
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1763,36 +1763,120 @@ function renderSubjectMetaControls(subject) {
   `;
 }
 
+function renderSubissueAssigneesCellHtml(subjectId) {
+  const collaborators = getActiveProjectCollaborators();
+  const collaboratorsById = new Map(collaborators.map((collaborator) => [collaborator.id, collaborator]));
+  const assigneeIds = normalizeAssigneeIds(getSubjectSidebarMeta(subjectId).assignees);
+  const selected = assigneeIds
+    .map((assigneeId) => findCollaboratorByAssigneeId(collaboratorsById, assigneeId) || {
+      id: assigneeId,
+      userId: "",
+      name: `Collaborateur ${String(assigneeId || "").slice(0, 8)}`,
+      email: "",
+      avatarUrl: ""
+    })
+    .slice(0, 3);
+
+  if (!selected.length) {
+    return `<span class="subissues-assignees-placeholder" aria-hidden="true">${svgIcon("circle", { className: "octicon octicon-circle" })}</span>`;
+  }
+
+  return `
+    <span class="issue-row-assignees" aria-label="${escapeHtml(`${selected.length} assigné(s)`)}}">
+      ${selected.map((collaborator) => renderCollaboratorAvatar({
+        ...collaborator,
+        avatarUrl: firstNonEmpty(
+          collaborator?.avatarUrl,
+          String(collaborator?.userId || "") === String(store?.user?.id || "") ? String(store?.user?.avatar || "") : ""
+        )
+      })).join("")}
+    </span>
+  `;
+}
+
 function renderSubIssuesForSujet(sujet, options = {}) {
   ensureViewUiState();
   const sujetRowClass = options.sujetRowClass || "js-row-sujet";
   const childSubjects = getChildSubjectList(sujet);
   if (!childSubjects.length) return "";
-  const rows = childSubjects.map((childSujet) => `
+  const uiState = getSubjectsViewState();
+  if (!(uiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
+    uiState.rightSubissuesExpandedSubjectIds = new Set(Array.isArray(uiState.rightSubissuesExpandedSubjectIds) ? uiState.rightSubissuesExpandedSubjectIds : []);
+  }
+  if (typeof uiState.rightSubissueMenuOpenId !== "string") uiState.rightSubissueMenuOpenId = "";
+
+  const expandedIds = uiState.rightSubissuesExpandedSubjectIds;
+  const openMenuId = String(uiState.rightSubissueMenuOpenId || "");
+  const rows = [];
+  const walkSubissueTree = (subjectNode, depth = 0, parentId = "") => {
+    const subjectId = String(subjectNode?.id || "");
+    if (!subjectId) return;
+    const nestedChildren = getChildSubjectList(subjectNode);
+    const hasChildren = nestedChildren.length > 0;
+    const isExpanded = hasChildren && expandedIds.has(subjectId);
+    const canDrag = depth === 0;
+    const isRowMenuOpen = openMenuId === subjectId;
+    const levelClass = depth <= 2 ? `lvl${depth}` : "lvl2";
+    const extraIndent = depth > 2 ? `style="padding-left:${44 + ((depth - 2) * 22)}px;"` : "";
+
+    rows.push(`
       <div
-        class="issue-row issue-row--pb click ${sujetRowClass} subissues-sortable-row"
-        data-sujet-id="${escapeHtml(childSujet.id)}"
-        data-subissue-sortable-row="true"
-        data-parent-subject-id="${escapeHtml(String(sujet?.id || ""))}"
-        data-child-subject-id="${escapeHtml(childSujet.id)}"
-        draggable="true"
+        class="issue-row issue-row--pb click ${sujetRowClass}${canDrag ? " subissues-sortable-row" : " subissues-tree-row"}"
+        data-sujet-id="${escapeHtml(subjectId)}"
+        ${canDrag ? `data-subissue-sortable-row="true"` : ""}
+        data-subissue-tree-row="${escapeHtml(subjectId)}"
+        data-subissue-depth="${depth}"
+        data-parent-subject-id="${escapeHtml(String(parentId || sujet?.id || ""))}"
+        data-child-subject-id="${escapeHtml(subjectId)}"
+        draggable="${canDrag ? "true" : "false"}"
       >
         <div class="cell cell-subissue-drag-handle">
-          <button type="button" class="subissue-drag-handle" data-subissue-drag-handle aria-label="Réordonner le sous-sujet">
-            ${svgIcon("grabber", { className: "octicon octicon-grabber" })}
-          </button>
+          ${canDrag
+            ? `<button type="button" class="subissue-drag-handle" data-subissue-drag-handle aria-label="Réordonner le sous-sujet">
+                ${svgIcon("grabber", { className: "octicon octicon-grabber" })}
+              </button>`
+            : ""}
         </div>
-        <div class="cell cell-subissue-drag-spacer" aria-hidden="true"></div>
-        <div class="cell cell-theme cell-theme--full lvl0">
-          ${issueIcon(getEffectiveSujetStatus(childSujet.id))}
-          <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(childSujet.title, childSujet.id, ""))}</span>
+        <div class="cell cell-subissue-drag-spacer">
+          ${hasChildren
+            ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">
+                ${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}
+              </button>`
+            : ""}
+        </div>
+        <div class="cell cell-theme cell-theme--full ${levelClass}" ${extraIndent}>
+          ${issueIcon(getEffectiveSujetStatus(subjectId))}
+          <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>
+        </div>
+        <div class="cell cell-subissue-assignees-value">
+          ${renderSubissueAssigneesCellHtml(subjectId)}
+        </div>
+        <div class="cell cell-subissue-actions">
+          <button type="button" class="subissue-actions-trigger" data-subissue-actions-trigger="${escapeHtml(subjectId)}" aria-label="Actions du sous-sujet">
+            ${svgIcon("kebab-horizontal", { className: "octicon octicon-kebab-horizontal" })}
+          </button>
+          ${isRowMenuOpen
+            ? `<div class="subissue-actions-menu gh-menu gh-menu--open" role="menu">
+                <button type="button" class="select-menu__item subissue-actions-menu__item" role="menuitem" data-subissue-remove-parent="${escapeHtml(subjectId)}">
+                  <span class="select-menu__item-text">
+                    <span class="select-menu__item-title">Enlever le sous-sujet</span>
+                  </span>
+                </button>
+              </div>`
+            : ""}
         </div>
       </div>
-    `).join("");
+    `);
+
+    if (!isExpanded) return;
+    nestedChildren.forEach((nestedChild) => walkSubissueTree(nestedChild, depth + 1, subjectId));
+  };
+
+  childSubjects.forEach((childSujet) => walkSubissueTree(childSujet, 0, String(sujet?.id || "")));
 
   const body = renderSubIssuesTable({
     className: "issues-table subissues-table subissues-table--sortable",
-    rowsHtml: rows,
+    rowsHtml: rows.join(""),
     emptyTitle: "Aucun sous-sujet"
   });
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2662,7 +2662,7 @@ body.is-resizing{
 .v-dot--so{ background:rgb(20, 31, 53); border-color:rgba(20,31,53,.55); }
 
 .details-subissues .subissues-table{ --issues-cols: 1fr; }
-.details-subissues .subissues-table--sortable{ --issues-cols: 24px 12px 1fr; }
+.details-subissues .subissues-table--sortable{ --issues-cols: 24px 16px minmax(0,1fr) 52px 36px; }
 .details-subissues .issues-table__head{ display:none !important; }
 .details-subissues .cell-theme{ padding-right:0; }
 .cell-subissue-drag-handle,
@@ -2670,6 +2670,22 @@ body.is-resizing{
   display:flex;
   align-items:center;
 }
+.cell-subissue-drag-spacer{
+  justify-content:center;
+}
+.subissue-tree-toggle{
+  width:16px;
+  height:16px;
+  border:0;
+  background:transparent;
+  color:var(--muted);
+  padding:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+}
+.subissue-tree-toggle:hover{color:var(--text);}
 
 .subissue-drag-handle{
   width:20px;
@@ -2695,6 +2711,10 @@ body.is-resizing{
 }
 
 .subissue-drag-handle:active{cursor:grabbing;}
+.subissues-tree-row .subissue-drag-handle{
+  opacity:0 !important;
+  visibility:hidden !important;
+}
 .subissues-sortable-row.is-subissue-dragging{
   position:relative;
 }
@@ -2729,6 +2749,51 @@ body.is-resizing{
 .subissues-sortable-row.is-subissue-drop-after{
   box-shadow:inset 0 -2px 0 0 rgba(56,139,253,.9);
   transform:translateY(-8px);
+}
+.cell-subissue-assignees-value{
+  display:flex;
+  justify-content:flex-end;
+}
+.subissues-assignees-placeholder{
+  color:var(--muted);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+.subissues-assignees-placeholder .octicon-circle{
+  width:18px;
+  height:18px;
+}
+.cell-subissue-actions{
+  position:relative;
+  display:flex;
+  justify-content:center;
+}
+.subissue-actions-trigger{
+  width:24px;
+  height:24px;
+  border:0;
+  border-radius:6px;
+  background:transparent;
+  color:var(--muted);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+.subissue-actions-trigger:hover{
+  background:var(--surface);
+  color:var(--text);
+}
+.subissue-actions-menu{
+  position:absolute;
+  top:calc(100% + 4px);
+  right:0;
+  z-index:15;
+  min-width:185px;
+}
+.subissue-actions-menu__item{
+  width:100%;
+  text-align:left;
 }
 
 #nativeDragPreviewRoot{


### PR DESCRIPTION
### Motivation
- Rendre la liste des sous-sujets plus utilisable en ajoutant informations et actions par ligne et en affichant la hiérarchie imbriquée directement dans la table de détail.

### Description
- Ajout d'un rendu arborescent récursif des sous-sujets avec chevrons (`chevron-right`/`chevron-down`) et expansion par ligne dans `apps/web/js/views/project-subjects/project-subjects-view.js`.
- Ajout de deux cellules à droite des lignes : une cellule `assignés` (avatars + placeholder cercle) rendue via `renderSubissueAssigneesCellHtml`, et une cellule d'`actions` contenant un bouton `kebab-horizontal` ouvrant un menu avec l'action `Enlever le sous-sujet` qui appelle `setSubjectParent(subjectId, "")` pour détacher le parent.
- Limitation du drag-and-drop aux sous-sujets fils directs (niveau 0 dans l'arbre) et fermeture automatique des descendants ouverts lors du `dragstart` d'un fils direct, gérée dans `project-subjects-events.js`.
- Ajout/initialisation de l'état UI `rightSubissuesExpandedSubjectIds` et `rightSubissueMenuOpenId` dans `project-subjects-state.js`, et styles + icônes (`chevron-right`, `circle`) et ajustements CSS dans `apps/web/style.css` et `apps/web/assets/icons.svg`.

### Testing
- Exécuté `node --test apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` et tous les tests sont passés (8/8 OK).
- Vérification syntaxique avec `node --check` sur `project-subjects-view.js`, `project-subjects-events.js` et `project-subjects-state.js` et sans erreur détectée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0990a0944832989efbd6294f5d066)