### PR TITLE
Comptage direct des sous-sujets et méta inline dans la liste de sous-sujets

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -24,26 +24,15 @@ function getSubjectChildrenCounts(sujet, getChildSubjects, getEffectiveSujetStat
     return { total: 0, closed: 0, open: 0 };
   }
 
-  const visited = new Set([rootSubjectId]);
-  const stack = [...getChildSubjects(rootSubjectId)];
-  let total = 0;
-  let closed = 0;
-
-  while (stack.length) {
-    const childSubject = stack.shift();
-    const childSubjectId = String(childSubject?.id || "");
-    if (!childSubjectId || visited.has(childSubjectId)) continue;
-    visited.add(childSubjectId);
-    total += 1;
-
-    const childStatus = String(getEffectiveSujetStatus(childSubjectId) || childSubject?.status || "open").toLowerCase();
-    if (childStatus !== "open") closed += 1;
-
-    const nestedChildren = getChildSubjects(childSubjectId);
-    if (Array.isArray(nestedChildren) && nestedChildren.length) {
-      stack.push(...nestedChildren);
-    }
-  }
+  const directChildren = Array.isArray(getChildSubjects(rootSubjectId)) ? getChildSubjects(rootSubjectId) : [];
+  const total = directChildren.length;
+  const closed = directChildren
+    .filter((childSubject) => {
+      const childSubjectId = String(childSubject?.id || "");
+      const childStatus = String(getEffectiveSujetStatus(childSubjectId) || childSubject?.status || "open").toLowerCase();
+      return childStatus !== "open";
+    })
+    .length;
 
   return {
     total,
@@ -58,7 +47,7 @@ function renderSubjectChildrenCounterHtml(sujet, deps) {
   return `
     <span class="subissues-counts subissues-counts--problems issue-row-subject-children-counter" aria-label="${counts.open} sous-sujets ouverts, ${counts.closed} fermés, ${counts.total} au total">
       ${renderProblemsCountsIconHtml(counts.closed, counts.total)}
-      <span>${counts.closed} / ${counts.total}</span>
+      <span>${counts.open} / ${counts.total}</span>
     </span>
   `;
 }

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -776,6 +776,26 @@ function subissuesHeadCountsHtml(subjects = []) {
   return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} sur ${totalSubjects}</span></div>`;
 }
 
+function renderSubissueInlineMetaHtml(subjectNode, childSubjects = []) {
+  const subjectId = String(subjectNode?.id || "");
+  if (!subjectId) return "";
+  const displayRef = getEntityDisplayRef("sujet", subjectId);
+  const hasChildren = Array.isArray(childSubjects) && childSubjects.length > 0;
+  const openChildren = hasChildren
+    ? childSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length
+    : 0;
+  const closedChildren = hasChildren ? Math.max(0, childSubjects.length - openChildren) : 0;
+  const childrenCounterHtml = hasChildren
+    ? `<span class="subissues-counts subissues-counts--problems subissue-inline-children-counter" aria-label="${escapeHtml(`${openChildren} sous-sujets ouverts, ${closedChildren} fermés, ${childSubjects.length} au total`)}">${problemsCountsIconHtml(closedChildren, childSubjects.length)}<span>${openChildren} / ${childSubjects.length}</span></span>`
+    : "";
+  return `
+    <span class="subissue-inline-meta mono-small">
+      <span class="subissue-inline-ref">${escapeHtml(displayRef)}</span>
+      ${childrenCounterHtml}
+    </span>
+  `;
+}
+
 /* =========================================================
    Table render
 ========================================================= */
@@ -1858,6 +1878,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
           <div class="cell cell-theme cell-theme--full">
             ${issueIcon(getEffectiveSujetStatus(subjectId))}
             <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>
+            ${renderSubissueInlineMetaHtml(subjectNode, nestedChildren)}
           </div>
           <div class="cell cell-subissue-assignees-value">
             ${renderSubissueAssigneesCellHtml(subjectId)}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2921,6 +2921,22 @@ body.is-resizing{
 
 
 .subissues-inline-count{margin-left:8px;color:var(--muted);font-size:12px;}
+.subissue-inline-meta{
+  margin-left:8px;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--muted);
+}
+.subissue-inline-ref{white-space:nowrap;}
+.subissue-inline-children-counter{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.subissue-inline-children-counter > span:last-child{
+  white-space:nowrap;
+}
 
 
 /* Sub-issues head: verdict counters (bar + legend) */


### PR DESCRIPTION
### Motivation
- Remettre à jour le système de comptage mutualisé des sous-sujets pour respecter la règle métier: ne compter que les enfants directs et afficher le ratio `ouverts / total`.
- Afficher dans la vue de détail des sous-sujets le `#numéro` de sujet et, pour les sujets parents, un compteur de sous-sujets directs en ligne.

### Description
- Modifie `getSubjectChildrenCounts` pour ne parcourir que les enfants directs au lieu d’une traversée récursive des descendants (fichier `apps/web/js/views/project-subjects/project-subjects-table.js`).
- Aligne le rendu du compteur mutualisé dans le tableau principal pour afficher `ouverts / total` (fichier `apps/web/js/views/project-subjects/project-subjects-table.js`).
- Ajoute `renderSubissueInlineMetaHtml` et intègre son rendu dans les lignes de sous-sujets pour afficher le `#numéro` (référence) et, si applicable, un compteur direct `ouverts / total` (fichier `apps/web/js/views/project-subjects/project-subjects-view.js`).
- Ajoute des règles CSS pour positionner et styler la méta inline et le compteur (`apps/web/style.css`).

### Testing
- Exécuté `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` which passed.
- Exécuté `node --test apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cb00d5088329b8d2a573952bed20)