### PR TITLE
Implement «Est bloqué par» / «Est bloquant pour» relations (UI, service, DB safeguards)

### DIFF
--- a/apps/web/js/services/subject-blocking-relation-service.js
+++ b/apps/web/js/services/subject-blocking-relation-service.js
@@ -1,0 +1,134 @@
+import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+
+const SUPABASE_URL = getSupabaseUrl();
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function normalizeProjectId(subject = {}) {
+  return normalizeId(subject?.project_id || subject?.projectId || subject?.raw?.project_id);
+}
+
+function getSubject(rawSubjectsResult, subjectId) {
+  const key = normalizeId(subjectId);
+  if (!key) return null;
+  return rawSubjectsResult?.subjectsById?.[key] || null;
+}
+
+function hasReverseBlockedByRelation(rawSubjectsResult, sourceSubjectId, targetSubjectId) {
+  const sourceKey = normalizeId(sourceSubjectId);
+  const targetKey = normalizeId(targetSubjectId);
+  if (!sourceKey || !targetKey) return false;
+  const links = Array.isArray(rawSubjectsResult?.linksBySubjectId?.[targetKey])
+    ? rawSubjectsResult.linksBySubjectId[targetKey]
+    : [];
+  return links.some((link) => {
+    const linkType = String(link?.link_type || "").toLowerCase();
+    return linkType === "blocked_by"
+      && normalizeId(link?.source_subject_id) === targetKey
+      && normalizeId(link?.target_subject_id) === sourceKey;
+  });
+}
+
+function assertBlockingRelationAllowed({ subjectId, blockedBySubjectId, rawSubjectsResult }) {
+  const sourceKey = normalizeId(subjectId);
+  const targetKey = normalizeId(blockedBySubjectId);
+  if (!sourceKey) throw new Error("subjectId est requis.");
+  if (!targetKey) throw new Error("blockedBySubjectId est requis.");
+  if (sourceKey === targetKey) {
+    throw new Error("Un sujet ne peut pas être lié à lui-même.");
+  }
+
+  const sourceSubject = getSubject(rawSubjectsResult, sourceKey);
+  const targetSubject = getSubject(rawSubjectsResult, targetKey);
+  if (!sourceSubject || !targetSubject) {
+    throw new Error("Le sujet sélectionné est introuvable.");
+  }
+
+  const sourceProjectId = normalizeProjectId(sourceSubject);
+  const targetProjectId = normalizeProjectId(targetSubject);
+  if (sourceProjectId && targetProjectId && sourceProjectId !== targetProjectId) {
+    throw new Error("Les sujets doivent appartenir au même projet.");
+  }
+
+  if (hasReverseBlockedByRelation(rawSubjectsResult, sourceKey, targetKey)) {
+    throw new Error("Cette relation est invalide : les deux sujets ne peuvent pas se bloquer mutuellement.");
+  }
+}
+
+export async function createBlockedByRelationInSupabase({ subjectId, blockedBySubjectId, rawSubjectsResult = null } = {}) {
+  const sourceKey = normalizeId(subjectId);
+  const targetKey = normalizeId(blockedBySubjectId);
+  assertBlockingRelationAllowed({
+    subjectId: sourceKey,
+    blockedBySubjectId: targetKey,
+    rawSubjectsResult
+  });
+
+  const sourceSubject = getSubject(rawSubjectsResult, sourceKey);
+  const projectId = normalizeProjectId(sourceSubject);
+  if (!projectId) {
+    throw new Error("project_id introuvable pour le sujet source.");
+  }
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_links`);
+  url.searchParams.set("on_conflict", "project_id,source_subject_id,target_subject_id,link_type");
+
+  const headers = await buildSupabaseAuthHeaders({
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    Prefer: "resolution=merge-duplicates,return=representation"
+  });
+
+  const payload = [{
+    project_id: projectId,
+    source_subject_id: sourceKey,
+    target_subject_id: targetKey,
+    link_type: "blocked_by"
+  }];
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    cache: "no-store"
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Ajout de la relation bloquante impossible (${res.status}) : ${text}`);
+  }
+
+  const rows = await res.json().catch(() => []);
+  return rows[0] || null;
+}
+
+export async function deleteBlockedByRelationInSupabase({ subjectId, blockedBySubjectId } = {}) {
+  const sourceKey = normalizeId(subjectId);
+  const targetKey = normalizeId(blockedBySubjectId);
+  if (!sourceKey) throw new Error("subjectId est requis.");
+  if (!targetKey) throw new Error("blockedBySubjectId est requis.");
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_links`);
+  url.searchParams.set("source_subject_id", `eq.${sourceKey}`);
+  url.searchParams.set("target_subject_id", `eq.${targetKey}`);
+  url.searchParams.set("link_type", "eq.blocked_by");
+
+  const headers = await buildSupabaseAuthHeaders({
+    Accept: "application/json"
+  });
+
+  const res = await fetch(url.toString(), {
+    method: "DELETE",
+    headers,
+    cache: "no-store"
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Suppression de la relation bloquante impossible (${res.status}) : ${text}`);
+  }
+
+  return true;
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -21,6 +21,10 @@ import {
   reorderSubjectChildrenInSupabase as reorderSubjectChildrenInSupabaseService
 } from "../services/subject-parent-relation-service.js";
 import {
+  createBlockedByRelationInSupabase as createBlockedByRelationInSupabaseService,
+  deleteBlockedByRelationInSupabase as deleteBlockedByRelationInSupabaseService
+} from "../services/subject-blocking-relation-service.js";
+import {
   bindProjectSituationsRunbar,
   syncProjectSituationsRunbar
 } from "./project-situations-runbar.js";
@@ -208,7 +212,9 @@ const {
   getSituationSubjects,
   getNestedSujet,
   getSituationBySujetId,
-  getChildSubjects
+  getChildSubjects,
+  getBlockedBySubjects,
+  getBlockingSubjects
 } = subjectsSelectors;
 
 
@@ -339,6 +345,8 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getToggleSubjectLabel: () => toggleSubjectLabel,
   getToggleSubjectAssignee: () => toggleSubjectAssignee,
   getSetSubjectParent: () => setSubjectParent,
+  getToggleSubjectBlockedByRelation: () => toggleSubjectBlockedByRelation,
+  getToggleSubjectBlockingForRelation: () => toggleSubjectBlockingForRelation,
   getReorderSubjectChildren: () => reorderSubjectChildren,
   syncDescriptionEditorDraft,
   startDescriptionEdit,
@@ -566,6 +574,15 @@ const projectSubjectsActions = createProjectSubjectsActions({
     parentSubjectId,
     rawSubjectsResult: store.projectSubjectsView?.rawSubjectsResult || null
   }),
+  createBlockedByRelationInSupabase: (subjectId, blockedBySubjectId) => createBlockedByRelationInSupabaseService({
+    subjectId,
+    blockedBySubjectId,
+    rawSubjectsResult: store.projectSubjectsView?.rawSubjectsResult || null
+  }),
+  deleteBlockedByRelationInSupabase: (subjectId, blockedBySubjectId) => deleteBlockedByRelationInSupabaseService({
+    subjectId,
+    blockedBySubjectId
+  }),
   reorderSubjectChildrenInSupabase: (parentSubjectId, orderedChildIds) => reorderSubjectChildrenInSupabaseService({
     parentSubjectId,
     orderedChildIds
@@ -580,6 +597,8 @@ const {
   toggleSubjectAssignee,
   toggleSubjectSituation,
   setSubjectParent,
+  toggleSubjectBlockedByRelation,
+  toggleSubjectBlockingForRelation,
   reorderSubjectChildren,
   setSubjectLabels,
   toggleSubjectLabel,
@@ -704,6 +723,8 @@ const projectSubjectsView = createProjectSubjectsView({
   getNestedSujet: (...args) => getNestedSujet(...args),
   getSituationSubjects: (...args) => getSituationSubjects(...args),
   getChildSubjects: (...args) => getChildSubjects(...args),
+  getBlockedBySubjects: (...args) => getBlockedBySubjects(...args),
+  getBlockingSubjects: (...args) => getBlockingSubjects(...args),
   getFilteredStandaloneSubjects: (...args) => getFilteredStandaloneSubjects(...args),
   getFilteredFlatSubjects: (...args) => getFilteredFlatSubjects(...args),
   getPaginatedFilteredFlatSubjects: (...args) => getPaginatedFilteredFlatSubjects(...args),

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -44,6 +44,8 @@ export function createProjectSubjectsActions(config) {
     addSubjectToObjectiveInSupabase,
     removeSubjectFromObjectiveInSupabase,
     setSubjectParentInSupabase,
+    createBlockedByRelationInSupabase,
+    deleteBlockedByRelationInSupabase,
     reorderSubjectChildrenInSupabase,
     rerenderPanels
   } = config;
@@ -291,6 +293,86 @@ export function createProjectSubjectsActions(config) {
       showError(`Mise à jour du sujet parent impossible : ${String(error?.message || error || "Erreur inconnue")}`);
       return false;
     }
+  }
+
+  function syncBlockedByLinkLocally(sourceSubjectId, targetSubjectId, shouldExist) {
+    const raw = store.projectSubjectsView?.rawSubjectsResult;
+    if (!raw || typeof raw !== "object") return;
+    const sourceKey = String(sourceSubjectId || "").trim();
+    const targetKey = String(targetSubjectId || "").trim();
+    if (!sourceKey || !targetKey) return;
+
+    raw.linksBySubjectId = raw.linksBySubjectId && typeof raw.linksBySubjectId === "object"
+      ? raw.linksBySubjectId
+      : {};
+
+    const sourceLinks = Array.isArray(raw.linksBySubjectId[sourceKey]) ? raw.linksBySubjectId[sourceKey] : [];
+    const targetLinks = Array.isArray(raw.linksBySubjectId[targetKey]) ? raw.linksBySubjectId[targetKey] : [];
+
+    const isSameLink = (link) => String(link?.link_type || "") === "blocked_by"
+      && String(link?.source_subject_id || "") === sourceKey
+      && String(link?.target_subject_id || "") === targetKey;
+
+    const existing = sourceLinks.find(isSameLink) || targetLinks.find(isSameLink) || null;
+    if (shouldExist) {
+      const projectId = String(raw?.subjectsById?.[sourceKey]?.project_id || raw?.subjectsById?.[sourceKey]?.raw?.project_id || "").trim() || null;
+      const nextLink = existing || {
+        id: `${sourceKey}:${targetKey}:blocked_by`,
+        project_id: projectId,
+        source_subject_id: sourceKey,
+        target_subject_id: targetKey,
+        link_type: "blocked_by",
+        created_at: nowIso()
+      };
+      if (!sourceLinks.some((link) => isSameLink(link))) sourceLinks.push(nextLink);
+      if (!targetLinks.some((link) => isSameLink(link))) targetLinks.push(nextLink);
+      raw.linksBySubjectId[sourceKey] = sourceLinks;
+      raw.linksBySubjectId[targetKey] = targetLinks;
+      return;
+    }
+
+    raw.linksBySubjectId[sourceKey] = sourceLinks.filter((link) => !isSameLink(link));
+    raw.linksBySubjectId[targetKey] = targetLinks.filter((link) => !isSameLink(link));
+  }
+
+  async function toggleSubjectBlockedByRelation(subjectId, blockedBySubjectId, options = {}) {
+    const sourceKey = String(subjectId || "").trim();
+    const targetKey = String(blockedBySubjectId || "").trim();
+    if (!sourceKey || !targetKey) return false;
+
+    const raw = store.projectSubjectsView?.rawSubjectsResult;
+    const links = Array.isArray(raw?.linksBySubjectId?.[sourceKey]) ? raw.linksBySubjectId[sourceKey] : [];
+    const alreadyLinked = links.some((link) => String(link?.link_type || "") === "blocked_by"
+      && String(link?.source_subject_id || "") === sourceKey
+      && String(link?.target_subject_id || "") === targetKey);
+
+    syncBlockedByLinkLocally(sourceKey, targetKey, !alreadyLinked);
+    if (!options.skipRerender) {
+      if (options.root) rerenderScope(options.root);
+      else rerenderPanels();
+    }
+
+    try {
+      if (alreadyLinked) await deleteBlockedByRelationInSupabase(sourceKey, targetKey);
+      else await createBlockedByRelationInSupabase(sourceKey, targetKey);
+      return true;
+    } catch (error) {
+      syncBlockedByLinkLocally(sourceKey, targetKey, alreadyLinked);
+      if (!options.skipRerender) {
+        if (options.root) rerenderScope(options.root);
+        else rerenderPanels();
+      }
+      console.warn("toggleSubjectBlockedByRelation failed", error);
+      showError(`Mise à jour de la relation « Est bloqué par » impossible : ${String(error?.message || error || "Erreur inconnue")}`);
+      return false;
+    }
+  }
+
+  async function toggleSubjectBlockingForRelation(subjectId, blockedSubjectId, options = {}) {
+    const subjectKey = String(subjectId || "").trim();
+    const blockedKey = String(blockedSubjectId || "").trim();
+    if (!subjectKey || !blockedKey) return false;
+    return toggleSubjectBlockedByRelation(blockedKey, subjectKey, options);
   }
 
   function applySubjectChildrenOrderLocally(parentSubjectId, orderedChildIds = []) {
@@ -926,6 +1008,8 @@ export function createProjectSubjectsActions(config) {
     toggleSubjectAssignee,
     toggleSubjectSituation,
     setSubjectParent,
+    toggleSubjectBlockedByRelation,
+    toggleSubjectBlockingForRelation,
     reorderSubjectChildren,
     setSubjectLabels,
     toggleSubjectLabel,

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -20,6 +20,8 @@ export function createProjectSubjectsEvents(config) {
     getToggleSubjectLabel,
     getToggleSubjectAssignee,
     getSetSubjectParent,
+    getToggleSubjectBlockedByRelation,
+    getToggleSubjectBlockingForRelation,
     getReorderSubjectChildren,
     syncDescriptionEditorDraft,
     startDescriptionEdit,
@@ -198,6 +200,8 @@ export function createProjectSubjectsEvents(config) {
     const toggleSubjectLabel = getToggleSubjectLabel?.();
     const toggleSubjectAssignee = getToggleSubjectAssignee?.();
     const setSubjectParent = getSetSubjectParent?.();
+    const toggleSubjectBlockedByRelation = getToggleSubjectBlockedByRelation?.();
+    const toggleSubjectBlockingForRelation = getToggleSubjectBlockingForRelation?.();
     const reorderSubjectChildren = getReorderSubjectChildren?.();
 
     dropdownHost.querySelectorAll("[data-subject-kanban-search]").forEach((input) => {
@@ -275,10 +279,23 @@ export function createProjectSubjectsEvents(config) {
           const activeKey = String(getSubjectsViewState().subjectMetaDropdown.activeKey || "");
           if (!activeKey) return;
           event.preventDefault();
-          if (field === "relations" && String(getSubjectsViewState().subjectMetaDropdown?.relationsView || "") === "parent") {
-            if (typeof setSubjectParent !== "function") return;
-            await applyNonDestructiveMetaToggle(root, field, () => setSubjectParent(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
-            return;
+          if (field === "relations") {
+            const relationsView = String(getSubjectsViewState().subjectMetaDropdown?.relationsView || "");
+            if (relationsView === "parent") {
+              if (typeof setSubjectParent !== "function") return;
+              await applyNonDestructiveMetaToggle(root, field, () => setSubjectParent(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+              return;
+            }
+            if (relationsView === "blocked_by") {
+              if (typeof toggleSubjectBlockedByRelation !== "function") return;
+              await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectBlockedByRelation(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+              return;
+            }
+            if (relationsView === "blocking_for") {
+              if (typeof toggleSubjectBlockingForRelation !== "function") return;
+              await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectBlockingForRelation(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+              return;
+            }
           }
           if (field === "objectives") {
             await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectObjective(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
@@ -380,6 +397,64 @@ export function createProjectSubjectsEvents(config) {
           dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
         }
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-open-blocked-by]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.relationsView = "blocked_by";
+        dropdown.query = "";
+        dropdown.activeKey = "";
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type === "sujet") {
+          const entries = getSubjectMetaMenuEntries(subjectSelection.item, "relations");
+          dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
+        }
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-open-blocking-for]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.relationsView = "blocking_for";
+        dropdown.query = "";
+        dropdown.activeKey = "";
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type === "sujet") {
+          const entries = getSubjectMetaMenuEntries(subjectSelection.item, "relations");
+          dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
+        }
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-blocked-by-entry]").forEach((btn) => {
+      btn.onclick = async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type !== "sujet") return;
+        if (typeof toggleSubjectBlockedByRelation !== "function") return;
+        const relationSubjectId = String(btn.dataset.subjectRelationsBlockedByEntry || "");
+        await applyNonDestructiveMetaToggle(root, "relations", () => toggleSubjectBlockedByRelation(subjectSelection.item.id, relationSubjectId, { root, skipRerender: true }));
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-relations-blocking-for-entry]").forEach((btn) => {
+      btn.onclick = async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectSelection = getScopedSelection(root);
+        if (subjectSelection?.type !== "sujet") return;
+        if (typeof toggleSubjectBlockingForRelation !== "function") return;
+        const relationSubjectId = String(btn.dataset.subjectRelationsBlockingForEntry || "");
+        await applyNonDestructiveMetaToggle(root, "relations", () => toggleSubjectBlockingForRelation(subjectSelection.item.id, relationSubjectId, { root, skipRerender: true }));
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -57,6 +57,8 @@ export function createProjectSubjectsView(deps) {
     getNestedSujet,
     getSituationSubjects,
     getChildSubjects,
+    getBlockedBySubjects,
+    getBlockingSubjects,
     getFilteredStandaloneSubjects,
     getFilteredFlatSubjects,
     getCurrentSubjectsStatusFilter,
@@ -1273,39 +1275,67 @@ function getSubjectParentSubject(subjectId) {
   return getNestedSujet(parentSubjectId);
 }
 
-function renderSubjectParentCard(subjectId) {
-  const parentSubject = getSubjectParentSubject(subjectId);
-  if (!parentSubject) return renderSubjectMetaButtonValue("Aucun sujet parent");
-
-  const parentStatus = getEffectiveSujetStatus(parentSubject.id);
-  const parentChildren = getChildSubjectList(parentSubject);
-  const displayRef = getEntityDisplayRef("sujet", parentSubject.id);
-  const author = getDisplayAuthorName(firstNonEmpty(
-    getEntityDescriptionState("sujet", parentSubject.id)?.author,
-    parentSubject?.agent,
-    parentSubject?.raw?.agent,
-    "system"
-  ), {
-    agent: firstNonEmpty(
-      getEntityDescriptionState("sujet", parentSubject.id)?.agent,
-      parentSubject?.agent,
-      parentSubject?.raw?.agent,
-      "system"
-    ),
-    fallback: "System"
-  });
-
+function renderSubjectRelationSubjectCard(subject, options = {}) {
+  const relationLabel = firstNonEmpty(options.label, "Relation");
+  const displayRef = getEntityDisplayRef("sujet", subject?.id);
+  const status = getEffectiveSujetStatus(subject?.id);
+  const extraCountHtml = options.countHtml ? `<span class="subject-meta-parent-card__count">${options.countHtml}</span>` : "";
   return `
-    <button type="button" class="subject-meta-parent-card" data-parent-subject-id="${escapeHtml(parentSubject.id)}">
-      <span class="subject-meta-parent-card__label">Sujet parent</span>
+    <button type="button" class="subject-meta-parent-card" data-parent-subject-id="${escapeHtml(subject?.id || "")}">
+      <span class="subject-meta-parent-card__label">${escapeHtml(relationLabel)}</span>
       <span class="subject-meta-parent-card__head">
-        <span class="subject-meta-parent-card__icon">${issueIcon(parentStatus)}</span>
-        <span class="subject-meta-parent-card__title">${escapeHtml(firstNonEmpty(parentSubject.title, parentSubject.id, "Sujet parent"))}</span>
-        <span class="subject-meta-parent-card__count">${subissuesHeadCountsHtml(parentChildren)}</span>
+        <span class="subject-meta-parent-card__icon">${issueIcon(status)}</span>
+        <span class="subject-meta-parent-card__title">${escapeHtml(firstNonEmpty(subject?.title, subject?.id, "Sujet"))}</span>
+        ${extraCountHtml}
       </span>
-      <span class="subject-meta-parent-card__meta">${escapeHtml(author)} ${escapeHtml(displayRef)}</span>
+      <span class="subject-meta-parent-card__meta">${escapeHtml(displayRef)}</span>
     </button>
   `;
+}
+
+function renderSubjectRelationsCards(subjectId) {
+  const parentSubject = getSubjectParentSubject(subjectId);
+  const blockedBySubjects = Array.isArray(getBlockedBySubjects(subjectId)) ? getBlockedBySubjects(subjectId) : [];
+  const blockingSubjects = Array.isArray(getBlockingSubjects(subjectId)) ? getBlockingSubjects(subjectId) : [];
+
+  const groups = [];
+  if (parentSubject) {
+    const parentChildren = getChildSubjectList(parentSubject);
+    groups.push(`
+      <div class="subject-meta-relations-group">
+        ${renderSubjectRelationSubjectCard(parentSubject, {
+    label: "Sujet parent",
+    countHtml: subissuesHeadCountsHtml(parentChildren)
+  })}
+      </div>
+    `);
+  }
+
+  if (blockedBySubjects.length) {
+    groups.push(`
+      <div class="subject-meta-relations-group">
+        <div class="subject-meta-relations-group__title">Est bloqué par <span class="subject-meta-relations-group__counter">${blockedBySubjects.length}</span></div>
+        <div class="subject-meta-relations-group__list">
+          ${blockedBySubjects.map((item) => renderSubjectRelationSubjectCard(item, { label: "Sujet" })).join("")}
+        </div>
+      </div>
+    `);
+  }
+
+  if (blockingSubjects.length) {
+    groups.push(`
+      <div class="subject-meta-relations-group">
+        <div class="subject-meta-relations-group__title">Est bloquant pour <span class="subject-meta-relations-group__counter">${blockingSubjects.length}</span></div>
+        <div class="subject-meta-relations-group__list">
+          ${blockingSubjects.map((item) => renderSubjectRelationSubjectCard(item, { label: "Sujet" })).join("")}
+        </div>
+      </div>
+    `);
+  }
+
+  if (!groups.length) return renderSubjectMetaButtonValue("Aucune relation");
+
+  return `<div class="subject-meta-relations-cards">${groups.join('<div class="subject-meta-relations-divider" aria-hidden="true"></div>')}</div>`;
 }
 
 function renderSubjectParentHeadHtml(subject, options = {}) {
@@ -1337,7 +1367,7 @@ function renderSubjectMetaFieldValue(subject, field) {
   if (field === "labels") return renderSubjectLabelsValue(subject.id);
   if (field === "situations") return renderSubjectSituationsValue(subject.id);
   if (field === "objectives") return renderSubjectObjectivesValue(subject.id);
-  if (field === "relations") return renderSubjectParentCard(subject.id);
+  if (field === "relations") return renderSubjectRelationsCards(subject.id);
   return renderSubjectMetaButtonValue("Aucune donnée");
 }
 
@@ -1384,6 +1414,43 @@ function getRelationParentSuggestions(subject, query = "") {
       return String(firstNonEmpty(left?.title, left?.id, "")).localeCompare(String(firstNonEmpty(right?.title, right?.id, "")), "fr");
     });
   return candidates.slice(0, 13);
+}
+
+function getRelationSubjectSuggestions(subject, query = "", options = {}) {
+  const currentSubjectId = String(subject?.id || "");
+  const normalizedQuery = String(query || "").trim().toLowerCase();
+  const excludedIds = new Set((Array.isArray(options.excludeSubjectIds) ? options.excludeSubjectIds : []).map((value) => String(value || "")).filter(Boolean));
+  const map = store.projectSubjectsView?.rawSubjectsResult?.subjectsById || {};
+  const candidates = Object.values(map)
+    .filter((item) => {
+      const itemId = String(item?.id || "");
+      if (!itemId || itemId === currentSubjectId || excludedIds.has(itemId)) return false;
+      return matchSearch([item?.title, item?.id], normalizedQuery);
+    })
+    .sort((left, right) => {
+      const tsDiff = getSubjectLastActivityTimestamp(right) - getSubjectLastActivityTimestamp(left);
+      if (tsDiff !== 0) return tsDiff;
+      return String(firstNonEmpty(left?.title, left?.id, "")).localeCompare(String(firstNonEmpty(right?.title, right?.id, "")), "fr");
+    });
+  return candidates.slice(0, 20);
+}
+
+function buildRelationSelectItem(candidate, { dropdownState, isSelected = false, dataAttr }) {
+  const candidateId = String(candidate?.id || "");
+  return {
+    key: candidateId,
+    isActive: String(dropdownState?.activeKey || "") === candidateId,
+    isSelected,
+    iconHtml: `
+      <span class="select-menu__situation-iconset" aria-hidden="true">
+        <span class="select-menu__checkbox ${isSelected ? "is-checked" : ""}">${svgIcon("check", { className: "octicon octicon-check" })}</span>
+        <span class="select-menu__situation-icon">${issueIcon(getEffectiveSujetStatus(candidateId))}</span>
+      </span>
+    `,
+    title: firstNonEmpty(candidate?.title, candidateId, "Sujet"),
+    metaHtml: escapeHtml(getEntityDisplayRef("sujet", candidateId)),
+    dataAttrs: { [dataAttr]: candidateId }
+  };
 }
 
 function buildSubjectMetaMenuItems(subject, field) {
@@ -1517,50 +1584,66 @@ function buildSubjectMetaMenuItems(subject, field) {
     };
   }
 
-  if (field === "relations" && String(dropdownState.relationsView || "menu") === "parent") {
-    const selectedParent = getSubjectParentSubject(subject.id);
-    const selectedParentId = String(selectedParent?.id || "");
-    const suggestions = getRelationParentSuggestions(subject, query);
-    const suggestionItems = suggestions
-      .filter((item) => String(item?.id || "") !== selectedParentId)
-      .map((candidate) => ({
-        key: String(candidate.id || ""),
-        isActive: String(dropdownState.activeKey || "") === String(candidate.id || ""),
+  if (field === "relations") {
+    const relationsView = String(dropdownState.relationsView || "menu");
+    if (relationsView === "parent") {
+      const selectedParent = getSubjectParentSubject(subject.id);
+      const selectedParentId = String(selectedParent?.id || "");
+      const suggestions = getRelationParentSuggestions(subject, query);
+      const suggestionItems = suggestions
+        .filter((item) => String(item?.id || "") !== selectedParentId)
+        .map((candidate) => buildRelationSelectItem(candidate, {
+          dropdownState,
+          dataAttr: "subject-relations-parent-entry"
+        }));
+
+      const selectedItem = selectedParent
+        ? buildRelationSelectItem(selectedParent, {
+          dropdownState,
+          isSelected: true,
+          dataAttr: "subject-relations-parent-entry"
+        })
+        : null;
+
+      return {
+        selectedItem,
+        suggestionItems,
+        items: [selectedItem, ...suggestionItems].filter(Boolean),
+        emptyHint: query ? "Aucun résultat pour cette recherche." : "Aucun sujet suggéré."
+      };
+    }
+
+    if (relationsView === "blocked_by" || relationsView === "blocking_for") {
+      const blockedBySubjects = Array.isArray(getBlockedBySubjects(subject.id)) ? getBlockedBySubjects(subject.id) : [];
+      const blockingSubjects = Array.isArray(getBlockingSubjects(subject.id)) ? getBlockingSubjects(subject.id) : [];
+      const selectedSubjects = relationsView === "blocked_by" ? blockedBySubjects : blockingSubjects;
+      const oppositeSubjects = relationsView === "blocked_by" ? blockingSubjects : blockedBySubjects;
+      const selectedIds = new Set(selectedSubjects.map((item) => String(item?.id || "")).filter(Boolean));
+      const oppositeIds = new Set(oppositeSubjects.map((item) => String(item?.id || "")).filter(Boolean));
+      const dataAttr = relationsView === "blocked_by" ? "subject-relations-blocked-by-entry" : "subject-relations-blocking-for-entry";
+
+      const selectedItems = selectedSubjects
+        .map((candidate) => buildRelationSelectItem(candidate, {
+          dropdownState,
+          isSelected: true,
+          dataAttr
+        }));
+
+      const suggestionItems = getRelationSubjectSuggestions(subject, query, {
+        excludeSubjectIds: [...selectedIds, ...oppositeIds]
+      }).map((candidate) => buildRelationSelectItem(candidate, {
+        dropdownState,
         isSelected: false,
-        iconHtml: `
-          <span class="select-menu__situation-iconset" aria-hidden="true">
-            <span class="select-menu__checkbox">${svgIcon("check", { className: "octicon octicon-check" })}</span>
-            <span class="select-menu__situation-icon">${issueIcon(getEffectiveSujetStatus(candidate.id))}</span>
-          </span>
-        `,
-        title: firstNonEmpty(candidate.title, candidate.id, "Sujet"),
-        metaHtml: escapeHtml(getEntityDisplayRef("sujet", candidate.id)),
-        dataAttrs: { "subject-relations-parent-entry": String(candidate.id || "") }
+        dataAttr
       }));
 
-    const selectedItem = selectedParent
-      ? {
-        key: selectedParentId,
-        isActive: String(dropdownState.activeKey || "") === selectedParentId,
-        isSelected: true,
-        iconHtml: `
-          <span class="select-menu__situation-iconset" aria-hidden="true">
-            <span class="select-menu__checkbox is-checked">${svgIcon("check", { className: "octicon octicon-check" })}</span>
-            <span class="select-menu__situation-icon">${issueIcon(getEffectiveSujetStatus(selectedParent.id))}</span>
-          </span>
-        `,
-        title: firstNonEmpty(selectedParent.title, selectedParent.id, "Sujet parent"),
-        metaHtml: escapeHtml(getEntityDisplayRef("sujet", selectedParent.id)),
-        dataAttrs: { "subject-relations-parent-entry": selectedParentId }
-      }
-      : null;
-
-    return {
-      selectedItem,
-      suggestionItems,
-      items: [selectedItem, ...suggestionItems].filter(Boolean),
-      emptyHint: query ? "Aucun résultat pour cette recherche." : "Aucun sujet suggéré."
-    };
+      return {
+        selectedItems,
+        suggestionItems,
+        items: [...selectedItems, ...suggestionItems],
+        emptyHint: query ? "Aucun résultat pour cette recherche." : "Aucun sujet suggéré."
+      };
+    }
   }
 
   const emptyHintMap = {
@@ -1605,8 +1688,12 @@ function renderSubjectMetaDropdown(subject, field) {
 
   if (field === "relations") {
     const relationsView = String(dropdownState.relationsView || "menu");
-    if (relationsView === "parent") {
-      const { selectedItem, suggestionItems, emptyHint } = buildSubjectMetaMenuItems(subject, field);
+    if (relationsView === "parent" || relationsView === "blocked_by" || relationsView === "blocking_for") {
+      const { selectedItem, selectedItems = [], suggestionItems = [], emptyHint } = buildSubjectMetaMenuItems(subject, field);
+      const selectedSectionItems = selectedItem ? [selectedItem] : selectedItems;
+      const searchPlaceholder = relationsView === "parent"
+        ? "Rechercher un sujet parent"
+        : "Rechercher un sujet";
       return `
         <div class="subject-meta-dropdown gh-menu gh-menu--open" role="dialog">
           <button type="button" class="subject-meta-relations-back" data-subject-relations-back>
@@ -1615,10 +1702,10 @@ function renderSubjectMetaDropdown(subject, field) {
           </button>
           <div class="subject-meta-dropdown__search">
             <span class="subject-meta-dropdown__search-icon" aria-hidden="true">${svgIcon("search", { className: "octicon octicon-search" })}</span>
-            <input type="search" class="subject-meta-dropdown__search-input" data-subject-meta-search="${escapeHtml(field)}" value="${escapeHtml(query)}" placeholder="Rechercher un sujet parent" autocomplete="off">
+            <input type="search" class="subject-meta-dropdown__search-input" data-subject-meta-search="${escapeHtml(field)}" value="${escapeHtml(query)}" placeholder="${escapeHtml(searchPlaceholder)}" autocomplete="off">
           </div>
           <div class="subject-meta-dropdown__body">
-            ${selectedItem ? renderSelectMenuSection({ title: "Sélectionné", items: [selectedItem] }) : `
+            ${relationsView === "parent" && !selectedItem ? `
               <div class="select-menu__section">
                 <button type="button" class="select-menu__item subject-meta-relations-menu__item" data-subject-relations-remove-parent>
                   <span class="select-menu__item-mainrow">
@@ -1629,7 +1716,7 @@ function renderSubjectMetaDropdown(subject, field) {
                   </span>
                 </button>
               </div>
-            `}
+            ` : renderSelectMenuSection({ title: "Sélectionné", items: selectedSectionItems, emptyTitle: "Aucune sélection", emptyHint: "Aucun sujet sélectionné." })}
             ${renderSelectMenuSection({
               title: "Suggestions",
               items: suggestionItems,
@@ -1652,17 +1739,17 @@ function renderSubjectMetaDropdown(subject, field) {
                 </span>
               </span>
             </button>
-            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem">
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-subject-relations-open-blocked-by>
               <span class="select-menu__item-mainrow">
                 <span class="select-menu__item-content">
-                  <span class="select-menu__item-title">Ajouter ou modifier « Bloqué par »</span>
+                  <span class="select-menu__item-title">Ajouter ou modifier « Est bloqué par »</span>
                 </span>
               </span>
             </button>
-            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem">
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-subject-relations-open-blocking-for>
               <span class="select-menu__item-mainrow">
                 <span class="select-menu__item-content">
-                  <span class="select-menu__item-title">Ajouter ou modifier « Bloquant »</span>
+                  <span class="select-menu__item-title">Ajouter ou modifier « Est bloquant pour »</span>
                 </span>
               </span>
             </button>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -706,6 +706,13 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
   color:var(--muted);
 }
 
+.subject-meta-relations-cards{display:flex;flex-direction:column;gap:10px;}
+.subject-meta-relations-group{display:flex;flex-direction:column;gap:8px;}
+.subject-meta-relations-group__title{display:flex;align-items:center;gap:6px;font-size:12px;font-weight:600;color:var(--muted);}
+.subject-meta-relations-group__counter{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 6px;border-radius:999px;background:rgba(56,139,253,.16);color:var(--text);font-size:11px;line-height:1;}
+.subject-meta-relations-group__list{display:flex;flex-direction:column;gap:8px;}
+.subject-meta-relations-divider{height:1px;background:var(--border);margin:2px 0;}
+
 .subject-meta-relations-menu__item{
   width:100%;
 }

--- a/supabase/migrations/202604170001_subject_blocked_by_constraints.sql
+++ b/supabase/migrations/202604170001_subject_blocked_by_constraints.sql
@@ -1,0 +1,56 @@
+create unique index if not exists idx_subject_links_blocked_by_pair_unique
+  on public.subject_links (
+    project_id,
+    least(source_subject_id, target_subject_id),
+    greatest(source_subject_id, target_subject_id)
+  )
+  where link_type = 'blocked_by';
+
+create or replace function public.validate_subject_blocked_by_link()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_source_project_id uuid;
+  v_target_project_id uuid;
+begin
+  if new.link_type is distinct from 'blocked_by' then
+    return new;
+  end if;
+
+  if new.source_subject_id is null or new.target_subject_id is null then
+    raise exception 'source_subject_id and target_subject_id are required for blocked_by links';
+  end if;
+
+  if new.source_subject_id = new.target_subject_id then
+    raise exception 'A subject cannot block itself';
+  end if;
+
+  select s.project_id into v_source_project_id
+  from public.subjects s
+  where s.id = new.source_subject_id;
+
+  select s.project_id into v_target_project_id
+  from public.subjects s
+  where s.id = new.target_subject_id;
+
+  if v_source_project_id is null or v_target_project_id is null then
+    raise exception 'Both source and target subjects must exist';
+  end if;
+
+  if v_source_project_id is distinct from v_target_project_id then
+    raise exception 'Blocked_by relation must use subjects from the same project';
+  end if;
+
+  if new.project_id is distinct from v_source_project_id then
+    raise exception 'project_id must match source subject project_id';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_validate_subject_blocked_by_link on public.subject_links;
+create trigger trg_validate_subject_blocked_by_link
+before insert or update on public.subject_links
+for each row execute function public.validate_subject_blocked_by_link();


### PR DESCRIPTION
### Motivation

- Provide full support for functional blocking relations between subjects so users can mark "Est bloqué par" and "Est bloquant pour" from the subject detail sidebar. 
- Reuse the existing parent-relation UX (back button, search, selected / suggestions) for a consistent, discoverable workflow. 
- Enforce business rules both on the frontend (optimistic updates + validation) and in the database to prevent invalid links (self-links, cross-project links, mutual blocking). 

### Description

- Added a new frontend service `apps/web/js/services/subject-blocking-relation-service.js` providing `createBlockedByRelationInSupabase` and `deleteBlockedByRelationInSupabase` with input validation. 
- Extended the subjects view to display relation groups (Parent / Est bloqué par / Est bloquant pour) with simple counters and dividers shown only when groups contain items, and replaced old menu labels with the requested wording. Changes are in `apps/web/js/views/project-subjects/project-subjects-view.js` and `apps/web/js/views/project-subjects.js`. 
- Implemented selection/suggestions and multi-select toggles for the two new relation views, keyboard handlers and dropdown flows by updating `project-subjects-view.js`, `project-subjects-events.js` and `project-subjects-actions.js`, including optimistic local updates and rollback on failure. 
- Added a Supabase migration `supabase/migrations/202604170001_subject_blocked_by_constraints.sql` introducing a unique unordered pair index for `blocked_by` links and a trigger `validate_subject_blocked_by_link()` to enforce same-project and payload constraints. 
- Added UI styles for relation cards/groups in `apps/web/style.css`. 

### Testing

- Ran syntax checks with `node --check` on updated modules (`apps/web/js/views/project-subjects.js`, `apps/web/js/views/project-subjects/project-subjects-view.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/project-subjects/project-subjects-actions.js`, and `apps/web/js/services/subject-blocking-relation-service.js`) and they completed without syntax errors. 
- Verified the modified files were committed to the working tree (local validation) and there were no outstanding syntax issues after edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1bf6d7a0c8329a8e6b79232c773b7)