### PR TITLE
feat(subject-thread): brancher le fil sujet sur la timeline persistée

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -39,7 +39,7 @@ export function createProjectSubjectsThread(config = {}) {
   } = config;
 
   const subjectTimelineCache = new Map();
-  const subjectTimelinePending = new Set();
+  const subjectTimelineState = new Map();
 
   function normalizeId(value) {
     return String(value || "").trim();
@@ -90,13 +90,21 @@ export function createProjectSubjectsThread(config = {}) {
     }
   }
 
-  function ensureSubjectTimelineLoaded(subjectId) {
+  function ensureSubjectTimelineLoaded(subjectId, options = {}) {
     const normalizedSubjectId = normalizeId(subjectId);
-    if (!normalizedSubjectId || !subjectMessagesService || subjectTimelinePending.has(normalizedSubjectId)) return;
+    if (!normalizedSubjectId || !subjectMessagesService) return;
 
-    subjectTimelinePending.add(normalizedSubjectId);
+    const force = !!options.force;
+    const currentState = subjectTimelineState.get(normalizedSubjectId) || { loading: false, requestId: 0 };
+    if (currentState.loading && !force) return;
+
+    const requestId = Number(currentState.requestId || 0) + 1;
+    subjectTimelineState.set(normalizedSubjectId, { loading: true, requestId });
     subjectMessagesService.listTimeline(normalizedSubjectId)
       .then((timeline) => {
+        const latestState = subjectTimelineState.get(normalizedSubjectId) || {};
+        if (Number(latestState.requestId || 0) !== requestId) return;
+
         const messages = Array.isArray(timeline?.messages) ? timeline.messages : [];
         const events = Array.isArray(timeline?.events) ? timeline.events : [];
         subjectTimelineCache.set(normalizedSubjectId, {
@@ -110,7 +118,9 @@ export function createProjectSubjectsThread(config = {}) {
         console.warn("[subject-messages] timeline load failed", error);
       })
       .finally(() => {
-        subjectTimelinePending.delete(normalizedSubjectId);
+        const latestState = subjectTimelineState.get(normalizedSubjectId) || {};
+        if (Number(latestState.requestId || 0) !== requestId) return;
+        subjectTimelineState.set(normalizedSubjectId, { loading: false, requestId });
       });
   }
 
@@ -132,7 +142,7 @@ export function createProjectSubjectsThread(config = {}) {
             bodyMarkdown: normalizedMessage
           });
 
-      ensureSubjectTimelineLoaded(normalizedEntityId);
+      ensureSubjectTimelineLoaded(normalizedEntityId, { force: true });
       return created;
     }
 
@@ -280,11 +290,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const isViewingSubject = !!subject;
 
     const persistedTimeline = subject ? (subjectTimelineCache.get(normalizeId(subject.id)) || null) : null;
-    const comments = subject && persistedTimeline
-      ? persistedTimeline.comments
+    const comments = subject
+      ? (persistedTimeline?.comments || [])
       : localComments;
-    const persistedActivities = subject && persistedTimeline
-      ? persistedTimeline.activities
+    const persistedActivities = subject
+      ? (persistedTimeline?.activities || [])
       : [];
 
     const humanEvents = [...comments, ...activities, ...persistedActivities].filter((e) => {


### PR DESCRIPTION
### Motivation
- Implémenter l'étape 3 du plan : remplacer le thread local/éphémère par la vraie lecture persistée afin que le détail sujet affiche la timeline backend.
- Éviter les courses et incohérences entre requêtes de timeline lors de rafraîchissements ou créations de messages.
- Conserver au maximum le rendu visuel existant tout en garantissant que l'état affiché reflète la source de vérité (Postgres/Supabase).

### Description
- Le fichier modifié est `apps/web/js/views/project-subjects/project-subjects-thread.js` et il est maintenant la source centrale du branchement du détail sujet sur la timeline persistée.
- Ajout d'un état par sujet `subjectTimelineState` et d'un mécanisme `requestId` pour `ensureSubjectTimelineLoaded` afin de gérer `loading` et d'ignorer les réponses obsolètes provenant de requêtes parallèles.
- Après création d'un message/réponse, le flux `addComment` force désormais un rechargement de la timeline via `ensureSubjectTimelineLoaded(subjectId, { force: true })` pour afficher l'état réellement persisté.
- Suppression du fallback qui utilisait systématiquement le store local quand un sujet était sélectionné : les commentaires affichés proviennent exclusivement de la timeline persistée quand on consulte un sujet (le stockage local reste utilisé pour autres contextes non-sujet).

### Testing
- Tests exécutés : `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` et `node --test apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs`.
- Résultat : les deux suites de tests automatiques sont passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2233061bc832996ec4721a29e6c0f)