### PR TITLE
Improve subject attachment uploads: diagnostics, project resolution, and storage RLS

### DIFF
--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -113,8 +113,120 @@ async function resolveProjectId(explicitProjectId = "") {
   return normalizeId(await resolveCurrentBackendProjectId().catch(() => ""));
 }
 
+async function resolveProjectIdFromSubject(subjectId = "") {
+  const normalizedSubjectId = normalizeId(subjectId);
+  if (!normalizedSubjectId) return "";
+  const params = new URLSearchParams();
+  params.set("select", "project_id");
+  params.set("id", `eq.${normalizedSubjectId}`);
+  params.set("limit", "1");
+  const rows = await restFetch("/rest/v1/subjects", params).catch(() => null);
+  const row = Array.isArray(rows) ? rows[0] : rows;
+  return normalizeId(row?.project_id);
+}
+
 async function resolveCurrentPersonId() {
   return normalizeId(await resolveCurrentUserDirectoryPersonId().catch(() => ""));
+}
+
+async function gatherAttachmentUploadDiagnostics({
+  projectId = "",
+  subjectId = "",
+  uploadSessionId = "",
+  storagePath = "",
+  fileName = "",
+  mimeType = "",
+  sizeBytes = null
+} = {}) {
+  const normalizedProjectId = normalizeId(projectId);
+  const normalizedSubjectId = normalizeId(subjectId);
+
+  const [sessionResult, personResult, accessResult, subjectResult, projectResult] = await Promise.allSettled([
+    supabase.auth.getSession(),
+    rpcCall("current_person_id", {}),
+    normalizedProjectId
+      ? rpcCall("can_access_project_subject_conversation", { p_project_id: normalizedProjectId })
+      : Promise.resolve(null),
+    normalizedSubjectId
+      ? restFetch("/rest/v1/subjects", (() => {
+          const params = new URLSearchParams();
+          params.set("select", "id,project_id");
+          params.set("id", `eq.${normalizedSubjectId}`);
+          params.set("limit", "1");
+          return params;
+        })())
+      : Promise.resolve(null),
+    normalizedProjectId
+      ? restFetch("/rest/v1/projects", (() => {
+          const params = new URLSearchParams();
+          params.set("select", "id,owner_id");
+          params.set("id", `eq.${normalizedProjectId}`);
+          params.set("limit", "1");
+          return params;
+        })())
+      : Promise.resolve(null)
+  ]);
+
+  const session = sessionResult.status === "fulfilled" ? sessionResult.value : null;
+  const personValue = personResult.status === "fulfilled" ? personResult.value : null;
+  const accessValue = accessResult.status === "fulfilled" ? accessResult.value : null;
+  const subjectValue = subjectResult.status === "fulfilled" ? subjectResult.value : null;
+  const projectValue = projectResult.status === "fulfilled" ? projectResult.value : null;
+
+  const normalizedPersonId = (() => {
+    if (Array.isArray(personValue)) return normalizeId(personValue[0] || "");
+    if (personValue && typeof personValue === "object") return normalizeId(personValue.id || personValue.current_person_id || "");
+    return normalizeId(personValue);
+  })();
+
+  const canAccessProject = (() => {
+    if (typeof accessValue === "boolean") return accessValue;
+    if (Array.isArray(accessValue)) return Boolean(accessValue[0]);
+    if (accessValue && typeof accessValue === "object") {
+      if (typeof accessValue.can_access_project_subject_conversation === "boolean") {
+        return accessValue.can_access_project_subject_conversation;
+      }
+      if (typeof accessValue.result === "boolean") return accessValue.result;
+    }
+    return null;
+  })();
+
+  const subjectRow = Array.isArray(subjectValue) ? subjectValue[0] : subjectValue;
+  const projectRow = Array.isArray(projectValue) ? projectValue[0] : projectValue;
+  const sessionUser = session?.data?.session?.user || null;
+
+  return {
+    uploadContext: {
+      projectId: normalizedProjectId,
+      subjectId: normalizedSubjectId,
+      uploadSessionId: normalizeId(uploadSessionId),
+      storagePath: String(storagePath || ""),
+      fileName: String(fileName || ""),
+      mimeType: String(mimeType || ""),
+      sizeBytes: Number.isFinite(Number(sizeBytes)) ? Number(sizeBytes) : null
+    },
+    auth: {
+      userId: normalizeId(sessionUser?.id || ""),
+      email: String(sessionUser?.email || ""),
+      hasSession: Boolean(session?.data?.session)
+    },
+    rpc: {
+      currentPersonId: normalizedPersonId,
+      canAccessProjectSubjectConversation: canAccessProject
+    },
+    visibility: {
+      subjectProjectId: normalizeId(subjectRow?.project_id || ""),
+      projectOwnerId: normalizeId(projectRow?.owner_id || ""),
+      projectVisible: Boolean(projectRow?.id),
+      subjectVisible: Boolean(subjectRow?.id)
+    },
+    transport: {
+      currentPersonIdRpc: personResult.status,
+      canAccessRpc: accessResult.status,
+      subjectRead: subjectResult.status,
+      projectRead: projectResult.status
+    }
+  };
 }
 
 export function createSubjectMessagesSupabaseRepository() {
@@ -380,11 +492,21 @@ export function createSubjectMessagesSupabaseRepository() {
       }
 
       const subjectId = normalizeId(payload.subjectId);
-      const projectId = await resolveProjectId(payload.projectId);
+      const requestedProjectId = await resolveProjectId(payload.projectId);
       const uploadSessionId = normalizeId(payload.uploadSessionId);
       if (!subjectId) throw new Error("subjectId is required");
-      if (!projectId) throw new Error("projectId is required");
       if (!uploadSessionId) throw new Error("uploadSessionId is required");
+
+      const subjectProjectId = await resolveProjectIdFromSubject(subjectId);
+      const projectId = subjectProjectId || requestedProjectId;
+      if (!projectId) throw new Error("projectId is required");
+      if (requestedProjectId && subjectProjectId && requestedProjectId !== subjectProjectId) {
+        console.warn("[subject-attachments] project id mismatch, using subject.project_id", {
+          subjectId,
+          requestedProjectId,
+          subjectProjectId
+        });
+      }
 
       const fileName = String(file?.name || payload.fileName || "attachment").trim();
       const storagePath = String(
@@ -398,14 +520,66 @@ export function createSubjectMessagesSupabaseRepository() {
         cacheControl: "3600"
       };
       if (resolvedMimeType) uploadOptions.contentType = resolvedMimeType;
+      console.info("[subject-attachments] upload start", {
+        bucket: SUBJECT_ATTACHMENTS_BUCKET,
+        subjectId,
+        projectId,
+        requestedProjectId,
+        subjectProjectId,
+        uploadSessionId,
+        storagePath,
+        fileName,
+        mimeType: resolvedMimeType,
+        sizeBytes: Number(file?.size || payload.sizeBytes || 0)
+      });
 
       const { error: uploadError } = await supabase
         .storage
         .from(SUBJECT_ATTACHMENTS_BUCKET)
         .upload(storagePath, file, uploadOptions);
       if (uploadError) {
+        const runtimeDiagnostics = await gatherAttachmentUploadDiagnostics({
+          projectId,
+          subjectId,
+          uploadSessionId,
+          storagePath,
+          fileName,
+          mimeType: resolvedMimeType,
+          sizeBytes: Number(file?.size || payload.sizeBytes || 0)
+        }).catch((error) => ({
+          diagnosticCollectionFailed: true,
+          message: String(error?.message || error || "")
+        }));
+        const diagnostic = {
+          bucket: SUBJECT_ATTACHMENTS_BUCKET,
+          subjectId,
+          projectId,
+          requestedProjectId,
+          subjectProjectId,
+          uploadSessionId,
+          storagePath,
+          fileName,
+          mimeType: resolvedMimeType,
+          sizeBytes: Number(file?.size || payload.sizeBytes || 0),
+          statusCode: uploadError?.statusCode || uploadError?.status || "unknown",
+          message: String(uploadError?.message || uploadError || ""),
+          error: uploadError,
+          runtimeDiagnostics
+        };
+        console.error("[subject-attachments] upload failed", diagnostic);
         throw new Error(
           `Attachment upload failed (${String(uploadError?.statusCode || uploadError?.status || "unknown")}): ${String(uploadError?.message || uploadError)}`
+          + ` | context=${JSON.stringify({
+            subjectId,
+            projectId,
+            requestedProjectId,
+            subjectProjectId,
+            uploadSessionId,
+            storagePath,
+            mimeType: resolvedMimeType,
+            sizeBytes: Number(file?.size || payload.sizeBytes || 0),
+            runtimeDiagnostics
+          })}`
         );
       }
 

--- a/supabase/migrations/202606150004_subject_message_attachments_storage_policy_auth_uid.sql
+++ b/supabase/migrations/202606150004_subject_message_attachments_storage_policy_auth_uid.sql
@@ -1,0 +1,143 @@
+-- Storage RLS for subject message attachments:
+-- avoid relying on helper function evaluation in storage context and
+-- check project access directly from auth.uid().
+
+drop policy if exists storage_subject_message_attachments_select on storage.objects;
+create policy storage_subject_message_attachments_select
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+drop policy if exists storage_subject_message_attachments_insert on storage.objects;
+create policy storage_subject_message_attachments_insert
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'subject-message-attachments'
+  and (storage.foldername(name))[1] is not null
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+drop policy if exists storage_subject_message_attachments_update on storage.objects;
+create policy storage_subject_message_attachments_update
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+)
+with check (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+drop policy if exists storage_subject_message_attachments_delete on storage.objects;
+create policy storage_subject_message_attachments_delete
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);


### PR DESCRIPTION
### Motivation
- Ensure attachment uploads are attributed to the correct project by resolving a subject's `project_id` instead of trusting caller-supplied values. 
- Improve observability and diagnosability of storage upload failures by collecting runtime context and RPC/state information. 
- Tighten storage Row-Level Security for the subject message attachments bucket to check project access directly from `auth.uid()`.

### Description
- Add `resolveProjectIdFromSubject` to fetch a subject's `project_id` from the `subjects` REST endpoint. 
- Add `gatherAttachmentUploadDiagnostics` to collect session, RPC, subject, and project state to help debug failed uploads. 
- Update `uploadAttachmentFile` to prefer the subject's `project_id` (falling back to the requested project id), warn on mismatches, log upload start via `console.info`, and on storage upload failure gather diagnostics and include them in `console.error` and the thrown `Error`. 
- Add a migration SQL file `supabase/migrations/202606150004_subject_message_attachments_storage_policy_auth_uid.sql` which creates storage RLS policies for `subject-message-attachments` (select/insert/update/delete) that verify project access using `auth.uid()` and project/collaborator tables.

### Testing
- Ran the JavaScript unit test suite with `yarn test` which completed successfully. 
- Ran the linter with `yarn lint` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3166b440883299bbe4c713d8414e0)