### PR TITLE
Encapsuler l'éditeur inline de réponse et ajuster l’alignement des réponses imbriquées

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -610,16 +610,18 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     return `
       <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
-        <div class="thread-inline-reply-editor__tabs" role="tablist" aria-label="Reply tabs">
-          <button class="comment-tab is-active" type="button">Write</button>
-          <button class="comment-tab" type="button" disabled>Preview</button>
-        </div>
-        <div class="thread-inline-reply-editor__body">
-          <textarea
-            class="textarea thread-inline-reply-editor__textarea"
-            data-thread-reply-draft="${escapeHtml(commentId)}"
-            placeholder="Write a reply"
-          >${escapeHtml(draft || "")}</textarea>
+        <div class="thread-inline-reply-editor__content">
+          <div class="thread-inline-reply-editor__tabs" role="tablist" aria-label="Reply tabs">
+            <button class="comment-tab is-active" type="button">Write</button>
+            <button class="comment-tab" type="button" disabled>Preview</button>
+          </div>
+          <div class="thread-inline-reply-editor__body">
+            <textarea
+              class="textarea thread-inline-reply-editor__textarea"
+              data-thread-reply-draft="${escapeHtml(commentId)}"
+              placeholder="Write a reply"
+            >${escapeHtml(draft || "")}</textarea>
+          </div>
         </div>
         <div class="thread-inline-reply-editor__actions">
           <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Cancel</button>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2598,6 +2598,10 @@ body.is-resizing{
   overflow:hidden;
   background:var(--bg-elev);
 }
+.thread-inline-reply-editor__content{
+  border:solid 1px var(--border2);
+  border-radius:6px;
+}
 .thread-inline-reply-editor__tabs{
   display:flex;
   align-items:center;
@@ -2635,13 +2639,13 @@ body.is-resizing{
   padding:0px;
 }
 .message-thread__comment--reply-item{
-  margin-left:12px;
-  width:calc(100% - 12px);
+  margin-left:0;
+  width:100%;
   box-sizing:border-box;
 }
 .message-thread__comment--reply-item .thread-wrapper{
   border-left:2px solid var(--border2);
-  padding-left:16px;
+  padding-left:0;
   width:100%;
   box-sizing:border-box;
 }
@@ -2651,7 +2655,7 @@ body.is-resizing{
   box-sizing:border-box;
 }
 .thread-comment-replies--github .message-thread__comment--reply-item .gh-avatar{
-  margin-left:-22px;
+  margin-left:-20px;
 }
 
 /* ===== Right panel: Sub-issues table (below description) ===== */


### PR DESCRIPTION
### Motivation
- Appliquer une bordure spécifique autour des onglets + zone de saisie des réponses imbriquées pour correspondre à la demande d'UI. 
- Faire en sorte que les boîtes de commentaires imbriqués aient la même largeur que la boîte de description principale. 
- Déplacer la ligne de timeline pour qu'elle passe au centre des avatars au lieu de rester à gauche.

### Description
- Modifié le rendu de l'éditeur inline dans `apps/web/js/views/project-subjects/project-subjects-thread.js` en encapsulant les éléments de tabs + body dans un nouveau wrapper `thread-inline-reply-editor__content`.
- Ajouté la règle CSS `.thread-inline-reply-editor__content { border: solid 1px var(--border2); border-radius: 6px; }` dans `apps/web/style.css` pour fournir la bordure demandée.
- Ajusté les styles des réponses imbriquées dans `apps/web/style.css` en définissant `.message-thread__comment--reply-item { margin-left: 0; width: 100%; }` et en supprimant le padding gauche sur `.message-thread__comment--reply-item .thread-wrapper` afin d'aligner la largeur avec la boîte de description.
- Affiné le positionnement de l'avatar dans les réponses imbriquées en modifiant `margin-left` pour `.thread-comment-replies--github .message-thread__comment--reply-item .gh-avatar` afin de recentrer la timeline visuellement.

### Testing
- Executé `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` et la vérification de syntaxe a réussi. 
- Aucun test automatisé de rendu CSS/visuel n'a été exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e255afbb908329bf2c28bc1100188a)