### PR TITLE
Resolve project ID from subject for attachment uploads, add diagnostics, and add storage RLS migration

### DIFF
--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -113,6 +113,18 @@ async function resolveProjectId(explicitProjectId = "") {
   return normalizeId(await resolveCurrentBackendProjectId().catch(() => ""));
 }
 
+async function resolveProjectIdFromSubject(subjectId = "") {
+  const normalizedSubjectId = normalizeId(subjectId);
+  if (!normalizedSubjectId) return "";
+  const params = new URLSearchParams();
+  params.set("select", "project_id");
+  params.set("id", `eq.${normalizedSubjectId}`);
+  params.set("limit", "1");
+  const rows = await restFetch("/rest/v1/subjects", params).catch(() => null);
+  const row = Array.isArray(rows) ? rows[0] : rows;
+  return normalizeId(row?.project_id);
+}
+
 async function resolveCurrentPersonId() {
   return normalizeId(await resolveCurrentUserDirectoryPersonId().catch(() => ""));
 }
@@ -380,11 +392,21 @@ export function createSubjectMessagesSupabaseRepository() {
       }
 
       const subjectId = normalizeId(payload.subjectId);
-      const projectId = await resolveProjectId(payload.projectId);
+      const requestedProjectId = await resolveProjectId(payload.projectId);
       const uploadSessionId = normalizeId(payload.uploadSessionId);
       if (!subjectId) throw new Error("subjectId is required");
-      if (!projectId) throw new Error("projectId is required");
       if (!uploadSessionId) throw new Error("uploadSessionId is required");
+
+      const subjectProjectId = await resolveProjectIdFromSubject(subjectId);
+      const projectId = subjectProjectId || requestedProjectId;
+      if (!projectId) throw new Error("projectId is required");
+      if (requestedProjectId && subjectProjectId && requestedProjectId !== subjectProjectId) {
+        console.warn("[subject-attachments] project id mismatch, using subject.project_id", {
+          subjectId,
+          requestedProjectId,
+          subjectProjectId
+        });
+      }
 
       const fileName = String(file?.name || payload.fileName || "attachment").trim();
       const storagePath = String(
@@ -398,14 +420,52 @@ export function createSubjectMessagesSupabaseRepository() {
         cacheControl: "3600"
       };
       if (resolvedMimeType) uploadOptions.contentType = resolvedMimeType;
+      console.info("[subject-attachments] upload start", {
+        bucket: SUBJECT_ATTACHMENTS_BUCKET,
+        subjectId,
+        projectId,
+        requestedProjectId,
+        subjectProjectId,
+        uploadSessionId,
+        storagePath,
+        fileName,
+        mimeType: resolvedMimeType,
+        sizeBytes: Number(file?.size || payload.sizeBytes || 0)
+      });
 
       const { error: uploadError } = await supabase
         .storage
         .from(SUBJECT_ATTACHMENTS_BUCKET)
         .upload(storagePath, file, uploadOptions);
       if (uploadError) {
+        const diagnostic = {
+          bucket: SUBJECT_ATTACHMENTS_BUCKET,
+          subjectId,
+          projectId,
+          requestedProjectId,
+          subjectProjectId,
+          uploadSessionId,
+          storagePath,
+          fileName,
+          mimeType: resolvedMimeType,
+          sizeBytes: Number(file?.size || payload.sizeBytes || 0),
+          statusCode: uploadError?.statusCode || uploadError?.status || "unknown",
+          message: String(uploadError?.message || uploadError || ""),
+          error: uploadError
+        };
+        console.error("[subject-attachments] upload failed", diagnostic);
         throw new Error(
           `Attachment upload failed (${String(uploadError?.statusCode || uploadError?.status || "unknown")}): ${String(uploadError?.message || uploadError)}`
+          + ` | context=${JSON.stringify({
+            subjectId,
+            projectId,
+            requestedProjectId,
+            subjectProjectId,
+            uploadSessionId,
+            storagePath,
+            mimeType: resolvedMimeType,
+            sizeBytes: Number(file?.size || payload.sizeBytes || 0)
+          })}`
         );
       }
 

--- a/supabase/migrations/202606150004_subject_message_attachments_storage_policy_auth_uid.sql
+++ b/supabase/migrations/202606150004_subject_message_attachments_storage_policy_auth_uid.sql
@@ -1,0 +1,143 @@
+-- Storage RLS for subject message attachments:
+-- avoid relying on helper function evaluation in storage context and
+-- check project access directly from auth.uid().
+
+drop policy if exists storage_subject_message_attachments_select on storage.objects;
+create policy storage_subject_message_attachments_select
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+drop policy if exists storage_subject_message_attachments_insert on storage.objects;
+create policy storage_subject_message_attachments_insert
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'subject-message-attachments'
+  and (storage.foldername(name))[1] is not null
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+drop policy if exists storage_subject_message_attachments_update on storage.objects;
+create policy storage_subject_message_attachments_update
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+)
+with check (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+drop policy if exists storage_subject_message_attachments_delete on storage.objects;
+create policy storage_subject_message_attachments_delete
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);


### PR DESCRIPTION
### Motivation

- Ensure attachment uploads use the authoritative `subject.project_id` when available rather than relying solely on a provided `projectId`, and surface useful diagnostics when uploads fail. 
- Enforce row-level security for the `subject-message-attachments` storage bucket by checking access via `auth.uid()` and project/collaborator relationships.

### Description

- Added `resolveProjectIdFromSubject` which fetches the `project_id` for a given `subjectId` via the REST API. 
- Updated `uploadAttachmentFile` to compute `projectId` as the `subject.project_id` when available, accept an optional requested project id, and prefer the subject-derived id while warning on mismatches. 
- Added informational `console.info` at upload start and enhanced error handling with a diagnostic payload and `console.error` for failed uploads, and appended contextual JSON to thrown error messages. 
- Added a new Supabase migration `supabase/migrations/202606150004_subject_message_attachments_storage_policy_auth_uid.sql` that creates storage policies for `select`, `insert`, `update`, and `delete` on the `subject-message-attachments` bucket by validating `auth.uid()` against project ownership and active collaborators.

### Testing

- Ran the JavaScript unit test suite via `yarn test` and the linter via `yarn lint`, and both completed successfully.
- Verified build and basic runtime checks locally via `yarn build` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3166b440883299bbe4c713d8414e0)