### PR TITLE
Étape 5 — Lecture des messages et inviolabilité après lecture

### DIFF
--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -63,19 +63,6 @@ async function resolveCurrentPersonId() {
   return normalizeId(await resolveCurrentUserDirectoryPersonId().catch(() => ""));
 }
 
-async function fetchMessageById(messageId) {
-  const normalizedMessageId = normalizeId(messageId);
-  if (!normalizedMessageId) return null;
-
-  const params = new URLSearchParams();
-  params.set("select", "id,project_id,subject_id,author_person_id");
-  params.set("id", `eq.${normalizedMessageId}`);
-  params.set("limit", "1");
-
-  const rows = await restFetch("/rest/v1/subject_messages", params);
-  return (Array.isArray(rows) ? rows[0] : rows) || null;
-}
-
 export function createSubjectMessagesSupabaseRepository() {
   return {
     async listMessages({ subjectId }) {
@@ -152,29 +139,8 @@ export function createSubjectMessagesSupabaseRepository() {
 
     async markMessageRead({ messageId, subjectId = "", projectId = "" } = {}) {
       const normalizedMessageId = normalizeId(messageId);
-      const personId = await resolveCurrentPersonId();
       if (!normalizedMessageId) throw new Error("messageId is required");
-      if (!personId) throw new Error("current person is required");
-
-      const message = await fetchMessageById(normalizedMessageId);
-      if (!message?.id) throw new Error("message not found");
-
-      const rows = await restFetch("/rest/v1/subject_message_reads", null, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Prefer: "resolution=merge-duplicates,return=representation"
-        },
-        body: JSON.stringify({
-          message_id: normalizedMessageId,
-          subject_id: normalizeId(subjectId) || normalizeId(message.subject_id),
-          project_id: await resolveProjectId(projectId || message.project_id),
-          reader_person_id: personId,
-          reader_user_id: normalizeId(store?.user?.id || "") || null
-        })
-      });
-
-      return (Array.isArray(rows) ? rows[0] : rows) || null;
+      return rpcCall("mark_subject_message_read", { p_message_id: normalizedMessageId });
     },
 
     async canEditMessage({ messageId }) {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -40,12 +40,20 @@ export function createProjectSubjectsThread(config = {}) {
 
   const subjectTimelineCache = new Map();
   const subjectTimelineState = new Map();
+  const subjectReadMarkState = new Map();
 
   function normalizeId(value) {
     return String(value || "").trim();
   }
 
   function mapMessageRowToThreadComment(row = {}) {
+    const isDeleted = !!row.deleted_at;
+    const isFrozen = !!row.is_frozen;
+    const stateLabel = isDeleted
+      ? "supprimé"
+      : isFrozen
+        ? "figé (vu par un tiers)"
+        : "modifiable";
     return {
       ts: firstNonEmpty(row.created_at, nowIso()),
       entity_type: "sujet",
@@ -60,9 +68,52 @@ export function createProjectSubjectsThread(config = {}) {
         source: "supabase",
         id: normalizeId(row.id),
         parent_message_id: normalizeId(row.parent_message_id),
-        is_frozen: !!row.is_frozen
-      }
+        is_frozen: isFrozen,
+        is_deleted: isDeleted,
+        state_label: stateLabel
+      },
+      stateLabel
     };
+  }
+
+  function queueSubjectMessageReadMarking(subjectId, messages = []) {
+    const normalizedSubjectId = normalizeId(subjectId);
+    if (!normalizedSubjectId || !subjectMessagesService) return;
+    const state = subjectReadMarkState.get(normalizedSubjectId) || { pending: false, markedIds: new Set() };
+    if (state.pending) return;
+
+    const toMark = (Array.isArray(messages) ? messages : [])
+      .filter((message) => !message?.deleted_at)
+      .map((message) => normalizeId(message?.id))
+      .filter((messageId, idx, list) => !!messageId && list.indexOf(messageId) === idx && !state.markedIds.has(messageId));
+    if (!toMark.length) return;
+
+    state.pending = true;
+    subjectReadMarkState.set(normalizedSubjectId, state);
+
+    (async () => {
+      let shouldRefresh = false;
+      for (const messageId of toMark) {
+        try {
+          await subjectMessagesService.markMessageRead(messageId, { subjectId: normalizedSubjectId });
+          state.markedIds.add(messageId);
+          shouldRefresh = true;
+        } catch (error) {
+          console.warn("[subject-messages] mark read failed", { subjectId: normalizedSubjectId, messageId, error });
+        }
+      }
+
+      if (shouldRefresh) {
+        ensureSubjectTimelineLoaded(normalizedSubjectId, { force: true });
+      }
+    })()
+      .finally(() => {
+        const latestState = subjectReadMarkState.get(normalizedSubjectId);
+        if (latestState) {
+          latestState.pending = false;
+          subjectReadMarkState.set(normalizedSubjectId, latestState);
+        }
+      });
   }
 
   function mapEventRowToThreadActivity(row = {}) {
@@ -127,6 +178,7 @@ export function createProjectSubjectsThread(config = {}) {
           activities: events.map((row) => mapEventRowToThreadActivity(row)),
           conversation: timeline?.conversation || null
         });
+        queueSubjectMessageReadMarking(normalizedSubjectId, messages);
         requestScopeRerender();
       })
       .catch((error) => {
@@ -369,7 +421,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
           idx,
           author: identity.displayName,
           tsHtml,
-          bodyHtml: mdToHtml(e?.message || ""),
+          bodyHtml: `
+            <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
+            ${mdToHtml(e?.message || "")}
+          `,
           avatarType: identity.avatarType,
           avatarHtml: identity.avatarHtml,
           avatarInitial: identity.avatarInitial

--- a/supabase/migrations/202606150004_subject_message_read_freeze_hardening.sql
+++ b/supabase/migrations/202606150004_subject_message_read_freeze_hardening.sql
@@ -1,0 +1,101 @@
+create or replace function public.mark_subject_message_read(
+  p_message_id uuid
+)
+returns public.subject_message_reads
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_message public.subject_messages;
+  v_person_id uuid;
+  v_read public.subject_message_reads;
+begin
+  select *
+    into v_message
+  from public.subject_messages sm
+  where sm.id = p_message_id;
+
+  if v_message.id is null then
+    raise exception 'Message not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_message.project_id) then
+    raise exception 'Not allowed to read this message';
+  end if;
+
+  v_person_id := public.current_person_id();
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  insert into public.subject_message_reads (
+    project_id,
+    subject_id,
+    message_id,
+    reader_person_id,
+    reader_user_id,
+    read_at
+  )
+  values (
+    v_message.project_id,
+    v_message.subject_id,
+    v_message.id,
+    v_person_id,
+    auth.uid(),
+    now()
+  )
+  on conflict (message_id, reader_person_id) do update
+  set
+    read_at = excluded.read_at,
+    reader_user_id = excluded.reader_user_id
+  returning * into v_read;
+
+  return v_read;
+end;
+$$;
+
+create or replace function public.trg_log_subject_message_frozen_event()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if old.is_frozen = false and new.is_frozen = true then
+    insert into public.subject_message_events (
+      project_id,
+      subject_id,
+      message_id,
+      event_type,
+      actor_person_id,
+      actor_user_id,
+      event_payload,
+      created_at
+    )
+    values (
+      new.project_id,
+      new.subject_id,
+      new.id,
+      'message_frozen',
+      new.author_person_id,
+      new.author_user_id,
+      jsonb_build_object(
+        'reason', coalesce(new.frozen_reason, 'seen_by_other_user'),
+        'frozen_at', coalesce(new.frozen_at, now())
+      ),
+      now()
+    );
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_log_subject_message_frozen_event on public.subject_messages;
+create trigger trg_log_subject_message_frozen_event
+after update on public.subject_messages
+for each row
+when (old.is_frozen is distinct from new.is_frozen)
+execute function public.trg_log_subject_message_frozen_event();
+
+grant execute on function public.mark_subject_message_read(uuid) to authenticated;


### PR DESCRIPTION
### Motivation
- Implémenter la règle métier centrale: un message reste éditable/supprimable tant qu’aucun autre utilisateur ne l’a vu, et devient inviolable dès qu’il est vu par un tiers, en garantissant cette règle côté backend.
- Eviter toute logique fragile côté client pour le marquage « vu » en consolidant le comportement via des RPC/triggers SQL et en alignant le front avec ces garanties.

### Description
- Ajout d’une migration SQL `supabase/migrations/202606150004_subject_message_read_freeze_hardening.sql` qui crée la RPC `mark_subject_message_read(p_message_id uuid)`, upsert sécurisée des lectures, et le trigger `trg_log_subject_message_frozen_event` qui journalise un événement `message_frozen` lorsqu’un message passe en `is_frozen = true`.
- Remplacement de l’insertion REST côté front par un appel RPC via `rpcCall("mark_subject_message_read", ...)` dans `apps/web/js/services/subject-messages-supabase.js` pour garantir que le marquage « lu » respecte les contrôles backend.
- Mise en place d’une logique côté UI dans `apps/web/js/views/project-subjects/project-subjects-thread.js` qui: 1) charge la timeline persistée, 2) queue le marquage des messages non supprimés comme lus via `queueSubjectMessageReadMarking` (déduplication par ID), et 3) force un refresh pour refléter immédiatement le gel éventuel.
- Affichage explicite de l’état de mutabilité dans la card message (`state_label` : `modifiable`, `figé (vu par un tiers)`, `supprimé`) et exclusion des messages supprimés du marquage automatique.
- Fichiers modifiés/ajoutés : `supabase/migrations/202606150004_subject_message_read_freeze_hardening.sql`, `apps/web/js/services/subject-messages-supabase.js`, `apps/web/js/views/project-subjects/project-subjects-thread.js`.

### Testing
- Vérifications statiques: `node --check apps/web/js/services/subject-messages-supabase.js` a réussi; `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` a réussi.
- Tests unitaires: `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` a été exécuté et a passé (2 tests ok, 0 fail).
- Remarques: les validations CI/DB (appliquer la migration et exécuter la RPC en environnement supabase) sont à faire en intégration; le comportement « vu dans viewport » n’a pas été implémenté et reste un arbitrage produit futur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22f07fb6c832991f9343241e6012c)