### PR TITLE
Add inline reply UI and nested reply handling for subject threads

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -290,6 +290,7 @@ const {
   setDecision,
   getDecision,
   getThreadForSelection,
+  getInlineReplyUiState,
   renderThreadBlock,
   renderIssueStatusAction,
   renderCommentBox
@@ -381,6 +382,7 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getProjectSubjectMilestones: () => projectSubjectMilestones,
   getProjectSubjectLabels: () => projectSubjectLabels,
   renderSubjectMetaFieldValue: (...args) => projectSubjectsView.renderSubjectMetaFieldValue(...args),
+  addComment: (...args) => addComment(...args),
   getSubjectsCurrentRoot: () => subjectsCurrentRoot,
   resolveCurrentUserAssigneeId: () => resolveCurrentUserDirectoryPersonId({
     email: store.user?.email || "",
@@ -756,7 +758,8 @@ const projectSubjectsView = createProjectSubjectsView({
   setProjectCompactEnabled,
   currentDecisionTarget: (...args) => currentDecisionTarget(...args),
   addComment: (...args) => addComment(...args),
-  getScopedSelection: (...args) => getScopedSelection(...args)
+  getScopedSelection: (...args) => getScopedSelection(...args),
+  getInlineReplyUiState: (...args) => getInlineReplyUiState(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -10,6 +10,7 @@ export function createProjectSubjectsEvents(config) {
     getSubjectMetaMenuEntries,
     getSubjectSidebarMeta,
     rerenderScope,
+    getInlineReplyUiState,
     syncSubjectMetaDropdownPosition,
     getSubjectMetaScopeRoot,
     getSubjectKanbanMenuEntries,
@@ -52,7 +53,8 @@ export function createProjectSubjectsEvents(config) {
     bindOverlayChromeCompact,
     getProjectSubjectMilestones,
     renderSubjectMetaFieldValue,
-    resolveCurrentUserAssigneeId
+    resolveCurrentUserAssigneeId,
+    addComment
   } = config;
 
   let detachDropdownDocumentEvents = null;
@@ -1254,6 +1256,143 @@ export function createProjectSubjectsEvents(config) {
         await applyCommentAction(root);
       };
     });
+
+    const selectorValue = (value) => String(value || "").replace(/["\\]/g, "\\$&");
+    const threadReplyDebugEnabled = (() => {
+      try {
+        const search = String(window?.location?.search || "");
+        if (search.includes("debugSubjectReplies=1")) return true;
+        const localValue = String(window?.localStorage?.getItem?.("mdall:debug-subject-replies") || "").trim().toLowerCase();
+        return localValue === "1" || localValue === "true";
+      } catch {
+        return false;
+      }
+    })();
+    const debugThreadReply = (eventName, payload = {}) => {
+      if (!threadReplyDebugEnabled) return;
+      console.log("[subject-thread-reply]", eventName, payload);
+    };
+    const resolveInlineReplyUiState = () => {
+      if (typeof getInlineReplyUiState === "function") {
+        const state = getInlineReplyUiState();
+        if (state && typeof state === "object") return state;
+      }
+      if (!store.situationsView || typeof store.situationsView !== "object") {
+        store.situationsView = {};
+      }
+      if (!store.situationsView.inlineReplyUi || typeof store.situationsView.inlineReplyUi !== "object") {
+        store.situationsView.inlineReplyUi = {
+          expandedMessageId: "",
+          draftsByMessageId: {}
+        };
+      }
+      debugThreadReply("reply_state_fallback", { hasAccessor: typeof getInlineReplyUiState === "function" });
+      return store.situationsView.inlineReplyUi;
+    };
+
+    root.querySelectorAll("[data-action='thread-reply-menu-toggle'][data-message-id]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const menu = btn.closest(".thread-comment-menu");
+        if (!menu) return;
+        const dropdown = menu.querySelector(".thread-comment-menu__dropdown");
+        if (!dropdown) return;
+        debugThreadReply("menu_toggle", { messageId: btn.dataset.messageId || "", wasOpen: dropdown.classList.contains("is-open") });
+
+        root.querySelectorAll(".thread-comment-menu__dropdown.is-open").forEach((opened) => {
+          if (opened !== dropdown) opened.classList.remove("is-open");
+        });
+        dropdown.classList.toggle("is-open");
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-reply-open'][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!messageId) return;
+        const parentMessageText = String(
+          btn.closest(".thread-item--comment")
+            ?.querySelector(".gh-comment-body")
+            ?.textContent || ""
+        ).trim();
+        debugThreadReply("menu_action_reply", { messageId, parentMessageLength: parentMessageText.length });
+        btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
+        const replyUi = resolveInlineReplyUiState();
+        const existingDraft = String(replyUi.draftsByMessageId?.[messageId] || "");
+        if (!existingDraft) {
+          const quoted = parentMessageText
+            ? `> ${parentMessageText.replace(/\n+/g, "\n> ")}\n\n`
+            : "";
+          replyUi.draftsByMessageId[messageId] = quoted;
+        }
+        replyUi.expandedMessageId = messageId;
+        debugThreadReply("reply_opened", {
+          messageId,
+          hasDraft: !!String(replyUi.draftsByMessageId?.[messageId] || "").trim()
+        });
+        rerenderScope(root);
+        requestAnimationFrame(() => {
+          const textarea = root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+          debugThreadReply("reply_editor_presence", { messageId, found: !!textarea });
+          textarea?.focus();
+        });
+      };
+    });
+
+    root.querySelectorAll("[data-thread-reply-draft]").forEach((textarea) => {
+      textarea.addEventListener("input", () => {
+        const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
+      });
+    });
+
+    root.querySelectorAll("[data-action='thread-reply-cancel'][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.dataset.messageId || "").trim();
+        debugThreadReply("reply_cancel", { messageId });
+        const replyUi = resolveInlineReplyUiState();
+        if (messageId) replyUi.draftsByMessageId[messageId] = "";
+        replyUi.expandedMessageId = "";
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-reply-submit'][data-message-id]").forEach((btn) => {
+      btn.onclick = async () => {
+        const selection = getScopedSelection(root);
+        if (selection?.type !== "sujet") return;
+        const parentMessageId = String(btn.dataset.messageId || "").trim();
+        if (!parentMessageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        const message = String(replyUi.draftsByMessageId?.[parentMessageId] || "").trim();
+        if (!message) return;
+        debugThreadReply("reply_submit", { parentMessageId, messageLength: message.length });
+        await addComment("sujet", selection.item.id, message, {
+          actor: "Human",
+          agent: "human",
+          parentMessageId
+        });
+        replyUi.draftsByMessageId[parentMessageId] = "";
+        replyUi.expandedMessageId = "";
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll(".thread-comment-menu__dropdown").forEach((dropdown) => {
+      dropdown.addEventListener("click", (event) => event.stopPropagation());
+    });
+
+    if (root.dataset.threadReplyDropdownDocumentBound !== "true") {
+      document.addEventListener("click", () => {
+        root.querySelectorAll(".thread-comment-menu__dropdown.is-open").forEach((opened) => {
+          opened.classList.remove("is-open");
+        });
+      });
+      root.dataset.threadReplyDropdownDocumentBound = "true";
+    }
 
     root.querySelectorAll("[data-subject-assign-self]").forEach((btn) => {
       btn.onclick = async (event) => {

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -39,6 +39,19 @@ export function createProjectSubjectsState({ store }) {
     if (typeof v.rightSubissueMenuOpenId !== "string") v.rightSubissueMenuOpenId = "";
     if (typeof v.commentPreviewMode !== "boolean") v.commentPreviewMode = false;
     if (typeof v.helpMode !== "boolean") v.helpMode = false;
+    if (!v.replyContext || typeof v.replyContext !== "object") {
+      v.replyContext = {
+        subjectId: "",
+        parentMessageId: "",
+        parentPreview: ""
+      };
+    }
+    if (!v.inlineReplyUi || typeof v.inlineReplyUi !== "object") {
+      v.inlineReplyUi = {
+        expandedMessageId: "",
+        draftsByMessageId: {}
+      };
+    }
     if (typeof v.showTableOnly !== "boolean") v.showTableOnly = true;
     if (!Number.isFinite(Number(v.tableScrollRestoreY))) v.tableScrollRestoreY = 0;
     if (!v.pagination || typeof v.pagination !== "object") {
@@ -212,6 +225,15 @@ export function createProjectSubjectsState({ store }) {
       activeKey: ""
     };
     v.rightSubissueMenuOpenId = "";
+    v.replyContext = {
+      subjectId: "",
+      parentMessageId: "",
+      parentPreview: ""
+    };
+    v.inlineReplyUi = {
+      expandedMessageId: "",
+      draftsByMessageId: {}
+    };
     return v;
   }
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -41,12 +41,40 @@ export function createProjectSubjectsThread(config = {}) {
   const subjectTimelineCache = new Map();
   const subjectTimelineState = new Map();
   const subjectReadMarkState = new Map();
+  const MAX_REPLY_VISUAL_DEPTH = 2;
 
   function normalizeId(value) {
     return String(value || "").trim();
   }
 
+  function getProjectCollaborators() {
+    return Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators : [];
+  }
+
+  function resolveAuthorProfile(row = {}) {
+    const personId = normalizeId(row?.author_person_id);
+    const collaborator = getProjectCollaborators().find((entry) => {
+      const collaboratorPersonId = normalizeId(entry?.personId || entry?.id);
+      return !!collaboratorPersonId && collaboratorPersonId === personId;
+    }) || null;
+
+    const displayName = firstNonEmpty(
+      collaborator?.displayName,
+      collaborator?.fullName,
+      `${firstNonEmpty(collaborator?.firstName, "")} ${firstNonEmpty(collaborator?.lastName, "")}`.trim(),
+      collaborator?.name,
+      collaborator?.email,
+      personId ? `Person ${personId.slice(0, 8)}` : "Human"
+    );
+
+    return {
+      displayName: String(displayName || "Human"),
+      avatarUrl: String(firstNonEmpty(collaborator?.avatarUrl, collaborator?.avatar, ""))
+    };
+  }
+
   function mapMessageRowToThreadComment(row = {}) {
+    const authorProfile = resolveAuthorProfile(row);
     const isDeleted = !!row.deleted_at;
     const isFrozen = !!row.is_frozen;
     const stateLabel = isDeleted
@@ -59,7 +87,7 @@ export function createProjectSubjectsThread(config = {}) {
       entity_type: "sujet",
       entity_id: normalizeId(row.subject_id),
       type: "COMMENT",
-      actor: row.author_person_id ? `Person ${normalizeId(row.author_person_id).slice(0, 8)}` : "Human",
+      actor: authorProfile.displayName,
       agent: "human",
       message: String(row.deleted_at ? "[message supprimé]" : row.body_markdown || ""),
       pending: false,
@@ -68,12 +96,134 @@ export function createProjectSubjectsThread(config = {}) {
         source: "supabase",
         id: normalizeId(row.id),
         parent_message_id: normalizeId(row.parent_message_id),
+        author_person_id: normalizeId(row.author_person_id),
+        author_user_id: normalizeId(row.author_user_id),
+        author_avatar_url: authorProfile.avatarUrl,
+        depth: 0,
+        reply_preview: "",
         is_frozen: isFrozen,
         is_deleted: isDeleted,
         state_label: stateLabel
       },
       stateLabel
     };
+  }
+
+  function getReplyContextState() {
+    ensureViewUiState();
+    const state = store.situationsView;
+    if (!state.replyContext || typeof state.replyContext !== "object") {
+      state.replyContext = {
+        subjectId: "",
+        parentMessageId: "",
+        parentPreview: ""
+      };
+    }
+    return state.replyContext;
+  }
+
+  function clearReplyContext() {
+    const context = getReplyContextState();
+    context.subjectId = "";
+    context.parentMessageId = "";
+    context.parentPreview = "";
+  }
+
+  function setReplyContext({ subjectId = "", parentMessageId = "", parentPreview = "" } = {}) {
+    const context = getReplyContextState();
+    context.subjectId = normalizeId(subjectId);
+    context.parentMessageId = normalizeId(parentMessageId);
+    context.parentPreview = String(parentPreview || "").trim();
+  }
+
+  function getReplyContextForSubject(subjectId = "") {
+    const context = getReplyContextState();
+    const normalizedSubjectId = normalizeId(subjectId);
+    if (!normalizedSubjectId) return null;
+    if (normalizeId(context.subjectId) !== normalizedSubjectId) return null;
+    const parentMessageId = normalizeId(context.parentMessageId);
+    if (!parentMessageId) return null;
+    return {
+      subjectId: normalizedSubjectId,
+      parentMessageId,
+      parentPreview: String(context.parentPreview || "")
+    };
+  }
+
+  function buildReplyPreview(markdown = "") {
+    const normalized = String(markdown || "")
+      .replace(/\s+/g, " ")
+      .replace(/^#+\s*/g, "")
+      .trim();
+    if (!normalized) return "";
+    return normalized.length > 120 ? `${normalized.slice(0, 117)}…` : normalized;
+  }
+
+  function getInlineReplyUiState() {
+    ensureViewUiState();
+    const state = store.situationsView;
+    if (!state.inlineReplyUi || typeof state.inlineReplyUi !== "object") {
+      state.inlineReplyUi = {
+        expandedMessageId: "",
+        draftsByMessageId: {}
+      };
+    }
+    if (typeof state.inlineReplyUi.expandedMessageId !== "string") state.inlineReplyUi.expandedMessageId = "";
+    if (!state.inlineReplyUi.draftsByMessageId || typeof state.inlineReplyUi.draftsByMessageId !== "object") {
+      state.inlineReplyUi.draftsByMessageId = {};
+    }
+    return state.inlineReplyUi;
+  }
+
+  function decorateNestedMessageComments(comments = []) {
+    const list = Array.isArray(comments) ? comments : [];
+    if (!list.length) return [];
+
+    const byId = new Map();
+    list.forEach((comment) => {
+      const commentId = normalizeId(comment?.meta?.id);
+      if (commentId) byId.set(commentId, comment);
+    });
+
+    const depthCache = new Map();
+    const parentChain = (comment) => {
+      const chain = [];
+      let current = comment;
+      const seen = new Set();
+      while (current) {
+        const currentId = normalizeId(current?.meta?.id);
+        if (!currentId || seen.has(currentId)) break;
+        seen.add(currentId);
+        const parentId = normalizeId(current?.meta?.parent_message_id);
+        if (!parentId) break;
+        chain.push(parentId);
+        current = byId.get(parentId) || null;
+      }
+      return chain;
+    };
+
+    list.forEach((comment) => {
+      const commentId = normalizeId(comment?.meta?.id);
+      if (!commentId) return;
+      if (depthCache.has(commentId)) return;
+      const chain = parentChain(comment);
+      depthCache.set(commentId, chain.length);
+    });
+
+    return list.map((comment) => {
+      const commentId = normalizeId(comment?.meta?.id);
+      const parentId = normalizeId(comment?.meta?.parent_message_id);
+      const parentComment = parentId ? byId.get(parentId) : null;
+      const depth = Math.min(MAX_REPLY_VISUAL_DEPTH, Number(depthCache.get(commentId) || 0));
+      return {
+        ...comment,
+        meta: {
+          ...(comment.meta || {}),
+          depth,
+          reply_preview: parentComment ? buildReplyPreview(parentComment.message) : ""
+        }
+      };
+    });
   }
 
   function queueSubjectMessageReadMarking(subjectId, messages = []) {
@@ -172,9 +322,17 @@ export function createProjectSubjectsThread(config = {}) {
         const messages = Array.isArray(timeline?.messages) ? timeline.messages : [];
         const events = Array.isArray(timeline?.events) ? timeline.events : [];
         const rows = Array.isArray(timeline?.rows) ? timeline.rows : [];
+        const mappedRows = rows.map((row) => mapTimelineRowToThreadEntry(row)).filter(Boolean);
+        const mappedComments = mappedRows.filter((entry) => String(entry?.type || "").toUpperCase() === "COMMENT");
+        const nestedComments = decorateNestedMessageComments(mappedComments);
+        const nestedById = new Map(nestedComments.map((comment) => [normalizeId(comment?.meta?.id), comment]));
         subjectTimelineCache.set(normalizedSubjectId, {
-          rows: rows.map((row) => mapTimelineRowToThreadEntry(row)).filter(Boolean),
-          comments: messages.map((row) => mapMessageRowToThreadComment(row)),
+          rows: mappedRows.map((entry) => {
+            if (String(entry?.type || "").toUpperCase() !== "COMMENT") return entry;
+            const nested = nestedById.get(normalizeId(entry?.meta?.id));
+            return nested || entry;
+          }),
+          comments: nestedComments,
           activities: events.map((row) => mapEventRowToThreadActivity(row)),
           conversation: timeline?.conversation || null
         });
@@ -396,34 +554,167 @@ priority=${firstNonEmpty(subject.priority, "")}`
     });
   }
 
+  function groupThreadReplies(thread = []) {
+    const commentEntries = (Array.isArray(thread) ? thread : [])
+      .filter((entry) => String(entry?.type || "").toUpperCase() === "COMMENT");
+    const commentsById = new Map();
+    const childrenByParentId = new Map();
+
+    commentEntries.forEach((entry) => {
+      const id = normalizeId(entry?.meta?.id);
+      if (!id) return;
+      commentsById.set(id, entry);
+    });
+
+    commentEntries.forEach((entry) => {
+      const id = normalizeId(entry?.meta?.id);
+      const parentId = normalizeId(entry?.meta?.parent_message_id);
+      if (!id || !parentId || !commentsById.has(parentId)) return;
+      const current = childrenByParentId.get(parentId) || [];
+      current.push(entry);
+      childrenByParentId.set(parentId, current);
+    });
+
+    childrenByParentId.forEach((list, parentId) => {
+      childrenByParentId.set(
+        parentId,
+        list.sort((left, right) => String(left?.ts || "").localeCompare(String(right?.ts || "")))
+      );
+    });
+
+    return { commentsById, childrenByParentId };
+  }
+
+  function renderInlineReplyComposer({ commentId, isExpanded, draft }) {
+    if (!commentId) return "";
+    if (!isExpanded) return "";
+
+    return `
+      <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
+        <div class="thread-inline-reply-editor__tabs" role="tablist" aria-label="Reply tabs">
+          <button class="comment-tab is-active" type="button">Write</button>
+          <button class="comment-tab" type="button" disabled>Preview</button>
+        </div>
+        <div class="thread-inline-reply-editor__body">
+          <textarea
+            class="textarea thread-inline-reply-editor__textarea"
+            data-thread-reply-draft="${escapeHtml(commentId)}"
+            placeholder="Write a reply"
+          >${escapeHtml(draft || "")}</textarea>
+        </div>
+        <div class="thread-inline-reply-editor__actions">
+          <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Cancel</button>
+          <button class="gh-btn gh-btn--comment" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}">Répondre</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderNestedReplyComment(entry, idx) {
+    const currentUserId = normalizeId(store?.user?.id);
+    const authorUserId = normalizeId(entry?.meta?.author_user_id);
+    const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
+    const agent = isCurrentUserAuthor ? "human" : "member";
+    const identity = getAuthorIdentity({
+      author: entry?.actor,
+      agent,
+      avatarUrl: entry?.meta?.author_avatar_url || "",
+      currentUserAvatar: isCurrentUserAuthor ? store?.user?.avatar : "",
+      humanAvatarHtml: SVG_AVATAR_HUMAN,
+      fallbackName: "System"
+    });
+    const tsHtml = entry?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(entry.ts))}</div>` : "";
+
+    return renderMessageThreadComment({
+      idx,
+      author: identity.displayName,
+      tsHtml,
+      bodyHtml: `
+        <div class="mono-small color-fg-muted">${escapeHtml(String(entry?.stateLabel || "modifiable"))}</div>
+        ${mdToHtml(entry?.message || "")}
+      `,
+      avatarType: identity.avatarType,
+      avatarHtml: identity.avatarHtml,
+      avatarInitial: identity.avatarInitial,
+      className: "message-thread__comment--nested message-thread__comment--reply-item"
+    });
+  }
+
   function renderThreadBlock() {
     const thread = getThreadForSelection();
     if (!thread.length) return "";
+    const replyUi = getInlineReplyUiState();
+    const { childrenByParentId } = groupThreadReplies(thread);
 
     const itemsHtml = thread.map((e, idx) => {
       const type = String(e?.type || "").toUpperCase();
 
       if (type === "COMMENT") {
-        const agent = String(e?.agent || "").toLowerCase();
+        const commentId = normalizeId(e?.meta?.id);
+        const parentId = normalizeId(e?.meta?.parent_message_id);
+        if (parentId) return "";
+
+        const currentUserId = normalizeId(store?.user?.id);
+        const authorUserId = normalizeId(e?.meta?.author_user_id);
+        const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
+        const agent = isCurrentUserAuthor ? "human" : "member";
         const isRapso = agent === "specialist_ps";
         const identity = isRapso
           ? { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" }
           : getAuthorIdentity({
               author: e?.actor,
               agent,
-              currentUserAvatar: store?.user?.avatar,
+              avatarUrl: e?.meta?.author_avatar_url || "",
+              currentUserAvatar: isCurrentUserAuthor ? store?.user?.avatar : "",
               humanAvatarHtml: SVG_AVATAR_HUMAN,
               fallbackName: "System"
             });
         const tsHtml = e?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(e.ts))}</div>` : "";
+        const childReplies = childrenByParentId.get(commentId) || [];
+        const isExpanded = replyUi.expandedMessageId === commentId;
+        const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
+        const repliesHtml = childReplies.length
+          ? `
+            <div class="thread-comment-replies">
+              ${childReplies.map((reply, replyIdx) => renderNestedReplyComment(reply, idx + replyIdx + 1)).join("")}
+            </div>
+          `
+          : "";
 
         return renderMessageThreadComment({
           idx,
           author: identity.displayName,
           tsHtml,
+          headerRightHtml: `
+            <div class="thread-comment-menu">
+              <button
+                class="thread-comment-menu__trigger"
+                type="button"
+                aria-label="Actions du message"
+                data-action="thread-reply-menu-toggle"
+                data-message-id="${escapeHtml(commentId)}"
+              >
+                ${svgIcon("kebab-horizontal")}
+              </button>
+              <div class="thread-comment-menu__dropdown">
+                <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
+              </div>
+            </div>
+          `,
           bodyHtml: `
             <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
             ${mdToHtml(e?.message || "")}
+            <div class="thread-comment-footer">
+              <span class="mono-small color-fg-muted">${childReplies.length} repl${childReplies.length > 1 ? "ies" : "y"}</span>
+            </div>
+            ${repliesHtml}
+            <div class="thread-comment-reply-box">
+              ${renderInlineReplyComposer({
+                commentId,
+                isExpanded,
+                draft
+              })}
+            </div>
           `,
           avatarType: identity.avatarType,
           avatarHtml: identity.avatarHtml,
@@ -679,6 +970,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
     setDecision,
     getDecision,
     getThreadForSelection,
+    setReplyContext,
+    clearReplyContext,
+    getReplyContextForSubject,
+    buildReplyPreview,
+    getInlineReplyUiState,
     renderThreadBlock,
     renderIssueStatusAction,
     renderCommentBox

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2341,9 +2341,24 @@ async function applyCommentAction(root) {
     return;
   }
 
-  await addComment(target.type, target.id, message, { actor: "Human", agent: "human" });
+  const replyContext = store.situationsView?.replyContext || {};
+  const replySubjectId = String(replyContext?.subjectId || "").trim();
+  const parentMessageId = target.type === "sujet" && replySubjectId === String(target.id || "").trim()
+    ? String(replyContext?.parentMessageId || "").trim()
+    : "";
+
+  await addComment(target.type, target.id, message, {
+    actor: "Human",
+    agent: "human",
+    parentMessageId: parentMessageId || undefined
+  });
   ta.value = "";
   store.situationsView.commentPreviewMode = false;
+  if (store.situationsView?.replyContext) {
+    store.situationsView.replyContext.subjectId = "";
+    store.situationsView.replyContext.parentMessageId = "";
+    store.situationsView.replyContext.parentPreview = "";
+  }
   rerenderScope(root);
 
 }

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -10,6 +10,7 @@ export function renderCommentComposer({
   textareaValue = "",
   placeholder = "",
   hintHtml = "",
+  contextHtml = "",
   actionsHtml = ""
 } = {}) {
   return `
@@ -20,6 +21,7 @@ export function renderCommentComposer({
         <div class="gh-timeline-title mono comment-composer__title">${escapeHtml(title)}</div>
 
         <div class="comment-box gh-comment-boxwrap comment-composer__box ${helpMode ? "gh-comment-box--help" : ""}">
+          ${contextHtml || ""}
           <div class="comment-tabs comment-composer__tabs ${helpMode ? "gh-comment-header--help" : ""}" role="tablist" aria-label="Comment tabs">
             <button class="comment-tab ${!previewMode ? "is-active" : ""}" data-action="tab-write" type="button">Write</button>
             <button class="comment-tab ${previewMode ? "is-active" : ""}" data-action="tab-preview" type="button">Preview</button>

--- a/apps/web/js/views/ui/message-thread.js
+++ b/apps/web/js/views/ui/message-thread.js
@@ -27,7 +27,8 @@ export function renderMessageCard({
   className = "",
   boxClassName = "",
   headerClassName = "",
-  bodyClassName = ""
+  bodyClassName = "",
+  headerRightHtml = ""
 } = {}) {
   return `
     <div class="gh-comment ${className}">
@@ -38,8 +39,11 @@ export function renderMessageCard({
       })}
       <div class="gh-comment-box ${boxClassName}">
         <div class="gh-comment-header ${headerClassName}">
-          <div class="gh-comment-author mono">${escapeHtml(author)}</div>
-          ${tsHtml || ""}
+          <div class="gh-comment-header-main">
+            <div class="gh-comment-author mono">${escapeHtml(author)}</div>
+            ${tsHtml || ""}
+          </div>
+          ${headerRightHtml || ""}
         </div>
         <div class="gh-comment-body ${bodyClassName}">${bodyHtml}</div>
       </div>
@@ -65,7 +69,8 @@ export function renderMessageThreadComment({
   className = "",
   boxClassName = "",
   headerClassName = "",
-  bodyClassName = ""
+  bodyClassName = "",
+  headerRightHtml = ""
 } = {}) {
   return `
     <div class="thread-item thread-item--comment thread-item--comment--flush message-thread__item ${className}" data-thread-kind="comment" data-thread-idx="${idx}">
@@ -79,7 +84,8 @@ export function renderMessageThreadComment({
           avatarInitial,
           boxClassName,
           headerClassName,
-          bodyClassName
+          bodyClassName,
+          headerRightHtml
         })}
       </div>
     </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2506,6 +2506,118 @@ body.is-resizing{
 .comment-composer__actions{padding-bottom:100px;}
 .comment-composer__actions-right{width:100%;}
 .comment-composer__hint{margin-right:auto;}
+.comment-composer__context{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  padding:8px 12px;
+  border-bottom:1px solid var(--border2);
+  background:rgba(56,139,253,.08);
+}
+.comment-composer__context-text{
+  color:var(--muted);
+}
+
+.message-thread__comment--nested{position:relative;}
+.message-thread__comment--depth-1{margin-left:24px;}
+.message-thread__comment--depth-2{margin-left:48px;}
+.comment-reply-preview{
+  margin-bottom:8px;
+  padding-left:8px;
+  border-left:2px solid var(--border2);
+  color:var(--muted);
+}
+.comment-reply-actions{
+  margin-top:10px;
+}
+.thread-comment-menu{
+  position:relative;
+  margin-left:auto;
+}
+.thread-comment-menu__trigger{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:24px;
+  height:24px;
+  border:none;
+  border-radius:6px;
+  background:transparent;
+  color:var(--muted);
+  cursor:pointer;
+}
+.thread-comment-menu__trigger:hover{background:rgba(110,118,129,.2);color:var(--text);}
+.thread-comment-menu__trigger .octicon{width:16px;height:16px;}
+.thread-comment-menu__dropdown{
+  position:absolute;
+  top:calc(100% + 6px);
+  right:0;
+  min-width:180px;
+  display:none;
+  z-index:220;
+  background:rgb(1, 4, 9);
+  box-shadow: rgb(61, 68, 77) 0px 0px 0px 1px, rgba(1, 4, 9, 0.4) 0px 6px 12px -3px, rgba(1, 4, 9, 0.4) 0px 6px 18px 0px;
+  border-radius:8px;
+  padding:4px;
+}
+.thread-comment-menu__dropdown.is-open{display:block;}
+.thread-comment-menu__dropdown .gh-menu__item{
+  width:100%;
+  text-align:left;
+  border:none;
+  background:transparent;
+  color:var(--text);
+  border-radius:6px;
+}
+.thread-comment-menu__dropdown .gh-menu__item:hover{
+  background:rgba(56,139,253,.14);
+}
+.thread-comment-footer{
+  display:flex;
+  justify-content:flex-end;
+  margin-top:8px;
+  margin-bottom:8px;
+}
+.thread-comment-reply-box{
+  border-top:1px solid var(--border2);
+  padding-top:10px;
+}
+.thread-inline-reply-editor{
+  border:1px solid var(--border2);
+  border-radius:6px;
+  overflow:hidden;
+  background:var(--bg-elev);
+}
+.thread-inline-reply-editor__tabs{
+  display:flex;
+  align-items:center;
+  gap:4px;
+  padding:6px 8px 0;
+  border-bottom:1px solid var(--border2);
+}
+.thread-inline-reply-editor__tabs .comment-tab[disabled]{opacity:.6;cursor:not-allowed;}
+.thread-inline-reply-editor__body{padding:10px;}
+.thread-inline-reply-editor__textarea{min-height:110px;}
+.thread-inline-reply-editor__actions{
+  display:flex;
+  justify-content:flex-end;
+  gap:8px;
+  padding:0 10px 10px;
+}
+.thread-comment-replies{
+  margin-top:8px;
+  margin-bottom:8px;
+  border-top:1px solid var(--border2);
+  padding-top:8px;
+}
+.message-thread__comment--reply-item{
+  margin-left:24px;
+}
+.message-thread__comment--reply-item .thread-wrapper{
+  border-left:1px solid var(--border2);
+  padding-left:8px;
+}
 
 /* ===== Right panel: Sub-issues table (below description) ===== */
 .details-subissues{margin-left:52px;width:calc(100% - 52px);margin-bottom:8px;margin-top:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden;container-type:inline-size;}


### PR DESCRIPTION
### Motivation
- Provide inline reply capabilities in the subject message thread so users can reply to specific messages and preserve reply drafts. 
- Improve rendering of message authors and avatars by resolving collaborator profiles rather than using raw person ids. 
- Support a preview of parent messages and visual nesting for short reply chains to make conversation context clearer.

### Description
- Added view state fields `inlineReplyUi` and `replyContext` and exposed `getInlineReplyUiState` from the thread module; updated `ensureViewUiState` to initialize these fields. 
- Implemented reply state helpers (`getInlineReplyUiState`, `setReplyContext`, `clearReplyContext`, `getReplyContextForSubject`, `buildReplyPreview`) and message-author resolution (`resolveAuthorProfile`) in `project-subjects-thread.js`, plus `MAX_REPLY_VISUAL_DEPTH` and comment decoration via `decorateNestedMessageComments`. 
- Render and wire inline reply UI: added reply composer rendering (`renderInlineReplyComposer`), nested reply rendering (`renderNestedReplyComment`), reply menu and actions in the thread (`headerRightHtml`, kebab menu, reply/cancel/submit handlers), and integrate parent `parentMessageId` into `addComment` calls in `applyCommentAction`. 
- Wire new event handlers in `project-subjects-events.js` to toggle reply menus, open reply editors, persist drafts, cancel and submit inline replies, and close dropdowns; added DOM-safe selector escaping and debug logging toggles. 
- Updated UI components to support context and header slotting by adding `contextHtml` to `renderCommentComposer` and `headerRightHtml` to message card rendering; added CSS rules to `style.css` for menu, reply editor, nested replies and composer context. 

### Testing
- Ran the project linting (`npm run lint`) and the JavaScript unit tests (`npm test`) against the modified codebase; the automated checks completed successfully. 
- No new automated unit tests were added for inline reply interactions in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23122df1483299223eede5ee2becb)