### PR TITLE
Add attachments UI and drag-and-drop support for subject comment composer

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -988,7 +988,7 @@ export function createProjectSubjectsEvents(config) {
       });
 
       const attachmentInput = root.querySelector("[data-role='subject-composer-file-input']");
-      const attachmentDropzone = root.querySelector("[data-role='subject-composer-dropzone']");
+      const attachmentDropzone = root.querySelector(".comment-composer__editor");
       root.querySelectorAll("[data-action='composer-attachments-pick']").forEach((btn) => {
         btn.onclick = () => attachmentInput?.click();
       });
@@ -1000,7 +1000,7 @@ export function createProjectSubjectsEvents(config) {
         });
       }
 
-      if (attachmentDropzone) {
+      if (attachmentDropzone && attachmentInput) {
         ["dragenter", "dragover"].forEach((eventName) => {
           attachmentDropzone.addEventListener(eventName, (event) => {
             event.preventDefault();

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1150,11 +1150,14 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const previewMode = !!store.situationsView.commentPreviewMode;
     const helpMode = !!store.situationsView.helpMode;
 
-    const hintHtml = `
-      <div class="rapso-mention-hint comment-composer__hint">
-        <span>Astuce : mentionne <span class="mono">@rapso</span> dans ton commentaire.</span>
-      </div>
-    `;
+    const hintHtml = type === "sujet"
+      ? `
+        <button class="subject-composer-attachments-pick-btn" type="button" data-action="composer-attachments-pick">
+          <span class="subject-composer-attachments-pick-btn__icon" aria-hidden="true">${svgIcon("image")}</span>
+          <span>Ajouter un fichier</span>
+        </button>
+      `
+      : "";
 
     const issueStatusActionHtml = renderIssueStatusAction(selection);
     const replyContext = type === "sujet" ? getReplyContextForSubject(item?.id) : null;
@@ -1242,22 +1245,14 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     const composerAttachmentsHtml = type === "sujet"
       ? `
+        <input id="subjectComposerAttachmentInput" type="file" class="subject-composer-file-input" data-role="subject-composer-file-input" multiple />
         <div
-          class="subject-composer-dropzone"
-          data-role="subject-composer-dropzone"
-          tabindex="0"
-          aria-label="Déposer des pièces jointes"
+          class="subject-composer-attachments-preview ${pendingAttachments.length ? "" : "hidden"}"
+          data-role="subject-composer-attachments-preview"
+          aria-live="polite"
         >
-          <input id="subjectComposerAttachmentInput" type="file" class="subject-composer-file-input" data-role="subject-composer-file-input" multiple />
-          <div class="subject-composer-dropzone__label mono-small">
-            Dépose des images, PDF ou autres fichiers ici
-          </div>
           ${pendingAttachmentsHtml}
         </div>
-        <button class="subject-composer-attachments-pick-btn" type="button" data-action="composer-attachments-pick">
-          <span class="subject-composer-attachments-pick-btn__icon" aria-hidden="true">${svgIcon("image")}</span>
-          <span>Ajouter un fichier</span>
-        </button>
       `
       : "";
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2619,22 +2619,21 @@ body.is-resizing{
 .subject-mention-popup__name{font-size:13px;}
 .subject-mention-popup__meta{font-size:12px;color:var(--muted);}
 .subject-mention-popup__empty{padding:10px 12px;font-size:12px;color:var(--muted);}
-.subject-composer-dropzone{
-  margin:0 0 10px;
-  border:1px dashed var(--border2);
-  border-radius:8px;
-  padding:10px;
-  background:rgba(110,118,129,.06);
-}
-.subject-composer-dropzone.is-dragover{
+.comment-composer__editor.is-dragover{
+  margin:4px;
+  border-width:2px;
+  border-style:dashed;
   border-color:rgba(56,139,253,.95);
-  background:rgba(56,139,253,.12);
+  background:transparent;
 }
-.subject-composer-dropzone__label{
-  display:flex;
-  align-items:center;
-  gap:8px;
-  color:var(--muted);
+.comment-composer__editor{
+  border:1px solid transparent;
+  border-radius:8px;
+}
+.subject-composer-attachments-preview{
+  margin:4px;
+  border:1px solid var(--border2);
+  border-radius:var(--radius);
 }
 .subject-composer-attachments-pick-btn{
   margin-top:0;


### PR DESCRIPTION
### Motivation

- Provide subject-specific attachment controls and previews when adding comments to a `sujet`, and reuse the comment editor area for drag-and-drop behavior. 
- Improve UX by moving the file picker into the composer header and showing a dedicated attachments preview area only for subjects.

### Description

- Render the attachments pick button only for `type === "sujet"` and move the file input into the subject composer markup (`id="subjectComposerAttachmentInput"` and `data-role="subject-composer-file-input"`).
- Replace the old `.subject-composer-dropzone` with a preview container `data-role="subject-composer-attachments-preview"` and reuse the `.comment-composer__editor` element as the drag target selector in event wiring.
- Guard dropzone event registration so drag/drop handlers are only added when the file input exists (`if (attachmentDropzone && attachmentInput)`) and wire file selection to `addComposerFiles` on both `change` and `drop` events.
- Add and adjust CSS rules to support the new `.comment-composer__editor` dragover state and `.subject-composer-attachments-preview` styling, and hide the file input via `.subject-composer-file-input{display:none;}`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e372ad24248329996d8bcfc10530d2)