### PR TITLE
Corrige le badge 'Parent' : label non cliquable et navigation drilldown

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1659,6 +1659,17 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
 
+      const parentSubjectLink = event.target.closest(".js-details-parent-subject-link[data-parent-subject-id]");
+      if (parentSubjectLink) {
+        event.preventDefault();
+        event.stopPropagation();
+        const parentSubjectId = String(parentSubjectLink.dataset.parentSubjectId || "");
+        if (parentSubjectId) {
+          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(parentSubjectId);
+        }
+        return;
+      }
+
       const titleTrigger = event.target.closest(".js-row-title-trigger");
       if (titleTrigger) {
         event.preventDefault();

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1318,13 +1318,14 @@ function renderSubjectParentHeadHtml(subject, options = {}) {
   return `
     <span class="${wrapperClass}" title="Sujet parent : ${title}">
       <span class="details-parent-badge__icon">${issueIcon(getEffectiveSujetStatus(parentSubject.id))}</span>
+      <span class="details-parent-badge__label">Parent :</span>
       <button
         type="button"
         class="details-parent-badge__link js-details-parent-subject-link"
         data-parent-subject-id="${parentSubjectId}"
         aria-label="Ouvrir le sujet parent ${title}"
       >
-        Parent: ${title}
+        <span class="details-parent-badge__title">${title}</span>
       </button>
     </span>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2560,6 +2560,7 @@ body.is-resizing{
 .details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;font-size:12px;line-height:16px;gap:4px;background:transparent;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge{display:inline-flex;align-items:center;gap:4px;font-size:12px;line-height:16px;color:var(--muted);min-width:0;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge__icon{display:inline-flex;align-items:center;flex:0 0 auto;}
+.details-title--compact .details-title-compact-bottom .details-parent-badge__label{flex:0 0 auto;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge__link{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
 .details-title--compact .details-title-compact-bottom .verdict-bar{flex:0 1 auto;}
 .details-title--compact .gh-state{font-size:14px;line-height:21px;padding:3px 10px;height:32px;}
@@ -2609,6 +2610,7 @@ body.is-resizing{
   min-width:0;
 }
 .details-title--expanded .details-parent-badge__icon{display:inline-flex;align-items:center;flex:0 0 auto;}
+.details-title--expanded .details-parent-badge__label{flex:0 0 auto;}
 .details-title--expanded .details-parent-badge__link{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
 .details-parent-badge__link{
   border:none;
@@ -2626,6 +2628,9 @@ body.is-resizing{
   color:var(--accent);
   text-decoration:none;
   outline:none;
+}
+.details-parent-badge__link .details-parent-badge__title{
+  color:inherit;
 }
 
 /* Expanded title layout: 2 lines */


### PR DESCRIPTION
### Motivation
- Le préfixe `Parent :` dans le header de détails devenait cliquable / surligné et la navigation vers le sujet parent ne fonctionnait pas de façon fiable en affichage normal ni en drilldown.
- L'objectif est de rendre le préfixe statique (non cliquable / pas de couleur au hover) et de s'assurer que le clic sur le titre du parent ouvre correctement le drilldown et met à jour l'affichage en mode drilldown.

### Description
- Sépare le label et le titre dans `renderSubjectParentHeadHtml` en rendant `Parent :` un `span` statique et le titre un élément interne `span` à l'intérieur du bouton cliquable, afin que seul le titre soit cliquable (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-view.js`).
- Ajoute une branche d'événement délégué pour `.js-details-parent-subject-link` dans le gestionnaire global afin que le clic sur le lien parent déclenche `openDrilldownFromSubjectPanel` / `openDrilldownFromSujetPanel` aussi bien en affichage normal qu'en drilldown (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Ajuste le CSS du badge parent pour supporter la nouvelle structure label/title en mode compact et expanded et prévenir tout changement de couleur du préfixe (fichier modifié : `apps/web/style.css`).

### Testing
- Exécution de la vérification syntaxique JavaScript via `node --check apps/web/js/views/project-subjects/project-subjects-view.js` (succès).
- Exécution de la vérification syntaxique JavaScript via `node --check apps/web/js/views/project-subjects/project-subjects-events.js` (succès).
- Exécution de `git diff --check` pour s'assurer qu'il n'y a pas d'erreurs de format/diff (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dbaf36e88329b47c2e864b819412)