### PR TITLE
feat: add subject message attachments upload/dropzone and timeline rendering

### DIFF
--- a/apps/web/js/services/subject-messages-service.js
+++ b/apps/web/js/services/subject-messages-service.js
@@ -98,8 +98,16 @@ export function createSubjectMessagesService({ repository } = {}) {
     return provider.uploadTemporaryAttachment(payload);
   }
 
+  async function uploadAttachmentFile(payload = {}) {
+    return provider.uploadAttachmentFile(payload);
+  }
+
   async function linkAttachmentsToMessage(payload = {}) {
     return provider.linkAttachmentsToMessage(payload);
+  }
+
+  async function removeTemporaryAttachment(payload = {}) {
+    return provider.removeTemporaryAttachment(payload);
   }
 
   async function lockConversation(subjectId, options = {}) {
@@ -129,7 +137,9 @@ export function createSubjectMessagesService({ repository } = {}) {
     editMessage,
     deleteMessage,
     uploadTemporaryAttachment,
+    uploadAttachmentFile,
     linkAttachmentsToMessage,
+    removeTemporaryAttachment,
     lockConversation,
     unlockConversation,
     listCollaboratorsForMentions,

--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -32,6 +32,27 @@ function safeJsonParse(text) {
   }
 }
 
+function normalizeFileName(value) {
+  return String(value || "")
+    .trim()
+    .replace(/[^\w.\- ]+/g, "_")
+    .replace(/\s+/g, "-")
+    .slice(0, 120);
+}
+
+function encodeStoragePath(path = "") {
+  return String(path || "")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildAuthenticatedStorageObjectUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
+  const normalizedPath = String(storagePath || "").trim();
+  if (!normalizedPath) return "";
+  return `${SUPABASE_URL}/storage/v1/object/authenticated/${encodeURIComponent(String(bucket || SUBJECT_ATTACHMENTS_BUCKET))}/${encodeStoragePath(normalizedPath)}`;
+}
+
 async function getAuthHeaders(extra = {}) {
   return buildSupabaseAuthHeaders(extra);
 }
@@ -79,6 +100,39 @@ async function resolveCurrentPersonId() {
 }
 
 export function createSubjectMessagesSupabaseRepository() {
+  async function listAttachmentsByMessageIds(messageIds = []) {
+    const ids = (Array.isArray(messageIds) ? messageIds : [])
+      .map((value) => normalizeId(value))
+      .filter(Boolean);
+    if (!ids.length) return new Map();
+
+    const params = new URLSearchParams();
+    params.set("select", "id,project_id,subject_id,message_id,storage_bucket,storage_path,file_name,mime_type,size_bytes,width,height,sort_order,created_at,linked_at");
+    params.set("message_id", `in.(${ids.join(",")})`);
+    params.set("deleted_at", "is.null");
+    params.set("order", "sort_order.asc");
+    params.append("order", "created_at.asc");
+    const rows = await restFetch("/rest/v1/subject_message_attachments", params);
+    const grouped = new Map();
+    (Array.isArray(rows) ? rows : []).forEach((row) => {
+      const messageId = normalizeId(row?.message_id);
+      if (!messageId) return;
+      const list = grouped.get(messageId) || [];
+      list.push({
+        ...row,
+        id: normalizeId(row?.id),
+        message_id: messageId,
+        storage_bucket: String(row?.storage_bucket || SUBJECT_ATTACHMENTS_BUCKET),
+        storage_path: String(row?.storage_path || ""),
+        file_name: String(row?.file_name || ""),
+        mime_type: String(row?.mime_type || ""),
+        object_url: buildAuthenticatedStorageObjectUrl(row?.storage_bucket, row?.storage_path)
+      });
+      grouped.set(messageId, list);
+    });
+    return grouped;
+  }
+
   async function listMentionsByMessageIds(messageIds = []) {
     const ids = (Array.isArray(messageIds) ? messageIds : [])
       .map((value) => normalizeId(value))
@@ -149,11 +203,13 @@ export function createSubjectMessagesSupabaseRepository() {
       const rows = await restFetch("/rest/v1/subject_messages", params);
       const messages = Array.isArray(rows) ? rows : [];
       const mentionsByMessageId = await listMentionsByMessageIds(messages.map((message) => message?.id));
+      const attachmentsByMessageId = await listAttachmentsByMessageIds(messages.map((message) => message?.id));
       return messages.map((message) => {
         const messageId = normalizeId(message?.id);
         return {
           ...message,
-          mentions: mentionsByMessageId.get(messageId) || []
+          mentions: mentionsByMessageId.get(messageId) || [],
+          attachments: attachmentsByMessageId.get(messageId) || []
         };
       });
     },
@@ -299,6 +355,61 @@ export function createSubjectMessagesSupabaseRepository() {
       return (Array.isArray(rows) ? rows[0] : rows) || null;
     },
 
+    async uploadAttachmentFile(payload = {}) {
+      const file = payload?.file;
+      if (!(file instanceof File || file instanceof Blob)) {
+        throw new Error("file is required");
+      }
+
+      const subjectId = normalizeId(payload.subjectId);
+      const projectId = await resolveProjectId(payload.projectId);
+      const uploadSessionId = normalizeId(payload.uploadSessionId);
+      if (!subjectId) throw new Error("subjectId is required");
+      if (!projectId) throw new Error("projectId is required");
+      if (!uploadSessionId) throw new Error("uploadSessionId is required");
+
+      const fileName = String(file?.name || payload.fileName || "attachment").trim();
+      const storagePath = String(
+        payload.storagePath
+          || `${projectId}/${subjectId}/temporary/${uploadSessionId}/${Date.now()}-${normalizeFileName(fileName) || "attachment"}`
+      ).trim();
+      if (!storagePath) throw new Error("storagePath is required");
+
+      const uploadResponse = await fetch(
+        `${SUPABASE_URL}/storage/v1/object/${encodeURIComponent(SUBJECT_ATTACHMENTS_BUCKET)}/${encodeStoragePath(storagePath)}`,
+        {
+          method: "POST",
+          headers: await getAuthHeaders({
+            "Content-Type": String(file?.type || payload.mimeType || "application/octet-stream"),
+            "x-upsert": "false"
+          }),
+          body: file
+        }
+      );
+      if (!uploadResponse.ok) {
+        const text = await uploadResponse.text().catch(() => "");
+        throw new Error(`Attachment upload failed (${uploadResponse.status}): ${text}`);
+      }
+
+      const attachment = await this.uploadTemporaryAttachment({
+        subjectId,
+        projectId,
+        uploadSessionId,
+        storagePath,
+        storageBucket: SUBJECT_ATTACHMENTS_BUCKET,
+        fileName,
+        mimeType: String(file?.type || payload.mimeType || ""),
+        sizeBytes: Number(file?.size || payload.sizeBytes || 0),
+        width: payload.width,
+        height: payload.height,
+        sortOrder: payload.sortOrder
+      });
+      return {
+        ...attachment,
+        object_url: buildAuthenticatedStorageObjectUrl(SUBJECT_ATTACHMENTS_BUCKET, storagePath)
+      };
+    },
+
     async linkAttachmentsToMessage({ subjectId, messageId, uploadSessionId }) {
       const normalizedSubjectId = normalizeId(subjectId);
       const normalizedMessageId = normalizeId(messageId);
@@ -314,6 +425,41 @@ export function createSubjectMessagesSupabaseRepository() {
       });
 
       return Array.isArray(rows) ? rows : [];
+    },
+
+    async removeTemporaryAttachment({ attachmentId }) {
+      const normalizedAttachmentId = normalizeId(attachmentId);
+      if (!normalizedAttachmentId) throw new Error("attachmentId is required");
+
+      const readParams = new URLSearchParams();
+      readParams.set("select", "id,storage_bucket,storage_path");
+      readParams.set("id", `eq.${normalizedAttachmentId}`);
+      readParams.set("limit", "1");
+      const currentRows = await restFetch("/rest/v1/subject_message_attachments", readParams);
+      const currentAttachment = (Array.isArray(currentRows) ? currentRows[0] : currentRows) || null;
+
+      const patchParams = new URLSearchParams();
+      patchParams.set("id", `eq.${normalizedAttachmentId}`);
+      await restFetch("/rest/v1/subject_message_attachments", patchParams, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Prefer: "return=minimal"
+        },
+        body: JSON.stringify({ deleted_at: new Date().toISOString() })
+      });
+
+      if (currentAttachment?.storage_path) {
+        await fetch(
+          `${SUPABASE_URL}/storage/v1/object/${encodeURIComponent(String(currentAttachment.storage_bucket || SUBJECT_ATTACHMENTS_BUCKET))}/${encodeStoragePath(currentAttachment.storage_path)}`,
+          {
+            method: "DELETE",
+            headers: await getAuthHeaders()
+          }
+        ).catch(() => {});
+      }
+
+      return true;
     },
 
     async lockConversation({ subjectId, reason = "" }) {

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -293,6 +293,7 @@ const {
   setDecision,
   getDecision,
   getMentionUiState,
+  getComposerAttachmentsState,
   getThreadForSelection,
   getInlineReplyUiState,
   renderThreadBlock,
@@ -390,7 +391,10 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   editSubjectMessage: (...args) => editSubjectMessage(...args),
   deleteSubjectMessage: (...args) => deleteSubjectMessage(...args),
   getMentionUiState: (...args) => getMentionUiState(...args),
+  getComposerAttachmentsState: (...args) => getComposerAttachmentsState(...args),
   listCollaboratorsForMentions: (...args) => subjectMessagesService.listCollaboratorsForMentions(...args),
+  uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args),
+  removeTemporaryAttachment: (...args) => subjectMessagesService.removeTemporaryAttachment(...args),
   getSubjectsCurrentRoot: () => subjectsCurrentRoot,
   resolveCurrentUserAssigneeId: () => resolveCurrentUserDirectoryPersonId({
     email: store.user?.email || "",

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -65,7 +65,10 @@ export function createProjectSubjectsEvents(config) {
     editSubjectMessage,
     deleteSubjectMessage,
     getMentionUiState,
-    listCollaboratorsForMentions
+    getComposerAttachmentsState,
+    listCollaboratorsForMentions,
+    uploadAttachmentFile,
+    removeTemporaryAttachment
   } = config;
 
   let detachDropdownDocumentEvents = null;
@@ -673,6 +676,132 @@ export function createProjectSubjectsEvents(config) {
 
     const commentTextarea = root.querySelector("#humanCommentBox");
     if (commentTextarea) {
+      const getComposerAttachments = () => {
+        if (typeof getComposerAttachmentsState === "function") return getComposerAttachmentsState();
+        if (!store.situationsView.subjectComposerAttachments || typeof store.situationsView.subjectComposerAttachments !== "object") {
+          store.situationsView.subjectComposerAttachments = {
+            subjectId: "",
+            uploadSessionId: "",
+            items: []
+          };
+        }
+        if (!Array.isArray(store.situationsView.subjectComposerAttachments.items)) {
+          store.situationsView.subjectComposerAttachments.items = [];
+        }
+        return store.situationsView.subjectComposerAttachments;
+      };
+
+      const createUploadSessionId = () => {
+        try {
+          if (window?.crypto?.randomUUID) return String(window.crypto.randomUUID());
+        } catch {}
+        return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      };
+
+      const ensureComposerAttachmentContext = () => {
+        const selection = getScopedSelection(root);
+        const state = getComposerAttachments();
+        const subjectId = selection?.type === "sujet" ? String(selection?.item?.id || "").trim() : "";
+        if (!subjectId) return { subjectId: "", state };
+        if (String(state.subjectId || "") !== subjectId) {
+          state.subjectId = subjectId;
+          state.uploadSessionId = "";
+          state.items = [];
+        }
+        if (!String(state.uploadSessionId || "")) {
+          state.uploadSessionId = createUploadSessionId();
+        }
+        return { subjectId, state };
+      };
+
+      const isImageFile = (file) => String(file?.type || "").toLowerCase().startsWith("image/");
+      const toObjectUrl = (file) => {
+        try {
+          return isImageFile(file) && window?.URL?.createObjectURL ? window.URL.createObjectURL(file) : "";
+        } catch {
+          return "";
+        }
+      };
+
+      const revokeObjectUrl = (value) => {
+        try {
+          if (value && window?.URL?.revokeObjectURL) window.URL.revokeObjectURL(value);
+        } catch {}
+      };
+
+      const addComposerFiles = async (files = []) => {
+        const list = Array.from(files || []).filter((entry) => !!entry);
+        if (!list.length) return;
+        const selection = getScopedSelection(root);
+        if (selection?.type !== "sujet") return;
+        const projectId = String(selection?.item?.project_id || "").trim();
+        if (!projectId) {
+          showError("Projet introuvable pour l’upload des pièces jointes.");
+          return;
+        }
+        const { subjectId, state } = ensureComposerAttachmentContext();
+        if (!subjectId || typeof uploadAttachmentFile !== "function") return;
+
+        for (const file of list) {
+          const tempId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+          const localPreview = toObjectUrl(file);
+          const pending = {
+            id: "",
+            tempId,
+            file_name: String(file?.name || "fichier"),
+            mime_type: String(file?.type || ""),
+            size_bytes: Number(file?.size || 0),
+            previewUrl: localPreview,
+            isImage: isImageFile(file),
+            uploading: true,
+            error: ""
+          };
+          state.items.push(pending);
+          rerenderScope(root);
+
+          try {
+            const uploaded = await uploadAttachmentFile({
+              subjectId,
+              projectId,
+              uploadSessionId: state.uploadSessionId,
+              file,
+              sortOrder: state.items.length - 1
+            });
+            pending.id = String(uploaded?.id || "");
+            pending.storage_path = String(uploaded?.storage_path || "");
+            pending.object_url = String(uploaded?.object_url || "");
+            pending.uploading = false;
+            pending.error = "";
+            if (pending.isImage && pending.object_url) {
+              revokeObjectUrl(localPreview);
+              pending.previewUrl = pending.object_url;
+            }
+          } catch (error) {
+            pending.uploading = false;
+            pending.error = String(error?.message || error || "Erreur d'upload");
+          }
+          rerenderScope(root);
+        }
+      };
+
+      const removeComposerAttachmentById = async (tempId = "", attachmentId = "") => {
+        const state = getComposerAttachments();
+        const normalizedAttachmentId = String(attachmentId || "").trim();
+        const targetIndex = state.items.findIndex((entry) => String(entry?.tempId || "") === String(tempId || "") || String(entry?.id || "") === normalizedAttachmentId);
+        if (targetIndex < 0) return;
+        const current = state.items[targetIndex];
+        state.items.splice(targetIndex, 1);
+        rerenderScope(root);
+        revokeObjectUrl(String(current?.previewUrl || ""));
+        if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
+          try {
+            await removeTemporaryAttachment({ attachmentId: normalizedAttachmentId });
+          } catch (error) {
+            console.warn("[subject-attachments] remove temporary attachment failed", error);
+          }
+        }
+      };
+
       let mentionCollaborators = [];
       let mentionCollaboratorsLoaded = false;
       let mentionLoadPromise = null;
@@ -832,6 +961,49 @@ export function createProjectSubjectsEvents(config) {
             personId: String(btn.dataset.personId || "").trim(),
             label: String(btn.dataset.label || "").trim()
           });
+        };
+      });
+
+      const attachmentInput = root.querySelector("[data-role='subject-composer-file-input']");
+      const attachmentDropzone = root.querySelector("[data-role='subject-composer-dropzone']");
+      root.querySelectorAll("[data-action='composer-attachments-pick']").forEach((btn) => {
+        btn.onclick = () => attachmentInput?.click();
+      });
+      if (attachmentInput) {
+        attachmentInput.addEventListener("change", async (event) => {
+          const files = Array.from(event?.target?.files || []);
+          if (files.length) await addComposerFiles(files);
+          attachmentInput.value = "";
+        });
+      }
+
+      if (attachmentDropzone) {
+        ["dragenter", "dragover"].forEach((eventName) => {
+          attachmentDropzone.addEventListener(eventName, (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            attachmentDropzone.classList.add("is-dragover");
+          });
+        });
+        ["dragleave", "dragend", "drop"].forEach((eventName) => {
+          attachmentDropzone.addEventListener(eventName, (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            attachmentDropzone.classList.remove("is-dragover");
+          });
+        });
+        attachmentDropzone.addEventListener("drop", async (event) => {
+          const files = Array.from(event?.dataTransfer?.files || []);
+          if (files.length) await addComposerFiles(files);
+        });
+      }
+
+      root.querySelectorAll("[data-action='composer-attachment-remove']").forEach((btn) => {
+        btn.onclick = async () => {
+          await removeComposerAttachmentById(
+            String(btn.dataset.tempId || ""),
+            String(btn.dataset.attachmentId || "")
+          );
         };
       });
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -104,7 +104,8 @@ export function createProjectSubjectsThread(config = {}) {
         is_frozen: isFrozen,
         is_deleted: isDeleted,
         state_label: stateLabel,
-        mentions: Array.isArray(row?.mentions) ? row.mentions : []
+        mentions: Array.isArray(row?.mentions) ? row.mentions : [],
+        attachments: Array.isArray(row?.attachments) ? row.attachments : []
       },
       stateLabel
     };
@@ -137,6 +138,22 @@ export function createProjectSubjectsThread(config = {}) {
       };
     }
     return state.replyContext;
+  }
+
+  function getComposerAttachmentsState() {
+    ensureViewUiState();
+    const state = store.situationsView;
+    if (!state.subjectComposerAttachments || typeof state.subjectComposerAttachments !== "object") {
+      state.subjectComposerAttachments = {
+        subjectId: "",
+        uploadSessionId: "",
+        items: []
+      };
+    }
+    if (!Array.isArray(state.subjectComposerAttachments.items)) {
+      state.subjectComposerAttachments.items = [];
+    }
+    return state.subjectComposerAttachments;
   }
 
   function clearReplyContext() {
@@ -385,6 +402,15 @@ export function createProjectSubjectsThread(config = {}) {
             bodyMarkdown: normalizedMessage,
             mentions: Array.isArray(options.mentions) ? options.mentions : []
           });
+
+      const uploadSessionId = normalizeId(options.uploadSessionId);
+      if (uploadSessionId && created?.id) {
+        await subjectMessagesService.linkAttachmentsToMessage({
+          subjectId: normalizedEntityId,
+          messageId: created.id,
+          uploadSessionId
+        });
+      }
 
       ensureSubjectTimelineLoaded(normalizedEntityId, { force: true });
       return created;
@@ -682,6 +708,47 @@ priority=${firstNonEmpty(subject.priority, "")}`
     });
   }
 
+  function renderAttachmentTile(attachment = {}, options = {}) {
+    const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
+    const mimeType = String(attachment?.mime_type || attachment?.mimeType || "").toLowerCase();
+    const objectUrl = String(attachment?.object_url || attachment?.previewUrl || "");
+    const isImage = options.forceImage || mimeType.startsWith("image/");
+    const isPdf = mimeType === "application/pdf";
+    const uploadState = String(options.uploadState || "").trim();
+    const metaLine = [
+      mimeType || "fichier",
+      Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
+        ? `${Math.max(1, Math.round(Number(attachment?.size_bytes || attachment?.sizeBytes) / 1024))} KB`
+        : ""
+    ].filter(Boolean).join(" · ");
+
+    if (isImage && objectUrl) {
+      return `
+        <div class="subject-attachment subject-attachment--image">
+          <a href="${escapeHtml(objectUrl)}" target="_blank" rel="noopener noreferrer">
+            <img src="${escapeHtml(objectUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
+          </a>
+          <div class="subject-attachment__caption mono-small">${escapeHtml(fileName)}</div>
+          ${uploadState ? `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>` : ""}
+        </div>
+      `;
+    }
+
+    return `
+      <div class="subject-attachment subject-attachment--file">
+        <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(isPdf ? "file" : "paperclip")}</div>
+        <div class="subject-attachment__file-body">
+          <div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>
+          <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
+        </div>
+        ${objectUrl
+          ? `<a class="subject-attachment__file-link" href="${escapeHtml(objectUrl)}" target="_blank" rel="noopener noreferrer">Ouvrir</a>`
+          : ""}
+        ${uploadState ? `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>` : ""}
+      </div>
+    `;
+  }
+
   function renderThreadBlock() {
     const thread = getThreadForSelection();
     if (!thread.length) return "";
@@ -756,6 +823,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
               <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
               ${mdToHtml(e?.message || "")}
             </div>
+            ${(Array.isArray(e?.meta?.attachments) && e.meta.attachments.length)
+              ? `<div class="subject-attachment-grid">${e.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
+              : ""}
             ${childReplies.length
               ? `
                 <div class="thread-comment-footer">
@@ -1039,6 +1109,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
 
     const mentionUi = getMentionUiState();
+    const attachmentState = getComposerAttachmentsState();
+    const normalizedSubjectId = type === "sujet" ? normalizeId(item.id) : "";
+    const pendingAttachments = normalizedSubjectId && normalizeId(attachmentState.subjectId) === normalizedSubjectId
+      ? attachmentState.items
+      : [];
     const mentionPopupHtml = mentionUi.open
       ? `
         <div class="subject-mention-popup" role="listbox" aria-label="Suggestions de mention">
@@ -1066,6 +1141,53 @@ priority=${firstNonEmpty(subject.priority, "")}`
       `
       : "";
 
+    const pendingAttachmentsHtml = pendingAttachments.length
+      ? `
+        <div class="subject-composer-attachments">
+          ${pendingAttachments.map((attachment, index) => `
+            <div class="subject-composer-attachment-item">
+              ${renderAttachmentTile(attachment, {
+                forceImage: !!attachment.isImage,
+                uploadState: attachment.error
+                  ? "Erreur d’upload"
+                  : attachment.uploading
+                    ? "Upload en cours…"
+                    : "Prêt"
+              })}
+              <button
+                class="subject-composer-attachment-remove"
+                type="button"
+                data-action="composer-attachment-remove"
+                data-attachment-id="${escapeHtml(normalizeId(attachment.id))}"
+                data-temp-id="${escapeHtml(String(attachment.tempId || index))}"
+                aria-label="Retirer la pièce jointe"
+              >
+                ${svgIcon("x")}
+              </button>
+            </div>
+          `).join("")}
+        </div>
+      `
+      : "";
+
+    const composerAttachmentsHtml = type === "sujet"
+      ? `
+        <div
+          class="subject-composer-dropzone"
+          data-role="subject-composer-dropzone"
+          tabindex="0"
+          aria-label="Déposer des pièces jointes"
+        >
+          <input id="subjectComposerAttachmentInput" type="file" class="subject-composer-file-input" data-role="subject-composer-file-input" multiple />
+          <div class="subject-composer-dropzone__label mono-small">
+            Dépose des images, PDF ou autres fichiers ici — ou
+            <button class="gh-btn gh-btn--sm" type="button" data-action="composer-attachments-pick">ajouter un fichier</button>
+          </div>
+          ${pendingAttachmentsHtml}
+        </div>
+      `
+      : "";
+
     return renderCommentComposer({
       title: "Add a comment",
       avatarHtml: getAuthorIdentity({
@@ -1087,7 +1209,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       contextHtml,
       actionsHtml,
       toolbarHtml,
-      footerHtml: mentionPopupHtml
+      footerHtml: `${mentionPopupHtml}${composerAttachmentsHtml}`
     });
   }
 
@@ -1104,6 +1226,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     getReplyContextForSubject,
     buildReplyPreview,
     getMentionUiState,
+    getComposerAttachmentsState,
     getInlineReplyUiState,
     renderThreadBlock,
     renderIssueStatusAction,

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2349,12 +2349,19 @@ async function applyCommentAction(root) {
   const parentMessageId = target.type === "sujet" && replySubjectId === String(target.id || "").trim()
     ? String(replyContext?.parentMessageId || "").trim()
     : "";
+  const composerAttachments = store.situationsView?.subjectComposerAttachments || {};
+  const hasAttachmentsForTarget = target.type === "sujet"
+    && String(composerAttachments?.subjectId || "").trim() === String(target.id || "").trim()
+    && Array.isArray(composerAttachments?.items)
+    && composerAttachments.items.some((entry) => !entry?.uploading && !entry?.error);
+  const uploadSessionId = hasAttachmentsForTarget ? String(composerAttachments?.uploadSessionId || "").trim() : "";
 
   await addComment(target.type, target.id, message, {
     actor: "Human",
     agent: "human",
     parentMessageId: parentMessageId || undefined,
-    mentions
+    mentions,
+    uploadSessionId: uploadSessionId || undefined
   });
   ta.value = "";
   store.situationsView.commentDraft = "";
@@ -2363,6 +2370,11 @@ async function applyCommentAction(root) {
     store.situationsView.replyContext.subjectId = "";
     store.situationsView.replyContext.parentMessageId = "";
     store.situationsView.replyContext.parentPreview = "";
+  }
+  if (store.situationsView?.subjectComposerAttachments && target.type === "sujet") {
+    store.situationsView.subjectComposerAttachments.subjectId = String(target.id || "");
+    store.situationsView.subjectComposerAttachments.uploadSessionId = "";
+    store.situationsView.subjectComposerAttachments.items = [];
   }
   rerenderScope(root);
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2593,6 +2593,90 @@ body.is-resizing{
 .subject-mention-popup__name{font-size:13px;}
 .subject-mention-popup__meta{font-size:12px;color:var(--muted);}
 .subject-mention-popup__empty{padding:10px 12px;font-size:12px;color:var(--muted);}
+.subject-composer-dropzone{
+  margin:0 10px 10px;
+  border:1px dashed var(--border2);
+  border-radius:8px;
+  padding:10px;
+  background:rgba(110,118,129,.06);
+}
+.subject-composer-dropzone.is-dragover{
+  border-color:rgba(56,139,253,.95);
+  background:rgba(56,139,253,.12);
+}
+.subject-composer-dropzone__label{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  color:var(--muted);
+}
+.subject-composer-file-input{display:none;}
+.subject-composer-attachments{
+  margin-top:10px;
+  display:grid;
+  gap:8px;
+}
+.subject-composer-attachment-item{
+  display:flex;
+  align-items:flex-start;
+  gap:8px;
+}
+.subject-composer-attachment-remove{
+  margin-left:auto;
+  border:none;
+  background:transparent;
+  color:var(--muted);
+  cursor:pointer;
+  width:24px;
+  height:24px;
+  border-radius:6px;
+}
+.subject-composer-attachment-remove:hover{background:rgba(110,118,129,.2);color:var(--text);}
+.subject-attachment-grid{
+  display:grid;
+  gap:8px;
+  margin:10px 12px 0;
+}
+.subject-attachment{
+  border:1px solid var(--border2);
+  border-radius:8px;
+  overflow:hidden;
+  background:rgba(13,17,23,.3);
+}
+.subject-attachment--image img{
+  display:block;
+  width:100%;
+  max-height:220px;
+  object-fit:cover;
+}
+.subject-attachment__caption{
+  padding:6px 8px;
+  color:var(--muted);
+}
+.subject-attachment--file{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  padding:8px;
+}
+.subject-attachment__file-icon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:28px;
+  height:28px;
+  color:var(--muted);
+}
+.subject-attachment__file-body{flex:1 1 auto;min-width:0;}
+.subject-attachment__file-name{
+  color:var(--text);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.subject-attachment__file-meta{color:var(--muted);}
+.subject-attachment__file-link{font-size:12px;}
+.subject-attachment__state{padding:0 8px 8px;color:var(--muted);}
 .md-render p{margin:0 0 10px;}
 .md-render p:last-child{margin-bottom:0;}
 .md-render ul,.md-render ol{margin:0 0 10px 20px;padding:0;}


### PR DESCRIPTION
### Motivation
- Implémenter l’étape 9 du plan de messagerie pour gérer proprement les pièces jointes (bucket séparé, upload temporaire, preview, rattachement au message et cycle de vie). 
- Évoluer l’existant sans refonte massive de la vue sujet ni du modèle métier déjà posé. 

### Description
- Backend / repository : ajout de la gestion des attachments dans `createSubjectMessagesSupabaseRepository` avec `listAttachmentsByMessageIds`, `uploadAttachmentFile` (upload binaire vers le bucket `subject-message-attachments` + création d’une ligne temporaire) et `removeTemporaryAttachment`, ainsi que helpers pour construire des URLs authentifiées et normaliser les chemins/nom de fichier (`apps/web/js/services/subject-messages-supabase.js`). 
- Service métier : exposition des nouvelles méthodes `uploadAttachmentFile` et `removeTemporaryAttachment` depuis `subject-messages-service` pour conserver l’abstraction front/back (`apps/web/js/services/subject-messages-service.js`). 
- Front : composer enrichi avec une dropzone drag & drop, bouton de sélection, upload asynchrone avec aperçu local puis URL objet authentifiée, liste d’attachments en attente (états uploading / ready / error), possibilité de retirer avant envoi, rattachement des pièces au message via `uploadSessionId` lors du `addComment`, et rendu des attachments dans la timeline (vignettes image ou carte fichier/PDF) (`apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/project-subjects/project-subjects-view.js`). 
- Intégration : passage des handlers et état attachments via l’assemblage `project-subjects` et ajout de styles CSS dédiés (dropzone, tiles, grille) (`apps/web/js/views/project-subjects.js`, `apps/web/style.css`). 

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check` sur les modules modifiés a réussi. 
- Test automatisé exécuté : `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` et il est passé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27611cc088329aefcbcf8009733eb)