### PR TITLE
Add regression tests for subject attachment upload transport defaults

### DIFF
--- a/apps/web/js/services/subject-message-attachments-transport.test.mjs
+++ b/apps/web/js/services/subject-message-attachments-transport.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  EDGE_UPLOAD_MODE,
+  resolveSubjectAttachmentUploadTransportMode
+} from "./subject-message-attachments-transport.js";
+
+function withWindow(windowValue, fn) {
+  const previousWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+  if (windowValue === undefined) {
+    delete globalThis.window;
+  } else {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: windowValue
+    });
+  }
+
+  try {
+    return fn();
+  } finally {
+    if (previousWindowDescriptor) {
+      Object.defineProperty(globalThis, "window", previousWindowDescriptor);
+    } else {
+      delete globalThis.window;
+    }
+  }
+}
+
+test("active l'upload edge par défaut quand aucun override n'est défini", () => {
+  withWindow({ location: { hostname: "app.example.com" } }, () => {
+    assert.equal(resolveSubjectAttachmentUploadTransportMode(), EDGE_UPLOAD_MODE.EDGE_ONLY);
+  });
+});
+
+test("un host github.io ne désactive pas l'upload edge", () => {
+  withWindow({ location: { hostname: "nicolbh.github.io" } }, () => {
+    assert.equal(resolveSubjectAttachmentUploadTransportMode(), EDGE_UPLOAD_MODE.EDGE_ONLY);
+  });
+});
+
+test("respecte un override explicite pour désactiver l'edge upload", () => {
+  withWindow({
+    location: { hostname: "nicolbh.github.io" },
+    MDALL_CONFIG: { enableEdgeAttachmentUpload: false }
+  }, () => {
+    assert.equal(
+      resolveSubjectAttachmentUploadTransportMode(),
+      EDGE_UPLOAD_MODE.EDGE_WITH_DIRECT_FALLBACK
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the transport decision for `subject-message-attachments` keeps edge upload enabled by default (including on `*.github.io`) and still respects an explicit `window.MDALL_CONFIG.enableEdgeAttachmentUpload` override.

### Description
- Add `apps/web/js/services/subject-message-attachments-transport.test.mjs` which asserts the transport mode is `EDGE_ONLY` by default, remains `EDGE_ONLY` for a `github.io` hostname, and becomes `EDGE_WITH_DIRECT_FALLBACK` when `MDALL_CONFIG.enableEdgeAttachmentUpload` is set to `false`.
- The test file mocks `window` and imports `EDGE_UPLOAD_MODE` and `resolveSubjectAttachmentUploadTransportMode` from the existing transport module to verify behavior.

### Testing
- Executed `node --test apps/web/js/services/subject-message-attachments-transport.test.mjs` and all 3 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33b44ddd08329a9cc147201c730f7)