### PR TITLE
fix(web): corrige l'upload de photo de profil Supabase

### DIFF
--- a/apps/web/js/services/avatar-url.js
+++ b/apps/web/js/services/avatar-url.js
@@ -2,7 +2,7 @@ import { supabase } from "../../assets/js/auth.js";
 
 export const DEFAULT_AVATAR_URL = "assets/images/260093543.png";
 
-const AVATARS_BUCKET = "avatars";
+export const AVATARS_BUCKET = "avatars";
 const AVATAR_SIGNED_URL_TTL_SECONDS = 60 * 60 * 24 * 30;
 
 function safeString(value = "") {

--- a/apps/web/js/services/profile-supabase-sync.js
+++ b/apps/web/js/services/profile-supabase-sync.js
@@ -2,7 +2,7 @@ import { store } from "../store.js";
 import { ensureProjectDocumentsState } from "./project-documents-store.js";
 import { ensureProjectAutomationDefaults } from "./project-automation.js";
 import { supabase, buildSupabaseAuthHeaders, getCurrentUser, getSupabaseUrl, getSupabaseAnonKey } from "../../assets/js/auth.js";
-import { DEFAULT_AVATAR_URL, resolveAvatarUrl } from "./avatar-url.js";
+import { AVATARS_BUCKET, DEFAULT_AVATAR_URL, resolveAvatarUrl } from "./avatar-url.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const SUPABASE_ANON_KEY = getSupabaseAnonKey();


### PR DESCRIPTION
### Motivation
- Corriger l'erreur qui empêchait l'upload/suppression d'avatar et déclenchait l'alerte navigateur "Impossible d'enregistrer la photo de profil dans Supabase." en raison de l'absence de définition/import de la constante `AVATARS_BUCKET` dans le service d'upload.

### Description
- Exporte la constante `AVATARS_BUCKET` depuis `apps/web/js/services/avatar-url.js` et l'importe dans `apps/web/js/services/profile-supabase-sync.js` pour utiliser un seul point de vérité pour le nom du bucket `avatars`.

### Testing
- Vérifié en syntaxe avec `node --check apps/web/js/services/avatar-url.js` et `node --check apps/web/js/services/profile-supabase-sync.js`, les vérifications sont passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12c0032708329bcd30f53f844361f)