### PR TITLE
Set subject row meta line to 20px height and vertically center content

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2100,6 +2100,9 @@ body.modal-open {
   grid-column:3;
   grid-row:2;
   min-width:0;
+  height:20px;
+  display:flex;
+  align-items:center;
 }
 .issue-row-meta-text{
   width:100%;


### PR DESCRIPTION
### Motivation
- Ensure the second description/meta line in the main subjects table (`.issue-row-title-grid__meta`) has a fixed height and its content is vertically centered for consistent row layout.

### Description
- Updated `apps/web/style.css` to add `height: 20px`, `display: flex` and `align-items: center` to the `.issue-row-title-grid__meta` rule so the second line is 20px tall and its contents are vertically centered.

### Testing
- Ran `git diff --check` and confirmed no whitespace/diff issues, and verified the file was committed; the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20a8074dc83298040cd367e926e3e)