### PR TITLE
Subissues DnD: collapse tree on drag, persist reorder on dragend, and improve native drag preview

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -41,10 +41,16 @@ test("le dragstart est armé par pointerdown sur le handle et utilise un drag pr
   assert.match(eventsSource, /const startGlobalSubissueDragTracking = \(\) => \{/);
   assert.match(eventsSource, /const previewRoot = document\.getElementById\("nativeDragPreviewRoot"\);/);
   assert.match(eventsSource, /const previewCard = document\.getElementById\("nativeDragPreviewCard"\);/);
-  assert.match(eventsSource, /const previewIssueIcon = row\.querySelector\("\.issue-status-icon"\);/);
+  assert.match(eventsSource, /const previewRowClone = row\.cloneNode\(true\);/);
   assert.match(eventsSource, /previewCard\.innerHTML = "";/);
   assert.match(eventsSource, /const issuesCols = String\(rowStyles\.getPropertyValue\("--issues-cols"\) \|\| ""\)\.trim\(\);/);
   assert.match(eventsSource, /if \(issuesCols\) previewCard\.style\.setProperty\("--issues-cols", issuesCols\);/);
+  assert.match(eventsSource, /previewCard\.style\.height = "48px";/);
+  assert.match(eventsSource, /previewCard\.style\.padding = "12px 8px";/);
+  assert.match(eventsSource, /previewCard\.style\.overflow = "hidden";/);
+  assert.match(eventsSource, /previewRowClone\.querySelectorAll\("button"\)\.forEach\(\(button\) => \{/);
+  assert.match(eventsSource, /Array\.from\(previewRowClone\.children\)\.forEach\(\(child\) => \{/);
+  assert.match(eventsSource, /previewCard\.appendChild\(child\.cloneNode\(true\)\);/);
   assert.match(eventsSource, /const resolveCssCustomProp = \(styles, name, fallback = ""\) => \{/);
   assert.match(eventsSource, /const previewBackgroundColor = resolveCssCustomProp\(rowStyles, "--bbg", resolveCssCustomProp\(rowStyles, "--bg", "#0d1117"\)\);/);
   assert.match(eventsSource, /const previewBorderColor = resolveCssCustomProp\(rowStyles, "--border", "rgba\(139,148,158,.35\)"\);/);
@@ -60,17 +66,11 @@ test("le dragstart est armé par pointerdown sur le handle et utilise un drag pr
   assert.match(eventsSource, /borderWidth: previewCard\.style\.borderWidth,/);
   assert.match(eventsSource, /borderColor: previewCard\.style\.borderColor,/);
   assert.match(eventsSource, /boxShadow: previewCard\.style\.boxShadow,/);
-  assert.match(eventsSource, /leftSpacer\.className = "cell cell-subissue-drag-handle";/);
-  assert.match(eventsSource, /middleSpacer\.className = "cell cell-subissue-drag-spacer";/);
-  assert.match(eventsSource, /contentCell\.className = "cell cell-theme cell-theme--full lvl0";/);
-  assert.match(eventsSource, /if \(previewIssueIcon\) contentCell\.appendChild\(previewIssueIcon\.cloneNode\(true\)\);/);
-  assert.match(eventsSource, /titleSpan\.className = "theme-text theme-text--pb";/);
-  assert.match(eventsSource, /previewCard\.append\(leftSpacer, middleSpacer, contentCell\);/);
   assert.match(eventsSource, /const previewPaintRect = previewCard\.getBoundingClientRect\(\);/);
   assert.match(eventsSource, /previewPaintRect: \{/);
   assert.match(eventsSource, /const canvasDragPreview = createSubissueDragCanvasPreview\(\{/);
-  assert.match(eventsSource, /const dragImageNode = canvasDragPreview \|\| dragPreviewNode \|\| row;/);
-  assert.match(eventsSource, /dragImageKind: canvasDragPreview \? "canvas" : \(dragPreviewNode \? "dom" : "row"\)/);
+  assert.match(eventsSource, /const dragImageNode = dragPreviewNode \|\| canvasDragPreview \|\| row;/);
+  assert.match(eventsSource, /dragImageKind: dragPreviewNode \? "dom" : \(canvasDragPreview \? "canvas" : "row"\)/);
   assert.match(eventsSource, /dragPreviewOffsetX = offsetX;/);
   assert.match(eventsSource, /dragPreviewOffsetY = offsetY;/);
   assert.match(eventsSource, /if \(!canvasDragPreview && dragPreviewNode\) \{/);
@@ -113,6 +113,21 @@ test("le dragover réordonne en direct avec animation FLIP pour faire la place d
   assert.match(eventsSource, /container\.insertBefore\(draggingRow, row\.nextElementSibling\);/);
   assert.match(eventsSource, /container\.insertBefore\(draggingRow, row\);/);
   assert.match(eventsSource, /item\.style\.transform = `translateY\(\$\{delta\}px\)`;/);
+});
+
+test("le drag replie toute l'arborescence puis restitue l'état d'ouverture initial", () => {
+  assert.match(eventsSource, /const collapseSubissueTreeForDrag = \(container\) => \{/);
+  assert.match(eventsSource, /const expandedSnapshot = Array\.from\(subissuesExpandedSet\);/);
+  assert.match(eventsSource, /subissuesExpandedSet\.clear\(\);/);
+  assert.match(eventsSource, /\.filter\(\(item\) => item\.dataset\.subissueSortableRow !== "true"\)/);
+  assert.match(eventsSource, /const restoreExpandedSubissueTreeAfterDrag = \(expandedSnapshot = \[\]\) => \{/);
+  assert.match(eventsSource, /restoreExpandedSubissueTreeAfterDrag\(draggedSubissueContext\?\.expandedSnapshot \|\| \[\]\);/);
+  assert.match(eventsSource, /draggedSubissueContext = \{\s*childSubjectId,\s*expandedSnapshot,\s*dropCommitted: false\s*\};/);
+});
+
+test("le dragend persiste l'ordre même sans drop explicite", () => {
+  assert.match(eventsSource, /const shouldCommitOrderOnDragEnd = dndContext && !dndContext\.dropCommitted;/);
+  assert.match(eventsSource, /await reorderSubjectChildren\(parentSubjectId, orderedChildIds, \{ root, skipRerender: false \}\);/);
 });
 
 test("l'instrumentation DnD est activable via query/localStorage", () => {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -676,6 +676,7 @@ export function createProjectSubjectsEvents(config) {
       let dragPreviewOffsetX = 0;
       let dragPreviewOffsetY = 0;
       let detachGlobalDragTracking = null;
+      let draggedSubissueContext = null;
 
       const clearDragPreview = () => {
         const previewRoot = document.getElementById("nativeDragPreviewRoot");
@@ -699,6 +700,25 @@ export function createProjectSubjectsEvents(config) {
       const clearDragClasses = () => {
         sortableRows.forEach((row) => {
           row.classList.remove("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after");
+        });
+      };
+
+      const collapseSubissueTreeForDrag = (container) => {
+        const expandedSnapshot = Array.from(subissuesExpandedSet);
+        subissuesExpandedSet.clear();
+        if (container) {
+          Array.from(container.querySelectorAll("[data-subissue-tree-row]"))
+            .filter((item) => item.dataset.subissueSortableRow !== "true")
+            .forEach((item) => item.remove());
+        }
+        return expandedSnapshot;
+      };
+
+      const restoreExpandedSubissueTreeAfterDrag = (expandedSnapshot = []) => {
+        subissuesExpandedSet.clear();
+        expandedSnapshot.forEach((subjectId) => {
+          const key = String(subjectId || "").trim();
+          if (key) subissuesExpandedSet.add(key);
         });
       };
 
@@ -731,7 +751,7 @@ export function createProjectSubjectsEvents(config) {
           || row.textContent
           || ""
         ).replace(/\s+/g, " ").trim();
-        const previewIssueIcon = row.querySelector(".issue-status-icon");
+        const previewRowClone = row.cloneNode(true);
 
         previewCard.setAttribute("data-child-subject-id", childSubjectId);
         previewCard.innerHTML = "";
@@ -739,7 +759,12 @@ export function createProjectSubjectsEvents(config) {
         if (issuesCols) previewCard.style.setProperty("--issues-cols", issuesCols);
         previewCard.style.display = "grid";
         previewCard.style.gridTemplateColumns = issuesCols || rowStyles.gridTemplateColumns;
-        previewCard.style.padding = rowStyles.padding;
+        previewCard.style.height = "48px";
+        previewCard.style.minHeight = "48px";
+        previewCard.style.padding = "12px 8px";
+        previewCard.style.alignItems = "center";
+        previewCard.style.boxSizing = "border-box";
+        previewCard.style.overflow = "hidden";
         previewCard.style.opacity = "1";
         previewCard.style.backgroundColor = previewBackgroundColor;
         previewCard.style.borderStyle = "solid";
@@ -747,20 +772,15 @@ export function createProjectSubjectsEvents(config) {
         previewCard.style.borderColor = previewBorderColor;
         previewCard.style.borderRadius = previewBorderRadius;
         previewCard.style.boxShadow = "0 14px 36px rgba(1,4,9,.55), 0 0 0 1px rgba(1,4,9,.35)";
-        const leftSpacer = document.createElement("div");
-        leftSpacer.className = "cell cell-subissue-drag-handle";
-        leftSpacer.setAttribute("aria-hidden", "true");
-        const middleSpacer = document.createElement("div");
-        middleSpacer.className = "cell cell-subissue-drag-spacer";
-        middleSpacer.setAttribute("aria-hidden", "true");
-        const contentCell = document.createElement("div");
-        contentCell.className = "cell cell-theme cell-theme--full lvl0";
-        if (previewIssueIcon) contentCell.appendChild(previewIssueIcon.cloneNode(true));
-        const titleSpan = document.createElement("span");
-        titleSpan.className = "theme-text theme-text--pb";
-        titleSpan.textContent = previewTitle;
-        contentCell.appendChild(titleSpan);
-        previewCard.append(leftSpacer, middleSpacer, contentCell);
+        previewRowClone.classList.remove("is-subissue-dragging", "is-subissue-drag-gap", "is-subissue-drop-before", "is-subissue-drop-after");
+        previewRowClone.removeAttribute("draggable");
+        previewRowClone.querySelectorAll("button").forEach((button) => {
+          button.tabIndex = -1;
+          button.setAttribute("aria-hidden", "true");
+        });
+        Array.from(previewRowClone.children).forEach((child) => {
+          previewCard.appendChild(child.cloneNode(true));
+        });
         const previewPaintRect = previewCard.getBoundingClientRect();
 
         debugSubissuesDnd("dragstart-preview", {
@@ -917,9 +937,13 @@ export function createProjectSubjectsEvents(config) {
             event.preventDefault();
             return;
           }
-          if (subissuesExpandedSet.has(childSubjectId)) {
-            subissuesExpandedSet.delete(childSubjectId);
-          }
+          const container = row.parentElement;
+          const expandedSnapshot = collapseSubissueTreeForDrag(container);
+          draggedSubissueContext = {
+            childSubjectId,
+            expandedSnapshot,
+            dropCommitted: false
+          };
           const uiState = getSubjectsViewState();
           uiState.rightSubissueMenuOpenId = "";
           event.dataTransfer?.setData("text/plain", childSubjectId);
@@ -950,13 +974,13 @@ export function createProjectSubjectsEvents(config) {
               if (previewRoot) previewRoot.classList.add("is-active");
               dragPreviewNode.getBoundingClientRect();
             }
-            const dragImageNode = canvasDragPreview || dragPreviewNode || row;
+            const dragImageNode = dragPreviewNode || canvasDragPreview || row;
             event.dataTransfer.setDragImage(dragImageNode, offsetX, offsetY);
             debugSubissuesDnd("dragstart-setDragImage", {
               offsetX,
               offsetY,
               hasNativePreview: !!dragPreviewNode,
-              dragImageKind: canvasDragPreview ? "canvas" : (dragPreviewNode ? "dom" : "row"),
+              dragImageKind: dragPreviewNode ? "dom" : (canvasDragPreview ? "canvas" : "row"),
               usesVisibleDomPreviewHost: !canvasDragPreview && !!dragPreviewNode
             });
           }
@@ -1034,12 +1058,31 @@ export function createProjectSubjectsEvents(config) {
             .map((item) => String(item.dataset.childSubjectId || ""))
             .filter(Boolean);
           debugSubissuesDnd("drop-reorder", { parentSubjectId, sourceId, targetId, orderedChildIds });
+          restoreExpandedSubissueTreeAfterDrag(draggedSubissueContext?.expandedSnapshot || []);
           await reorderSubjectChildren(parentSubjectId, orderedChildIds, { root, skipRerender: false });
+          if (draggedSubissueContext) draggedSubissueContext.dropCommitted = true;
+          draggedSubissueContext = null;
           clearDragClasses();
           clearDragPreview();
         });
 
-        row.addEventListener("dragend", () => {
+        row.addEventListener("dragend", async () => {
+          const dndContext = draggedSubissueContext;
+          const shouldCommitOrderOnDragEnd = dndContext && !dndContext.dropCommitted;
+          restoreExpandedSubissueTreeAfterDrag(dndContext?.expandedSnapshot || []);
+          if (shouldCommitOrderOnDragEnd) {
+            const container = row.parentElement;
+            const parentSubjectId = String(row.dataset.parentSubjectId || "");
+            const orderedChildIds = Array.from(container?.querySelectorAll?.("[data-subissue-sortable-row='true']") || [])
+              .map((item) => String(item.dataset.childSubjectId || ""))
+              .filter(Boolean);
+            if (parentSubjectId && orderedChildIds.length && typeof reorderSubjectChildren === "function") {
+              await reorderSubjectChildren(parentSubjectId, orderedChildIds, { root, skipRerender: false });
+            } else {
+              rerenderPanels();
+            }
+          }
+          draggedSubissueContext = null;
           clearDragClasses();
           clearDragPreview();
           row.dataset.subissueDragFromHandle = "false";


### PR DESCRIPTION
### Motivation

- Improve the subissue drag-and-drop UX by hiding nested rows during dragging to simplify reordering and by restoring the previous expanded state afterwards.
- Ensure reordering is persisted even when a `dragend` happens without an explicit `drop` event to avoid lost changes.
- Replace the ad-hoc native drag preview DOM build with a cloned-row preview that preserves visual fidelity and accessibility attributes.

### Description

- Added `collapseSubissueTreeForDrag` and `restoreExpandedSubissueTreeAfterDrag` helpers and a `draggedSubissueContext` to snapshot and restore `subissuesExpandedSet` during DnD. 
- On `dragstart` the code now collapses the subissue tree and stores an `expandedSnapshot`, and on `drop` or `dragend` the snapshot is restored and `dropCommitted` is tracked. 
- On `dragend` the code will persist the new order by calling `reorderSubjectChildren` when no explicit `drop` was committed, otherwise it rerenders panels as fallback. 
- Reworked native drag preview creation to clone the dragged row (`row.cloneNode(true)`), strip interactive attributes, set consistent sizing and overflow styles, and adjust the `dragImage` selection and metadata for debug logging. 
- Minor adjustments to preview styling and accessibility such as setting `button.tabIndex = -1` and `aria-hidden` on cloned controls.

### Testing

- Updated and added unit tests in `project-subjects-events-subissues-dnd.test.mjs` to reflect the new preview structure and the collapse/restore and dragend-persist behaviors. 
- Ran the JavaScript unit test suite with `npm test` and the updated DnD tests completed successfully. 
- Existing DnD-related assertions were updated to match the new DOM preview and reorder persistence logic and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c0a445ac8329932eb27aff45f0b3)