### PR TITLE
Add subject priority to details sidebar and refine subject relation UI/layout

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -416,6 +416,7 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   renderCommentBox,
   renderDetailedMetaForSelection: (...args) => projectSubjectsView.renderDetailedMetaForSelection(...args),
   renderSubjectMetaControls: (...args) => projectSubjectsView.renderSubjectMetaControls(...args),
+  priorityBadge: (...args) => projectSubjectsView.priorityBadge(...args),
   renderDocumentRefsCard: (...args) => projectSubjectsView.renderDocumentRefsCard(...args)
 });
 

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -22,6 +22,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderCommentBox,
     renderDetailedMetaForSelection,
     renderSubjectMetaControls,
+    priorityBadge,
     renderDocumentRefsCard
   } = config;
 
@@ -32,9 +33,14 @@ export function createProjectSubjectsDetailsRenderer(config) {
         const item = currentSelection.item;
         const entityType = getSelectionEntityType(currentSelection.type);
         const titleSeenClass = getReviewTitleStateClass(entityType, item.id);
-        return `<span class="details-title-text ${titleSeenClass}">${escapeHtml(firstNonEmpty(item.title, item.id, "Détail"))}</span>`;
+        const titleHtml = `<span class="details-title-text ${titleSeenClass}">${escapeHtml(firstNonEmpty(item.title, item.id, "Détail"))}</span>`;
+        if (currentSelection.type === "sujet") {
+          return `${titleHtml} <span class="details-title-inline-ref mono">${entityDisplayLinkHtml(currentSelection.type, item.id)}</span>`;
+        }
+        return titleHtml;
       },
       buildIdHtml(currentSelection) {
+        if (currentSelection.type === "sujet") return "";
         return entityDisplayLinkHtml(currentSelection.type, currentSelection.item.id);
       },
       buildExpandedBottomHtml(currentSelection) {
@@ -127,8 +133,17 @@ export function createProjectSubjectsDetailsRenderer(config) {
       : renderSubIssuesForSituation(item, options.subissuesOptions || {});
     const threadHtml = renderThreadBlock();
     const commentBoxHtml = renderCommentBox(selection);
-    const metaHtml = renderDetailedMetaForSelection(selection);
     const subjectMetaControlsHtml = selection.type === "sujet" ? renderSubjectMetaControls(item) : "";
+    const subjectPriorityHtml = selection.type === "sujet"
+      ? `
+        <div class="subject-sidebar-priority">
+          <span class="subject-sidebar-priority__label">Priority</span>
+          <span class="subject-sidebar-priority__value">${priorityBadge(firstNonEmpty(item.priority, item.raw?.priority, "medium"))}</span>
+        </div>
+      `
+      : "";
+    const metaHtml = selection.type === "sujet" ? "" : renderDetailedMetaForSelection(selection);
+    const metaTitleHtml = selection.type === "sujet" ? "" : `<div class="meta-title">Metadata</div>`;
 
     return `
       <div class="details-grid">
@@ -143,7 +158,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
         </div>
         <aside class="details-meta-col">
           ${subjectMetaControlsHtml}
-          <div class="meta-title">Metadata</div>
+          ${subjectPriorityHtml}
+          ${metaTitleHtml}
           ${metaHtml}
         </aside>
       </div>

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1277,19 +1277,25 @@ function getSubjectParentSubject(subjectId) {
 }
 
 function renderSubjectRelationSubjectCard(subject, options = {}) {
-  const relationLabel = firstNonEmpty(options.label, "Relation");
+  const relationLabel = String(firstNonEmpty(options.label, "")).trim();
   const displayRef = getEntityDisplayRef("sujet", subject?.id);
   const status = getEffectiveSujetStatus(subject?.id);
+  const descriptionState = getEntityDescriptionState("sujet", subject?.id) || {};
+  const author = getDisplayAuthorName(firstNonEmpty(descriptionState.author, subject?.agent, subject?.raw?.agent, "system"), {
+    agent: firstNonEmpty(descriptionState.agent, subject?.agent, subject?.raw?.agent, "system"),
+    fallback: "System"
+  });
+  const authorAndRef = `${author}/${displayRef}`;
   const extraCountHtml = options.countHtml ? `<span class="subject-meta-parent-card__count">${options.countHtml}</span>` : "";
   return `
     <button type="button" class="subject-meta-parent-card" data-parent-subject-id="${escapeHtml(subject?.id || "")}">
-      <span class="subject-meta-parent-card__label">${escapeHtml(relationLabel)}</span>
-      <span class="subject-meta-parent-card__head">
+      ${relationLabel ? `<span class="subject-meta-parent-card__label">${escapeHtml(relationLabel)}</span>` : ""}
+      <span class="subject-meta-parent-card__body">
         <span class="subject-meta-parent-card__icon">${issueIcon(status)}</span>
         <span class="subject-meta-parent-card__title">${escapeHtml(firstNonEmpty(subject?.title, subject?.id, "Sujet"))}</span>
         ${extraCountHtml}
+        <span class="subject-meta-parent-card__meta">${escapeHtml(authorAndRef)}</span>
       </span>
-      <span class="subject-meta-parent-card__meta">${escapeHtml(displayRef)}</span>
     </button>
   `;
 }
@@ -1317,7 +1323,7 @@ function renderSubjectRelationsCards(subjectId) {
       <div class="subject-meta-relations-group">
         <div class="subject-meta-relations-group__title">Est bloqué par <span class="subject-meta-relations-group__counter">${blockedBySubjects.length}</span></div>
         <div class="subject-meta-relations-group__list">
-          ${blockedBySubjects.map((item) => renderSubjectRelationSubjectCard(item, { label: "Sujet" })).join("")}
+          ${blockedBySubjects.map((item) => renderSubjectRelationSubjectCard(item)).join("")}
         </div>
       </div>
     `);
@@ -1328,7 +1334,7 @@ function renderSubjectRelationsCards(subjectId) {
       <div class="subject-meta-relations-group">
         <div class="subject-meta-relations-group__title">Est bloquant pour <span class="subject-meta-relations-group__counter">${blockingSubjects.length}</span></div>
         <div class="subject-meta-relations-group__list">
-          ${blockingSubjects.map((item) => renderSubjectRelationSubjectCard(item, { label: "Sujet" })).join("")}
+          ${blockingSubjects.map((item) => renderSubjectRelationSubjectCard(item)).join("")}
         </div>
       </div>
     `);
@@ -1393,6 +1399,8 @@ function renderSubjectParentHeadHtml(subject, options = {}) {
   const parentSubject = getSubjectParentSubject(subject?.id || subject);
   if (!parentSubject) return "";
   const title = escapeHtml(firstNonEmpty(parentSubject.title, parentSubject.id, "Sujet parent"));
+  const parentRef = escapeHtml(firstNonEmpty(getEntityDisplayRef("sujet", parentSubject.id), `#${parentSubject.id || ""}`));
+  const linkTitle = compact ? parentRef : title;
   const parentSubjectId = escapeHtml(String(parentSubject.id || ""));
   const wrapperClass = compact ? "details-parent-badge details-parent-badge--compact" : "details-parent-badge";
   return `
@@ -1405,7 +1413,7 @@ function renderSubjectParentHeadHtml(subject, options = {}) {
         data-parent-subject-id="${parentSubjectId}"
         aria-label="Ouvrir le sujet parent ${title}"
       >
-        <span class="details-parent-badge__title">${title}</span>
+        <span class="details-parent-badge__title">${linkTitle}</span>
       </button>
     </span>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -563,6 +563,18 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
 .meta-k{font-size:12px;color:var(--muted);font-weight: 600;}
 .meta-v{font-size:13px;margin-top:2px;word-break:break-word;color: var(--muted);font-weight: 400;}
 
+.subject-sidebar-priority{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  margin-bottom:20px;
+  padding:2px 0 10px;
+  border-bottom:1px solid var(--border);
+}
+.subject-sidebar-priority__label{font-size:11px;font-weight:600;color:var(--muted);}
+.subject-sidebar-priority__value{display:inline-flex;align-items:center;flex:0 0 auto;}
+
 .subject-meta-controls{display:flex;flex-direction:column;gap:8px;margin-bottom:24px;}
 .subject-meta-field{position:relative;padding:0 0 10px 0;border-bottom:1px solid var(--border);}
 
@@ -673,37 +685,53 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
   font-weight:600;
   color:var(--muted);
 }
-.subject-meta-parent-card__head{
-  display:flex;
-  align-items:center;
-  gap:8px;
+.subject-meta-parent-card__body{
+  display:grid;
+  grid-template-columns:auto minmax(0, 1fr) auto;
+  grid-template-rows:auto auto;
+  column-gap:8px;
+  row-gap:4px;
+  align-items:start;
   min-width:0;
 }
 .subject-meta-parent-card__icon{
+  grid-column:1;
+  grid-row:1;
   display:inline-flex;
   align-items:center;
   flex:0 0 auto;
+  margin-top:1px;
 }
 .subject-meta-parent-card__title{
+  grid-column:2;
+  grid-row:1;
   min-width:0;
   font-size:13px;
   line-height:18px;
   font-weight:600;
   color:var(--text);
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
+  white-space:normal;
+  overflow:visible;
+  text-overflow:clip;
+  word-break:break-word;
 }
 .subject-meta-parent-card__count{
-  margin-left:auto;
+  grid-column:3;
+  grid-row:1;
+  margin-left:2px;
   flex:0 0 auto;
 }
 .subject-meta-parent-card__count .subissues-counts{
   margin-left:0;
 }
 .subject-meta-parent-card__meta{
+  grid-column:2 / -1;
+  grid-row:2;
   font-size:12px;
   color:var(--muted);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
 .subject-meta-relations-cards{display:flex;flex-direction:column;gap:10px;}
@@ -2100,6 +2128,9 @@ body.modal-open {
   grid-column:3;
   grid-row:2;
   min-width:0;
+  height:20px;
+  display:flex;
+  align-items:center;
 }
 .issue-row-meta-text{
   width:100%;
@@ -2598,10 +2629,33 @@ body.is-resizing{
 .details-title-row{display:flex;align-items:center;gap:10px;min-width:0;flex-wrap:wrap;}
 
 .details-title-text{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;}
+.details-title-inline-ref{
+  color:var(--muted);
+  white-space:nowrap;
+  font-size:inherit;
+  font-weight:400;
+}
+.details-title-inline-ref a{
+  color:inherit;
+  text-decoration:none;
+}
+.details-title-inline-ref a:hover,
+.details-title-inline-ref a:focus-visible{
+  color:var(--accent);
+  text-decoration:underline;
+  outline:none;
+}
 .details-title-id a{color:var(--muted);text-decoration:none;}
 .details-title-id a:hover{color:var(--accent);text-decoration:underline;}
 
 .details-title--expanded .details-title-text{font-size:32px;font-weight:400;line-height:43px;color:#fff;}
+.details-title--expanded .details-title-topline .details-title-text{
+  white-space:normal;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+}
 .details-title--expanded .gh-state{font-size:14px;line-height:21px;padding:3px 10px;}
 .details-title--expanded .subissues-counts--problems{
   display:inline-flex;


### PR DESCRIPTION
### Motivation

- Surface the priority of `sujet` entities in the details sidebar so users can see priority without opening edit controls.
- Improve how subject references and parent/blocked relations are displayed in the details header and relation cards. 
- Tidy up metadata placement so `sujet` details emphasize priority and controls while situations retain full metadata.

### Description

- Added a `priorityBadge` config option to the project subjects details renderer and wired it through `project-subjects.js` via `priorityBadge: (...args) => projectSubjectsView.priorityBadge(...args)`.
- Render a new priority block in the details sidebar for `sujet` selections using `priorityBadge(firstNonEmpty(item.priority, item.raw?.priority, "medium"))` and hide the full metadata panel for `sujet` while keeping it for `situation` selections.
- Show an inline entity reference next to the `sujet` title in the expanded title (`details-title-inline-ref`) and avoid duplicating the reference in the title ID for sujets.
- Revamped relation cards by trimming empty `label` values, switching to a grid layout (`subject-meta-parent-card__body`), including an author/ref line, and simplifying blocked/blocking group rendering to omit redundant labels.
- Updated styles in `style.css` to add `.subject-sidebar-priority`, adjust `.subject-meta-parent-card` layout and truncation behavior, and add `.details-title-inline-ref` and expanded title wrapping rules for multi-line titles.

### Testing

- Ran the JavaScript test suite with `yarn test` and static checks with `yarn lint`, and both completed successfully.
- Performed a quick UI smoke check by running the dev server and verifying `sujet` details show the priority block and relation cards render with the new layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20a8074dc83298040cd367e926e3e)