### PR TITLE
Harden upload-subject-message-attachment edge function (validation & logging)

### DIFF
--- a/supabase/functions/upload-subject-message-attachment/index.ts
+++ b/supabase/functions/upload-subject-message-attachment/index.ts
@@ -31,7 +31,8 @@ Deno.serve(async (req) => {
     const authHeader = req.headers.get("Authorization") ?? req.headers.get("authorization") ?? "";
 
     if (!supabaseUrl || !supabaseAnonKey || !serviceRoleKey) {
-      throw new Error("Missing Supabase environment variables.");
+      console.error("[upload-subject-message-attachment] missing Supabase environment variables");
+      return jsonResponse({ ok: false, error: "Server misconfiguration." }, 500);
     }
     if (!authHeader) {
       return jsonResponse({ ok: false, error: "Missing authorization header." }, 401);
@@ -65,23 +66,40 @@ Deno.serve(async (req) => {
     if (!storagePath) {
       return jsonResponse({ ok: false, error: "storagePath is required." }, 400);
     }
+    if (storagePath.startsWith("/") || storagePath.includes("..")) {
+      return jsonResponse({ ok: false, error: "Invalid storage path." }, 400);
+    }
     if (!(file instanceof File)) {
       return jsonResponse({ ok: false, error: "file is required." }, 400);
     }
+    if (file.size <= 0) {
+      return jsonResponse({ ok: false, error: "file is empty." }, 400);
+    }
 
-    const projectId = storagePath.split("/")[0] || "";
+    const [projectId = "", subjectId = ""] = storagePath.split("/");
     if (!projectId) {
       return jsonResponse({ ok: false, error: "Invalid storage path." }, 400);
     }
+    const logContext = {
+      userId: user.id,
+      projectId,
+      subjectId: subjectId || null,
+      storagePath
+    };
 
     const { data: canAccess, error: accessError } = await userClient.rpc("can_access_project_subject_conversation", {
       p_project_id: projectId
     });
     if (accessError) {
-      console.error("[upload-subject-message-attachment] access rpc failed", accessError);
+      console.error("[upload-subject-message-attachment] access rpc failed", {
+        ...logContext,
+        message: accessError.message,
+        code: accessError.code
+      });
       return jsonResponse({ ok: false, error: "Project access check failed." }, 403);
     }
     if (!canAccess) {
+      console.warn("[upload-subject-message-attachment] access denied", logContext);
       return jsonResponse({ ok: false, error: "Access denied." }, 403);
     }
 
@@ -92,6 +110,7 @@ Deno.serve(async (req) => {
     });
     if (uploadError) {
       console.error("[upload-subject-message-attachment] upload failed", {
+        ...logContext,
         message: uploadError.message,
         statusCode: uploadError.statusCode,
         error: uploadError


### PR DESCRIPTION
### Motivation
- Improve robustness and observability of the server-mediated upload path for `subject-message-attachments` so the edge function can be the nominal write path.
- Add minimal input validation to prevent malformed `storagePath` and empty uploads from reaching the storage service and to make production failures easier to diagnose.

### Description
- Replace the thrown error on missing Supabase env vars with an explicit `500` JSON response and a server log via `jsonResponse(...)` for clearer production behavior. 
- Reject suspicious `storagePath` values that start with `/` or include `..`, and reject empty files by checking `file.size <= 0`. 
- Parse `storagePath` into `[projectId, subjectId]` and attach a `logContext` `{ userId, projectId, subjectId, storagePath }` to improve logs for RPC failures, access denials, and storage upload errors. 
- Keep the public request contract unchanged (still expects the same POST form fields) while improving error messages and operational logs in `supabase/functions/upload-subject-message-attachment/index.ts`.

### Testing
- Attempted to run formatter with `deno fmt supabase/functions/upload-subject-message-attachment/index.ts`, but the command could not be executed in this environment (`deno: command not found`).
- Verified repository state with `git status --short` and created a commit containing the changes successfully. 
- No automated unit tests were added or executed as part of this patch; only the targeted function was hardened and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3347b2b2c83298cc7853c7ff191ab)