### PR TITLE
Reset nested reply draft, hide zero replies, and localize inline reply UI to French

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1321,13 +1321,7 @@ export function createProjectSubjectsEvents(config) {
         debugThreadReply("menu_action_reply", { messageId, parentMessageLength: parentMessageText.length });
         btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
         const replyUi = resolveInlineReplyUiState();
-        const existingDraft = String(replyUi.draftsByMessageId?.[messageId] || "");
-        if (!existingDraft) {
-          const quoted = parentMessageText
-            ? `> ${parentMessageText.replace(/\n+/g, "\n> ")}\n\n`
-            : "";
-          replyUi.draftsByMessageId[messageId] = quoted;
-        }
+        replyUi.draftsByMessageId[messageId] = "";
         replyUi.expandedMessageId = messageId;
         debugThreadReply("reply_opened", {
           messageId,

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -611,7 +611,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     return `
       <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
         <div class="thread-inline-reply-editor__content">
-          <div class="thread-inline-reply-editor__tabs" role="tablist" aria-label="Reply tabs">
+          <div class="thread-inline-reply-editor__tabs" role="tablist" aria-label="Onglets de réponse">
             <button class="comment-tab is-active" type="button">Write</button>
             <button class="comment-tab" type="button" disabled>Preview</button>
           </div>
@@ -619,13 +619,13 @@ priority=${firstNonEmpty(subject.priority, "")}`
             <textarea
               class="textarea thread-inline-reply-editor__textarea"
               data-thread-reply-draft="${escapeHtml(commentId)}"
-              placeholder="Write a reply"
+              placeholder="Écrire une réponse"
             >${escapeHtml(draft || "")}</textarea>
           </div>
         </div>
         <div class="thread-inline-reply-editor__actions">
-          <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Cancel</button>
-          <button class="gh-btn gh-btn--comment" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}">Répondre</button>
+          <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
+          <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}">Répondre</button>
         </div>
       </div>
     `;
@@ -737,9 +737,13 @@ priority=${firstNonEmpty(subject.priority, "")}`
               <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
               ${mdToHtml(e?.message || "")}
             </div>
-            <div class="thread-comment-footer">
-              <span class="mono-small color-fg-muted">${childReplies.length} repl${childReplies.length > 1 ? "ies" : "y"}</span>
-            </div>
+            ${childReplies.length
+              ? `
+                <div class="thread-comment-footer">
+                  <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
+                </div>
+              `
+              : ""}
             ${repliesHtml}
             <div class="thread-comment-reply-box">
               ${renderInlineReplyComposer({


### PR DESCRIPTION
### Motivation
- Prevent the inline nested reply composer from pre-filling with the parent message text when opening "Répondre au message" from the kebab menu so the textarea is empty by default.
- Avoid rendering an unhelpful "0 reply" label when there are no replies and show localized French labels instead.
- Make inline reply actions clearer by translating buttons and emphasizing the submit action.

### Description
- Stop pre-filling the nested reply draft and instead initialize the draft to empty in `apps/web/js/views/project-subjects/project-subjects-events.js` by setting `replyUi.draftsByMessageId[messageId] = ""` when opening a reply.
- Translate the inline reply composer UI in `apps/web/js/views/project-subjects/project-subjects-thread.js` by changing the tabs `aria-label` to `"Onglets de réponse"` and the textarea `placeholder` to `"Écrire une réponse"`.
- Replace the cancel button label from `Cancel` to `Annuler` and add the `gh-btn--primary` class to the inline reply submit button so the `Répondre` button appears primary.
- Hide the replies counter when there are zero replies and render the localized French label (`"réponse"` / `"réponses"`) when replies exist.

### Testing
- Ran `git diff --check` which produced no warnings or errors and passed successfully.
- Performed a source search and manual inspection of the modified templates and event handlers to validate the label and behavior changes.
- Committed the changes to the repository; no automated UI/browser tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25cf3e3288329adc7da10ea1d92ea)