### PR TITLE
Autoriser l’envoi de commentaires de sujet sans texte (pièce jointe seule)

### DIFF
--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -510,29 +510,50 @@ export function createSubjectMessagesSupabaseRepository() {
     async createMessage(payload = {}) {
       const subjectId = normalizeId(payload.subjectId);
       const bodyMarkdown = String(payload.bodyMarkdown || "").trim();
+      const uploadSessionId = normalizeId(payload.uploadSessionId);
       const projectId = await resolveProjectId(payload.projectId);
       const personId = await resolveCurrentPersonId();
 
       if (!subjectId) throw new Error("subjectId is required");
       if (!projectId) throw new Error("projectId is required");
       if (!personId) throw new Error("current person is required");
-      if (!bodyMarkdown) throw new Error("bodyMarkdown is required");
+      if (!bodyMarkdown && !uploadSessionId) throw new Error("bodyMarkdown or uploadSessionId is required");
 
-      const rows = await restFetch("/rest/v1/subject_messages", null, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Prefer: "return=representation"
-        },
-        body: JSON.stringify({
-          project_id: projectId,
-          subject_id: subjectId,
-          parent_message_id: normalizeId(payload.parentMessageId) || null,
-          author_person_id: personId,
-          author_user_id: normalizeId(store?.user?.id || "") || null,
-          body_markdown: bodyMarkdown
-        })
-      });
+      const baseInsertPayload = {
+        project_id: projectId,
+        subject_id: subjectId,
+        parent_message_id: normalizeId(payload.parentMessageId) || null,
+        author_person_id: personId,
+        author_user_id: normalizeId(store?.user?.id || "") || null
+      };
+
+      let rows = null;
+      try {
+        rows = await restFetch("/rest/v1/subject_messages", null, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Prefer: "return=representation"
+          },
+          body: JSON.stringify({
+            ...baseInsertPayload,
+            body_markdown: bodyMarkdown
+          })
+        });
+      } catch (error) {
+        if (bodyMarkdown || !uploadSessionId) throw error;
+        rows = await restFetch("/rest/v1/subject_messages", null, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Prefer: "return=representation"
+          },
+          body: JSON.stringify({
+            ...baseInsertPayload,
+            body_markdown: "\u200B"
+          })
+        });
+      }
 
       const createdMessage = (Array.isArray(rows) ? rows[0] : rows) || null;
       const mentions = normalizeMentions(payload.mentions);

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -387,7 +387,8 @@ export function createProjectSubjectsThread(config = {}) {
     const normalizedEntityType = String(entityType || "").toLowerCase();
     const normalizedEntityId = normalizeId(entityId);
     const normalizedMessage = String(message || "").trim();
-    if (!normalizedMessage) return null;
+    const normalizedUploadSessionId = normalizeId(options.uploadSessionId);
+    if (!normalizedMessage && !normalizedUploadSessionId) return null;
 
     if (normalizedEntityType === "sujet" && normalizedEntityId && subjectMessagesService) {
       const created = options.parentMessageId
@@ -395,20 +396,21 @@ export function createProjectSubjectsThread(config = {}) {
             subjectId: normalizedEntityId,
             parentMessageId: options.parentMessageId,
             bodyMarkdown: normalizedMessage,
+            uploadSessionId: normalizedUploadSessionId || undefined,
             mentions: Array.isArray(options.mentions) ? options.mentions : []
           })
         : await subjectMessagesService.createMessage({
             subjectId: normalizedEntityId,
             bodyMarkdown: normalizedMessage,
+            uploadSessionId: normalizedUploadSessionId || undefined,
             mentions: Array.isArray(options.mentions) ? options.mentions : []
           });
 
-      const uploadSessionId = normalizeId(options.uploadSessionId);
-      if (uploadSessionId && created?.id) {
+      if (normalizedUploadSessionId && created?.id) {
         await subjectMessagesService.linkAttachmentsToMessage({
           subjectId: normalizedEntityId,
           messageId: created.id,
-          uploadSessionId
+          uploadSessionId: normalizedUploadSessionId
         });
       }
 
@@ -1101,20 +1103,25 @@ priority=${firstNonEmpty(subject.priority, "")}`
       </button>
     `).join("");
 
-    const actionsHtml = `
-      <button class="gh-btn gh-btn--help-mode ${helpMode ? "is-on" : ""}" data-action="toggle-help" type="button">Help</button>
-
-      ${issueStatusActionHtml}
-
-      <button class="gh-btn gh-btn--comment" data-action="add-comment" type="button">Comment</button>
-    `;
-
     const mentionUi = getMentionUiState();
     const attachmentState = getComposerAttachmentsState();
     const normalizedSubjectId = type === "sujet" ? normalizeId(item.id) : "";
     const pendingAttachments = normalizedSubjectId && normalizeId(attachmentState.subjectId) === normalizedSubjectId
       ? attachmentState.items
       : [];
+    const hasReadyAttachment = pendingAttachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+    const normalizedDraftMessage = String(store?.situationsView?.commentDraft || "").trim();
+    const canSubmitComment = !!normalizedDraftMessage || hasReadyAttachment;
+    const commentButtonClassName = canSubmitComment
+      ? "gh-btn gh-btn--comment gh-btn--primary"
+      : "gh-btn gh-btn--comment";
+    const actionsHtml = `
+      <button class="gh-btn gh-btn--help-mode ${helpMode ? "is-on" : ""}" data-action="toggle-help" type="button">Help</button>
+
+      ${issueStatusActionHtml}
+
+      <button class="${commentButtonClassName}" data-action="add-comment" type="button" ${canSubmitComment ? "" : "disabled"}>Comment</button>
+    `;
     const mentionPopupHtml = mentionUi.open
       ? `
         <div class="subject-mention-popup" role="listbox" aria-label="Suggestions de mention">

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2333,7 +2333,12 @@ async function applyCommentAction(root) {
   if (!ta) return;
 
   const message = String(ta.value || "").trim();
-  if (!message) return;
+  const composerAttachments = store.situationsView?.subjectComposerAttachments || {};
+  const hasAttachmentsForTarget = target.type === "sujet"
+    && String(composerAttachments?.subjectId || "").trim() === String(target.id || "").trim()
+    && Array.isArray(composerAttachments?.items)
+    && composerAttachments.items.some((entry) => String(entry?.uploadStatus || "").trim() === "ready" && !entry?.error);
+  if (!message && !hasAttachmentsForTarget) return;
   const mentions = extractStructuredMentions(message);
 
   const helpActive = !!store.situationsView.helpMode;
@@ -2349,11 +2354,6 @@ async function applyCommentAction(root) {
   const parentMessageId = target.type === "sujet" && replySubjectId === String(target.id || "").trim()
     ? String(replyContext?.parentMessageId || "").trim()
     : "";
-  const composerAttachments = store.situationsView?.subjectComposerAttachments || {};
-  const hasAttachmentsForTarget = target.type === "sujet"
-    && String(composerAttachments?.subjectId || "").trim() === String(target.id || "").trim()
-    && Array.isArray(composerAttachments?.items)
-    && composerAttachments.items.some((entry) => String(entry?.uploadStatus || "").trim() === "ready" && !entry?.error);
   const uploadSessionId = hasAttachmentsForTarget ? String(composerAttachments?.uploadSessionId || "").trim() : "";
 
   await addComment(target.type, target.id, message, {


### PR DESCRIPTION
### Motivation
- Le composeur UI doit permettre d’envoyer un commentaire si **texte non vide OU au moins une pièce jointe `ready`** pour le sujet courant afin d’éviter des clics silencieux sans effet. 
- La couche repository doit accepter un envoi sans `bodyMarkdown` dès qu’un `uploadSessionId` est fourni pour lier correctement les pièces jointes au message. 
- La persistance (Supabase) doit tolérer l’insertion d’un message sans texte quand une pièce jointe est liée, avec un fallback technique discret si la contrainte DB refuse une chaîne vide.

### Description
- UI: dans `apps/web/js/views/project-subjects/project-subjects-view.js` la fonction `applyCommentAction(root)` calcule maintenant `composerAttachments` et `hasAttachmentsForTarget` puis autorise l’envoi si `message` **ou** `hasAttachmentsForTarget` est vrai (`if (!message && !hasAttachmentsForTarget) return;`).
- Thread adapter: dans `apps/web/js/views/project-subjects/project-subjects-thread.js` la fonction `addComment(...)` accepte désormais un `message` vide si `options.uploadSessionId` est présent (`if (!normalizedMessage && !normalizedUploadSessionId) return null;`) et propage `uploadSessionId` vers `createMessage/createReply` puis appelle `linkAttachmentsToMessage` quand pertinent.
- Repository/DB: dans `apps/web/js/services/subject-messages-supabase.js` la méthode `createMessage(payload)` accepte maintenant `bodyMarkdown` **ou** `uploadSessionId`, elle tente d’insérer avec le `body_markdown` fourni et, si la base rejette une chaîne vide et qu’un `uploadSessionId` existe, retente l’insertion avec un caractère invisible (`"\u200B"`) pour garantir la création sans ajouter de placeholder visible.
- UX: dans le composer thread (`project-subjects-thread.js`) le bouton `Comment` devient actif et reçoit la classe `gh-btn--primary` uniquement si le draft texte n’est pas vide ou s’il existe au moins une pièce jointe en état `ready`; sinon il est rendu désactivé/gris pour éviter un no-op silencieux.

### Testing
- Exécution de `node --check apps/web/js/views/project-subjects/project-subjects-view.js` a réussi. 
- Exécution de `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` a réussi. 
- Exécution de `node --check apps/web/js/services/subject-messages-supabase.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3472531508329be08f6d1ff7b576c)