### PR TITLE
Fix subject message attachment upload transport and align storage write model

### DIFF
--- a/apps/web/js/services/subject-message-attachments-transport.js
+++ b/apps/web/js/services/subject-message-attachments-transport.js
@@ -1,0 +1,46 @@
+const EDGE_UPLOAD_MODE = Object.freeze({
+  EDGE_ONLY: "edge_only",
+  EDGE_WITH_DIRECT_FALLBACK: "edge_with_direct_fallback"
+});
+
+function readBooleanConfigFlag(flagName, defaultValue = false) {
+  try {
+    if (!window?.MDALL_CONFIG || !Object.prototype.hasOwnProperty.call(window.MDALL_CONFIG, flagName)) {
+      return defaultValue;
+    }
+    return Boolean(window.MDALL_CONFIG[flagName]);
+  } catch {
+    return defaultValue;
+  }
+}
+
+export function resolveSubjectAttachmentUploadTransportMode() {
+  const edgeUploadEnabled = readBooleanConfigFlag("enableEdgeAttachmentUpload", true);
+  if (!edgeUploadEnabled) return EDGE_UPLOAD_MODE.EDGE_WITH_DIRECT_FALLBACK;
+
+  const allowDirectFallback = readBooleanConfigFlag("allowDirectAttachmentUploadFallback", false);
+  if (allowDirectFallback) return EDGE_UPLOAD_MODE.EDGE_WITH_DIRECT_FALLBACK;
+
+  return EDGE_UPLOAD_MODE.EDGE_ONLY;
+}
+
+export function shouldFallbackToDirectUploadFromEdgeHttpFailure(status = 0, responseBody = "") {
+  const bodyText = String(responseBody || "");
+  return (
+    status === 404
+    || status === 405
+    || status >= 500
+    || /cors|preflight|failed to fetch/i.test(bodyText)
+  );
+}
+
+export function shouldFallbackToDirectUploadFromEdgeNetworkFailure(error) {
+  const message = String(error?.message || error || "");
+  return /failed to fetch|networkerror|cors|preflight/i.test(message);
+}
+
+export function logSubjectAttachmentUploadTransport(mode, details = {}) {
+  console.info("[subject-attachments] upload transport", { mode, ...details });
+}
+
+export { EDGE_UPLOAD_MODE };

--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -1,6 +1,13 @@
 import { store } from "../store.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl, supabase } from "../../assets/js/auth.js";
 import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
+import {
+  EDGE_UPLOAD_MODE,
+  logSubjectAttachmentUploadTransport,
+  resolveSubjectAttachmentUploadTransportMode,
+  shouldFallbackToDirectUploadFromEdgeHttpFailure,
+  shouldFallbackToDirectUploadFromEdgeNetworkFailure
+} from "./subject-message-attachments-transport.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const SUBJECT_ATTACHMENTS_BUCKET = "subject-message-attachments";
@@ -125,55 +132,36 @@ async function uploadStorageObject({
 
   const functionHeaders = await getAuthHeaders();
   delete functionHeaders["Content-Type"];
+  const transportMode = resolveSubjectAttachmentUploadTransportMode();
+  const allowDirectFallback = transportMode === EDGE_UPLOAD_MODE.EDGE_WITH_DIRECT_FALLBACK;
+  logSubjectAttachmentUploadTransport(transportMode, { host: String(window?.location?.hostname || "") });
 
-  const canUseEdgeUpload = (() => {
-    try {
-      const host = String(window?.location?.hostname || "").toLowerCase();
-      if (host.endsWith("github.io")) return false;
-      if (window?.MDALL_CONFIG && Object.prototype.hasOwnProperty.call(window.MDALL_CONFIG, "enableEdgeAttachmentUpload")) {
-        return Boolean(window.MDALL_CONFIG.enableEdgeAttachmentUpload);
-      }
-      return true;
-    } catch {
-      return true;
+  try {
+    const functionResponse = await fetch(functionUrl, {
+      method: "POST",
+      headers: functionHeaders,
+      body: formData
+    });
+    if (functionResponse.ok) return true;
+
+    const functionBody = await functionResponse.text().catch(() => "");
+    const fallbackEligible = shouldFallbackToDirectUploadFromEdgeHttpFailure(functionResponse.status, functionBody);
+    if (!(allowDirectFallback && fallbackEligible)) {
+      const error = new Error(`storage upload failed (${functionResponse.status}): ${functionBody || functionResponse.statusText || "edge function failed"}`);
+      error.status = functionResponse.status;
+      error.statusCode = String(functionResponse.status);
+      error.responseBody = functionBody;
+      throw error;
     }
-  })();
-
-  if (canUseEdgeUpload) {
-    try {
-      const functionResponse = await fetch(functionUrl, {
-        method: "POST",
-        headers: functionHeaders,
-        body: formData
-      });
-      if (functionResponse.ok) return true;
-
-      const functionBody = await functionResponse.text().catch(() => "");
-      const shouldFallbackToStorage =
-        functionResponse.status === 404
-        || functionResponse.status === 405
-        || functionResponse.status >= 500
-        || /cors|preflight|failed to fetch/i.test(functionBody);
-      if (!shouldFallbackToStorage) {
-        const error = new Error(`storage upload failed (${functionResponse.status}): ${functionBody || functionResponse.statusText || "edge function failed"}`);
-        error.status = functionResponse.status;
-        error.statusCode = String(functionResponse.status);
-        error.responseBody = functionBody;
-        throw error;
-      }
-      console.warn("[subject-attachments] edge upload unavailable, fallback to direct storage", {
-        status: functionResponse.status,
-        body: functionBody
-      });
-    } catch (functionError) {
-      const message = String(functionError?.message || functionError || "");
-      const isNetworkFailure = /failed to fetch|networkerror|cors|preflight/i.test(message);
-      if (!isNetworkFailure) throw functionError;
-      console.warn("[subject-attachments] edge upload network failure, fallback to direct storage", { message });
-    }
-  } else {
-    console.info("[subject-attachments] edge upload disabled for this origin; using direct storage upload", {
-      host: String(window?.location?.hostname || "")
+    console.warn("[subject-attachments] edge upload unavailable, fallback to direct storage", {
+      status: functionResponse.status,
+      body: functionBody
+    });
+  } catch (functionError) {
+    const fallbackEligible = shouldFallbackToDirectUploadFromEdgeNetworkFailure(functionError);
+    if (!(allowDirectFallback && fallbackEligible)) throw functionError;
+    console.warn("[subject-attachments] edge upload network failure, fallback to direct storage", {
+      message: String(functionError?.message || functionError || "")
     });
   }
 

--- a/supabase/migrations/202606150009_subject_message_attachments_edge_write_model.sql
+++ b/supabase/migrations/202606150009_subject_message_attachments_edge_write_model.sql
@@ -1,0 +1,8 @@
+-- Finalize subject message attachment storage security model:
+-- - Reads remain available to authorized authenticated users via storage SELECT policy.
+-- - Writes are server-mediated via edge functions/service role.
+--   (service role bypasses RLS; authenticated client direct writes are disabled.)
+
+drop policy if exists storage_subject_message_attachments_insert on storage.objects;
+drop policy if exists storage_subject_message_attachments_update on storage.objects;
+drop policy if exists storage_subject_message_attachments_delete on storage.objects;


### PR DESCRIPTION
### Motivation
- Production uploads on GitHub Pages were forced to direct Storage writes by a host-based front-end rule, which re-exposed storage RLS false negatives for the `subject-message-attachments` bucket. 
- The intended architecture is business access checks in the edge function plus service-role writes; the client should not perform direct authenticated writes to this bucket in prod. 
- Migration history shows contradictory storage policies for this bucket, so a corrective migration is required to make the write model explicit and robust.

### Description
- Add a dedicated transport helper module `apps/web/js/services/subject-message-attachments-transport.js` that centralizes transport mode resolution, fallback guards, and transport logging, exposing `resolveSubjectAttachmentUploadTransportMode`, `shouldFallbackToDirectUploadFromEdgeHttpFailure`, and `shouldFallbackToDirectUploadFromEdgeNetworkFailure`.
- Update `apps/web/js/services/subject-messages-supabase.js` to use the new transport module, remove the implicit `host.endsWith("github.io")` special-case, make edge-function upload the default, and only allow direct Storage fallback when explicitly enabled via `MDALL_CONFIG.allowDirectAttachmentUploadFallback` (and subject to eligible error conditions).
- Add a migration `supabase/migrations/202606150009_subject_message_attachments_edge_write_model.sql` that drops `INSERT/UPDATE/DELETE` storage policies for `subject-message-attachments` so writes are server-mediated (reads remain controlled via SELECT policies).
- Keep existing edge function `upload-subject-message-attachment` as the canonical write path and add transport-level logging (`logSubjectAttachmentUploadTransport`) to make the chosen transport visible in logs.

### Testing
- Ran `node --check apps/web/js/services/subject-message-attachments-transport.js` which succeeded.
- Ran `node --check apps/web/js/services/subject-messages-supabase.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3338254ec832985adeaa89ea792f0)