### PR TITLE
Update composer attachment dropzone UX

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -988,7 +988,7 @@ export function createProjectSubjectsEvents(config) {
       });
 
       const attachmentInput = root.querySelector("[data-role='subject-composer-file-input']");
-      const attachmentDropzone = root.querySelector("[data-role='subject-composer-dropzone']");
+      const attachmentDropzone = root.querySelector(".comment-composer__editor");
       root.querySelectorAll("[data-action='composer-attachments-pick']").forEach((btn) => {
         btn.onclick = () => attachmentInput?.click();
       });
@@ -1000,7 +1000,7 @@ export function createProjectSubjectsEvents(config) {
         });
       }
 
-      if (attachmentDropzone) {
+      if (attachmentDropzone && attachmentInput) {
         ["dragenter", "dragover"].forEach((eventName) => {
           attachmentDropzone.addEventListener(eventName, (event) => {
             event.preventDefault();

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1242,16 +1242,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     const composerAttachmentsHtml = type === "sujet"
       ? `
+        <input id="subjectComposerAttachmentInput" type="file" class="subject-composer-file-input" data-role="subject-composer-file-input" multiple />
         <div
-          class="subject-composer-dropzone"
-          data-role="subject-composer-dropzone"
-          tabindex="0"
-          aria-label="Déposer des pièces jointes"
+          class="subject-composer-attachments-preview ${pendingAttachments.length ? "" : "hidden"}"
+          data-role="subject-composer-attachments-preview"
+          aria-live="polite"
         >
-          <input id="subjectComposerAttachmentInput" type="file" class="subject-composer-file-input" data-role="subject-composer-file-input" multiple />
-          <div class="subject-composer-dropzone__label mono-small">
-            Dépose des images, PDF ou autres fichiers ici
-          </div>
           ${pendingAttachmentsHtml}
         </div>
         <button class="subject-composer-attachments-pick-btn" type="button" data-action="composer-attachments-pick">

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2619,22 +2619,17 @@ body.is-resizing{
 .subject-mention-popup__name{font-size:13px;}
 .subject-mention-popup__meta{font-size:12px;color:var(--muted);}
 .subject-mention-popup__empty{padding:10px 12px;font-size:12px;color:var(--muted);}
-.subject-composer-dropzone{
-  margin:0 0 10px;
-  border:1px dashed var(--border2);
-  border-radius:8px;
-  padding:10px;
-  background:rgba(110,118,129,.06);
-}
-.subject-composer-dropzone.is-dragover{
+.comment-composer__editor.is-dragover{
+  border-style:dashed;
   border-color:rgba(56,139,253,.95);
   background:rgba(56,139,253,.12);
 }
-.subject-composer-dropzone__label{
-  display:flex;
-  align-items:center;
-  gap:8px;
-  color:var(--muted);
+.comment-composer__editor{
+  border:1px solid transparent;
+  border-radius:8px;
+}
+.subject-composer-attachments-preview{
+  margin:0 0 10px;
 }
 .subject-composer-attachments-pick-btn{
   margin-top:0;


### PR DESCRIPTION
### Motivation
- Modernize the composer UX by moving drag-and-drop interaction from the attachment preview panel into the main editor area so drag feedback is visible where the user is writing.
- Keep the write/click-to-type behavior unchanged while separating preview/rendering responsibilities for attachments.

### Description
- Replaced the old `subject-composer-dropzone` with a preview-only container `subject-composer-attachments-preview` that is hidden by default and only shown when `pendingAttachments` exist in the composer template (`apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Made the main editor (`.comment-composer__editor`) the new drag-and-drop target and added event handlers to show an `.is-dragover` visual state and to handle `drop` events, delegating file processing to the existing `addComposerFiles` flow (`apps/web/js/views/project-subjects/project-subjects-events.js`).
- Moved the file input into the composer footer markup and ensured the attachment picker button still triggers the input click (`apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Updated CSS to apply dashed border/background drag-over visuals to `.comment-composer__editor.is-dragover` and added a simple style for the new `.subject-composer-attachments-preview` container (`apps/web/style.css`).

### Testing
- Ran `git diff --check` to validate diffs and found no issues (success).
- Verified repository status with `git status --short` to confirm the three modified files are present (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e372ad24248329996d8bcfc10530d2)