### PR TITLE
Harmonise la toolbar des messages, réduit séparateurs et nettoie la dropzone

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -684,7 +684,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
       </button>
     `;
 
-    if (buttonAction !== "composer-format") {
+    const shouldUseComposerLayout = buttonAction === "composer-format" || buttonAction === "thread-reply-format";
+    if (!shouldUseComposerLayout) {
       return toolbarButtons.map((button) => renderToolbarButton(button)).join("");
     }
 
@@ -1251,10 +1252,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
           <div class="subject-composer-dropzone__label mono-small">
             Dépose des images, PDF ou autres fichiers ici
           </div>
-          <button class="subject-composer-attachments-pick-btn" type="button" data-action="composer-attachments-pick">
-            <span class="subject-composer-attachments-pick-btn__icon" aria-hidden="true">${svgIcon("image")}</span>
-            <span>Ajouter un fichier</span>
-          </button>
           ${pendingAttachmentsHtml}
         </div>
         <button class="subject-composer-attachments-pick-btn" type="button" data-action="composer-attachments-pick">

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2558,11 +2558,21 @@ body.is-resizing{
   display:flex;
   align-items:center;
   gap:2px;
+  position:relative;
 }
 .comment-toolbar-layout__group + .comment-toolbar-layout__group{
-  border-left:1px solid var(--border2);
   margin-left:8px;
   padding-left:8px;
+}
+.comment-toolbar-layout__group + .comment-toolbar-layout__group::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:50%;
+  width:1px;
+  height:18px;
+  transform:translateY(-50%);
+  background:var(--border2);
 }
 .comment-toolbar-btn{
   display:inline-flex;


### PR DESCRIPTION
### Motivation

- Harmoniser la barre de formatage des réponses imbriquées avec celle des messages principaux pour une expérience utilisateur cohérente.
- Réduire visuellement la hauteur des séparateurs verticaux entre chaque groupe de boutons afin d’alléger l’interface.
- Supprimer le bouton redondant “Ajouter un fichier” dans la dropzone pour ne conserver qu’un seul point d’action.

### Description

- Autorise l’utilisation de la même mise en page des groupes de boutons pour les formats `composer-format` et `thread-reply-format` en étendant la condition de rendu dans `apps/web/js/views/project-subjects/project-subjects-thread.js` (fonction `renderMarkdownToolbar`).
- Supprime le bouton `Ajouter un fichier` rendu à l’intérieur de la dropzone et conserve uniquement le bouton situé en dessous dans `apps/web/js/views/project-subjects/project-subjects-thread.js` (bloc `composerAttachmentsHtml`).
- Remplace la bordure gauche pleine par un pseudo-élément centré pour les séparateurs entre groupes en CSS, en ajoutant `position: relative` et `::before` avec `height: 18px` dans `apps/web/style.css` (sélecteur `.comment-toolbar-layout__group + .comment-toolbar-layout__group::before`).

### Testing

- Exécution de `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3704e9f90832985c017d9c11113cf)