### PR TITLE
Fix attachment preview fallback and align storage read-access policy

### DIFF
--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -73,12 +73,6 @@ function encodeStoragePath(path = "") {
     .join("/");
 }
 
-function buildAuthenticatedStorageObjectUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
-  const normalizedPath = String(storagePath || "").trim();
-  if (!normalizedPath) return "";
-  return `${SUPABASE_URL}/storage/v1/object/authenticated/${encodeURIComponent(String(bucket || SUBJECT_ATTACHMENTS_BUCKET))}/${encodeStoragePath(normalizedPath)}`;
-}
-
 async function createAttachmentSignedUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
   const normalizedBucket = String(bucket || SUBJECT_ATTACHMENTS_BUCKET).trim();
   const normalizedPath = String(storagePath || "").trim();
@@ -99,13 +93,13 @@ async function resolveAttachmentObjectUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, s
     const signedUrl = await createAttachmentSignedUrl(normalizedBucket, normalizedPath);
     if (signedUrl) return signedUrl;
   } catch (error) {
-    console.warn("[subject-attachments] signed url failed; fallback to authenticated object url", {
+    console.warn("[subject-attachments] signed url failed; preview disabled until next refresh", {
       bucket: normalizedBucket,
       storagePath: normalizedPath,
       message: String(error?.message || error || "")
     });
   }
-  return buildAuthenticatedStorageObjectUrl(normalizedBucket, normalizedPath);
+  return "";
 }
 
 async function uploadStorageObject({
@@ -721,9 +715,18 @@ export function createSubjectMessagesSupabaseRepository() {
         height: payload.height,
         sortOrder: payload.sortOrder
       });
+      const objectUrl = await resolveAttachmentObjectUrl(SUBJECT_ATTACHMENTS_BUCKET, storagePath).catch((error) => {
+        console.warn("[subject-attachments] object url resolution failed; preview disabled", {
+          bucket: SUBJECT_ATTACHMENTS_BUCKET,
+          storagePath,
+          message: String(error?.message || error || "")
+        });
+        return "";
+      });
+
       return {
         ...attachment,
-        object_url: await resolveAttachmentObjectUrl(SUBJECT_ATTACHMENTS_BUCKET, storagePath)
+        object_url: objectUrl
       };
     },
 

--- a/supabase/migrations/202606150011_subject_message_attachments_storage_select_alignment.sql
+++ b/supabase/migrations/202606150011_subject_message_attachments_storage_select_alignment.sql
@@ -1,0 +1,17 @@
+-- Align attachment storage read policy with the same project access predicate
+-- used by subject messaging edge uploads.
+
+drop policy if exists storage_subject_message_attachments_select on storage.objects;
+create policy storage_subject_message_attachments_select
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.projects p
+    where p.id::text = (storage.foldername(name))[1]
+      and public.can_access_project_subject_conversation(p.id)
+  )
+);


### PR DESCRIPTION
### Motivation
- Immediate signed URL creation after an edge upload can fail with `400 Object not found`, leaving the front-end to use an `authenticated` storage URL that is incompatible with `<img src>` and triggers CORB. 
- The code previously fell back to `/storage/v1/object/authenticated/...` which requires auth headers and is not usable directly from the DOM. 
- The storage `SELECT` policy for the `subject-message-attachments` bucket was not using the same project-access predicate as the edge upload, causing an access-logic drift between upload and read.

### Description
- Stop returning authenticated storage URLs on signed-URL failure by changing `resolveAttachmentObjectUrl` to log the failure and return an empty string instead of `.../storage/v1/object/authenticated/...`.
- Make `uploadAttachmentFile` tolerant: resolve of `object_url` is now wrapped with `.catch(...)` so upload and attachment persistence always succeed and the returned `object_url` is `""` when immediate signing fails.
- Remove the previous `buildAuthenticatedStorageObjectUrl` fallback usage in the resolver to avoid producing DOM-incompatible URLs.
- Add a migration `supabase/migrations/202606150011_subject_message_attachments_storage_select_alignment.sql` that re-creates the `storage_subject_message_attachments_select` policy using `public.can_access_project_subject_conversation(p.id)` so read authorization matches the edge upload predicate.

### Testing
- Ran a JavaScript syntax check with `node --check apps/web/js/services/subject-messages-supabase.js` which succeeded. 
- Verified the code changes were applied and committed (`git commit`), with the migration file added. 
- No unit tests were modified or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3404c20808329a92b9b2230a6637a)