### PR TITLE
Show closed child counts inline and count only direct children for subissue counters

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -24,26 +24,15 @@ function getSubjectChildrenCounts(sujet, getChildSubjects, getEffectiveSujetStat
     return { total: 0, closed: 0, open: 0 };
   }
 
-  const visited = new Set([rootSubjectId]);
-  const stack = [...getChildSubjects(rootSubjectId)];
-  let total = 0;
-  let closed = 0;
-
-  while (stack.length) {
-    const childSubject = stack.shift();
-    const childSubjectId = String(childSubject?.id || "");
-    if (!childSubjectId || visited.has(childSubjectId)) continue;
-    visited.add(childSubjectId);
-    total += 1;
-
-    const childStatus = String(getEffectiveSujetStatus(childSubjectId) || childSubject?.status || "open").toLowerCase();
-    if (childStatus !== "open") closed += 1;
-
-    const nestedChildren = getChildSubjects(childSubjectId);
-    if (Array.isArray(nestedChildren) && nestedChildren.length) {
-      stack.push(...nestedChildren);
-    }
-  }
+  const directChildren = Array.isArray(getChildSubjects(rootSubjectId)) ? getChildSubjects(rootSubjectId) : [];
+  const total = directChildren.length;
+  const closed = directChildren
+    .filter((childSubject) => {
+      const childSubjectId = String(childSubject?.id || "");
+      const childStatus = String(getEffectiveSujetStatus(childSubjectId) || childSubject?.status || "open").toLowerCase();
+      return childStatus !== "open";
+    })
+    .length;
 
   return {
     total,

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -764,7 +764,7 @@ function problemsCountsHtml(item, options = {}) {
   const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
   const closedSubjects = Math.max(0, totalSubjects - openSubjects);
   const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
-  return `<div class="subissues-counts subissues-counts--problems" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} / ${totalSubjects}</span></div>`;
+  return `<div class="subissues-counts subissues-counts--problems" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} / ${totalSubjects}</span></div>`;
 }
 
 function subissuesHeadCountsHtml(subjects = []) {
@@ -773,7 +773,27 @@ function subissuesHeadCountsHtml(subjects = []) {
   const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
   const closedSubjects = Math.max(0, totalSubjects - openSubjects);
   const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
-  return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${openSubjects} sur ${totalSubjects}</span></div>`;
+  return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} sur ${totalSubjects}</span></div>`;
+}
+
+function renderSubissueInlineMetaHtml(subjectNode, childSubjects = []) {
+  const subjectId = String(subjectNode?.id || "");
+  if (!subjectId) return "";
+  const displayRef = getEntityDisplayRef("sujet", subjectId);
+  const hasChildren = Array.isArray(childSubjects) && childSubjects.length > 0;
+  const openChildren = hasChildren
+    ? childSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length
+    : 0;
+  const closedChildren = hasChildren ? Math.max(0, childSubjects.length - openChildren) : 0;
+  const childrenCounterHtml = hasChildren
+    ? `<span class="subissues-counts subissues-counts--problems subissue-inline-children-counter" aria-label="${escapeHtml(`${openChildren} sous-sujets ouverts, ${closedChildren} fermés, ${childSubjects.length} au total`)}">${problemsCountsIconHtml(closedChildren, childSubjects.length)}<span>${closedChildren} / ${childSubjects.length}</span></span>`
+    : "";
+  return `
+    <span class="subissue-inline-meta mono-small">
+      <span class="subissue-inline-ref">${escapeHtml(displayRef)}</span>
+      ${childrenCounterHtml}
+    </span>
+  `;
 }
 
 /* =========================================================
@@ -1858,6 +1878,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
           <div class="cell cell-theme cell-theme--full">
             ${issueIcon(getEffectiveSujetStatus(subjectId))}
             <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>
+            ${renderSubissueInlineMetaHtml(subjectNode, nestedChildren)}
           </div>
           <div class="cell cell-subissue-assignees-value">
             ${renderSubissueAssigneesCellHtml(subjectId)}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2921,6 +2921,22 @@ body.is-resizing{
 
 
 .subissues-inline-count{margin-left:8px;color:var(--muted);font-size:12px;}
+.subissue-inline-meta{
+  margin-left:8px;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  color:var(--muted);
+}
+.subissue-inline-ref{white-space:nowrap;}
+.subissue-inline-children-counter{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.subissue-inline-children-counter > span:last-child{
+  white-space:nowrap;
+}
 
 
 /* Sub-issues head: verdict counters (bar + legend) */


### PR DESCRIPTION
### Motivation
- Simplify subissue counters to reflect only direct children instead of walking the full nested tree, for clearer and cheaper counts.
- Surface a compact inline meta next to subissue titles that shows the entity reference and closed/total child counts.
- Keep visual styling consistent by adding CSS for the new inline meta elements.

### Description
- Replace the previous tree-walking implementation in `getSubjectChildrenCounts` with a direct-children-only count using `getChildSubjects(rootSubjectId)` and compute `total`, `closed`, and `open` from that list.
- Update rendered counters to display closed counts in place of previously shown open counts in `problemsCountsHtml` and `subissuesHeadCountsHtml` in `project-subjects-view.js`.
- Add `renderSubissueInlineMetaHtml(subjectNode, childSubjects)` and include it in the subissue row rendering so each subissue shows its display reference and a compact closed/total child counter inline.
- Add CSS rules in `style.css` for `.subissue-inline-meta`, `.subissue-inline-ref`, and `.subissue-inline-children-counter` to style the new inline metadata.

### Testing
- Ran the project test suite with `yarn test` and the linter with `yarn lint`; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cb00d5088329b8d2a573952bed20)