### PR TITLE
Commentaires : toolbar mutualisée, téléchargement des pièces jointes et réponses imbriquées

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1653,8 +1653,12 @@ export function createProjectSubjectsEvents(config) {
       if (!store.situationsView.inlineReplyUi || typeof store.situationsView.inlineReplyUi !== "object") {
         store.situationsView.inlineReplyUi = {
           expandedMessageId: "",
-          draftsByMessageId: {}
+          draftsByMessageId: {},
+          previewByMessageId: {}
         };
+      }
+      if (!store.situationsView.inlineReplyUi.previewByMessageId || typeof store.situationsView.inlineReplyUi.previewByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.previewByMessageId = {};
       }
       debugThreadReply("reply_state_fallback", { hasAccessor: typeof getInlineReplyUiState === "function" });
       return store.situationsView.inlineReplyUi;
@@ -1690,6 +1694,7 @@ export function createProjectSubjectsEvents(config) {
         btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = "";
+        replyUi.previewByMessageId[messageId] = false;
         replyUi.expandedMessageId = messageId;
         debugThreadReply("reply_opened", {
           messageId,
@@ -1748,6 +1753,47 @@ export function createProjectSubjectsEvents(config) {
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
       });
+      textarea.addEventListener("keydown", (event) => {
+        if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
+        event.preventDefault();
+        const submitButton = textarea.closest(".thread-inline-reply-editor")?.querySelector("[data-action='thread-reply-submit'][data-message-id]");
+        submitButton?.click();
+      });
+    });
+
+    root.querySelectorAll("[data-action='thread-reply-tab-write']").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.closest("[data-inline-reply-editor]")?.dataset.inlineReplyEditor || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.previewByMessageId[messageId] = false;
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-reply-tab-preview']").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.closest("[data-inline-reply-editor]")?.dataset.inlineReplyEditor || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.previewByMessageId[messageId] = true;
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-reply-format'][data-format][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const action = String(btn.dataset.format || "").trim();
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!action || !messageId) return;
+        const textarea = root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+        if (!textarea) return;
+        const didApply = applyMarkdownComposerAction(textarea, action);
+        if (!didApply) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
+        rerenderScope(root);
+      };
     });
 
     root.querySelectorAll("[data-action='thread-reply-cancel'][data-message-id]").forEach((btn) => {
@@ -1756,6 +1802,7 @@ export function createProjectSubjectsEvents(config) {
         debugThreadReply("reply_cancel", { messageId });
         const replyUi = resolveInlineReplyUiState();
         if (messageId) replyUi.draftsByMessageId[messageId] = "";
+        if (messageId) replyUi.previewByMessageId[messageId] = false;
         replyUi.expandedMessageId = "";
         rerenderScope(root);
       };
@@ -1779,6 +1826,7 @@ export function createProjectSubjectsEvents(config) {
           mentions
         });
         replyUi.draftsByMessageId[parentMessageId] = "";
+        replyUi.previewByMessageId[parentMessageId] = false;
         replyUi.expandedMessageId = "";
         rerenderScope(root);
       };

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1,5 +1,4 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
-import { renderUploadProgressBar } from "../ui/upload-progress.js";
 export function createProjectSubjectsThread(config = {}) {
   const {
     store,
@@ -200,12 +199,16 @@ export function createProjectSubjectsThread(config = {}) {
     if (!state.inlineReplyUi || typeof state.inlineReplyUi !== "object") {
       state.inlineReplyUi = {
         expandedMessageId: "",
-        draftsByMessageId: {}
+        draftsByMessageId: {},
+        previewByMessageId: {}
       };
     }
     if (typeof state.inlineReplyUi.expandedMessageId !== "string") state.inlineReplyUi.expandedMessageId = "";
     if (!state.inlineReplyUi.draftsByMessageId || typeof state.inlineReplyUi.draftsByMessageId !== "object") {
       state.inlineReplyUi.draftsByMessageId = {};
+    }
+    if (!state.inlineReplyUi.previewByMessageId || typeof state.inlineReplyUi.previewByMessageId !== "object") {
+      state.inlineReplyUi.previewByMessageId = {};
     }
     return state.inlineReplyUi;
   }
@@ -652,29 +655,62 @@ priority=${firstNonEmpty(subject.priority, "")}`
     return { commentsById, childrenByParentId };
   }
 
-  function renderInlineReplyComposer({ commentId, isExpanded, draft }) {
+  function renderMarkdownToolbar(buttonAction, extraData = {}) {
+    const toolbarButtons = [
+      { action: "bold", icon: "markdown-bold", label: "Gras" },
+      { action: "italic", icon: "markdown-italic", label: "Italique" },
+      { action: "underline", icon: "markdown-underline", label: "Souligné" },
+      { action: "bullet-list", icon: "markdown-list-unordered", label: "Liste à puces" },
+      { action: "ordered-list", icon: "markdown-list-ordered", label: "Liste numérotée" },
+      { action: "checklist", icon: "markdown-tasklist", label: "Checklist" },
+      { action: "quote", icon: "markdown-quote", label: "Citation" },
+      { action: "link", icon: "markdown-link", label: "Lien" },
+      { action: "mention", icon: "markdown-mention", label: "Mention" }
+    ];
+    const extraAttributes = Object.entries(extraData)
+      .map(([key, value]) => `data-${escapeHtml(key)}="${escapeHtml(String(value || ""))}"`)
+      .join(" ");
+
+    return toolbarButtons.map((button) => `
+      <button
+        class="comment-toolbar-btn"
+        type="button"
+        data-action="${escapeHtml(buttonAction)}"
+        data-format="${escapeHtml(button.action)}"
+        ${extraAttributes}
+        title="${escapeHtml(button.label)}"
+        aria-label="${escapeHtml(button.label)}"
+      >
+        ${svgIcon(button.icon)}
+      </button>
+    `).join("");
+  }
+
+  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode }) {
     if (!commentId) return "";
     if (!isExpanded) return "";
-
+    const normalizedDraft = String(draft || "");
+    const canSubmit = !!normalizedDraft.trim();
     return `
       <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
-        <div class="thread-inline-reply-editor__content">
-          <div class="thread-inline-reply-editor__tabs" role="tablist" aria-label="Onglets de réponse">
-            <button class="comment-tab is-active" type="button">Write</button>
-            <button class="comment-tab" type="button" disabled>Preview</button>
-          </div>
-          <div class="thread-inline-reply-editor__body">
-            <textarea
-              class="textarea thread-inline-reply-editor__textarea"
-              data-thread-reply-draft="${escapeHtml(commentId)}"
-              placeholder="Écrire une réponse"
-            >${escapeHtml(draft || "")}</textarea>
-          </div>
-        </div>
-        <div class="thread-inline-reply-editor__actions">
-          <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
-          <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}">Répondre</button>
-        </div>
+        ${renderCommentComposer({
+          hideAvatar: true,
+          hideTitle: true,
+          previewMode,
+          textareaId: `threadReplyBox-${commentId}`,
+          previewId: `threadReplyPreview-${commentId}`,
+          textareaValue: normalizedDraft,
+          placeholder: "Écrire une réponse",
+          tabWriteAction: "thread-reply-tab-write",
+          tabPreviewAction: "thread-reply-tab-preview",
+          toolbarHtml: renderMarkdownToolbar("thread-reply-format", { messageId: commentId }),
+          previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
+          actionsHtml: `
+            <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
+            <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}" ${canSubmit ? "" : "disabled"}>Répondre</button>
+          `,
+          previewEmptyHint: "Use Markdown to format your reply"
+        })}
       </div>
     `;
   }
@@ -722,8 +758,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const objectUrl = String(attachment?.remoteObjectUrl || attachment?.object_url || previewUrl || "");
     const isImage = options.forceImage || mimeType.startsWith("image/");
     const uploadState = String(options.uploadState || "").trim();
-    const isUploading = String(attachment?.uploadStatus || "").trim() === "uploading";
-    const isReady = String(attachment?.uploadStatus || "").trim() === "ready";
     const typeIcon = mimeType === "application/pdf" || extension === "pdf"
       ? "file-pdf"
       : mimeType.includes("javascript") || extension === "js" || extension === "ts"
@@ -731,17 +765,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
         : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
           ? "file-dwg"
           : "file-generic";
-    const progressHtml = uploadState
-      ? `
-        <div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>
-        ${renderUploadProgressBar({
-          progressPercent: isReady ? 100 : 45,
-          indeterminate: isUploading,
-          className: "subject-attachment__progress",
-          label: `Progression de l’envoi de ${fileName}`
-        })}
-      `
-      : "";
+    const progressHtml = uploadState ? `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>` : "";
     const metaLine = [
       mimeType || "fichier",
       Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
@@ -766,12 +790,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
         <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
         <div class="subject-attachment__file-body">
           ${objectUrl
-            ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(objectUrl)}" target="_blank" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
+            ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(objectUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
             : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
           <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
           ${progressHtml}
         </div>
-        ${objectUrl ? `<a class="subject-attachment__file-link" href="${escapeHtml(objectUrl)}" target="_blank" rel="noopener noreferrer" download="${escapeHtml(fileName)}">Télécharger</a>` : ""}
+        ${objectUrl ? `<a class="subject-attachment__file-link" href="${escapeHtml(objectUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">Télécharger</a>` : ""}
       </div>
     `;
   }
@@ -809,6 +833,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
         const childReplies = childrenByParentId.get(commentId) || [];
         const isExpanded = replyUi.expandedMessageId === commentId;
         const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
+        const previewMode = !!replyUi.previewByMessageId?.[commentId];
         const isEditable = !e?.meta?.is_frozen && !e?.meta?.is_deleted;
         const repliesHtml = childReplies.length
           ? `
@@ -865,7 +890,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
               ${renderInlineReplyComposer({
                 commentId,
                 isExpanded,
-                draft
+                draft,
+                previewMode
               })}
             </div>
           `,
@@ -1102,30 +1128,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       `
       : "";
 
-    const toolbarButtons = [
-      { action: "bold", icon: "markdown-bold", label: "Gras" },
-      { action: "italic", icon: "markdown-italic", label: "Italique" },
-      { action: "underline", icon: "markdown-underline", label: "Souligné" },
-      { action: "bullet-list", icon: "markdown-list-unordered", label: "Liste à puces" },
-      { action: "ordered-list", icon: "markdown-list-ordered", label: "Liste numérotée" },
-      { action: "checklist", icon: "markdown-tasklist", label: "Checklist" },
-      { action: "quote", icon: "markdown-quote", label: "Citation" },
-      { action: "link", icon: "markdown-link", label: "Lien" },
-      { action: "mention", icon: "markdown-mention", label: "Mention" }
-    ];
-
-    const toolbarHtml = toolbarButtons.map((button) => `
-      <button
-        class="comment-toolbar-btn"
-        type="button"
-        data-action="composer-format"
-        data-format="${escapeHtml(button.action)}"
-        title="${escapeHtml(button.label)}"
-        aria-label="${escapeHtml(button.label)}"
-      >
-        ${svgIcon(button.icon)}
-      </button>
-    `).join("");
+    const toolbarHtml = renderMarkdownToolbar("composer-format");
 
     const mentionUi = getMentionUiState();
     const attachmentState = getComposerAttachmentsState();

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -3,6 +3,8 @@ import { escapeHtml } from "../../utils/escape-html.js";
 export function renderCommentComposer({
   title = "Add a comment",
   avatarHtml = "",
+  hideAvatar = false,
+  hideTitle = false,
   previewMode = false,
   helpMode = false,
   textareaId = "humanCommentBox",
@@ -14,21 +16,24 @@ export function renderCommentComposer({
   footerHtml = "",
   actionsHtml = "",
   toolbarHtml = "",
+  tabWriteAction = "tab-write",
+  tabPreviewAction = "tab-preview",
+  previewHtml = "",
   previewEmptyHint = "Use Markdown to format your comment"
 } = {}) {
   return `
     <div class="human-action comment-composer">
-      <div class="gh-avatar gh-avatar--human comment-composer__avatar" aria-hidden="true">${avatarHtml}</div>
+      ${hideAvatar ? "" : `<div class="gh-avatar gh-avatar--human comment-composer__avatar" aria-hidden="true">${avatarHtml}</div>`}
 
       <div class="comment-general-block comment-composer__main">
-        <div class="gh-timeline-title mono comment-composer__title">${escapeHtml(title)}</div>
+        ${hideTitle ? "" : `<div class="gh-timeline-title mono comment-composer__title">${escapeHtml(title)}</div>`}
 
         <div class="comment-box gh-comment-boxwrap comment-composer__box ${helpMode ? "gh-comment-box--help" : ""}">
           ${contextHtml || ""}
           <div class="comment-tabs comment-composer__tabs ${helpMode ? "gh-comment-header--help" : ""}" role="tablist" aria-label="Comment tabs">
             <div class="comment-composer__tabs-left">
-              <button class="comment-tab ${!previewMode ? "is-active" : ""}" data-action="tab-write" type="button">Write</button>
-              <button class="comment-tab ${previewMode ? "is-active" : ""}" data-action="tab-preview" type="button">Preview</button>
+              <button class="comment-tab ${!previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabWriteAction)}" type="button">Write</button>
+              <button class="comment-tab ${previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabPreviewAction)}" type="button">Preview</button>
             </div>
             ${toolbarHtml ? `<div class="comment-composer__toolbar" role="toolbar" aria-label="Markdown toolbar">${toolbarHtml}</div>` : ""}
           </div>
@@ -42,7 +47,7 @@ export function renderCommentComposer({
           </div>
 
           <div class="comment-editor comment-composer__preview-wrap ${previewMode ? "" : "hidden"}">
-            <div class="comment-preview comment-composer__preview" id="${escapeHtml(previewId)}" data-empty-hint="${escapeHtml(previewEmptyHint)}"></div>
+            <div class="comment-preview comment-composer__preview" id="${escapeHtml(previewId)}" data-empty-hint="${escapeHtml(previewEmptyHint)}">${previewHtml || ""}</div>
           </div>
           ${footerHtml || ""}
         </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2679,15 +2679,12 @@ body.is-resizing{
   text-decoration:none;
 }
 .subject-attachment__file-link--name:hover{
+  color:var(--accent, #2f81f7);
   text-decoration:underline;
 }
 .subject-attachment__file-meta{color:var(--muted);}
 .subject-attachment__file-link{font-size:12px;}
 .subject-attachment__state{padding:0 8px 8px;color:var(--muted);}
-.subject-attachment__progress{
-  margin:0 8px 8px;
-  height:6px;
-}
 .md-render p{margin:0 0 10px;}
 .md-render p:last-child{margin-bottom:0;}
 .md-render ul,.md-render ol{margin:0 0 10px 20px;padding:0;}
@@ -2771,34 +2768,13 @@ body.is-resizing{
   border-top:none;
 }
 .thread-inline-reply-editor{
-  border-radius:var(--radius);
-  overflow:hidden;
-  padding: 12px;
-  background-color: var(--bg-input);
-  border-top-right-radius: 0px;
-  border-top-left-radius: 0px;
-  border-top: solid 1px var(--border);
+  border-top:1px solid var(--border);
+  padding:12px;
+  background-color:var(--bg-input);
 }
-.thread-inline-reply-editor__content{
-  border:solid 1px var(--border2);
-  border-radius:6px;
-  background: var(--bgAssistPanel);
-}
-.thread-inline-reply-editor__tabs{
-  display:flex;
-  align-items:center;
-  gap:4px;
-  padding:6px 8px 0;
-  border-bottom:1px solid var(--border2);
-}
-.thread-inline-reply-editor__tabs .comment-tab[disabled]{opacity:.6;cursor:not-allowed;}
-.thread-inline-reply-editor__body{padding:10px;}
-.thread-inline-reply-editor__textarea{min-height:110px;background: var(--bgAssistPanel);}
-.thread-inline-reply-editor__actions{
-  display:flex;
-  justify-content:flex-end;
-  gap:8px;
-  padding: 10px 0px 0px;
+.thread-inline-reply-editor .comment-composer__textarea{
+  min-height:110px;
+  background:var(--bgAssistPanel);
 }
 .thread-comment-replies{
   margin-top:8px;


### PR DESCRIPTION
### Motivation
- Uniformiser le composer de commentaire entre le flux principal et les réponses imbriquées pour réduire la duplication UI/JS. 
- Rendre le titre des pièces jointes cliquable pour déclencher un téléchargement et indiquer visuellement l'interaction au survol. 
- Supprimer la barre de progression visuelle des uploads pour simplifier l’UI tout en conservant l’état textuel.

### Description
- Rendre `renderCommentComposer` réutilisable avec options `hideAvatar`, `hideTitle`, `tabWriteAction`, `tabPreviewAction` et `previewHtml` pour servir aussi bien le commentaire principal que les replies imbriquées (fichier modifié : `apps/web/js/views/ui/comment-composer.js`).
- Centraliser la génération de la toolbar Markdown avec `renderMarkdownToolbar` et l’utiliser pour le composer principal et le composer des réponses (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Remplacer l’éditeur inline custom des réponses par une instance de `comment-composer` pour les réponses imbriquées, en ajoutant la gestion Write/Preview, la preview Markdown, le bouton Répondre activé/désactivé selon le contenu, et la preview par message (fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Ajouter les handlers UI pour les replies imbriquées : bascule onglets Write/Preview (`thread-reply-tab-*`), actions de formatage dédiées (`thread-reply-format`), raccourci Ctrl/Cmd+Enter pour soumettre, et reset des états à ouverture/annulation/envoi (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Pièces jointes : suppression du rendu de la barre de progression visuelle (statut texte conservé), ajout de l’attribut `download` et suppression du `target="_blank"` sur les liens de nom/téléchargement, et ajout d’un style pour passer le nom en bleu au survol (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/style.css`).
- Ajustements CSS pour intégrer proprement le composer imbriqué et la coloration au survol (`apps/web/style.css`).

### Testing
- Exécuté `node --check apps/web/js/views/ui/comment-composer.js` et la vérification a réussi. 
- Exécuté `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` et la vérification a réussi. 
- Exécuté `node --check apps/web/js/views/project-subjects/project-subjects-events.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34f1688f08329a396322a6bf7a7cd)