### PR TITLE
Make parent subject badge clickable to open drilldown and adjust styling

### DIFF
--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -175,6 +175,16 @@ export function createProjectSubjectDrilldownController(config) {
     title.innerHTML = selection ? renderDetailsTitleWrapHtml(selection) : "—";
     body.innerHTML = details.bodyHtml;
 
+    title.querySelectorAll(".js-details-parent-subject-link[data-parent-subject-id]").forEach((link) => {
+      link.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const parentSubjectId = String(link.dataset.parentSubjectId || "");
+        if (!parentSubjectId) return;
+        openDrilldownFromSubject(parentSubjectId);
+      };
+    });
+
     wireDetailsInteractive(body);
     bindDetailsScroll(panel);
     applyNormalDetailsCompactSnapshot(viewState.drilldown?.normalDetailsCompactSnapshot);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1659,6 +1659,17 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
 
+      const parentSubjectLink = event.target.closest(".js-details-parent-subject-link[data-parent-subject-id]");
+      if (parentSubjectLink) {
+        event.preventDefault();
+        event.stopPropagation();
+        const parentSubjectId = String(parentSubjectLink.dataset.parentSubjectId || "");
+        if (parentSubjectId) {
+          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(parentSubjectId);
+        }
+        return;
+      }
+
       const titleTrigger = event.target.closest(".js-row-title-trigger");
       if (titleTrigger) {
         event.preventDefault();

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1318,13 +1318,14 @@ function renderSubjectParentHeadHtml(subject, options = {}) {
   return `
     <span class="${wrapperClass}" title="Sujet parent : ${title}">
       <span class="details-parent-badge__icon">${issueIcon(getEffectiveSujetStatus(parentSubject.id))}</span>
+      <span class="details-parent-badge__label">Parent :</span>
       <button
         type="button"
         class="details-parent-badge__link js-details-parent-subject-link"
         data-parent-subject-id="${parentSubjectId}"
         aria-label="Ouvrir le sujet parent ${title}"
       >
-        Parent: ${title}
+        <span class="details-parent-badge__title">${title}</span>
       </button>
     </span>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2560,6 +2560,7 @@ body.is-resizing{
 .details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;font-size:12px;line-height:16px;gap:4px;background:transparent;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge{display:inline-flex;align-items:center;gap:4px;font-size:12px;line-height:16px;color:var(--muted);min-width:0;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge__icon{display:inline-flex;align-items:center;flex:0 0 auto;}
+.details-title--compact .details-title-compact-bottom .details-parent-badge__label{flex:0 0 auto;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge__link{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
 .details-title--compact .details-title-compact-bottom .verdict-bar{flex:0 1 auto;}
 .details-title--compact .gh-state{font-size:14px;line-height:21px;padding:3px 10px;height:32px;}
@@ -2609,6 +2610,7 @@ body.is-resizing{
   min-width:0;
 }
 .details-title--expanded .details-parent-badge__icon{display:inline-flex;align-items:center;flex:0 0 auto;}
+.details-title--expanded .details-parent-badge__label{flex:0 0 auto;}
 .details-title--expanded .details-parent-badge__link{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
 .details-parent-badge__link{
   border:none;
@@ -2626,6 +2628,9 @@ body.is-resizing{
   color:var(--accent);
   text-decoration:none;
   outline:none;
+}
+.details-parent-badge__link .details-parent-badge__title{
+  color:inherit;
 }
 
 /* Expanded title layout: 2 lines */


### PR DESCRIPTION
### Motivation
- Enable quick navigation to a parent subject from the details view and parent badges so users can open the parent sujet drilldown directly.
- Improve the visual layout of the parent badge and ensure the link title is properly wrapped for truncation and styling.

### Description
- Add click handlers in `project-subject-drilldown.js` to wire `.js-details-parent-subject-link[data-parent-subject-id]` buttons to `openDrilldownFromSubject` and prevent event propagation. 
- Add delegated click handling in `project-subjects-events.js` for `.js-details-parent-subject-link[data-parent-subject-id]` to reuse `openDrilldownFromSubjectPanel`/`openDrilldownFromSujetPanel`. 
- Update `renderSubjectParentHeadHtml` in `project-subjects-view.js` to include a visible label and wrap the parent title in a `.details-parent-badge__title` span inside the `.js-details-parent-subject-link` button. 
- Add CSS tweaks in `style.css` to position the new label and ensure the badge title inherits color and truncates correctly.

### Testing
- Ran the JavaScript/CSS linter via `npm run lint` and it completed successfully. 
- Built the frontend with `npm run build:web` and the build succeeded without errors. 
- Ran the unit test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dbaf36e88329b47c2e864b819412)