### PR TITLE
Corrige compteurs sous‑sujets (fermés/total) et ajoute des tests

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-counters.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-counters.test.mjs
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderFlatSujetRow } from "./project-subjects-table.js";
+import { renderProblemsCountsIconHtml } from "../ui/subissues-counts.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test("renderFlatSujetRow affiche fermé/total pour les enfants directs", () => {
+  const subject = { id: "parent", title: "Sujet parent", status: "open" };
+  const childrenById = {
+    parent: [
+      { id: "child-open", status: "open" },
+      { id: "child-closed", status: "closed" }
+    ],
+    "child-open": [{ id: "grand-child-closed", status: "closed" }]
+  };
+
+  const html = renderFlatSujetRow(subject, "sit-1", {
+    deps: {
+      escapeHtml: (value) => String(value ?? ""),
+      svgIcon: () => "",
+      issueIcon: () => "",
+      getEffectiveSujetStatus: (id) => {
+        if (id === "child-closed") return "closed";
+        return "open";
+      },
+      getEntityReviewMeta: () => ({ review_state: "", is_seen: true }),
+      getReviewTitleStateClass: () => "",
+      getEntityDisplayRef: () => "S-1",
+      getEntityDescriptionState: () => ({ author: "System" }),
+      formatRelativeTimeLabel: () => "opened now",
+      getEntityListTimestamp: () => Date.now(),
+      getSubjectSidebarMeta: () => ({ labels: [], objectiveIds: [] }),
+      getSubjectLabelDefinition: () => null,
+      renderSubjectLabelBadge: () => "",
+      getObjectiveById: () => null,
+      getChildSubjects: (id) => childrenById[id] || [],
+      firstNonEmpty: (...values) => values.find((value) => value !== undefined && value !== null && value !== "") || "",
+      store: { user: null, projectForm: { collaborators: [] } }
+    }
+  });
+
+  assert.match(html, />1 \/ 2<\//);
+  assert.doesNotMatch(html, />2 \/ 3<\//);
+});
+
+test("subissues-counts utilise bien le ratio fermé/total pour le ring", () => {
+  const complete = renderProblemsCountsIconHtml(2, 2);
+  const partial = renderProblemsCountsIconHtml(1, 2);
+
+  assert.match(complete, /subissues-problems-icon--complete/);
+  assert.doesNotMatch(partial, /subissues-problems-icon--complete/);
+  assert.match(partial, /stroke-dasharray="50 100"/);
+});
+
+test("project-subjects-view garde un seul rendu inline cohérent en fermé/total", () => {
+  const viewPath = path.resolve(__dirname, "./project-subjects-view.js");
+  const source = fs.readFileSync(viewPath, "utf8");
+
+  const declarations = source.match(/function renderSubissueInlineMetaHtml\(/g) ?? [];
+  assert.equal(declarations.length, 1);
+  assert.doesNotMatch(source, /\$\{openChildren\} \/ \$\{childSubjects\.length\}/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -47,7 +47,7 @@ function renderSubjectChildrenCounterHtml(sujet, deps) {
   return `
     <span class="subissues-counts subissues-counts--problems issue-row-subject-children-counter" aria-label="${counts.open} sous-sujets ouverts, ${counts.closed} fermés, ${counts.total} au total">
       ${renderProblemsCountsIconHtml(counts.closed, counts.total)}
-      <span>${counts.open} / ${counts.total}</span>
+      <span>${counts.closed} / ${counts.total}</span>
     </span>
   `;
 }

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -773,7 +773,7 @@ function subissuesHeadCountsHtml(subjects = []) {
   const openSubjects = linkedSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length;
   const closedSubjects = Math.max(0, totalSubjects - openSubjects);
   const ariaLabel = `${openSubjects} sous-sujets ouverts, ${closedSubjects} fermés, ${totalSubjects} au total`;
-  return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} sur ${totalSubjects}</span></div>`;
+  return `<div class="subissues-counts subissues-counts--problems subissues-counts--head" aria-label="${escapeHtml(ariaLabel)}">${problemsCountsIconHtml(closedSubjects, totalSubjects)}<span>${closedSubjects} / ${totalSubjects}</span></div>`;
 }
 
 function renderSubissueInlineMetaHtml(subjectNode, childSubjects = []) {
@@ -787,26 +787,6 @@ function renderSubissueInlineMetaHtml(subjectNode, childSubjects = []) {
   const closedChildren = hasChildren ? Math.max(0, childSubjects.length - openChildren) : 0;
   const childrenCounterHtml = hasChildren
     ? `<span class="subissues-counts subissues-counts--problems subissue-inline-children-counter" aria-label="${escapeHtml(`${openChildren} sous-sujets ouverts, ${closedChildren} fermés, ${childSubjects.length} au total`)}">${problemsCountsIconHtml(closedChildren, childSubjects.length)}<span>${closedChildren} / ${childSubjects.length}</span></span>`
-    : "";
-  return `
-    <span class="subissue-inline-meta mono-small">
-      <span class="subissue-inline-ref">${escapeHtml(displayRef)}</span>
-      ${childrenCounterHtml}
-    </span>
-  `;
-}
-
-function renderSubissueInlineMetaHtml(subjectNode, childSubjects = []) {
-  const subjectId = String(subjectNode?.id || "");
-  if (!subjectId) return "";
-  const displayRef = getEntityDisplayRef("sujet", subjectId);
-  const hasChildren = Array.isArray(childSubjects) && childSubjects.length > 0;
-  const openChildren = hasChildren
-    ? childSubjects.filter((subject) => String(getEffectiveSujetStatus(subject?.id) || "open").toLowerCase() === "open").length
-    : 0;
-  const closedChildren = hasChildren ? Math.max(0, childSubjects.length - openChildren) : 0;
-  const childrenCounterHtml = hasChildren
-    ? `<span class="subissues-counts subissues-counts--problems subissue-inline-children-counter" aria-label="${escapeHtml(`${openChildren} sous-sujets ouverts, ${closedChildren} fermés, ${childSubjects.length} au total`)}">${problemsCountsIconHtml(closedChildren, childSubjects.length)}<span>${openChildren} / ${childSubjects.length}</span></span>`
     : "";
   return `
     <span class="subissue-inline-meta mono-small">


### PR DESCRIPTION
### Motivation
- Homogénéiser l’affichage et la logique des compteurs de sous‑sujets pour que tous les éléments (tableau principal, head détaillé, inline, anneau) montrent le même ratio et décrivent uniquement les enfants directs.
- Éviter les incohérences textuelles (`ouverts / total` vs `fermés / total`, `sur` vs `/`) et supprimer le code dupliqué qui réintroduisait un format erroné.
- Verrouiller le comportement par des tests automatiques pour prévenir les régressions futures.

### Description
- L’affichage du compteur dans la ligne principale des sujets (`renderSubjectChildrenCounterHtml` dans `project-subjects-table.js`) affiche maintenant `closed / total` au lieu de `open / total` et utilise bien les enfants directs fournis par `getChildSubjects`.
- Le compteur du head de la table des sous‑sujets (`subissuesHeadCountsHtml` dans `project-subjects-view.js`) utilise `closed / total` (remplacement de `X sur Y` → `X / Y`) pour uniformiser le format.
- Suppression d’une implémentation dupliquée et incorrecte de `renderSubissueInlineMetaHtml` dans `project-subjects-view.js` pour ne conserver qu’une version cohérente qui affiche `closed / total`.
- Aucune modification de schéma ou migration Supabase n’a été effectuée car la correction concerne uniquement le rendu UI et la logique côté client.
- Ajout d’un nouveau fichier de tests `apps/web/js/views/project-subjects/project-subjects-counters.test.mjs` qui couvre le rendu `closed / total` pour la table principale, la cohérence du ring (ratio) et l’absence de formatage `open / total` dans les renderers inline.

### Testing
- Tests unitaires exécutés via : `node --test apps/web/js/views/project-subjects/project-subjects-counters.test.mjs apps/web/js/views/project-subjects/project-subjects-imports.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs apps/web/js/services/subject-assignees-service.test.mjs`.
- Résultat : tous les tests exécutés sont passés (`# pass 25`, `# fail 0`).
- Vérification rapide du tree : les fichiers modifiés et le nouveau test ont été ajoutés et commités (working tree propre après commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cf5b87a883298f085fe8c17707cd)