### PR TITLE
Add migration to enforce server-managed writes for subject-message-attachments

### DIFF
--- a/supabase/migrations/202606150010_subject_message_attachments_server_managed_write_alignment.sql
+++ b/supabase/migrations/202606150010_subject_message_attachments_server_managed_write_alignment.sql
@@ -1,0 +1,51 @@
+-- Align final storage policy state for subject message attachments.
+--
+-- Security model:
+--   * `documents` and `avatars` keep their direct client upload flows.
+--   * `subject-message-attachments` uses server-managed writes (edge function + service role).
+--
+-- This migration intentionally keeps read access scoped to authenticated users that
+-- can access the project encoded in the first storage path segment,
+-- while disabling authenticated direct writes on storage.objects.
+--
+-- NOTE: service role uploads are not blocked by these RLS policies.
+
+-- Keep the bucket private (no anonymous/public object access).
+update storage.buckets
+set public = false
+where id = 'subject-message-attachments';
+
+-- Re-assert the SELECT policy as the explicit final read policy for this bucket.
+drop policy if exists storage_subject_message_attachments_select on storage.objects;
+create policy storage_subject_message_attachments_select
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and (
+        p.owner_id = auth.uid()
+        or exists (
+          select 1
+          from public.project_collaborators pc
+          left join public.directory_people dp on dp.id = pc.person_id
+          where pc.project_id = p.id
+            and lower(coalesce(pc.status, '')) = 'actif'
+            and pc.removed_at is null
+            and (
+              pc.collaborator_user_id = auth.uid()
+              or dp.linked_user_id = auth.uid()
+            )
+        )
+      )
+  )
+);
+
+-- Server-managed write model: remove authenticated direct write/delete policies.
+drop policy if exists storage_subject_message_attachments_insert on storage.objects;
+drop policy if exists storage_subject_message_attachments_update on storage.objects;
+drop policy if exists storage_subject_message_attachments_delete on storage.objects;


### PR DESCRIPTION
### Motivation
- Les migrations précédentes pour le bucket `subject-message-attachments` étaient contradictoires et provoquaient des faux négatifs RLS lors d'uploads directs depuis le client, il faut donc imposer un modèle d'écriture server-managed via l'edge/service role.
- L'objectif est de conserver un contrôle de lecture projet-scopé tout en désactivant les écritures directes côté `authenticated` pour éviter la fragilité et restaurer un flux sûr en production.

### Description
- Ajout de la migration `supabase/migrations/202606150010_subject_message_attachments_server_managed_write_alignment.sql` qui met le bucket en privé avec `update storage.buckets set public = false where id = 'subject-message-attachments'`.
- La migration réaffirme la policy `SELECT` projet-scopée pour les utilisateurs authentifiés en recréant `storage_subject_message_attachments_select` avec la vérification `p.owner_id = auth.uid()` ou collaborateur actif.
- La migration supprime explicitement les policies `INSERT/UPDATE/DELETE` directes côté `authenticated` en appelant `drop policy if exists ...` pour forcer le modèle d'écriture via edge/service role.
- La migration est documentée en-tête pour expliquer le modèle (documents/avatars = client uploads, subject-message-attachments = server-managed) et utilise des `drop policy if exists` idempotents.

### Testing
- Exécution de `git diff --check HEAD~1..HEAD` pour vérifier l'absence d'erreurs de diff/whitespace, qui a réussi.
- Commit du nouveau fichier via `git commit` (message: "Add corrective migration for message attachment storage policies") qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33554cb4483299b234ba2f2889254)