### PR TITLE
Fix DnD des sous-sujets parents déployés

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -115,6 +115,15 @@ test("le dragover réordonne en direct avec animation FLIP pour faire la place d
   assert.match(eventsSource, /item\.style\.transform = `translateY\(\$\{delta\}px\)`;/);
 });
 
+test("le drag d'un parent déployé replie les descendants puis restaure l'état d'ouverture après dépôt", () => {
+  assert.match(eventsSource, /const collectDraggedSubissueDescendantRows = \(draggingRow\) => \{/);
+  assert.match(eventsSource, /const wasExpandedOnDragStart = subissuesExpandedSet\.has\(childSubjectId\);/);
+  assert.match(eventsSource, /const descendantRows = wasExpandedOnDragStart \? collectDraggedSubissueDescendantRows\(row\) : \[\];/);
+  assert.match(eventsSource, /descendantRows\.forEach\(\(descendantRow\) => descendantRow\.remove\(\)\);/);
+  assert.match(eventsSource, /draggedSubissueContext = \{\s*childSubjectId,\s*wasExpandedOnDragStart\s*\};/);
+  assert.match(eventsSource, /if \(draggedSubissueContext\?\.wasExpandedOnDragStart && draggedSubissueContext\?\.childSubjectId\) \{\s*subissuesExpandedSet\.add\(draggedSubissueContext\.childSubjectId\);\s*\}/);
+});
+
 test("l'instrumentation DnD est activable via query/localStorage", () => {
   assert.match(eventsSource, /function isSubissuesDndDebugEnabled\(\)/);
   assert.match(eventsSource, /debugSubissuesDnd=1/);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -676,6 +676,7 @@ export function createProjectSubjectsEvents(config) {
       let dragPreviewOffsetX = 0;
       let dragPreviewOffsetY = 0;
       let detachGlobalDragTracking = null;
+      let draggedSubissueContext = null;
 
       const clearDragPreview = () => {
         const previewRoot = document.getElementById("nativeDragPreviewRoot");
@@ -700,6 +701,19 @@ export function createProjectSubjectsEvents(config) {
         sortableRows.forEach((row) => {
           row.classList.remove("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after");
         });
+      };
+
+      const collectDraggedSubissueDescendantRows = (draggingRow) => {
+        if (!draggingRow) return [];
+        const descendants = [];
+        let cursor = draggingRow.nextElementSibling;
+        while (cursor) {
+          if (cursor.matches?.("[data-subissue-sortable-row='true']")) break;
+          const isTreeRow = cursor.matches?.("[data-subissue-tree-row]");
+          if (isTreeRow) descendants.push(cursor);
+          cursor = cursor.nextElementSibling;
+        }
+        return descendants;
       };
 
       const resolveCssCustomProp = (styles, name, fallback = "") => {
@@ -917,9 +931,16 @@ export function createProjectSubjectsEvents(config) {
             event.preventDefault();
             return;
           }
-          if (subissuesExpandedSet.has(childSubjectId)) {
+          const wasExpandedOnDragStart = subissuesExpandedSet.has(childSubjectId);
+          if (wasExpandedOnDragStart) {
             subissuesExpandedSet.delete(childSubjectId);
           }
+          const descendantRows = wasExpandedOnDragStart ? collectDraggedSubissueDescendantRows(row) : [];
+          descendantRows.forEach((descendantRow) => descendantRow.remove());
+          draggedSubissueContext = {
+            childSubjectId,
+            wasExpandedOnDragStart
+          };
           const uiState = getSubjectsViewState();
           uiState.rightSubissueMenuOpenId = "";
           event.dataTransfer?.setData("text/plain", childSubjectId);
@@ -1034,12 +1055,21 @@ export function createProjectSubjectsEvents(config) {
             .map((item) => String(item.dataset.childSubjectId || ""))
             .filter(Boolean);
           debugSubissuesDnd("drop-reorder", { parentSubjectId, sourceId, targetId, orderedChildIds });
+          if (draggedSubissueContext?.wasExpandedOnDragStart && draggedSubissueContext?.childSubjectId) {
+            subissuesExpandedSet.add(draggedSubissueContext.childSubjectId);
+          }
           await reorderSubjectChildren(parentSubjectId, orderedChildIds, { root, skipRerender: false });
+          draggedSubissueContext = null;
           clearDragClasses();
           clearDragPreview();
         });
 
         row.addEventListener("dragend", () => {
+          if (draggedSubissueContext?.wasExpandedOnDragStart && draggedSubissueContext?.childSubjectId) {
+            subissuesExpandedSet.add(draggedSubissueContext.childSubjectId);
+            rerenderPanels();
+          }
+          draggedSubissueContext = null;
           clearDragClasses();
           clearDragPreview();
           row.dataset.subissueDragFromHandle = "false";


### PR DESCRIPTION
### Motivation
- Corriger un bug du drag-and-drop où déplacer un sous-sujet parent déployé laissait ses enfants à l'ancienne position et faisait revenir le parent à sa place d'origine après interaction.

### Description
- Ajout d'un contexte de drag `draggedSubissueContext` pour mémoriser si le parent était ouvert au démarrage du drag et son `childSubjectId`.
- Au `dragstart` on replie visuellement le parent en supprimant temporairement les lignes descendantes via `collectDraggedSubissueDescendantRows` et on stocke l'état de repli dans `draggedSubissueContext`.
- Au `drop` et au `dragend` on restaure l'état d'ouverture du parent si nécessaire (`subissuesExpandedSet.add(...)`) et on appelle l'existant `reorderSubjectChildren(...)` pour persister la nouvelle position.
- Fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-events.js` et `apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs`.

### Testing
- Exécution des tests unitaires ciblés via `node --test apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` a réussi avec toutes les assertions (9 ok).
- Les nouveaux tests de non-régression vérifient la collecte/suppression temporaire des descendants et la restauration de l'état d'ouverture après dépôt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c0a445ac8329932eb27aff45f0b3)