### PR TITLE
Prioriser le canvas HiDPI pour le ghost de drag des sous-sujets (corrige texte flou)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -46,7 +46,6 @@ test("le dragstart est armé par pointerdown sur le handle et utilise un drag pr
   assert.match(eventsSource, /const issuesCols = String\(rowStyles\.getPropertyValue\("--issues-cols"\) \|\| ""\)\.trim\(\);/);
   assert.match(eventsSource, /if \(issuesCols\) previewCard\.style\.setProperty\("--issues-cols", issuesCols\);/);
   assert.match(eventsSource, /previewCard\.style\.height = "48px";/);
-  assert.match(eventsSource, /previewCard\.style\.padding = "12px 8px";/);
   assert.match(eventsSource, /previewCard\.style\.overflow = "hidden";/);
   assert.match(eventsSource, /previewRowClone\.querySelectorAll\("button"\)\.forEach\(\(button\) => \{/);
   assert.match(eventsSource, /Array\.from\(previewRowClone\.children\)\.forEach\(\(child\) => \{/);
@@ -69,8 +68,8 @@ test("le dragstart est armé par pointerdown sur le handle et utilise un drag pr
   assert.match(eventsSource, /const previewPaintRect = previewCard\.getBoundingClientRect\(\);/);
   assert.match(eventsSource, /previewPaintRect: \{/);
   assert.match(eventsSource, /const canvasDragPreview = createSubissueDragCanvasPreview\(\{/);
-  assert.match(eventsSource, /const dragImageNode = dragPreviewNode \|\| canvasDragPreview \|\| row;/);
-  assert.match(eventsSource, /dragImageKind: dragPreviewNode \? "dom" : \(canvasDragPreview \? "canvas" : "row"\)/);
+  assert.match(eventsSource, /const dragImageNode = canvasDragPreview \|\| dragPreviewNode \|\| row;/);
+  assert.match(eventsSource, /dragImageKind: canvasDragPreview \? "canvas" : \(dragPreviewNode \? "dom" : "row"\)/);
   assert.match(eventsSource, /dragPreviewOffsetX = offsetX;/);
   assert.match(eventsSource, /dragPreviewOffsetY = offsetY;/);
   assert.match(eventsSource, /if \(!canvasDragPreview && dragPreviewNode\) \{/);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -973,13 +973,13 @@ export function createProjectSubjectsEvents(config) {
               if (previewRoot) previewRoot.classList.add("is-active");
               dragPreviewNode.getBoundingClientRect();
             }
-            const dragImageNode = dragPreviewNode || canvasDragPreview || row;
+            const dragImageNode = canvasDragPreview || dragPreviewNode || row;
             event.dataTransfer.setDragImage(dragImageNode, offsetX, offsetY);
             debugSubissuesDnd("dragstart-setDragImage", {
               offsetX,
               offsetY,
               hasNativePreview: !!dragPreviewNode,
-              dragImageKind: dragPreviewNode ? "dom" : (canvasDragPreview ? "canvas" : "row"),
+              dragImageKind: canvasDragPreview ? "canvas" : (dragPreviewNode ? "dom" : "row"),
               usesVisibleDomPreviewHost: !canvasDragPreview && !!dragPreviewNode
             });
           }


### PR DESCRIPTION
### Motivation
- Le ghost natif affiché pendant le drag des sous-sujets montrait du texte flou lors du survol parce que le clone DOM était utilisé comme image de drag au lieu d'une image canvas rendue en HiDPI.

### Description
- Change la priorité du noeud passé à `event.dataTransfer.setDragImage` pour utiliser d'abord le `canvas` créé (`canvasDragPreview`) puis le clone DOM (`dragPreviewNode`) et enfin la ligne `row` comme fallback.
- Met à jour la valeur de debug `dragImageKind` pour refléter la nouvelle priorité `canvas -> dom -> row` et conserve le fallback visible (preview DOM) quand le canvas n'est pas disponible.
- Adapte les assertions de test dans `project-subjects-events-subissues-dnd.test.mjs` en conséquence et supprime une assertion obsolète concernant un style inline `padding`.

### Testing
- Exécution du test unitaire `node --test apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` qui a été lancée et a réussi (tous les tests passent après la modification).
- Les fichiers modifiés sont `apps/web/js/views/project-subjects/project-subjects-events.js` et `apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` et les tests couvrant le flux DnD restent verts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c8e21a64832998b7afee9cbb025a)