### PR TITLE
Collapse/restore subissue tree during drag and persist reorder on dragend

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -115,6 +115,21 @@ test("le dragover réordonne en direct avec animation FLIP pour faire la place d
   assert.match(eventsSource, /item\.style\.transform = `translateY\(\$\{delta\}px\)`;/);
 });
 
+test("le drag replie toute l'arborescence puis restitue l'état d'ouverture initial", () => {
+  assert.match(eventsSource, /const collapseSubissueTreeForDrag = \(container\) => \{/);
+  assert.match(eventsSource, /const expandedSnapshot = Array\.from\(subissuesExpandedSet\);/);
+  assert.match(eventsSource, /subissuesExpandedSet\.clear\(\);/);
+  assert.match(eventsSource, /\.filter\(\(item\) => item\.dataset\.subissueSortableRow !== "true"\)/);
+  assert.match(eventsSource, /const restoreExpandedSubissueTreeAfterDrag = \(expandedSnapshot = \[\]\) => \{/);
+  assert.match(eventsSource, /restoreExpandedSubissueTreeAfterDrag\(draggedSubissueContext\?\.expandedSnapshot \|\| \[\]\);/);
+  assert.match(eventsSource, /draggedSubissueContext = \{\s*childSubjectId,\s*expandedSnapshot,\s*dropCommitted: false\s*\};/);
+});
+
+test("le dragend persiste l'ordre même sans drop explicite", () => {
+  assert.match(eventsSource, /const shouldCommitOrderOnDragEnd = dndContext && !dndContext\.dropCommitted;/);
+  assert.match(eventsSource, /await reorderSubjectChildren\(parentSubjectId, orderedChildIds, \{ root, skipRerender: false \}\);/);
+});
+
 test("l'instrumentation DnD est activable via query/localStorage", () => {
   assert.match(eventsSource, /function isSubissuesDndDebugEnabled\(\)/);
   assert.match(eventsSource, /debugSubissuesDnd=1/);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -676,6 +676,7 @@ export function createProjectSubjectsEvents(config) {
       let dragPreviewOffsetX = 0;
       let dragPreviewOffsetY = 0;
       let detachGlobalDragTracking = null;
+      let draggedSubissueContext = null;
 
       const clearDragPreview = () => {
         const previewRoot = document.getElementById("nativeDragPreviewRoot");
@@ -699,6 +700,25 @@ export function createProjectSubjectsEvents(config) {
       const clearDragClasses = () => {
         sortableRows.forEach((row) => {
           row.classList.remove("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after");
+        });
+      };
+
+      const collapseSubissueTreeForDrag = (container) => {
+        const expandedSnapshot = Array.from(subissuesExpandedSet);
+        subissuesExpandedSet.clear();
+        if (container) {
+          Array.from(container.querySelectorAll("[data-subissue-tree-row]"))
+            .filter((item) => item.dataset.subissueSortableRow !== "true")
+            .forEach((item) => item.remove());
+        }
+        return expandedSnapshot;
+      };
+
+      const restoreExpandedSubissueTreeAfterDrag = (expandedSnapshot = []) => {
+        subissuesExpandedSet.clear();
+        expandedSnapshot.forEach((subjectId) => {
+          const key = String(subjectId || "").trim();
+          if (key) subissuesExpandedSet.add(key);
         });
       };
 
@@ -917,9 +937,13 @@ export function createProjectSubjectsEvents(config) {
             event.preventDefault();
             return;
           }
-          if (subissuesExpandedSet.has(childSubjectId)) {
-            subissuesExpandedSet.delete(childSubjectId);
-          }
+          const container = row.parentElement;
+          const expandedSnapshot = collapseSubissueTreeForDrag(container);
+          draggedSubissueContext = {
+            childSubjectId,
+            expandedSnapshot,
+            dropCommitted: false
+          };
           const uiState = getSubjectsViewState();
           uiState.rightSubissueMenuOpenId = "";
           event.dataTransfer?.setData("text/plain", childSubjectId);
@@ -1034,12 +1058,31 @@ export function createProjectSubjectsEvents(config) {
             .map((item) => String(item.dataset.childSubjectId || ""))
             .filter(Boolean);
           debugSubissuesDnd("drop-reorder", { parentSubjectId, sourceId, targetId, orderedChildIds });
+          restoreExpandedSubissueTreeAfterDrag(draggedSubissueContext?.expandedSnapshot || []);
           await reorderSubjectChildren(parentSubjectId, orderedChildIds, { root, skipRerender: false });
+          if (draggedSubissueContext) draggedSubissueContext.dropCommitted = true;
+          draggedSubissueContext = null;
           clearDragClasses();
           clearDragPreview();
         });
 
-        row.addEventListener("dragend", () => {
+        row.addEventListener("dragend", async () => {
+          const dndContext = draggedSubissueContext;
+          const shouldCommitOrderOnDragEnd = dndContext && !dndContext.dropCommitted;
+          restoreExpandedSubissueTreeAfterDrag(dndContext?.expandedSnapshot || []);
+          if (shouldCommitOrderOnDragEnd) {
+            const container = row.parentElement;
+            const parentSubjectId = String(row.dataset.parentSubjectId || "");
+            const orderedChildIds = Array.from(container?.querySelectorAll?.("[data-subissue-sortable-row='true']") || [])
+              .map((item) => String(item.dataset.childSubjectId || ""))
+              .filter(Boolean);
+            if (parentSubjectId && orderedChildIds.length && typeof reorderSubjectChildren === "function") {
+              await reorderSubjectChildren(parentSubjectId, orderedChildIds, { root, skipRerender: false });
+            } else {
+              rerenderPanels();
+            }
+          }
+          draggedSubissueContext = null;
           clearDragClasses();
           clearDragPreview();
           row.dataset.subissueDragFromHandle = "false";


### PR DESCRIPTION
### Motivation
- Simplify dragging by collapsing the subissue tree while dragging and restore the previous expanded state after the operation to avoid layout instability and preserve user context.
- Ensure the new order of subissues is persisted even when the user ends a drag without an explicit drop, preventing lost reorders.

### Description
- Introduce `draggedSubissueContext` and add `collapseSubissueTreeForDrag` and `restoreExpandedSubissueTreeAfterDrag` helper functions to snapshot and restore expanded subissue state. 
- Update `dragstart` to collapse the tree for the drag target, store the `expandedSnapshot` and initialize the `draggedSubissueContext`. 
- On drop, restore the expanded snapshot, call `reorderSubjectChildren` with the new order, mark the drag context as committed, and clear the context. 
- Make the `dragend` handler `async` to restore the expanded snapshot and, if the drag ended without an explicit drop, persist the current order via `reorderSubjectChildren` (or fall back to `rerenderPanels`) before clearing the context. 
- Add/extend tests in `project-subjects-events-subissues-dnd.test.mjs` to assert the collapse/restore behavior and the dragend persistence logic. 

### Testing
- Ran the updated test suite including `apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` via `npm test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c0a445ac8329932eb27aff45f0b3)