### PR TITLE
Limit parent-subject click handler to parent card to fix drilldown navigation

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -129,6 +129,11 @@ test("le dragend persiste l'ordre même sans drop explicite", () => {
   assert.match(eventsSource, /await reorderSubjectChildren\(parentSubjectId, orderedChildIds, \{ root, skipRerender: false \}\);/);
 });
 
+test("la navigation vers le sujet parent ne capte que la carte parent dédiée", () => {
+  assert.match(eventsSource, /\.subject-meta-parent-card\[data-parent-subject-id\]/);
+  assert.doesNotMatch(eventsSource, /event\.target\.closest\("\[data-parent-subject-id\]"\)/);
+});
+
 test("l'instrumentation DnD est activable via query/localStorage", () => {
   assert.match(eventsSource, /function isSubissuesDndDebugEnabled\(\)/);
   assert.match(eventsSource, /debugSubissuesDnd=1/);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1117,7 +1117,7 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
-    root.querySelectorAll("[data-parent-subject-id]").forEach((card) => {
+    root.querySelectorAll(".subject-meta-parent-card[data-parent-subject-id]").forEach((card) => {
       card.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -1621,7 +1621,7 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
 
-      const parentSubjectCard = event.target.closest("[data-parent-subject-id]");
+      const parentSubjectCard = event.target.closest(".subject-meta-parent-card[data-parent-subject-id]");
       if (parentSubjectCard) {
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
### Motivation
- A click handler collision made clicks on sub-subject rows (which carry `data-parent-subject-id` for DnD) be interpreted as clicks on the parent card, preventing the drilldown from following the clicked sub-subject.

### Description
- Restrict delegated and direct parent-card click bindings to the specific selector `.subject-meta-parent-card[data-parent-subject-id]` instead of the generic `[data-parent-subject-id]` in `apps/web/js/views/project-subjects/project-subjects-events.js` to avoid capturing subissue rows used for DnD.
- Add a regression assertion in `apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` that ensures the code no longer uses the generic `[data-parent-subject-id]` selection for navigation.

### Testing
- Ran the focused node tests with `node --test apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs`, and all tests passed (`16/16` successful).
- The new regression check verifies the selector change and the drilldown-related tests still succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d29d38288329adfc21f0f3759f76)