### PR TITLE
Display subject priority in details sidebar and small UI fixes

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -416,6 +416,7 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   renderCommentBox,
   renderDetailedMetaForSelection: (...args) => projectSubjectsView.renderDetailedMetaForSelection(...args),
   renderSubjectMetaControls: (...args) => projectSubjectsView.renderSubjectMetaControls(...args),
+  priorityBadge: (...args) => projectSubjectsView.priorityBadge(...args),
   renderDocumentRefsCard: (...args) => projectSubjectsView.renderDocumentRefsCard(...args)
 });
 

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -22,6 +22,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderCommentBox,
     renderDetailedMetaForSelection,
     renderSubjectMetaControls,
+    priorityBadge,
     renderDocumentRefsCard
   } = config;
 
@@ -127,8 +128,17 @@ export function createProjectSubjectsDetailsRenderer(config) {
       : renderSubIssuesForSituation(item, options.subissuesOptions || {});
     const threadHtml = renderThreadBlock();
     const commentBoxHtml = renderCommentBox(selection);
-    const metaHtml = renderDetailedMetaForSelection(selection);
     const subjectMetaControlsHtml = selection.type === "sujet" ? renderSubjectMetaControls(item) : "";
+    const subjectPriorityHtml = selection.type === "sujet"
+      ? `
+        <div class="subject-sidebar-priority">
+          <span class="subject-sidebar-priority__label">Priority</span>
+          <span class="subject-sidebar-priority__value">${priorityBadge(firstNonEmpty(item.priority, item.raw?.priority, "medium"))}</span>
+        </div>
+      `
+      : "";
+    const metaHtml = selection.type === "sujet" ? "" : renderDetailedMetaForSelection(selection);
+    const metaTitleHtml = selection.type === "sujet" ? "" : `<div class="meta-title">Metadata</div>`;
 
     return `
       <div class="details-grid">
@@ -143,7 +153,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
         </div>
         <aside class="details-meta-col">
           ${subjectMetaControlsHtml}
-          <div class="meta-title">Metadata</div>
+          ${subjectPriorityHtml}
+          ${metaTitleHtml}
           ${metaHtml}
         </aside>
       </div>

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1393,6 +1393,8 @@ function renderSubjectParentHeadHtml(subject, options = {}) {
   const parentSubject = getSubjectParentSubject(subject?.id || subject);
   if (!parentSubject) return "";
   const title = escapeHtml(firstNonEmpty(parentSubject.title, parentSubject.id, "Sujet parent"));
+  const parentRef = escapeHtml(firstNonEmpty(getEntityDisplayRef("sujet", parentSubject.id), `#${parentSubject.id || ""}`));
+  const linkTitle = compact ? parentRef : title;
   const parentSubjectId = escapeHtml(String(parentSubject.id || ""));
   const wrapperClass = compact ? "details-parent-badge details-parent-badge--compact" : "details-parent-badge";
   return `
@@ -1405,7 +1407,7 @@ function renderSubjectParentHeadHtml(subject, options = {}) {
         data-parent-subject-id="${parentSubjectId}"
         aria-label="Ouvrir le sujet parent ${title}"
       >
-        <span class="details-parent-badge__title">${title}</span>
+        <span class="details-parent-badge__title">${linkTitle}</span>
       </button>
     </span>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -563,6 +563,18 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
 .meta-k{font-size:12px;color:var(--muted);font-weight: 600;}
 .meta-v{font-size:13px;margin-top:2px;word-break:break-word;color: var(--muted);font-weight: 400;}
 
+.subject-sidebar-priority{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-bottom:20px;
+  padding:2px 0 10px;
+  border-bottom:1px solid var(--border);
+}
+.subject-sidebar-priority__label{font-size:11px;font-weight:600;color:var(--muted);}
+.subject-sidebar-priority__value{display:inline-flex;align-items:center;flex:0 0 auto;}
+
 .subject-meta-controls{display:flex;flex-direction:column;gap:8px;margin-bottom:24px;}
 .subject-meta-field{position:relative;padding:0 0 10px 0;border-bottom:1px solid var(--border);}
 
@@ -2100,6 +2112,9 @@ body.modal-open {
   grid-column:3;
   grid-row:2;
   min-width:0;
+  height:20px;
+  display:flex;
+  align-items:center;
 }
 .issue-row-meta-text{
   width:100%;


### PR DESCRIPTION
### Motivation
- Surface a sujet's priority in the details sidebar so reviewers can quickly see priority without scanning metadata. 
- Improve the compact display of a parent subject link and adjust some metadata layout to better fit the new priority block.

### Description
- Wire `priorityBadge` through `project-subjects.js` into the details renderer by adding `priorityBadge: (...args) => projectSubjectsView.priorityBadge(...args)`. 
- Render a new priority block in the details sidebar for `sujet` items using `priorityBadge(firstNonEmpty(item.priority, item.raw?.priority, "medium"))`, and hide the detailed metadata block for sujets. 
- Keep `renderDetailedMetaForSelection` and its title for non-`sujet` selections only by conditionally rendering `metaHtml` and `metaTitleHtml`. 
- Change the parent-subject compact link to show a compact `linkTitle` using `getEntityDisplayRef("sujet", parentSubject.id)` when available. 
- Add CSS for the new priority block (`.subject-sidebar-priority`, label and value) and minor layout tweaks to `.issue-row-meta`/`.issue-row-meta-text` to align content.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20a8074dc83298040cd367e926e3e)