### PR TITLE
Ajout d'un service de messagerie sujets (Supabase) et branchement du thread persistant

### DIFF
--- a/apps/web/js/services/subject-messages-service.js
+++ b/apps/web/js/services/subject-messages-service.js
@@ -1,0 +1,140 @@
+import { createSubjectMessagesSupabaseRepository } from "./subject-messages-supabase.js";
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function toTimelineRows(messages = [], events = []) {
+  const messageRows = (Array.isArray(messages) ? messages : []).map((message) => ({
+    kind: "message",
+    created_at: message?.created_at || "",
+    message
+  }));
+  const eventRows = (Array.isArray(events) ? events : []).map((event) => ({
+    kind: "event",
+    created_at: event?.created_at || "",
+    event
+  }));
+
+  return [...messageRows, ...eventRows].sort((left, right) => {
+    const lt = String(left?.created_at || "");
+    const rt = String(right?.created_at || "");
+    return lt.localeCompare(rt);
+  });
+}
+
+export function createSubjectMessagesService({ repository } = {}) {
+  const provider = repository || createSubjectMessagesSupabaseRepository();
+
+  async function listMessages(subjectId) {
+    const normalizedSubjectId = normalizeId(subjectId);
+    if (!normalizedSubjectId) return [];
+    return provider.listMessages({ subjectId: normalizedSubjectId });
+  }
+
+  async function listTimeline(subjectId) {
+    const normalizedSubjectId = normalizeId(subjectId);
+    if (!normalizedSubjectId) return { rows: [], messages: [], events: [], conversation: null };
+
+    const [messages, events, conversation] = await Promise.all([
+      provider.listMessages({ subjectId: normalizedSubjectId }),
+      provider.listEvents({ subjectId: normalizedSubjectId }),
+      provider.getConversationSettings({ subjectId: normalizedSubjectId })
+    ]);
+
+    return {
+      rows: toTimelineRows(messages, events),
+      messages,
+      events,
+      conversation
+    };
+  }
+
+  async function createMessage(payload = {}) {
+    return provider.createMessage(payload);
+  }
+
+  async function createReply(payload = {}) {
+    return provider.createMessage({
+      ...payload,
+      parentMessageId: normalizeId(payload.parentMessageId)
+    });
+  }
+
+  async function markMessageRead(messageId, context = {}) {
+    return provider.markMessageRead({ messageId, ...context });
+  }
+
+  async function markTimelineRead(subjectId) {
+    const messages = await listMessages(subjectId);
+    for (const message of messages) {
+      const messageId = normalizeId(message?.id);
+      if (!messageId) continue;
+      await provider.markMessageRead({
+        messageId,
+        subjectId,
+        projectId: message?.project_id
+      });
+    }
+    return true;
+  }
+
+  async function canEditMessage(messageId) {
+    return provider.canEditMessage({ messageId });
+  }
+
+  async function editMessage(messageId, patch = {}) {
+    return provider.editMessage({
+      messageId,
+      bodyMarkdown: patch.bodyMarkdown
+    });
+  }
+
+  async function deleteMessage(messageId) {
+    return provider.deleteMessage({ messageId });
+  }
+
+  async function uploadTemporaryAttachment(payload = {}) {
+    return provider.uploadTemporaryAttachment(payload);
+  }
+
+  async function linkAttachmentsToMessage(payload = {}) {
+    return provider.linkAttachmentsToMessage(payload);
+  }
+
+  async function lockConversation(subjectId, options = {}) {
+    return provider.lockConversation({ subjectId, reason: options.reason });
+  }
+
+  async function unlockConversation(subjectId) {
+    return provider.unlockConversation({ subjectId });
+  }
+
+  async function listCollaboratorsForMentions(projectId) {
+    return provider.listCollaboratorsForMentions({ projectId });
+  }
+
+  async function listUnreadConversationNotifications(context = {}) {
+    return provider.listUnreadConversationNotifications(context);
+  }
+
+  return {
+    listTimeline,
+    listMessages,
+    createMessage,
+    createReply,
+    markMessageRead,
+    markTimelineRead,
+    canEditMessage,
+    editMessage,
+    deleteMessage,
+    uploadTemporaryAttachment,
+    linkAttachmentsToMessage,
+    lockConversation,
+    unlockConversation,
+    listCollaboratorsForMentions,
+    listUnreadConversationNotifications
+  };
+}
+
+export const subjectMessagesService = createSubjectMessagesService();

--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -1,0 +1,329 @@
+import { store } from "../store.js";
+import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
+
+const SUPABASE_URL = getSupabaseUrl();
+const SUBJECT_ATTACHMENTS_BUCKET = "subject-message-attachments";
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function safeJsonParse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+async function getAuthHeaders(extra = {}) {
+  return buildSupabaseAuthHeaders(extra);
+}
+
+async function restFetch(pathname, searchParams = null, options = {}) {
+  const url = new URL(`${SUPABASE_URL}${pathname}`);
+  if (searchParams instanceof URLSearchParams) {
+    searchParams.forEach((value, key) => url.searchParams.append(key, value));
+  }
+
+  const response = await fetch(url.toString(), {
+    method: options.method || "GET",
+    headers: await getAuthHeaders({ Accept: "application/json", ...(options.headers || {}) }),
+    cache: options.cache || "no-store",
+    body: options.body
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`${pathname} failed (${response.status}): ${text}`);
+  }
+
+  if (response.status === 204) return null;
+  const text = await response.text().catch(() => "");
+  if (!text) return null;
+  return safeJsonParse(text);
+}
+
+async function rpcCall(functionName, payload = {}) {
+  return restFetch(`/rest/v1/rpc/${functionName}`, null, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+async function resolveProjectId(explicitProjectId = "") {
+  const normalized = normalizeId(explicitProjectId);
+  if (normalized) return normalized;
+  return normalizeId(await resolveCurrentBackendProjectId().catch(() => ""));
+}
+
+async function resolveCurrentPersonId() {
+  return normalizeId(await resolveCurrentUserDirectoryPersonId().catch(() => ""));
+}
+
+async function fetchMessageById(messageId) {
+  const normalizedMessageId = normalizeId(messageId);
+  if (!normalizedMessageId) return null;
+
+  const params = new URLSearchParams();
+  params.set("select", "id,project_id,subject_id,author_person_id");
+  params.set("id", `eq.${normalizedMessageId}`);
+  params.set("limit", "1");
+
+  const rows = await restFetch("/rest/v1/subject_messages", params);
+  return (Array.isArray(rows) ? rows[0] : rows) || null;
+}
+
+export function createSubjectMessagesSupabaseRepository() {
+  return {
+    async listMessages({ subjectId }) {
+      const normalizedSubjectId = normalizeId(subjectId);
+      if (!normalizedSubjectId) return [];
+
+      const params = new URLSearchParams();
+      params.set(
+        "select",
+        "id,project_id,subject_id,parent_message_id,author_person_id,author_user_id,body_markdown,created_at,updated_at,deleted_at,is_frozen,frozen_at,frozen_reason"
+      );
+      params.set("subject_id", `eq.${normalizedSubjectId}`);
+      params.set("order", "created_at.asc");
+
+      const rows = await restFetch("/rest/v1/subject_messages", params);
+      return Array.isArray(rows) ? rows : [];
+    },
+
+    async listEvents({ subjectId }) {
+      const normalizedSubjectId = normalizeId(subjectId);
+      if (!normalizedSubjectId) return [];
+
+      const params = new URLSearchParams();
+      params.set("select", "id,project_id,subject_id,message_id,event_type,actor_person_id,actor_user_id,event_payload,created_at");
+      params.set("subject_id", `eq.${normalizedSubjectId}`);
+      params.set("order", "created_at.asc");
+
+      const rows = await restFetch("/rest/v1/subject_message_events", params);
+      return Array.isArray(rows) ? rows : [];
+    },
+
+    async getConversationSettings({ subjectId }) {
+      const normalizedSubjectId = normalizeId(subjectId);
+      if (!normalizedSubjectId) return null;
+
+      const params = new URLSearchParams();
+      params.set("select", "subject_id,project_id,is_locked,locked_at,locked_by_person_id,locked_by_user_id,lock_reason,updated_at");
+      params.set("subject_id", `eq.${normalizedSubjectId}`);
+      params.set("limit", "1");
+
+      const rows = await restFetch("/rest/v1/subject_conversation_settings", params);
+      return (Array.isArray(rows) ? rows[0] : rows) || null;
+    },
+
+    async createMessage(payload = {}) {
+      const subjectId = normalizeId(payload.subjectId);
+      const bodyMarkdown = String(payload.bodyMarkdown || "").trim();
+      const projectId = await resolveProjectId(payload.projectId);
+      const personId = await resolveCurrentPersonId();
+
+      if (!subjectId) throw new Error("subjectId is required");
+      if (!projectId) throw new Error("projectId is required");
+      if (!personId) throw new Error("current person is required");
+      if (!bodyMarkdown) throw new Error("bodyMarkdown is required");
+
+      const rows = await restFetch("/rest/v1/subject_messages", null, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Prefer: "return=representation"
+        },
+        body: JSON.stringify({
+          project_id: projectId,
+          subject_id: subjectId,
+          parent_message_id: normalizeId(payload.parentMessageId) || null,
+          author_person_id: personId,
+          author_user_id: normalizeId(store?.user?.id || "") || null,
+          body_markdown: bodyMarkdown
+        })
+      });
+
+      return (Array.isArray(rows) ? rows[0] : rows) || null;
+    },
+
+    async markMessageRead({ messageId, subjectId = "", projectId = "" } = {}) {
+      const normalizedMessageId = normalizeId(messageId);
+      const personId = await resolveCurrentPersonId();
+      if (!normalizedMessageId) throw new Error("messageId is required");
+      if (!personId) throw new Error("current person is required");
+
+      const message = await fetchMessageById(normalizedMessageId);
+      if (!message?.id) throw new Error("message not found");
+
+      const rows = await restFetch("/rest/v1/subject_message_reads", null, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Prefer: "resolution=merge-duplicates,return=representation"
+        },
+        body: JSON.stringify({
+          message_id: normalizedMessageId,
+          subject_id: normalizeId(subjectId) || normalizeId(message.subject_id),
+          project_id: await resolveProjectId(projectId || message.project_id),
+          reader_person_id: personId,
+          reader_user_id: normalizeId(store?.user?.id || "") || null
+        })
+      });
+
+      return (Array.isArray(rows) ? rows[0] : rows) || null;
+    },
+
+    async canEditMessage({ messageId }) {
+      const normalizedMessageId = normalizeId(messageId);
+      if (!normalizedMessageId) return false;
+      const result = await rpcCall("subject_message_is_editable", { p_message_id: normalizedMessageId });
+      return !!result;
+    },
+
+    async editMessage({ messageId, bodyMarkdown }) {
+      const normalizedMessageId = normalizeId(messageId);
+      const nextBody = String(bodyMarkdown || "").trim();
+      if (!normalizedMessageId) throw new Error("messageId is required");
+      if (!nextBody) throw new Error("bodyMarkdown is required");
+
+      const params = new URLSearchParams();
+      params.set("id", `eq.${normalizedMessageId}`);
+
+      const rows = await restFetch("/rest/v1/subject_messages", params, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Prefer: "return=representation"
+        },
+        body: JSON.stringify({ body_markdown: nextBody })
+      });
+
+      return (Array.isArray(rows) ? rows[0] : rows) || null;
+    },
+
+    async deleteMessage({ messageId }) {
+      const normalizedMessageId = normalizeId(messageId);
+      if (!normalizedMessageId) throw new Error("messageId is required");
+      return rpcCall("soft_delete_subject_message", { p_message_id: normalizedMessageId });
+    },
+
+    async uploadTemporaryAttachment(payload = {}) {
+      const subjectId = normalizeId(payload.subjectId);
+      const projectId = await resolveProjectId(payload.projectId);
+      const personId = await resolveCurrentPersonId();
+      const storagePath = String(payload.storagePath || "").trim();
+      const fileName = String(payload.fileName || "").trim();
+
+      if (!subjectId) throw new Error("subjectId is required");
+      if (!projectId) throw new Error("projectId is required");
+      if (!personId) throw new Error("current person is required");
+      if (!storagePath) throw new Error("storagePath is required");
+      if (!fileName) throw new Error("fileName is required");
+
+      const rows = await restFetch("/rest/v1/subject_message_attachments", null, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Prefer: "return=representation"
+        },
+        body: JSON.stringify({
+          project_id: projectId,
+          subject_id: subjectId,
+          upload_session_id: normalizeId(payload.uploadSessionId) || null,
+          storage_bucket: String(payload.storageBucket || SUBJECT_ATTACHMENTS_BUCKET),
+          storage_path: storagePath,
+          file_name: fileName,
+          mime_type: String(payload.mimeType || "") || null,
+          size_bytes: Number.isFinite(Number(payload.sizeBytes)) ? Number(payload.sizeBytes) : null,
+          width: Number.isFinite(Number(payload.width)) ? Number(payload.width) : null,
+          height: Number.isFinite(Number(payload.height)) ? Number(payload.height) : null,
+          sort_order: Number.isFinite(Number(payload.sortOrder)) ? Number(payload.sortOrder) : 0,
+          uploaded_by_person_id: personId
+        })
+      });
+
+      return (Array.isArray(rows) ? rows[0] : rows) || null;
+    },
+
+    async linkAttachmentsToMessage({ subjectId, messageId, uploadSessionId }) {
+      const normalizedSubjectId = normalizeId(subjectId);
+      const normalizedMessageId = normalizeId(messageId);
+      const normalizedUploadSessionId = normalizeId(uploadSessionId);
+      if (!normalizedSubjectId) throw new Error("subjectId is required");
+      if (!normalizedMessageId) throw new Error("messageId is required");
+      if (!normalizedUploadSessionId) throw new Error("uploadSessionId is required");
+
+      const rows = await rpcCall("link_subject_message_attachments", {
+        p_subject_id: normalizedSubjectId,
+        p_message_id: normalizedMessageId,
+        p_upload_session_id: normalizedUploadSessionId
+      });
+
+      return Array.isArray(rows) ? rows : [];
+    },
+
+    async lockConversation({ subjectId, reason = "" }) {
+      const normalizedSubjectId = normalizeId(subjectId);
+      if (!normalizedSubjectId) throw new Error("subjectId is required");
+      return rpcCall("lock_subject_conversation", {
+        p_subject_id: normalizedSubjectId,
+        p_lock_reason: String(reason || "") || null
+      });
+    },
+
+    async unlockConversation({ subjectId }) {
+      const normalizedSubjectId = normalizeId(subjectId);
+      if (!normalizedSubjectId) throw new Error("subjectId is required");
+      return rpcCall("unlock_subject_conversation", { p_subject_id: normalizedSubjectId });
+    },
+
+    async listCollaboratorsForMentions({ projectId }) {
+      const normalizedProjectId = await resolveProjectId(projectId);
+      if (!normalizedProjectId) return [];
+
+      const params = new URLSearchParams();
+      params.set("select", "person_id,collaborator_user_id,collaborator_email,collaborator_name,collaborator_first_name,collaborator_last_name,status,role_group_code,role_group_label");
+      params.set("project_id", `eq.${normalizedProjectId}`);
+      params.set("removed_at", "is.null");
+
+      const rows = await restFetch("/rest/v1/project_collaborators_view", params);
+      const list = Array.isArray(rows) ? rows : [];
+      return list
+        .filter((row) => String(row?.status || "").trim().toLowerCase() !== "retiré")
+        .map((row) => ({
+          personId: normalizeId(row?.person_id),
+          userId: normalizeId(row?.collaborator_user_id),
+          email: String(row?.collaborator_email || "").trim(),
+          label: String(
+            row?.collaborator_name
+              || [row?.collaborator_first_name, row?.collaborator_last_name].filter(Boolean).join(" ")
+              || row?.collaborator_email
+              || "Utilisateur"
+          ).trim(),
+          roleGroupCode: String(row?.role_group_code || "").trim().toLowerCase(),
+          roleGroupLabel: String(row?.role_group_label || "").trim()
+        }))
+        .filter((row) => !!row.personId);
+    },
+
+    async listUnreadConversationNotifications({ projectId, personId = "" } = {}) {
+      const normalizedProjectId = await resolveProjectId(projectId);
+      const resolvedPersonId = normalizeId(personId) || await resolveCurrentPersonId();
+      if (!normalizedProjectId || !resolvedPersonId) return [];
+
+      const params = new URLSearchParams();
+      params.set("select", "id,project_id,subject_id,person_id,notification_type,message_id,event_id,is_read,created_at,read_at");
+      params.set("project_id", `eq.${normalizedProjectId}`);
+      params.set("person_id", `eq.${resolvedPersonId}`);
+      params.set("is_read", "eq.false");
+      params.set("order", "created_at.desc");
+
+      const rows = await restFetch("/rest/v1/subject_notifications", params);
+      return Array.isArray(rows) ? rows : [];
+    }
+  };
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -91,6 +91,7 @@ import {
   resolveCurrentUserDirectoryPersonId,
   syncProjectCollaboratorsFromSupabase
 } from "../services/project-supabase-sync.js";
+import { subjectMessagesService } from "../services/subject-messages-service.js";
 import {
   getSituationsTableGridTemplate,
   renderFlatSujetRow,
@@ -275,6 +276,8 @@ const projectSubjectsThread = createProjectSubjectsThread({
   getNestedSujet,
   getEffectiveSujetStatus,
   getEffectiveSituationStatus,
+  subjectMessagesService,
+  requestRerender: (...args) => projectSubjectsView.rerenderScope(...args),
   entityDisplayLinkHtml: (...args) => projectSubjectsView.entityDisplayLinkHtml(...args),
   inferAgent: (...args) => projectSubjectsView.inferAgent(...args),
   normActorName: (...args) => projectSubjectsView.normActorName(...args),

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -30,13 +30,112 @@ export function createProjectSubjectsThread(config = {}) {
     getNestedSujet,
     getEffectiveSujetStatus,
     getEffectiveSituationStatus,
+    subjectMessagesService,
+    requestRerender,
     entityDisplayLinkHtml,
     inferAgent,
     normActorName,
     miniAuthorIconHtml
   } = config;
 
-  function addComment(entityType, entityId, message, options = {}) {
+  const subjectTimelineCache = new Map();
+  const subjectTimelinePending = new Set();
+
+  function normalizeId(value) {
+    return String(value || "").trim();
+  }
+
+  function mapMessageRowToThreadComment(row = {}) {
+    return {
+      ts: firstNonEmpty(row.created_at, nowIso()),
+      entity_type: "sujet",
+      entity_id: normalizeId(row.subject_id),
+      type: "COMMENT",
+      actor: row.author_person_id ? `Person ${normalizeId(row.author_person_id).slice(0, 8)}` : "Human",
+      agent: "human",
+      message: String(row.deleted_at ? "[message supprimé]" : row.body_markdown || ""),
+      pending: false,
+      request_id: null,
+      meta: {
+        source: "supabase",
+        id: normalizeId(row.id),
+        parent_message_id: normalizeId(row.parent_message_id),
+        is_frozen: !!row.is_frozen
+      }
+    };
+  }
+
+  function mapEventRowToThreadActivity(row = {}) {
+    return {
+      ts: firstNonEmpty(row.created_at, nowIso()),
+      entity_type: "sujet",
+      entity_id: normalizeId(row.subject_id),
+      type: "ACTIVITY",
+      kind: String(row.event_type || "timeline_event").toLowerCase(),
+      actor: row.actor_person_id ? `Person ${normalizeId(row.actor_person_id).slice(0, 8)}` : "System",
+      agent: "system",
+      message: String(row.event_payload?.message || ""),
+      meta: {
+        source: "supabase",
+        id: normalizeId(row.id),
+        event_type: String(row.event_type || ""),
+        event_payload: row.event_payload || {}
+      }
+    };
+  }
+
+  function requestScopeRerender() {
+    if (typeof requestRerender === "function") {
+      requestRerender(document.getElementById("situationsDetailsHost") || document);
+    }
+  }
+
+  function ensureSubjectTimelineLoaded(subjectId) {
+    const normalizedSubjectId = normalizeId(subjectId);
+    if (!normalizedSubjectId || !subjectMessagesService || subjectTimelinePending.has(normalizedSubjectId)) return;
+
+    subjectTimelinePending.add(normalizedSubjectId);
+    subjectMessagesService.listTimeline(normalizedSubjectId)
+      .then((timeline) => {
+        const messages = Array.isArray(timeline?.messages) ? timeline.messages : [];
+        const events = Array.isArray(timeline?.events) ? timeline.events : [];
+        subjectTimelineCache.set(normalizedSubjectId, {
+          comments: messages.map((row) => mapMessageRowToThreadComment(row)),
+          activities: events.map((row) => mapEventRowToThreadActivity(row)),
+          conversation: timeline?.conversation || null
+        });
+        requestScopeRerender();
+      })
+      .catch((error) => {
+        console.warn("[subject-messages] timeline load failed", error);
+      })
+      .finally(() => {
+        subjectTimelinePending.delete(normalizedSubjectId);
+      });
+  }
+
+  async function addComment(entityType, entityId, message, options = {}) {
+    const normalizedEntityType = String(entityType || "").toLowerCase();
+    const normalizedEntityId = normalizeId(entityId);
+    const normalizedMessage = String(message || "").trim();
+    if (!normalizedMessage) return null;
+
+    if (normalizedEntityType === "sujet" && normalizedEntityId && subjectMessagesService) {
+      const created = options.parentMessageId
+        ? await subjectMessagesService.createReply({
+            subjectId: normalizedEntityId,
+            parentMessageId: options.parentMessageId,
+            bodyMarkdown: normalizedMessage
+          })
+        : await subjectMessagesService.createMessage({
+            subjectId: normalizedEntityId,
+            bodyMarkdown: normalizedMessage
+          });
+
+      ensureSubjectTimelineLoaded(normalizedEntityId);
+      return created;
+    }
+
     persistRunBucket((bucket) => {
       bucket.comments.push({
         ts: nowIso(),
@@ -51,6 +150,8 @@ export function createProjectSubjectsThread(config = {}) {
         meta: options.meta || {}
       });
     });
+
+    return null;
   }
 
   function addActivity(entityType, entityId, kind, message = "", meta = {}, options = {}) {
@@ -124,7 +225,7 @@ export function createProjectSubjectsThread(config = {}) {
     if (!selection) return [];
 
     const { bucket } = getRunBucket();
-    const comments = Array.isArray(bucket?.comments) ? bucket.comments : [];
+    const localComments = Array.isArray(bucket?.comments) ? bucket.comments : [];
     const activities = Array.isArray(bucket?.activities) ? bucket.activities : [];
     const events = [];
 
@@ -167,6 +268,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const entityKey = (type, id) => `${String(type || "").toLowerCase()}:${String(id || "")}`;
 
     if (subject) {
+      ensureSubjectTimelineLoaded(subject.id);
       allowedComments.add(entityKey("sujet", subject.id));
       allowedActivities.add(entityKey("sujet", subject.id));
       if (situation) allowedActivities.add(entityKey("situation", situation.id));
@@ -177,7 +279,15 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     const isViewingSubject = !!subject;
 
-    const humanEvents = [...comments, ...activities].filter((e) => {
+    const persistedTimeline = subject ? (subjectTimelineCache.get(normalizeId(subject.id)) || null) : null;
+    const comments = subject && persistedTimeline
+      ? persistedTimeline.comments
+      : localComments;
+    const persistedActivities = subject && persistedTimeline
+      ? persistedTimeline.activities
+      : [];
+
+    const humanEvents = [...comments, ...activities, ...persistedActivities].filter((e) => {
       const k = entityKey(e.entity_type, e.entity_id);
       const t = String(e?.type || "").toUpperCase();
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2341,7 +2341,7 @@ async function applyCommentAction(root) {
     return;
   }
 
-  addComment(target.type, target.id, message, { actor: "Human", agent: "human" });
+  await addComment(target.type, target.id, message, { actor: "Human", agent: "human" });
   ta.value = "";
   store.situationsView.commentPreviewMode = false;
   rerenderScope(root);


### PR DESCRIPTION
### Motivation
- Fournir une couche front métier décorrélée du transport pour remplacer le stockage local éphémère du thread par des données persistées.
- Préparer le terrain pour les étapes suivantes (timeline unifiée, lecture/figement, realtime) sans refonte visuelle.

### Description
- Ajout d'un service métier `createSubjectMessagesService` exposant l'API attendue (`listTimeline`, `listMessages`, `createMessage`, `createReply`, `markMessageRead`, `canEditMessage`, `editMessage`, `deleteMessage`, `uploadTemporaryAttachment`, `linkAttachmentsToMessage`, `lockConversation`, `unlockConversation`, `listCollaboratorsForMentions`, `listUnreadConversationNotifications`) implémenté dans `apps/web/js/services/subject-messages-service.js`.
- Implémentation Supabase séparée `createSubjectMessagesSupabaseRepository` encapsulant les appels REST/RPC vers les tables/RPC (subject_messages, subject_message_events, subject_message_reads, subject_conversation_settings, link_subject_message_attachments, lock/unlock, etc.) dans `apps/web/js/services/subject-messages-supabase.js`.
- Branchement du module thread pour hydrater la timeline persistée d'un sujet via le service, avec cache local (`subjectTimelineCache`) et prévention des rechargements concurrents (`subjectTimelinePending`), et mapping des rows Supabase vers le format attendu par le thread (fonctions `mapMessageRowToThreadComment` / `mapEventRowToThreadActivity`).
- Adaptation du flux d'envoi de commentaire pour persister de façon asynchrone quand il s'agit d'un `sujet` (`await addComment(...)`) et déclenchement d'un rechargement de timeline après création; conservation du comportement local/éphémère en dehors du périmètre sujet.
- Fichiers créés/modifiés : `apps/web/js/services/subject-messages-service.js` (nouveau), `apps/web/js/services/subject-messages-supabase.js` (nouveau), `apps/web/js/views/project-subjects.js` (modifié), `apps/web/js/views/project-subjects/project-subjects-thread.js` (modifié), `apps/web/js/views/project-subjects/project-subjects-view.js` (modifié).

### Testing
- Exécution des tests unitaires ciblés `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown.test.mjs apps/web/js/views/project-subjects/project-subjects-counters.test.mjs` réussie (tous les tests passés).
- Import dynamique via Node `node -e "import('./apps/web/js/services/subject-messages-service.js').then(()=>console.log('ok'))"` échoue dans l'environnement Node attendu en raison d'import front dépendant d'URLs/ressources `https:` (comportement attendu pour du code côté navigateur, non bloquant pour la livraison front).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2205b71b483298716f825befaa096)