### PR TITLE
Filter invalid parent-subject suggestions in relations sidebar

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1353,14 +1353,29 @@ function getSubjectLastActivityTimestamp(subject = {}) {
   return Number.isFinite(ts) ? ts : 0;
 }
 
+function collectDescendantSubjectIds(subjectId, visited = new Set()) {
+  const rootId = String(subjectId || "");
+  if (!rootId || visited.has(rootId)) return visited;
+  visited.add(rootId);
+
+  const children = Array.isArray(getChildSubjects(rootId)) ? getChildSubjects(rootId) : [];
+  for (const child of children) {
+    const childId = String(child?.id || "");
+    if (!childId || visited.has(childId)) continue;
+    collectDescendantSubjectIds(childId, visited);
+  }
+  return visited;
+}
+
 function getRelationParentSuggestions(subject, query = "") {
   const currentSubjectId = String(subject?.id || "");
   const normalizedQuery = String(query || "").trim().toLowerCase();
+  const forbiddenParentIds = collectDescendantSubjectIds(currentSubjectId);
   const map = store.projectSubjectsView?.rawSubjectsResult?.subjectsById || {};
   const candidates = Object.values(map)
     .filter((item) => {
       const itemId = String(item?.id || "");
-      if (!itemId || itemId === currentSubjectId) return false;
+      if (!itemId || forbiddenParentIds.has(itemId)) return false;
       return matchSearch([item?.title, item?.id], normalizedQuery);
     })
     .sort((left, right) => {


### PR DESCRIPTION
### Motivation
- Améliorer l’UX lors du choix d’un sujet parent dans la sidebar « relations » en n’affichant plus les sujets qui provoqueraient une boucle hiérarchique (un sujet ne peut pas avoir plus d’un parent).

### Description
- Ajout de la fonction `collectDescendantSubjectIds(subjectId)` pour rassembler l’ID du sujet courant et tous ses descendants.
- Utilisation de cette collection dans `getRelationParentSuggestions` pour exclure le sujet courant et tous ses descendants des suggestions proposées.
- La validation serveur/locale existante (anti-boucle) reste inchangée comme filet de sécurité.

### Testing
- Exécution des tests unitaires avec `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs` which passed (`6` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ba77df108329b6f107bf125bf9ce)