### PR TITLE
Adjust subissue spacer DOM hierarchy

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1847,15 +1847,15 @@ function renderSubIssuesForSujet(sujet, options = {}) {
               </button>`
             : ""}
         </div>
+        <div class="cell cell-subissue-drag-spacer">
+          ${hasChildren
+            ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">
+                ${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}
+              </button>`
+            : ""}
+        </div>
         <div class="subissue-row-main">
           ${nestedSpacerCells}
-          <div class="cell cell-subissue-drag-spacer">
-            ${hasChildren
-              ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">
-                  ${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}
-                </button>`
-              : ""}
-          </div>
           <div class="cell cell-theme cell-theme--full ${levelClass}">
             ${issueIcon(getEffectiveSujetStatus(subjectId))}
             <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2662,7 +2662,7 @@ body.is-resizing{
 .v-dot--so{ background:rgb(20, 31, 53); border-color:rgba(20,31,53,.55); }
 
 .details-subissues .subissues-table{ --issues-cols: 1fr; }
-.details-subissues .subissues-table--sortable{ --issues-cols: 24px minmax(0,1fr); }
+.details-subissues .subissues-table--sortable{ --issues-cols: 24px 16px minmax(0,1fr); }
 .details-subissues .issues-table__head{ display:none !important; }
 .details-subissues .cell-theme{ padding-right:0; }
 .details-subissues .issue-row{border-bottom:none;padding:0px;}


### PR DESCRIPTION
### Motivation
- Rendre la cellule de basculement d'arbre (`.cell.cell-subissue-drag-spacer`) sœur de la ligne principale pour que le toggle soit au même niveau DOM que `.subissue-row-main`.
- Conserver les spacers d'indentation imbriqués à l'intérieur de la ligne principale pour préserver le rendu hiérarchique.
- Adapter la grille CSS des lignes triables pour réserver une colonne dédiée au spacer afin de maintenir l'alignement visuel.

### Description
- Déplacé la `div.cell.cell-subissue-drag-spacer` contenant le bouton de toggle juste après la poignée de drag dans `apps/web/js/views/project-subjects/project-subjects-view.js` pour qu'elle soit sœur de la `div.subissue-row-main` et supprimé le doublon à l'intérieur de `.subissue-row-main`.
- Conservé `nestedSpacerCells` (les spacers d'indentation générés selon la profondeur) à l'intérieur de `.subissue-row-main` pour l'indentation des enfants.
- Ajouté une colonne dédiée de 16px dans la variable de colonnes des tables triables en `apps/web/style.css` via `--issues-cols: 24px 16px minmax(0,1fr);` pour aligner la nouvelle structure DOM.
- Modifiés les fichiers `apps/web/js/views/project-subjects/project-subjects-view.js` et `apps/web/style.css`.

### Testing
- Executed `node apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` and all tests passed (`8` tests, `0` failures).
- The changes were linted/committed locally and no other automated test failures were observed when running the subissues DnD test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b08a0e1083299523b89c7bff1c54)