### PR TITLE
Add structured @mention support to subject messages (UI, parsing, storage)

### DIFF
--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -9,6 +9,21 @@ function normalizeId(value) {
   return String(value || "").trim();
 }
 
+function normalizeMentions(rawMentions = []) {
+  const list = Array.isArray(rawMentions) ? rawMentions : [];
+  const seen = new Set();
+  return list
+    .map((entry) => ({
+      personId: normalizeId(entry?.personId || entry?.mentionedPersonId),
+      label: String(entry?.label || entry?.displayLabel || "").trim()
+    }))
+    .filter((entry) => {
+      if (!entry.personId || seen.has(entry.personId)) return false;
+      seen.add(entry.personId);
+      return true;
+    });
+}
+
 function safeJsonParse(text) {
   try {
     return JSON.parse(text);
@@ -64,6 +79,60 @@ async function resolveCurrentPersonId() {
 }
 
 export function createSubjectMessagesSupabaseRepository() {
+  async function listMentionsByMessageIds(messageIds = []) {
+    const ids = (Array.isArray(messageIds) ? messageIds : [])
+      .map((value) => normalizeId(value))
+      .filter(Boolean);
+    if (!ids.length) return new Map();
+
+    const params = new URLSearchParams();
+    params.set("select", "id,project_id,subject_id,message_id,mentioned_person_id,display_label,created_at");
+    params.set("message_id", `in.(${ids.join(",")})`);
+    params.set("order", "created_at.asc");
+    const rows = await restFetch("/rest/v1/subject_message_mentions", params);
+    const grouped = new Map();
+    (Array.isArray(rows) ? rows : []).forEach((row) => {
+      const messageId = normalizeId(row?.message_id);
+      if (!messageId) return;
+      const mentions = grouped.get(messageId) || [];
+      mentions.push({
+        id: normalizeId(row?.id),
+        message_id: messageId,
+        mentioned_person_id: normalizeId(row?.mentioned_person_id),
+        display_label: String(row?.display_label || "").trim(),
+        created_at: String(row?.created_at || "")
+      });
+      grouped.set(messageId, mentions);
+    });
+    return grouped;
+  }
+
+  async function insertMessageMentions({ message = null, mentions = [] } = {}) {
+    const messageId = normalizeId(message?.id);
+    const projectId = normalizeId(message?.project_id);
+    const subjectId = normalizeId(message?.subject_id);
+    if (!messageId || !projectId || !subjectId) return [];
+
+    const normalizedMentions = normalizeMentions(mentions);
+    if (!normalizedMentions.length) return [];
+
+    const rows = await restFetch("/rest/v1/subject_message_mentions", null, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Prefer: "resolution=merge-duplicates,return=representation"
+      },
+      body: JSON.stringify(normalizedMentions.map((mention) => ({
+        project_id: projectId,
+        subject_id: subjectId,
+        message_id: messageId,
+        mentioned_person_id: mention.personId,
+        display_label: mention.label || null
+      })))
+    });
+    return Array.isArray(rows) ? rows : [];
+  }
+
   return {
     async listMessages({ subjectId }) {
       const normalizedSubjectId = normalizeId(subjectId);
@@ -78,7 +147,15 @@ export function createSubjectMessagesSupabaseRepository() {
       params.set("order", "created_at.asc");
 
       const rows = await restFetch("/rest/v1/subject_messages", params);
-      return Array.isArray(rows) ? rows : [];
+      const messages = Array.isArray(rows) ? rows : [];
+      const mentionsByMessageId = await listMentionsByMessageIds(messages.map((message) => message?.id));
+      return messages.map((message) => {
+        const messageId = normalizeId(message?.id);
+        return {
+          ...message,
+          mentions: mentionsByMessageId.get(messageId) || []
+        };
+      });
     },
 
     async listEvents({ subjectId }) {
@@ -134,7 +211,14 @@ export function createSubjectMessagesSupabaseRepository() {
         })
       });
 
-      return (Array.isArray(rows) ? rows[0] : rows) || null;
+      const createdMessage = (Array.isArray(rows) ? rows[0] : rows) || null;
+      const mentions = normalizeMentions(payload.mentions);
+      if (!createdMessage || !mentions.length) return createdMessage;
+      const insertedMentions = await insertMessageMentions({ message: createdMessage, mentions });
+      return {
+        ...createdMessage,
+        mentions: insertedMentions
+      };
     },
 
     async markMessageRead({ messageId, subjectId = "", projectId = "" } = {}) {
@@ -252,7 +336,7 @@ export function createSubjectMessagesSupabaseRepository() {
       if (!normalizedProjectId) return [];
 
       const params = new URLSearchParams();
-      params.set("select", "person_id,collaborator_user_id,collaborator_email,collaborator_name,collaborator_first_name,collaborator_last_name,status,role_group_code,role_group_label");
+      params.set("select", "person_id,collaborator_user_id,collaborator_email,first_name,last_name,full_name,email,status,removed_at,role_group_code,role_group_label");
       params.set("project_id", `eq.${normalizedProjectId}`);
       params.set("removed_at", "is.null");
 
@@ -263,10 +347,11 @@ export function createSubjectMessagesSupabaseRepository() {
         .map((row) => ({
           personId: normalizeId(row?.person_id),
           userId: normalizeId(row?.collaborator_user_id),
-          email: String(row?.collaborator_email || "").trim(),
+          email: String(row?.email || row?.collaborator_email || "").trim(),
           label: String(
-            row?.collaborator_name
-              || [row?.collaborator_first_name, row?.collaborator_last_name].filter(Boolean).join(" ")
+            row?.full_name
+              || [row?.first_name, row?.last_name].filter(Boolean).join(" ")
+              || row?.email
               || row?.collaborator_email
               || "Utilisateur"
           ).trim(),

--- a/apps/web/js/utils/markdown-composer.js
+++ b/apps/web/js/utils/markdown-composer.js
@@ -75,7 +75,7 @@ export function applyMarkdownComposerAction(textarea, action = "") {
       }
       break;
     case "mention":
-      result = applyWrap(value, start, end, "@", "", "collaborateur");
+      result = applyWrap(value, start, end, "@", "", "");
       break;
     default:
       return false;

--- a/apps/web/js/utils/subject-mentions.js
+++ b/apps/web/js/utils/subject-mentions.js
@@ -1,0 +1,68 @@
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function escapeMarkdownLabel(value = "") {
+  return String(value || "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\]/g, "\\]");
+}
+
+export function extractStructuredMentions(markdown = "") {
+  const source = String(markdown || "");
+  const pattern = /\[@((?:\\.|[^\]])+)\]\(\/people\/([0-9a-fA-F-]{8,})\)/g;
+  const seen = new Set();
+  const mentions = [];
+  let match = pattern.exec(source);
+  while (match) {
+    const label = String(match[1] || "").replace(/\\]/g, "]").trim();
+    const personId = normalizeId(match[2]);
+    if (personId && !seen.has(personId)) {
+      seen.add(personId);
+      mentions.push({ personId, label: label || `Person ${personId.slice(0, 8)}` });
+    }
+    match = pattern.exec(source);
+  }
+  return mentions;
+}
+
+export function resolveMentionTriggerContext(text = "", cursorIndex = 0) {
+  const source = String(text || "");
+  const caret = Math.max(0, Math.min(Number(cursorIndex || 0), source.length));
+  const before = source.slice(0, caret);
+
+  let index = before.length - 1;
+  while (index >= 0) {
+    const char = before[index];
+    if (char === "\n" || char === "\r" || char === "\t" || char === " ") break;
+    index -= 1;
+  }
+
+  const tokenStart = index + 1;
+  const token = before.slice(tokenStart);
+  if (!token.startsWith("@")) return null;
+  if (token.length >= 2 && token[1] === "[") return null;
+
+  return {
+    triggerStart: tokenStart,
+    triggerEnd: caret,
+    query: token.slice(1)
+  };
+}
+
+export function applyMentionSuggestion(text = "", context = {}, suggestion = {}) {
+  const source = String(text || "");
+  const triggerStart = Math.max(0, Math.min(Number(context?.triggerStart || 0), source.length));
+  const triggerEnd = Math.max(triggerStart, Math.min(Number(context?.triggerEnd || triggerStart), source.length));
+  const personId = normalizeId(suggestion?.personId);
+  const label = String(suggestion?.label || "").trim();
+
+  if (!personId || !label) {
+    return { nextText: source, nextCursorIndex: triggerEnd };
+  }
+
+  const mentionMarkdown = `[@${escapeMarkdownLabel(label)}](/people/${personId}) `;
+  const nextText = `${source.slice(0, triggerStart)}${mentionMarkdown}${source.slice(triggerEnd)}`;
+  const nextCursorIndex = triggerStart + mentionMarkdown.length;
+  return { nextText, nextCursorIndex };
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -292,6 +292,7 @@ const {
   addActivity,
   setDecision,
   getDecision,
+  getMentionUiState,
   getThreadForSelection,
   getInlineReplyUiState,
   renderThreadBlock,
@@ -388,6 +389,8 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   addComment: (...args) => addComment(...args),
   editSubjectMessage: (...args) => editSubjectMessage(...args),
   deleteSubjectMessage: (...args) => deleteSubjectMessage(...args),
+  getMentionUiState: (...args) => getMentionUiState(...args),
+  listCollaboratorsForMentions: (...args) => subjectMessagesService.listCollaboratorsForMentions(...args),
   getSubjectsCurrentRoot: () => subjectsCurrentRoot,
   resolveCurrentUserAssigneeId: () => resolveCurrentUserDirectoryPersonId({
     email: store.user?.email || "",

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1,4 +1,9 @@
 import { applyMarkdownComposerAction } from "../../utils/markdown-composer.js";
+import {
+  applyMentionSuggestion,
+  extractStructuredMentions,
+  resolveMentionTriggerContext
+} from "../../utils/subject-mentions.js";
 
 export function createProjectSubjectsEvents(config) {
   const {
@@ -58,7 +63,9 @@ export function createProjectSubjectsEvents(config) {
     resolveCurrentUserAssigneeId,
     addComment,
     editSubjectMessage,
-    deleteSubjectMessage
+    deleteSubjectMessage,
+    getMentionUiState,
+    listCollaboratorsForMentions
   } = config;
 
   let detachDropdownDocumentEvents = null;
@@ -666,11 +673,140 @@ export function createProjectSubjectsEvents(config) {
 
     const commentTextarea = root.querySelector("#humanCommentBox");
     if (commentTextarea) {
+      let mentionCollaborators = [];
+      let mentionCollaboratorsLoaded = false;
+      let mentionLoadPromise = null;
+
+      const getMentionState = () => {
+        if (typeof getMentionUiState === "function") return getMentionUiState();
+        if (!store.situationsView.mentionUi || typeof store.situationsView.mentionUi !== "object") {
+          store.situationsView.mentionUi = {
+            open: false,
+            query: "",
+            activeIndex: 0,
+            triggerStart: -1,
+            triggerEnd: -1,
+            suggestions: []
+          };
+        }
+        return store.situationsView.mentionUi;
+      };
+
+      const closeMentionPopup = ({ rerender = true } = {}) => {
+        const mentionState = getMentionState();
+        mentionState.open = false;
+        mentionState.query = "";
+        mentionState.activeIndex = 0;
+        mentionState.triggerStart = -1;
+        mentionState.triggerEnd = -1;
+        mentionState.suggestions = [];
+        if (rerender) rerenderScope(root);
+      };
+
+      const ensureMentionCollaboratorsLoaded = async () => {
+        if (mentionCollaboratorsLoaded) return mentionCollaborators;
+        if (mentionLoadPromise) return mentionLoadPromise;
+        const selection = getScopedSelection(root);
+        if (!selection?.item?.project_id || typeof listCollaboratorsForMentions !== "function") {
+          mentionCollaborators = [];
+          mentionCollaboratorsLoaded = true;
+          return mentionCollaborators;
+        }
+        mentionLoadPromise = listCollaboratorsForMentions(selection.item.project_id)
+          .then((rows) => {
+            mentionCollaborators = Array.isArray(rows) ? rows : [];
+            mentionCollaboratorsLoaded = true;
+            return mentionCollaborators;
+          })
+          .catch((error) => {
+            console.warn("[subject-mentions] collaborators load failed", error);
+            mentionCollaborators = [];
+            mentionCollaboratorsLoaded = true;
+            return mentionCollaborators;
+          })
+          .finally(() => {
+            mentionLoadPromise = null;
+          });
+        return mentionLoadPromise;
+      };
+
+      const syncMentionPopup = async ({ forceOpen = false } = {}) => {
+        const mentionState = getMentionState();
+        const context = resolveMentionTriggerContext(commentTextarea.value || "", commentTextarea.selectionStart || 0);
+        if (!context && !forceOpen) {
+          if (mentionState.open) closeMentionPopup();
+          return;
+        }
+
+        const collaborators = await ensureMentionCollaboratorsLoaded();
+        const query = String(context?.query || "").trim().toLowerCase();
+        const suggestions = collaborators
+          .filter((entry) => {
+            if (!query) return true;
+            return [
+              String(entry?.label || "").toLowerCase(),
+              String(entry?.email || "").toLowerCase()
+            ].some((field) => field.includes(query));
+          })
+          .slice(0, 8);
+
+        mentionState.triggerStart = Number(context?.triggerStart ?? -1);
+        mentionState.triggerEnd = Number(context?.triggerEnd ?? -1);
+        mentionState.query = query;
+        mentionState.suggestions = suggestions;
+        mentionState.open = !!context || forceOpen;
+        mentionState.activeIndex = Math.max(0, Math.min(Number(mentionState.activeIndex || 0), Math.max(0, suggestions.length - 1)));
+        rerenderScope(root);
+      };
+
+      const pickMentionSuggestion = (suggestion) => {
+        const mentionState = getMentionState();
+        const context = {
+          triggerStart: mentionState.triggerStart,
+          triggerEnd: Number(commentTextarea.selectionStart || mentionState.triggerEnd || 0)
+        };
+        const result = applyMentionSuggestion(commentTextarea.value || "", context, suggestion);
+        commentTextarea.value = result.nextText;
+        store.situationsView.commentDraft = String(result.nextText || "");
+        commentTextarea.focus();
+        commentTextarea.selectionStart = result.nextCursorIndex;
+        commentTextarea.selectionEnd = result.nextCursorIndex;
+        closeMentionPopup({ rerender: false });
+        if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
+        rerenderScope(root);
+      };
+
       commentTextarea.addEventListener("input", () => {
         store.situationsView.commentDraft = String(commentTextarea.value || "");
+        void syncMentionPopup();
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
       });
       commentTextarea.addEventListener("keydown", (ev) => {
+        const mentionState = getMentionState();
+        if (mentionState.open && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length) {
+          if (ev.key === "ArrowDown") {
+            ev.preventDefault();
+            mentionState.activeIndex = (Number(mentionState.activeIndex || 0) + 1) % mentionState.suggestions.length;
+            rerenderScope(root);
+            return;
+          }
+          if (ev.key === "ArrowUp") {
+            ev.preventDefault();
+            mentionState.activeIndex = (Number(mentionState.activeIndex || 0) - 1 + mentionState.suggestions.length) % mentionState.suggestions.length;
+            rerenderScope(root);
+            return;
+          }
+          if (ev.key === "Enter") {
+            ev.preventDefault();
+            pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0]);
+            return;
+          }
+          if (ev.key === "Escape") {
+            ev.preventDefault();
+            closeMentionPopup();
+            return;
+          }
+        }
         if (ev.key === "Enter" && (ev.ctrlKey || ev.metaKey)) {
           ev.preventDefault();
           applyCommentAction(root);
@@ -683,9 +819,33 @@ export function createProjectSubjectsEvents(config) {
           if (!action) return;
           const didApply = applyMarkdownComposerAction(commentTextarea, action);
           if (!didApply) return;
+          if (action === "mention") void syncMentionPopup({ forceOpen: true });
+          else closeMentionPopup({ rerender: false });
+          store.situationsView.commentDraft = String(commentTextarea.value || "");
           if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
         };
       });
+
+      root.querySelectorAll("[data-action='mention-pick'][data-person-id]").forEach((btn) => {
+        btn.onclick = () => {
+          pickMentionSuggestion({
+            personId: String(btn.dataset.personId || "").trim(),
+            label: String(btn.dataset.label || "").trim()
+          });
+        };
+      });
+
+      if (root.dataset.subjectMentionDocumentBound !== "true") {
+        document.addEventListener("click", (event) => {
+          const target = event?.target;
+          if (!target || !(target instanceof Element)) return;
+          if (target.closest(".subject-mention-popup") || target.closest("#humanCommentBox")) return;
+          const mentionState = getMentionState();
+          if (!mentionState.open) return;
+          closeMentionPopup();
+        });
+        root.dataset.subjectMentionDocumentBound = "true";
+      }
 
       root.querySelectorAll(".js-issue-status-action").forEach((actionRoot) => {
         if (actionRoot.dataset.issueStatusBound === "true") return;
@@ -1415,11 +1575,13 @@ export function createProjectSubjectsEvents(config) {
         const replyUi = resolveInlineReplyUiState();
         const message = String(replyUi.draftsByMessageId?.[parentMessageId] || "").trim();
         if (!message) return;
+        const mentions = extractStructuredMentions(message);
         debugThreadReply("reply_submit", { parentMessageId, messageLength: message.length });
         await addComment("sujet", selection.item.id, message, {
           actor: "Human",
           agent: "human",
-          parentMessageId
+          parentMessageId,
+          mentions
         });
         replyUi.draftsByMessageId[parentMessageId] = "";
         replyUi.expandedMessageId = "";

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -103,10 +103,27 @@ export function createProjectSubjectsThread(config = {}) {
         reply_preview: "",
         is_frozen: isFrozen,
         is_deleted: isDeleted,
-        state_label: stateLabel
+        state_label: stateLabel,
+        mentions: Array.isArray(row?.mentions) ? row.mentions : []
       },
       stateLabel
     };
+  }
+
+  function getMentionUiState() {
+    ensureViewUiState();
+    const state = store.situationsView;
+    if (!state.mentionUi || typeof state.mentionUi !== "object") {
+      state.mentionUi = {
+        open: false,
+        query: "",
+        activeIndex: 0,
+        triggerStart: -1,
+        triggerEnd: -1,
+        suggestions: []
+      };
+    }
+    return state.mentionUi;
   }
 
   function getReplyContextState() {
@@ -360,11 +377,13 @@ export function createProjectSubjectsThread(config = {}) {
         ? await subjectMessagesService.createReply({
             subjectId: normalizedEntityId,
             parentMessageId: options.parentMessageId,
-            bodyMarkdown: normalizedMessage
+            bodyMarkdown: normalizedMessage,
+            mentions: Array.isArray(options.mentions) ? options.mentions : []
           })
         : await subjectMessagesService.createMessage({
             subjectId: normalizedEntityId,
-            bodyMarkdown: normalizedMessage
+            bodyMarkdown: normalizedMessage,
+            mentions: Array.isArray(options.mentions) ? options.mentions : []
           });
 
       ensureSubjectTimelineLoaded(normalizedEntityId, { force: true });
@@ -1019,6 +1038,34 @@ priority=${firstNonEmpty(subject.priority, "")}`
       <button class="gh-btn gh-btn--comment" data-action="add-comment" type="button">Comment</button>
     `;
 
+    const mentionUi = getMentionUiState();
+    const mentionPopupHtml = mentionUi.open
+      ? `
+        <div class="subject-mention-popup" role="listbox" aria-label="Suggestions de mention">
+          ${(Array.isArray(mentionUi.suggestions) ? mentionUi.suggestions : []).length
+            ? mentionUi.suggestions.map((suggestion, index) => {
+            const personId = normalizeId(suggestion?.personId);
+            const isActive = Number(mentionUi.activeIndex || 0) === index;
+            return `
+              <button
+                class="subject-mention-popup__item ${isActive ? "is-active" : ""}"
+                type="button"
+                role="option"
+                aria-selected="${isActive ? "true" : "false"}"
+                data-action="mention-pick"
+                data-person-id="${escapeHtml(personId)}"
+                data-label="${escapeHtml(String(suggestion?.label || ""))}"
+              >
+                <span class="subject-mention-popup__name">${escapeHtml(String(suggestion?.label || ""))}</span>
+                <span class="subject-mention-popup__meta">${escapeHtml(String(suggestion?.email || ""))}</span>
+              </button>
+            `;
+          }).join("")
+            : `<div class="subject-mention-popup__empty">Aucun collaborateur trouvé</div>`}
+        </div>
+      `
+      : "";
+
     return renderCommentComposer({
       title: "Add a comment",
       avatarHtml: getAuthorIdentity({
@@ -1039,7 +1086,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
       hintHtml,
       contextHtml,
       actionsHtml,
-      toolbarHtml
+      toolbarHtml,
+      footerHtml: mentionPopupHtml
     });
   }
 
@@ -1055,6 +1103,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     clearReplyContext,
     getReplyContextForSubject,
     buildReplyPreview,
+    getMentionUiState,
     getInlineReplyUiState,
     renderThreadBlock,
     renderIssueStatusAction,

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -13,6 +13,7 @@ import {
   renderSelectDropdownHost,
   syncSelectDropdownPosition
 } from "../ui/select-dropdown-controller.js";
+import { extractStructuredMentions } from "../../utils/subject-mentions.js";
 export function createProjectSubjectsView(deps) {
   const {
     store,
@@ -2333,6 +2334,7 @@ async function applyCommentAction(root) {
 
   const message = String(ta.value || "").trim();
   if (!message) return;
+  const mentions = extractStructuredMentions(message);
 
   const helpActive = !!store.situationsView.helpMode;
   if (helpActive) {
@@ -2351,7 +2353,8 @@ async function applyCommentAction(root) {
   await addComment(target.type, target.id, message, {
     actor: "Human",
     agent: "human",
-    parentMessageId: parentMessageId || undefined
+    parentMessageId: parentMessageId || undefined,
+    mentions
   });
   ta.value = "";
   store.situationsView.commentDraft = "";

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -11,6 +11,7 @@ export function renderCommentComposer({
   placeholder = "",
   hintHtml = "",
   contextHtml = "",
+  footerHtml = "",
   actionsHtml = "",
   toolbarHtml = "",
   previewEmptyHint = "Use Markdown to format your comment"
@@ -43,6 +44,7 @@ export function renderCommentComposer({
           <div class="comment-editor comment-composer__preview-wrap ${previewMode ? "" : "hidden"}">
             <div class="comment-preview comment-composer__preview" id="${escapeHtml(previewId)}" data-empty-hint="${escapeHtml(previewEmptyHint)}"></div>
           </div>
+          ${footerHtml || ""}
         </div>
 
         <div class="actions-row actions-row--details comment-composer__actions" style="margin-top:10px;">

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2565,6 +2565,34 @@ body.is-resizing{
 .comment-toolbar-btn .ui-icon{width:16px;height:16px;}
 .comment-composer__preview{min-height:170px;padding:12px;}
 .comment-composer__preview-empty{color:var(--muted);font-size:14px;}
+.subject-mention-popup{
+  margin:0 10px 10px;
+  border:1px solid var(--border2);
+  border-radius:8px;
+  background:var(--bgElevated, #0d1117);
+  overflow:hidden;
+  box-shadow:0 8px 28px rgba(1,4,9,.45);
+}
+.subject-mention-popup__item{
+  width:100%;
+  border:none;
+  background:transparent;
+  color:var(--text);
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  padding:8px 12px;
+  cursor:pointer;
+}
+.subject-mention-popup__item + .subject-mention-popup__item{border-top:1px solid rgba(110,118,129,.2);}
+.subject-mention-popup__item:hover,
+.subject-mention-popup__item.is-active{
+  background:rgba(56,139,253,.18);
+}
+.subject-mention-popup__name{font-size:13px;}
+.subject-mention-popup__meta{font-size:12px;color:var(--muted);}
+.subject-mention-popup__empty{padding:10px 12px;font-size:12px;color:var(--muted);}
 .md-render p{margin:0 0 10px;}
 .md-render p:last-child{margin-bottom:0;}
 .md-render ul,.md-render ol{margin:0 0 10px 20px;padding:0;}


### PR DESCRIPTION
### Motivation

- Add first-class support for structured mentions in subject messages so users can insert, autocomplete and persist references to people in comments and replies.
- Provide a lightweight mention suggestion UI that queries project collaborators and lets users pick suggestions via keyboard or mouse.
- Persist mention records to the backend and include them when loading messages so mentions can be rendered/processed elsewhere.

### Description

- Introduces a new utility `apps/web/js/utils/subject-mentions.js` that implements `extractStructuredMentions`, `resolveMentionTriggerContext`, and `applyMentionSuggestion` to parse mention markdown, detect triggers and build structured mention markdown. 
- Extends the Supabase repository in `subject-messages-supabase.js` with `normalizeMentions`, `listMentionsByMessageIds`, and `insertMessageMentions`, wires mention insertion into `createMessage`/`createReply`, and includes `mentions` when listing messages. 
- Adds frontend mention UI and behavior in the subjects view and events: integrates mention popup rendering into the composer (`comment-composer.js`, stylesheet), keyboard navigation and selection, collaborator loading (`listCollaboratorsForMentions` mapping improved), and extraction of structured mentions on submit (`project-subjects-view.js`, `project-subjects-events.js`, and thread code). 
- Minor UX tweaks: remove default placeholder label for the composer mention action in `markdown-composer.js` and include mention state management (`getMentionUiState`) in the thread renderer.

### Testing

- Ran lint and static checks with `npm run lint` which completed successfully. 
- Performed a front-end build with `npm run build` which succeeded without errors. 
- Executed the test suite with `npm test` and existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27168b9688329b064a846bc3e0f42)