### PR TITLE
Align subissue tree toggle and add spacer column for nested rows

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1847,15 +1847,15 @@ function renderSubIssuesForSujet(sujet, options = {}) {
               </button>`
             : ""}
         </div>
+        ${nestedSpacerCells}
+        <div class="cell cell-subissue-drag-spacer">
+          ${hasChildren
+            ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">
+                ${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}
+              </button>`
+            : ""}
+        </div>
         <div class="subissue-row-main">
-          ${nestedSpacerCells}
-          <div class="cell cell-subissue-drag-spacer">
-            ${hasChildren
-              ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">
-                  ${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}
-                </button>`
-              : ""}
-          </div>
           <div class="cell cell-theme cell-theme--full ${levelClass}">
             ${issueIcon(getEffectiveSujetStatus(subjectId))}
             <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2662,10 +2662,10 @@ body.is-resizing{
 .v-dot--so{ background:rgb(20, 31, 53); border-color:rgba(20,31,53,.55); }
 
 .details-subissues .subissues-table{ --issues-cols: 1fr; }
-.details-subissues .subissues-table--sortable{ --issues-cols: 24px minmax(0,1fr); }
+.details-subissues .subissues-table--sortable{ --issues-cols: 24px 16px minmax(0,1fr); }
 .details-subissues .issues-table__head{ display:none !important; }
 .details-subissues .cell-theme{ padding-right:0; }
-.details-subissues .issue-row{border-bottom:none;padding:0px;}
+.details-subissues .issue-row{display:flex;align-items:center;border-bottom:none;padding:0px;}
 .subissue-row-main{
   display:flex;
   align-items:center;


### PR DESCRIPTION
### Motivation

- Fix visual misalignment of the nested subissue toggle and spacers when rendering subissue rows, especially for nested depths and sortable rows.
- Ensure consistent spacing between the drag handle, toggle, and main content so tree controls do not overlap with issue content.

### Description

- Move the depth indent `nestedSpacerCells` out of `.subissue-row-main` so indentation is rendered to the left of the main content and next to the drag handle. 
- Insert an explicit `.cell-subissue-drag-spacer` cell between the drag handle and main content that contains the subissue tree toggle button when the subject has children. 
- Update layout CSS for subissues by changing `--issues-cols` in `.details-subissues .subissues-table--sortable` from `24px minmax(0,1fr)` to `24px 16px minmax(0,1fr)` to reserve a 16px column for the toggle spacer. 
- Make `.details-subissues .issue-row` a flex container with center alignment so rows and their internal cells align consistently.

### Testing

- Ran frontend unit tests with `yarn test` and they passed. 
- Ran the linting step with `yarn lint` and there were no new errors. 
- Performed a local dev build and manual smoke-check of subissue lists to verify toggle positioning and nested indentation visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b08a0e1083299523b89c7bff1c54)