### PR TITLE
Fix consistent widths for subissue drag handle/spacer cells

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2682,11 +2682,11 @@ body.is-resizing{
 .cell-subissue-drag-spacer{
   display:flex;
   align-items:center;
-}
-.cell-subissue-drag-spacer{
   justify-content:center;
-  width:16px;
+  flex:0 0 auto;
 }
+.cell-subissue-drag-handle{width:14px;}
+.cell-subissue-drag-spacer{width:24px;}
 .subissue-tree-toggle{
   width:16px;
   height:16px;


### PR DESCRIPTION
### Motivation
- Ensure the subissue rows' drag handle and spacer cells keep a stable width so indentation and controls stay aligned regardless of icon presence or chevron orientation.

### Description
- Update `apps/web/style.css` to add `justify-content:center; flex:0 0 auto;` to `.cell-subissue-drag-handle, .cell-subissue-drag-spacer` and set fixed widths with `.cell-subissue-drag-handle { width: 14px; }` and `.cell-subissue-drag-spacer { width: 24px; }`.

### Testing
- No automated tests were run for this CSS-only adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b9a4713083298431e66ff80d0e10)