### PR TITLE
Canonicalize subject attachment storage paths and align storage policy

### DIFF
--- a/apps/web/js/services/subject-attachments-storage-path.js
+++ b/apps/web/js/services/subject-attachments-storage-path.js
@@ -1,0 +1,26 @@
+const EDGE_TRIM_PATTERN = /^[\s\u200B\u200C\u200D\u2060\uFEFF]+|[\s\u200B\u200C\u200D\u2060\uFEFF]+$/g;
+
+function escapeRegExp(value = "") {
+  return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function normalizeAttachmentBucket(bucket = "", fallbackBucket = "") {
+  return String(bucket || fallbackBucket || "").trim();
+}
+
+export function normalizeSubjectAttachmentStoragePath(storagePath = "", bucket = "") {
+  const rawValue = String(storagePath ?? "");
+  const normalizedBucket = normalizeAttachmentBucket(bucket);
+  let canonicalValue = rawValue.replace(EDGE_TRIM_PATTERN, "");
+
+  canonicalValue = canonicalValue.replace(/\/{2,}/g, "/");
+  canonicalValue = canonicalValue.replace(/^\/+/, "");
+
+  if (normalizedBucket) {
+    const bucketPrefixPattern = new RegExp(`^${escapeRegExp(normalizedBucket)}\/+`);
+    canonicalValue = canonicalValue.replace(bucketPrefixPattern, "");
+  }
+
+  canonicalValue = canonicalValue.replace(/\/{2,}/g, "/");
+  return canonicalValue;
+}

--- a/apps/web/js/services/subject-attachments-storage-path.test.mjs
+++ b/apps/web/js/services/subject-attachments-storage-path.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeSubjectAttachmentStoragePath } from "./subject-attachments-storage-path.js";
+
+test("garde un chemin déjà canonique inchangé", () => {
+  const value = "project-1/subject-2/temporary/session/file.pdf";
+  assert.equal(normalizeSubjectAttachmentStoragePath(value, "subject-message-attachments"), value);
+});
+
+test("supprime un slash initial", () => {
+  assert.equal(
+    normalizeSubjectAttachmentStoragePath("/project-1/subject-2/temporary/file.pdf", "subject-message-attachments"),
+    "project-1/subject-2/temporary/file.pdf"
+  );
+});
+
+test("retire un préfixe bucket injecté dans le storage_path", () => {
+  assert.equal(
+    normalizeSubjectAttachmentStoragePath(
+      "subject-message-attachments/project-1/subject-2/temporary/file.pdf",
+      "subject-message-attachments"
+    ),
+    "project-1/subject-2/temporary/file.pdf"
+  );
+});
+
+test("réduit les doubles slashs accidentels", () => {
+  assert.equal(
+    normalizeSubjectAttachmentStoragePath("project-1//subject-2///temporary/file.pdf", "subject-message-attachments"),
+    "project-1/subject-2/temporary/file.pdf"
+  );
+});
+
+test("supprime espaces et caractères invisibles en bord", () => {
+  assert.equal(
+    normalizeSubjectAttachmentStoragePath("\uFEFF  /project-1/subject-2/file.pdf\u200B ", "subject-message-attachments"),
+    "project-1/subject-2/file.pdf"
+  );
+});

--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -8,6 +8,10 @@ import {
   shouldFallbackToDirectUploadFromEdgeHttpFailure,
   shouldFallbackToDirectUploadFromEdgeNetworkFailure
 } from "./subject-message-attachments-transport.js";
+import {
+  normalizeAttachmentBucket,
+  normalizeSubjectAttachmentStoragePath
+} from "./subject-attachments-storage-path.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const SUBJECT_ATTACHMENTS_BUCKET = "subject-message-attachments";
@@ -74,9 +78,17 @@ function encodeStoragePath(path = "") {
 }
 
 async function createAttachmentSignedUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
-  const normalizedBucket = String(bucket || SUBJECT_ATTACHMENTS_BUCKET).trim();
-  const normalizedPath = String(storagePath || "").trim();
+  const normalizedBucket = normalizeAttachmentBucket(bucket, SUBJECT_ATTACHMENTS_BUCKET);
+  const rawPath = String(storagePath ?? "");
+  const normalizedPath = normalizeSubjectAttachmentStoragePath(rawPath, normalizedBucket);
   if (!normalizedBucket || !normalizedPath) return "";
+  if (normalizedPath !== rawPath) {
+    console.info("[subject-attachments] storage path normalized before signed url", {
+      bucket: normalizedBucket,
+      storagePathRaw: rawPath,
+      storagePathCanonical: normalizedPath
+    });
+  }
 
   const { data, error } = await supabase.storage
     .from(normalizedBucket)
@@ -86,8 +98,9 @@ async function createAttachmentSignedUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, st
 }
 
 async function resolveAttachmentObjectUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
-  const normalizedBucket = String(bucket || SUBJECT_ATTACHMENTS_BUCKET).trim();
-  const normalizedPath = String(storagePath || "").trim();
+  const normalizedBucket = normalizeAttachmentBucket(bucket, SUBJECT_ATTACHMENTS_BUCKET);
+  const rawPath = String(storagePath ?? "");
+  const normalizedPath = normalizeSubjectAttachmentStoragePath(rawPath, normalizedBucket);
   if (!normalizedBucket || !normalizedPath) return "";
   try {
     const signedUrl = await createAttachmentSignedUrl(normalizedBucket, normalizedPath);
@@ -378,19 +391,42 @@ export function createSubjectMessagesSupabaseRepository() {
     const grouped = new Map();
     const attachmentRows = Array.isArray(rows) ? rows : [];
     const resolvedObjectUrls = await Promise.all(
-      attachmentRows.map((row) => resolveAttachmentObjectUrl(row?.storage_bucket, row?.storage_path))
+      attachmentRows.map((row) => {
+        const storageBucket = normalizeAttachmentBucket(row?.storage_bucket, SUBJECT_ATTACHMENTS_BUCKET);
+        const storagePath = normalizeSubjectAttachmentStoragePath(row?.storage_path, storageBucket);
+        return resolveAttachmentObjectUrl(storageBucket, storagePath);
+      })
     );
 
     attachmentRows.forEach((row, index) => {
       const messageId = normalizeId(row?.message_id);
       if (!messageId) return;
+      const storageBucket = normalizeAttachmentBucket(row?.storage_bucket, SUBJECT_ATTACHMENTS_BUCKET);
+      const rawStoragePath = String(row?.storage_path ?? "");
+      const canonicalStoragePath = normalizeSubjectAttachmentStoragePath(rawStoragePath, storageBucket);
+      if (rawStoragePath !== canonicalStoragePath) {
+        console.info("[subject-attachments] storage path normalized on read", {
+          attachmentId: normalizeId(row?.id),
+          messageId,
+          bucket: storageBucket,
+          storagePathRaw: rawStoragePath,
+          storagePathCanonical: canonicalStoragePath
+        });
+      }
+      console.info("[subject-attachments] storage path read for signed url", {
+        attachmentId: normalizeId(row?.id),
+        messageId,
+        bucket: storageBucket,
+        storagePathRaw: rawStoragePath,
+        storagePathCanonical: canonicalStoragePath
+      });
       const list = grouped.get(messageId) || [];
       list.push({
         ...row,
         id: normalizeId(row?.id),
         message_id: messageId,
-        storage_bucket: String(row?.storage_bucket || SUBJECT_ATTACHMENTS_BUCKET),
-        storage_path: String(row?.storage_path || ""),
+        storage_bucket: storageBucket,
+        storage_path: canonicalStoragePath,
         file_name: String(row?.file_name || ""),
         mime_type: String(row?.mime_type || ""),
         object_url: String(resolvedObjectUrls[index] || "")
@@ -609,7 +645,8 @@ export function createSubjectMessagesSupabaseRepository() {
       const subjectId = normalizeId(payload.subjectId);
       const projectId = await resolveProjectId(payload.projectId);
       const personId = await resolveCurrentPersonId();
-      const storagePath = String(payload.storagePath || "").trim();
+      const storageBucket = normalizeAttachmentBucket(payload.storageBucket, SUBJECT_ATTACHMENTS_BUCKET);
+      const storagePath = normalizeSubjectAttachmentStoragePath(payload.storagePath, storageBucket);
       const fileName = String(payload.fileName || "").trim();
 
       if (!subjectId) throw new Error("subjectId is required");
@@ -628,7 +665,7 @@ export function createSubjectMessagesSupabaseRepository() {
           project_id: projectId,
           subject_id: subjectId,
           upload_session_id: normalizeId(payload.uploadSessionId) || null,
-          storage_bucket: String(payload.storageBucket || SUBJECT_ATTACHMENTS_BUCKET),
+          storage_bucket: storageBucket,
           storage_path: storagePath,
           file_name: fileName,
           mime_type: String(payload.mimeType || "") || null,
@@ -667,10 +704,11 @@ export function createSubjectMessagesSupabaseRepository() {
       }
 
       const fileName = String(file?.name || payload.fileName || "attachment").trim();
-      const storagePath = String(
+      const rawStoragePath = String(
         payload.storagePath
           || `${projectId}/${subjectId}/temporary/${uploadSessionId}/${Date.now()}-${randomToken()}-${normalizeFileName(fileName) || "attachment"}`
-      ).trim();
+      );
+      const storagePath = normalizeSubjectAttachmentStoragePath(rawStoragePath, SUBJECT_ATTACHMENTS_BUCKET);
       if (!storagePath) throw new Error("storagePath is required");
       const resolvedMimeType = String(file?.type || payload.mimeType || inferMimeTypeFromFileName(fileName) || "").trim();
       const uploadOptions = {
@@ -818,8 +856,18 @@ export function createSubjectMessagesSupabaseRepository() {
       });
 
       if (currentAttachment?.storage_path) {
+        const normalizedBucket = normalizeAttachmentBucket(currentAttachment.storage_bucket, SUBJECT_ATTACHMENTS_BUCKET);
+        const normalizedStoragePath = normalizeSubjectAttachmentStoragePath(currentAttachment.storage_path, normalizedBucket);
+        if (normalizedStoragePath !== String(currentAttachment.storage_path ?? "")) {
+          console.info("[subject-attachments] storage path normalized before delete", {
+            attachmentId: normalizedAttachmentId,
+            bucket: normalizedBucket,
+            storagePathRaw: String(currentAttachment.storage_path ?? ""),
+            storagePathCanonical: normalizedStoragePath
+          });
+        }
         await fetch(
-          `${SUPABASE_URL}/storage/v1/object/${encodeURIComponent(String(currentAttachment.storage_bucket || SUBJECT_ATTACHMENTS_BUCKET))}/${encodeStoragePath(currentAttachment.storage_path)}`,
+          `${SUPABASE_URL}/storage/v1/object/${encodeURIComponent(normalizedBucket)}/${encodeStoragePath(normalizedStoragePath)}`,
           {
             method: "DELETE",
             headers: await getAuthHeaders()

--- a/supabase/functions/upload-subject-message-attachment/index.ts
+++ b/supabase/functions/upload-subject-message-attachment/index.ts
@@ -14,6 +14,7 @@ const jsonHeaders = {
 };
 
 const BUCKET = "subject-message-attachments";
+const EDGE_TRIM_PATTERN = /^[\s\u200B\u200C\u200D\u2060\uFEFF]+|[\s\u200B\u200C\u200D\u2060\uFEFF]+$/g;
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -55,7 +56,8 @@ Deno.serve(async (req) => {
 
     const formData = await req.formData();
     const bucket = String(formData.get("bucket") || BUCKET).trim() || BUCKET;
-    const storagePath = String(formData.get("storagePath") || "").trim();
+    const rawStoragePath = String(formData.get("storagePath") || "");
+    const storagePath = normalizeStoragePath(rawStoragePath, bucket);
     const upsert = String(formData.get("upsert") || "true").trim().toLowerCase() === "true";
     const contentType = String(formData.get("contentType") || "").trim();
     const file = formData.get("file");
@@ -84,8 +86,17 @@ Deno.serve(async (req) => {
       userId: user.id,
       projectId,
       subjectId: subjectId || null,
-      storagePath
+      storagePath,
+      storagePathRaw: rawStoragePath
     };
+    if (rawStoragePath !== storagePath) {
+      console.info("[upload-subject-message-attachment] storage path normalized", {
+        userId: user.id,
+        bucket,
+        storagePathRaw: rawStoragePath,
+        storagePathCanonical: storagePath
+      });
+    }
 
     const { data: canAccess, error: accessError } = await userClient.rpc("can_access_project_subject_conversation", {
       p_project_id: projectId
@@ -135,4 +146,21 @@ Deno.serve(async (req) => {
 
 function jsonResponse(body: Record<string, unknown>, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function normalizeStoragePath(storagePath = "", bucket = "") {
+  const normalizedBucket = String(bucket || "").trim();
+  let normalizedPath = String(storagePath ?? "").replace(EDGE_TRIM_PATTERN, "");
+  normalizedPath = normalizedPath.replace(/\/{2,}/g, "/");
+  normalizedPath = normalizedPath.replace(/^\/+/, "");
+  if (normalizedBucket) {
+    const bucketPrefixPattern = new RegExp(`^${escapeRegExp(normalizedBucket)}\/+`);
+    normalizedPath = normalizedPath.replace(bucketPrefixPattern, "");
+  }
+  normalizedPath = normalizedPath.replace(/\/{2,}/g, "/");
+  return normalizedPath;
+}
+
+function escapeRegExp(value = "") {
+  return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/supabase/migrations/202606150012_subject_message_attachments_storage_select_via_attachment_table.sql
+++ b/supabase/migrations/202606150012_subject_message_attachments_storage_select_via_attachment_table.sql
@@ -1,0 +1,20 @@
+-- Align Storage select access with the attachment source-of-truth table.
+-- This avoids inferring authorization from path segments only.
+
+drop policy if exists storage_subject_message_attachments_select on storage.objects;
+
+create policy storage_subject_message_attachments_select
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'subject-message-attachments'
+  and exists (
+    select 1
+    from public.subject_message_attachments sma
+    where sma.storage_bucket = storage.objects.bucket_id
+      and sma.storage_path = storage.objects.name
+      and sma.deleted_at is null
+      and public.can_access_project_subject_conversation(sma.project_id)
+  )
+);


### PR DESCRIPTION
### Motivation
- Ensure subject attachment storage paths are canonicalized to avoid mismatches between uploaded objects and DB records. 
- Robustly handle edge whitespace and invisible characters, bucket prefixes, and redundant slashes across client and edge upload code. 
- Align storage select authorization with the attachment source-of-truth table to avoid inferring access solely from path segments.

### Description
- Added `apps/web/js/services/subject-attachments-storage-path.js` with `normalizeAttachmentBucket` and `normalizeSubjectAttachmentStoragePath` helpers to trim, remove invisible edge characters, strip bucket prefixes, and collapse duplicate slashes. 
- Updated `apps/web/js/services/subject-messages-supabase.js` to use the new normalization helpers for signed URL creation, object URL resolution, listing, uploads, and deletes, and added informational logs when normalization occurs. 
- Updated the Edge upload function `supabase/functions/upload-subject-message-attachment/index.ts` to normalize incoming `storagePath`, validate it safely, and log raw vs canonical paths. 
- Added a DB migration `supabase/migrations/202606150012_subject_message_attachments_storage_select_via_attachment_table.sql` to restrict `storage.objects` select access by checking `public.subject_message_attachments` as the authorization source. 
- Added unit tests `apps/web/js/services/subject-attachments-storage-path.test.mjs` covering canonicalization, leading slash removal, bucket prefix stripping, collapsing duplicate slashes, and trimming invisible characters.

### Testing
- Ran the new unit tests with `node --test apps/web/js/services/subject-attachments-storage-path.test.mjs` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e35eba60d48329813dda8755f9af76)