### PR TITLE
feat(subject-messages): add nested replies in subject timeline

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -290,6 +290,9 @@ const {
   setDecision,
   getDecision,
   getThreadForSelection,
+  setReplyContext,
+  clearReplyContext,
+  buildReplyPreview,
   renderThreadBlock,
   renderIssueStatusAction,
   renderCommentBox
@@ -756,7 +759,10 @@ const projectSubjectsView = createProjectSubjectsView({
   setProjectCompactEnabled,
   currentDecisionTarget: (...args) => currentDecisionTarget(...args),
   addComment: (...args) => addComment(...args),
-  getScopedSelection: (...args) => getScopedSelection(...args)
+  getScopedSelection: (...args) => getScopedSelection(...args),
+  setReplyContext: (...args) => setReplyContext(...args),
+  clearReplyContext: (...args) => clearReplyContext(...args),
+  buildReplyPreview: (...args) => buildReplyPreview(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -10,6 +10,9 @@ export function createProjectSubjectsEvents(config) {
     getSubjectMetaMenuEntries,
     getSubjectSidebarMeta,
     rerenderScope,
+    setReplyContext,
+    clearReplyContext,
+    buildReplyPreview,
     syncSubjectMetaDropdownPosition,
     getSubjectMetaScopeRoot,
     getSubjectKanbanMenuEntries,
@@ -1252,6 +1255,40 @@ export function createProjectSubjectsEvents(config) {
     root.querySelectorAll("[data-action='add-comment']").forEach((btn) => {
       btn.onclick = async () => {
         await applyCommentAction(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='reply-to-message'][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const selection = getScopedSelection(root);
+        if (selection?.type !== "sujet") return;
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!messageId) return;
+        const messageBody = String(
+          btn.closest?.("[data-thread-kind='comment']")
+            ?.querySelector?.(".gh-comment-body")
+            ?.textContent || ""
+        ).trim();
+        if (typeof setReplyContext === "function") {
+          setReplyContext({
+            subjectId: selection.item.id,
+            parentMessageId: messageId,
+            parentPreview: typeof buildReplyPreview === "function"
+              ? buildReplyPreview(messageBody)
+              : messageBody
+          });
+        }
+        rerenderScope(root);
+        requestAnimationFrame(() => {
+          root.querySelector("#humanCommentBox")?.focus();
+        });
+      };
+    });
+
+    root.querySelectorAll("[data-action='clear-reply-target']").forEach((btn) => {
+      btn.onclick = () => {
+        if (typeof clearReplyContext === "function") clearReplyContext();
+        rerenderScope(root);
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -39,6 +39,13 @@ export function createProjectSubjectsState({ store }) {
     if (typeof v.rightSubissueMenuOpenId !== "string") v.rightSubissueMenuOpenId = "";
     if (typeof v.commentPreviewMode !== "boolean") v.commentPreviewMode = false;
     if (typeof v.helpMode !== "boolean") v.helpMode = false;
+    if (!v.replyContext || typeof v.replyContext !== "object") {
+      v.replyContext = {
+        subjectId: "",
+        parentMessageId: "",
+        parentPreview: ""
+      };
+    }
     if (typeof v.showTableOnly !== "boolean") v.showTableOnly = true;
     if (!Number.isFinite(Number(v.tableScrollRestoreY))) v.tableScrollRestoreY = 0;
     if (!v.pagination || typeof v.pagination !== "object") {
@@ -212,6 +219,11 @@ export function createProjectSubjectsState({ store }) {
       activeKey: ""
     };
     v.rightSubissueMenuOpenId = "";
+    v.replyContext = {
+      subjectId: "",
+      parentMessageId: "",
+      parentPreview: ""
+    };
     return v;
   }
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -41,6 +41,7 @@ export function createProjectSubjectsThread(config = {}) {
   const subjectTimelineCache = new Map();
   const subjectTimelineState = new Map();
   const subjectReadMarkState = new Map();
+  const MAX_REPLY_VISUAL_DEPTH = 2;
 
   function normalizeId(value) {
     return String(value || "").trim();
@@ -68,12 +69,115 @@ export function createProjectSubjectsThread(config = {}) {
         source: "supabase",
         id: normalizeId(row.id),
         parent_message_id: normalizeId(row.parent_message_id),
+        depth: 0,
+        reply_preview: "",
         is_frozen: isFrozen,
         is_deleted: isDeleted,
         state_label: stateLabel
       },
       stateLabel
     };
+  }
+
+  function getReplyContextState() {
+    ensureViewUiState();
+    const state = store.situationsView;
+    if (!state.replyContext || typeof state.replyContext !== "object") {
+      state.replyContext = {
+        subjectId: "",
+        parentMessageId: "",
+        parentPreview: ""
+      };
+    }
+    return state.replyContext;
+  }
+
+  function clearReplyContext() {
+    const context = getReplyContextState();
+    context.subjectId = "";
+    context.parentMessageId = "";
+    context.parentPreview = "";
+  }
+
+  function setReplyContext({ subjectId = "", parentMessageId = "", parentPreview = "" } = {}) {
+    const context = getReplyContextState();
+    context.subjectId = normalizeId(subjectId);
+    context.parentMessageId = normalizeId(parentMessageId);
+    context.parentPreview = String(parentPreview || "").trim();
+  }
+
+  function getReplyContextForSubject(subjectId = "") {
+    const context = getReplyContextState();
+    const normalizedSubjectId = normalizeId(subjectId);
+    if (!normalizedSubjectId) return null;
+    if (normalizeId(context.subjectId) !== normalizedSubjectId) return null;
+    const parentMessageId = normalizeId(context.parentMessageId);
+    if (!parentMessageId) return null;
+    return {
+      subjectId: normalizedSubjectId,
+      parentMessageId,
+      parentPreview: String(context.parentPreview || "")
+    };
+  }
+
+  function buildReplyPreview(markdown = "") {
+    const normalized = String(markdown || "")
+      .replace(/\s+/g, " ")
+      .replace(/^#+\s*/g, "")
+      .trim();
+    if (!normalized) return "";
+    return normalized.length > 120 ? `${normalized.slice(0, 117)}…` : normalized;
+  }
+
+  function decorateNestedMessageComments(comments = []) {
+    const list = Array.isArray(comments) ? comments : [];
+    if (!list.length) return [];
+
+    const byId = new Map();
+    list.forEach((comment) => {
+      const commentId = normalizeId(comment?.meta?.id);
+      if (commentId) byId.set(commentId, comment);
+    });
+
+    const depthCache = new Map();
+    const parentChain = (comment) => {
+      const chain = [];
+      let current = comment;
+      const seen = new Set();
+      while (current) {
+        const currentId = normalizeId(current?.meta?.id);
+        if (!currentId || seen.has(currentId)) break;
+        seen.add(currentId);
+        const parentId = normalizeId(current?.meta?.parent_message_id);
+        if (!parentId) break;
+        chain.push(parentId);
+        current = byId.get(parentId) || null;
+      }
+      return chain;
+    };
+
+    list.forEach((comment) => {
+      const commentId = normalizeId(comment?.meta?.id);
+      if (!commentId) return;
+      if (depthCache.has(commentId)) return;
+      const chain = parentChain(comment);
+      depthCache.set(commentId, chain.length);
+    });
+
+    return list.map((comment) => {
+      const commentId = normalizeId(comment?.meta?.id);
+      const parentId = normalizeId(comment?.meta?.parent_message_id);
+      const parentComment = parentId ? byId.get(parentId) : null;
+      const depth = Math.min(MAX_REPLY_VISUAL_DEPTH, Number(depthCache.get(commentId) || 0));
+      return {
+        ...comment,
+        meta: {
+          ...(comment.meta || {}),
+          depth,
+          reply_preview: parentComment ? buildReplyPreview(parentComment.message) : ""
+        }
+      };
+    });
   }
 
   function queueSubjectMessageReadMarking(subjectId, messages = []) {
@@ -172,9 +276,17 @@ export function createProjectSubjectsThread(config = {}) {
         const messages = Array.isArray(timeline?.messages) ? timeline.messages : [];
         const events = Array.isArray(timeline?.events) ? timeline.events : [];
         const rows = Array.isArray(timeline?.rows) ? timeline.rows : [];
+        const mappedRows = rows.map((row) => mapTimelineRowToThreadEntry(row)).filter(Boolean);
+        const mappedComments = mappedRows.filter((entry) => String(entry?.type || "").toUpperCase() === "COMMENT");
+        const nestedComments = decorateNestedMessageComments(mappedComments);
+        const nestedById = new Map(nestedComments.map((comment) => [normalizeId(comment?.meta?.id), comment]));
         subjectTimelineCache.set(normalizedSubjectId, {
-          rows: rows.map((row) => mapTimelineRowToThreadEntry(row)).filter(Boolean),
-          comments: messages.map((row) => mapMessageRowToThreadComment(row)),
+          rows: mappedRows.map((entry) => {
+            if (String(entry?.type || "").toUpperCase() !== "COMMENT") return entry;
+            const nested = nestedById.get(normalizeId(entry?.meta?.id));
+            return nested || entry;
+          }),
+          comments: nestedComments,
           activities: events.map((row) => mapEventRowToThreadActivity(row)),
           conversation: timeline?.conversation || null
         });
@@ -422,12 +534,27 @@ priority=${firstNonEmpty(subject.priority, "")}`
           author: identity.displayName,
           tsHtml,
           bodyHtml: `
+            ${e?.meta?.reply_preview
+              ? `<div class="comment-reply-preview mono-small">↪ ${escapeHtml(String(e.meta.reply_preview || ""))}</div>`
+              : ""}
             <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
             ${mdToHtml(e?.message || "")}
+            ${e?.meta?.id
+              ? `
+                <div class="comment-reply-actions">
+                  <button class="gh-btn gh-btn--sm" type="button" data-action="reply-to-message" data-message-id="${escapeHtml(String(e.meta.id || ""))}">
+                    Répondre
+                  </button>
+                </div>
+              `
+              : ""}
           `,
           avatarType: identity.avatarType,
           avatarHtml: identity.avatarHtml,
-          avatarInitial: identity.avatarInitial
+          avatarInitial: identity.avatarInitial,
+          className: Number(e?.meta?.depth || 0) > 0
+            ? `message-thread__comment--nested message-thread__comment--depth-${Math.min(MAX_REPLY_VISUAL_DEPTH, Number(e?.meta?.depth || 0))}`
+            : ""
         });
       }
 
@@ -643,6 +770,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
 
     const issueStatusActionHtml = renderIssueStatusAction(selection);
+    const replyContext = type === "sujet" ? getReplyContextForSubject(item?.id) : null;
+    const contextHtml = replyContext
+      ? `
+        <div class="comment-composer__context">
+          <div class="comment-composer__context-text mono-small">
+            Réponse à un message${replyContext.parentPreview ? ` : “${escapeHtml(replyContext.parentPreview)}”` : ""}
+          </div>
+          <button class="gh-btn gh-btn--sm" type="button" data-action="clear-reply-target">Annuler la réponse</button>
+        </div>
+      `
+      : "";
 
     const actionsHtml = `
       <button class="gh-btn gh-btn--help-mode ${helpMode ? "is-on" : ""}" data-action="toggle-help" type="button">Help</button>
@@ -669,6 +807,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
         ? "Help (éphémère) — décrivez l’écran / l’action souhaitée."
         : `Réponse humaine (Markdown) sur ce ${type === "sujet" ? "sujet" : "regroupement"} — mentionne @rapso pour solliciter l’agent.`,
       hintHtml,
+      contextHtml,
       actionsHtml
     });
   }
@@ -679,6 +818,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
     setDecision,
     getDecision,
     getThreadForSelection,
+    setReplyContext,
+    clearReplyContext,
+    getReplyContextForSubject,
+    buildReplyPreview,
     renderThreadBlock,
     renderIssueStatusAction,
     renderCommentBox

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2341,9 +2341,24 @@ async function applyCommentAction(root) {
     return;
   }
 
-  await addComment(target.type, target.id, message, { actor: "Human", agent: "human" });
+  const replyContext = store.situationsView?.replyContext || {};
+  const replySubjectId = String(replyContext?.subjectId || "").trim();
+  const parentMessageId = target.type === "sujet" && replySubjectId === String(target.id || "").trim()
+    ? String(replyContext?.parentMessageId || "").trim()
+    : "";
+
+  await addComment(target.type, target.id, message, {
+    actor: "Human",
+    agent: "human",
+    parentMessageId: parentMessageId || undefined
+  });
   ta.value = "";
   store.situationsView.commentPreviewMode = false;
+  if (store.situationsView?.replyContext) {
+    store.situationsView.replyContext.subjectId = "";
+    store.situationsView.replyContext.parentMessageId = "";
+    store.situationsView.replyContext.parentPreview = "";
+  }
   rerenderScope(root);
 
 }

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -10,6 +10,7 @@ export function renderCommentComposer({
   textareaValue = "",
   placeholder = "",
   hintHtml = "",
+  contextHtml = "",
   actionsHtml = ""
 } = {}) {
   return `
@@ -20,6 +21,7 @@ export function renderCommentComposer({
         <div class="gh-timeline-title mono comment-composer__title">${escapeHtml(title)}</div>
 
         <div class="comment-box gh-comment-boxwrap comment-composer__box ${helpMode ? "gh-comment-box--help" : ""}">
+          ${contextHtml || ""}
           <div class="comment-tabs comment-composer__tabs ${helpMode ? "gh-comment-header--help" : ""}" role="tablist" aria-label="Comment tabs">
             <button class="comment-tab ${!previewMode ? "is-active" : ""}" data-action="tab-write" type="button">Write</button>
             <button class="comment-tab ${previewMode ? "is-active" : ""}" data-action="tab-preview" type="button">Preview</button>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2506,6 +2506,31 @@ body.is-resizing{
 .comment-composer__actions{padding-bottom:100px;}
 .comment-composer__actions-right{width:100%;}
 .comment-composer__hint{margin-right:auto;}
+.comment-composer__context{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  padding:8px 12px;
+  border-bottom:1px solid var(--border2);
+  background:rgba(56,139,253,.08);
+}
+.comment-composer__context-text{
+  color:var(--muted);
+}
+
+.message-thread__comment--nested{position:relative;}
+.message-thread__comment--depth-1{margin-left:24px;}
+.message-thread__comment--depth-2{margin-left:48px;}
+.comment-reply-preview{
+  margin-bottom:8px;
+  padding-left:8px;
+  border-left:2px solid var(--border2);
+  color:var(--muted);
+}
+.comment-reply-actions{
+  margin-top:10px;
+}
 
 /* ===== Right panel: Sub-issues table (below description) ===== */
 .details-subissues{margin-left:52px;width:calc(100% - 52px);margin-bottom:8px;margin-top:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden;container-type:inline-size;}


### PR DESCRIPTION
### Motivation
- Permettre des réponses ciblées à un message dans la timeline des sujets en exploitant le `parent_message_id` déjà présent en base pour offrir une UX de fil léger sans refonte complète de la vue sujet. 
- Garder une profondeur visuelle limitée et réutiliser l’infrastructure existante (service messages, composer) tout en préparant l’intégration des règles de lecture/figement et des pièces jointes.

### Description
- Ajout du support de réponses imbriquées côté UI en calculant une profondeur visuelle bornée (`MAX_REPLY_VISUAL_DEPTH = 2`) et une prévisualisation du message parent via `decorateNestedMessageComments` et `buildReplyPreview` (`apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Exposition d’actions et d’état de contexte de réponse : bouton **Répondre** sur chaque commentaire, sélection du parent et bannière contextuelle dans le composer avec option d’annulation (`apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/ui/comment-composer.js`).
- Envoi de réponses réel : `applyCommentAction` utilise désormais le `parentMessageId` du `replyContext` lors de la création d’un commentaire pour créer une reply persistée (`apps/web/js/views/project-subjects/project-subjects-view.js`).
- Persistance et initialisation de l’état de contexte de réponse dans le state de la vue (`replyContext`) avec nettoyage lors des ré-renders/tab resets (`apps/web/js/views/project-subjects/project-subjects-state.js`).
- Ajustements d’affichage CSS pour indentation, preview du parent et bannière contextuelle (`apps/web/style.css`).
- Petits raccords de propagation des nouvelles fonctions entre modules (`apps/web/js/views/project-subjects.js`).

Fichiers clés modifiés : `project-subjects-thread.js`, `project-subjects-events.js`, `project-subjects-view.js`, `project-subjects-state.js`, `project-subjects.js`, `comment-composer.js`, `style.css`.

### Testing
- Exécution des tests unitaires ciblés : `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` — OK (passé).
- Exécution des tests unitaires ciblés : `node --test apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs` — OK (passé).
- Aucune erreur runtime détectée pendant les tests exécutés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23122df1483299223eede5ee2becb)