### PR TITLE
Scope right-side subissues UI state to drilldown, pass subissue options to renders, and fix parent-card click targeting

### DIFF
--- a/apps/web/js/views/project-subjects/project-subject-detail.js
+++ b/apps/web/js/views/project-subjects/project-subject-detail.js
@@ -47,6 +47,14 @@ export function createProjectSubjectDetailController(config) {
       || store.projectSubjectsView?.expandedSubjectIds
       || store.situationsView?.rightExpandedSujets
       || new Set();
+    const expandedSubissueSubjectIds = store.projectSubjectsView?.rightSubissuesExpandedSubjectIds
+      || store.situationsView?.rightSubissuesExpandedSubjectIds
+      || new Set();
+    const openSubissueMenuId = String(
+      store.projectSubjectsView?.rightSubissueMenuOpenId
+      || store.situationsView?.rightSubissueMenuOpenId
+      || ""
+    );
 
     const bodyScrollState = getScrollableElementScrollState(body);
     const details = renderDetailsHtml(null, {
@@ -54,7 +62,9 @@ export function createProjectSubjectDetailController(config) {
         sujetRowClass: "js-modal-drilldown-sujet",
         sujetToggleClass: "js-modal-toggle-sujet",
         expandedSujets: expandedSubjectIds,
-        expandedSubjectIds
+        expandedSubjectIds: expandedSubissueSubjectIds,
+        openMenuId: openSubissueMenuId,
+        isOpen: (store.projectSubjectsView?.rightSubissuesOpen ?? store.situationsView?.rightSubissuesOpen ?? true) !== false
       }
     });
 

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -135,10 +135,15 @@ export function createProjectSubjectDrilldownController(config) {
     if (!panel || !title || !body || !shell) return;
 
     const shellScrollState = getScrollableElementScrollState(shell);
-    const expandedSubjectIds = store.projectSubjectsView?.drilldown?.expandedSubjectIds
-      || store.situationsView?.drilldown?.expandedSubjectIds
+    const drilldownState = store.projectSubjectsView?.drilldown
+      || store.situationsView?.drilldown
+      || {};
+    const expandedSubjectIds = drilldownState.expandedSubjectIds
       || store.situationsView?.drilldown?.expandedSujets
       || new Set();
+    const expandedSubissueSubjectIds = drilldownState.rightSubissuesExpandedSubjectIds || new Set();
+    const subissuesOpen = drilldownState.rightSubissuesOpen !== false;
+    const openSubissueMenuId = String(drilldownState.rightSubissueMenuOpenId || "");
 
     const selection = getDrilldownSelection();
     const details = renderDetailsHtml(selection, {
@@ -146,7 +151,9 @@ export function createProjectSubjectDrilldownController(config) {
         sujetRowClass: "js-drilldown-select-sujet",
         sujetToggleClass: "js-drilldown-toggle-sujet",
         expandedSujets: expandedSubjectIds,
-        expandedSubjectIds
+        expandedSubjectIds: expandedSubissueSubjectIds,
+        openMenuId: openSubissueMenuId,
+        isOpen: subissuesOpen
       }
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs
@@ -129,6 +129,17 @@ test("le dragend persiste l'ordre même sans drop explicite", () => {
   assert.match(eventsSource, /await reorderSubjectChildren\(parentSubjectId, orderedChildIds, \{ root, skipRerender: false \}\);/);
 });
 
+test("la navigation vers le sujet parent ne capte que la carte parent dédiée", () => {
+  assert.match(eventsSource, /\.subject-meta-parent-card\[data-parent-subject-id\]/);
+  assert.doesNotMatch(eventsSource, /event\.target\.closest\("\[data-parent-subject-id\]"\)/);
+});
+
+test("les toggles de sous-sujets utilisent l'état du scope drilldown quand présent", () => {
+  assert.match(eventsSource, /const isDrilldownScope = !!root\.closest\?\.\("#drilldownPanel"\);/);
+  assert.match(eventsSource, /const scopedUiState = \(\(\) => \{/);
+  assert.match(eventsSource, /if \(isDrilldownScope\) \{\s*updateDrilldownPanel\(\);\s*\}\s*else \{\s*rerenderPanels\(\);\s*\}/);
+});
+
 test("l'instrumentation DnD est activable via query/localStorage", () => {
   assert.match(eventsSource, /function isSubissuesDndDebugEnabled\(\)/);
   assert.match(eventsSource, /debugSubissuesDnd=1/);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -611,22 +611,43 @@ export function createProjectSubjectsEvents(config) {
       });
     }
 
+    const isDrilldownScope = !!root.closest?.("#drilldownPanel");
+    const scopedUiState = (() => {
+      const uiState = getSubjectsViewState();
+      if (!isDrilldownScope) return uiState;
+      if (!uiState.drilldown || typeof uiState.drilldown !== "object") {
+        uiState.drilldown = {};
+      }
+      return uiState.drilldown;
+    })();
+
+    if (typeof scopedUiState.rightSubissuesOpen !== "boolean") scopedUiState.rightSubissuesOpen = true;
+    if (!(scopedUiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
+      scopedUiState.rightSubissuesExpandedSubjectIds = new Set(
+        Array.isArray(scopedUiState.rightSubissuesExpandedSubjectIds)
+          ? scopedUiState.rightSubissuesExpandedSubjectIds
+          : []
+      );
+    }
+    if (typeof scopedUiState.rightSubissueMenuOpenId !== "string") scopedUiState.rightSubissueMenuOpenId = "";
+
+    const rerenderDetailsScope = () => {
+      if (isDrilldownScope) {
+        updateDrilldownPanel();
+      } else {
+        rerenderPanels();
+      }
+    };
+
     root.querySelectorAll("[data-action='toggle-subissues']").forEach((btn) => {
       btn.onclick = () => {
-        store.situationsView.rightSubissuesOpen = !store.situationsView.rightSubissuesOpen;
-        rerenderPanels();
+        scopedUiState.rightSubissuesOpen = !scopedUiState.rightSubissuesOpen;
+        rerenderDetailsScope();
       };
     });
 
     const setSubjectParent = getSetSubjectParent?.();
-    const subissuesExpandedSet = (() => {
-      const uiState = getSubjectsViewState();
-      if (!(uiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
-        uiState.rightSubissuesExpandedSubjectIds = new Set(Array.isArray(uiState.rightSubissuesExpandedSubjectIds) ? uiState.rightSubissuesExpandedSubjectIds : []);
-      }
-      if (typeof uiState.rightSubissueMenuOpenId !== "string") uiState.rightSubissueMenuOpenId = "";
-      return uiState.rightSubissuesExpandedSubjectIds;
-    })();
+    const subissuesExpandedSet = scopedUiState.rightSubissuesExpandedSubjectIds;
 
     root.querySelectorAll("[data-subissue-tree-toggle]").forEach((btn) => {
       btn.onclick = (event) => {
@@ -636,7 +657,7 @@ export function createProjectSubjectsEvents(config) {
         if (!subjectId) return;
         if (subissuesExpandedSet.has(subjectId)) subissuesExpandedSet.delete(subjectId);
         else subissuesExpandedSet.add(subjectId);
-        rerenderPanels();
+        rerenderDetailsScope();
       };
     });
 
@@ -645,9 +666,8 @@ export function createProjectSubjectsEvents(config) {
         event.preventDefault();
         event.stopPropagation();
         const subjectId = String(btn.dataset.subissueActionsTrigger || "");
-        const uiState = getSubjectsViewState();
-        uiState.rightSubissueMenuOpenId = String(uiState.rightSubissueMenuOpenId || "") === subjectId ? "" : subjectId;
-        rerenderPanels();
+        scopedUiState.rightSubissueMenuOpenId = String(scopedUiState.rightSubissueMenuOpenId || "") === subjectId ? "" : subjectId;
+        rerenderDetailsScope();
       };
     });
 
@@ -658,10 +678,9 @@ export function createProjectSubjectsEvents(config) {
         const subjectId = String(btn.dataset.subissueRemoveParent || "");
         if (!subjectId || typeof setSubjectParent !== "function") return;
         await setSubjectParent(subjectId, "", { root, skipRerender: false });
-        const uiState = getSubjectsViewState();
-        uiState.rightSubissueMenuOpenId = "";
+        scopedUiState.rightSubissueMenuOpenId = "";
         subissuesExpandedSet.delete(subjectId);
-        rerenderPanels();
+        rerenderDetailsScope();
       };
     });
 
@@ -1089,7 +1108,6 @@ export function createProjectSubjectsEvents(config) {
       });
     }
 
-    const isDrilldownScope = !!root.closest?.("#drilldownPanel");
     root.querySelectorAll(".js-sub-right-toggle-sujet, .js-modal-toggle-sujet, .js-drilldown-toggle-sujet").forEach((btn) => {
       btn.onclick = (ev) => {
         ev.stopPropagation();
@@ -1117,7 +1135,7 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
-    root.querySelectorAll("[data-parent-subject-id]").forEach((card) => {
+    root.querySelectorAll(".subject-meta-parent-card[data-parent-subject-id]").forEach((card) => {
       card.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -1621,7 +1639,7 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
 
-      const parentSubjectCard = event.target.closest("[data-parent-subject-id]");
+      const parentSubjectCard = event.target.closest(".subject-meta-parent-card[data-parent-subject-id]");
       if (parentSubjectCard) {
         event.preventDefault();
         event.stopPropagation();

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -74,10 +74,20 @@ export function createProjectSubjectsState({ store }) {
         selectedSituationId: null,
         selectedSujetId: null,
         selectedSubjectId: null,
+        rightSubissuesOpen: true,
+        rightSubissuesExpandedSubjectIds: new Set(),
+        rightSubissueMenuOpenId: "",
         expandedSujets: new Set(),
         expandedSubjectIds: new Set()
       };
     }
+    if (typeof v.drilldown.rightSubissuesOpen !== "boolean") v.drilldown.rightSubissuesOpen = true;
+    if (!(v.drilldown.rightSubissuesExpandedSubjectIds instanceof Set)) {
+      v.drilldown.rightSubissuesExpandedSubjectIds = new Set(
+        Array.isArray(v.drilldown.rightSubissuesExpandedSubjectIds) ? v.drilldown.rightSubissuesExpandedSubjectIds : []
+      );
+    }
+    if (typeof v.drilldown.rightSubissueMenuOpenId !== "string") v.drilldown.rightSubissueMenuOpenId = "";
     if (!(v.drilldown.expandedSubjectIds instanceof Set)) {
       const legacyExpanded = v.drilldown.expandedSujets instanceof Set
         ? Array.from(v.drilldown.expandedSujets)

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1827,14 +1827,18 @@ function renderSubIssuesForSujet(sujet, options = {}) {
   const sujetRowClass = options.sujetRowClass || "js-row-sujet";
   const childSubjects = getChildSubjectList(sujet);
   if (!childSubjects.length) return "";
-  const uiState = getSubjectsViewState();
-  if (!(uiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
-    uiState.rightSubissuesExpandedSubjectIds = new Set(Array.isArray(uiState.rightSubissuesExpandedSubjectIds) ? uiState.rightSubissuesExpandedSubjectIds : []);
-  }
-  if (typeof uiState.rightSubissueMenuOpenId !== "string") uiState.rightSubissueMenuOpenId = "";
-
-  const expandedIds = uiState.rightSubissuesExpandedSubjectIds;
-  const openMenuId = String(uiState.rightSubissueMenuOpenId || "");
+  const expandedIds = options.expandedSubjectIds instanceof Set
+    ? options.expandedSubjectIds
+    : (() => {
+      const uiState = getSubjectsViewState();
+      if (!(uiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
+        uiState.rightSubissuesExpandedSubjectIds = new Set(
+          Array.isArray(uiState.rightSubissuesExpandedSubjectIds) ? uiState.rightSubissuesExpandedSubjectIds : []
+        );
+      }
+      return uiState.rightSubissuesExpandedSubjectIds;
+    })();
+  const openMenuId = String(firstNonEmpty(options.openMenuId, getSubjectsViewState().rightSubissueMenuOpenId, ""));
   const rows = [];
   const walkSubissueTree = (subjectNode, depth = 0, parentId = "") => {
     const subjectId = String(subjectNode?.id || "");
@@ -1918,7 +1922,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
     leftMetaHtml: subissuesHeadCountsHtml(childSubjects),
     rightMetaHtml: "",
     bodyHtml: body,
-    isOpen: store.situationsView.rightSubissuesOpen !== false
+    isOpen: options.isOpen !== false
   });
 }
 
@@ -2106,7 +2110,10 @@ function rerenderPanels() {
           sujetRowClass: "js-modal-drilldown-sujet",
           sujetToggleClass: "js-modal-toggle-sujet",
           avisRowClass: "js-modal-drilldown-avis",
-          expandedSujets: store.situationsView.rightExpandedSujets
+          expandedSujets: store.situationsView.rightExpandedSujets,
+          expandedSubjectIds: store.situationsView.rightSubissuesExpandedSubjectIds,
+          openMenuId: store.situationsView.rightSubissueMenuOpenId,
+          isOpen: store.situationsView.rightSubissuesOpen
         }
       });
       panelHost.innerHTML = `


### PR DESCRIPTION
### Motivation
- Keep right-side subissues UI state (expanded rows, menu open id, open/closed) scoped per-details context so drilldown and main panels do not interfere with each other.
- Ensure renderers receive explicit `subissuesOptions` so the right-side subissues panel respects the intended expanded/menu/open state.
- Prevent accidental navigation when clicking elements inside a row by targeting only the dedicated parent-card element.

### Description
- Add `rightSubissuesOpen`, `rightSubissuesExpandedSubjectIds`, and `rightSubissueMenuOpenId` to the drilldown UI state initialization and normalize their types in `project-subjects-state.js`.
- Introduce a `scopedUiState` (drilldown-scoped when inside the drilldown panel) in `project-subjects-events.js` and update subissue toggles, menu triggers, and remove-parent handlers to mutate that scoped state and call a `rerenderDetailsScope()` helper which updates either the drilldown panel or the main panels.
- Narrow parent-card click targets to `.subject-meta-parent-card[data-parent-subject-id]` in event wiring so only the dedicated parent card triggers navigation into the parent subject.
- Propagate `subissuesOptions` (including `expandedSubjectIds`, `openMenuId`, and `isOpen`) into render paths and use those options in `renderSubIssuesForSujet`, `updateDrilldownPanel`, `updateDetailsModal`, and `rerenderPanels` so rendering respects the scoped UI state.
- Add tests asserting the stricter parent-card selector and that toggles use the drilldown-scoped UI state, and keep existing DnD instrumentation tests.

### Testing
- Ran the updated `project-subjects-events-subissues-dnd.test.mjs` unit tests, which include new assertions for the parent-card selector and drilldown-scoped toggles, and they passed.
- Executed the JavaScript unit test suite covering project-subjects view/event behavior and the suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d29d38288329adfc21f0f3759f76)