### PR TITLE
Fix inline subject replies and add inline attachment handling

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1664,14 +1664,163 @@ export function createProjectSubjectsEvents(config) {
         store.situationsView.inlineReplyUi = {
           expandedMessageId: "",
           draftsByMessageId: {},
-          previewByMessageId: {}
+          previewByMessageId: {},
+          attachmentsByMessageId: {},
+          uploadSessionByMessageId: {}
         };
       }
       if (!store.situationsView.inlineReplyUi.previewByMessageId || typeof store.situationsView.inlineReplyUi.previewByMessageId !== "object") {
         store.situationsView.inlineReplyUi.previewByMessageId = {};
       }
+      if (!store.situationsView.inlineReplyUi.attachmentsByMessageId || typeof store.situationsView.inlineReplyUi.attachmentsByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.attachmentsByMessageId = {};
+      }
+      if (!store.situationsView.inlineReplyUi.uploadSessionByMessageId || typeof store.situationsView.inlineReplyUi.uploadSessionByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.uploadSessionByMessageId = {};
+      }
       debugThreadReply("reply_state_fallback", { hasAccessor: typeof getInlineReplyUiState === "function" });
       return store.situationsView.inlineReplyUi;
+    };
+    const createUploadSessionId = () => {
+      try {
+        if (window?.crypto?.randomUUID) return String(window.crypto.randomUUID());
+      } catch {}
+      return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    };
+    const isImageFile = (file) => String(file?.type || "").toLowerCase().startsWith("image/");
+    const toObjectUrl = (file) => {
+      try {
+        return isImageFile(file) && window?.URL?.createObjectURL ? window.URL.createObjectURL(file) : "";
+      } catch {
+        return "";
+      }
+    };
+    const revokeObjectUrl = (value) => {
+      try {
+        if (value && window?.URL?.revokeObjectURL) window.URL.revokeObjectURL(value);
+      } catch {}
+    };
+    const releaseAttachmentPreviewUrls = (attachment = {}) => {
+      revokeObjectUrl(String(attachment?.localPreviewUrl || ""));
+    };
+    const getInlineReplyAttachmentsState = (messageId = "", { createIfMissing = false } = {}) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      const replyUi = resolveInlineReplyUiState();
+      if (!normalizedMessageId) return { replyUi, items: [], uploadSessionId: "" };
+      if (!Array.isArray(replyUi.attachmentsByMessageId[normalizedMessageId])) {
+        if (createIfMissing) replyUi.attachmentsByMessageId[normalizedMessageId] = [];
+      }
+      if (createIfMissing && !String(replyUi.uploadSessionByMessageId[normalizedMessageId] || "")) {
+        replyUi.uploadSessionByMessageId[normalizedMessageId] = createUploadSessionId();
+      }
+      return {
+        replyUi,
+        items: Array.isArray(replyUi.attachmentsByMessageId[normalizedMessageId]) ? replyUi.attachmentsByMessageId[normalizedMessageId] : [],
+        uploadSessionId: String(replyUi.uploadSessionByMessageId[normalizedMessageId] || "")
+      };
+    };
+    const clearInlineReplyAttachmentsState = (messageId = "", { keepUploadSession = false } = {}) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const replyUi = resolveInlineReplyUiState();
+      const items = Array.isArray(replyUi.attachmentsByMessageId?.[normalizedMessageId])
+        ? replyUi.attachmentsByMessageId[normalizedMessageId]
+        : [];
+      items.forEach((attachment) => releaseAttachmentPreviewUrls(attachment));
+      delete replyUi.attachmentsByMessageId[normalizedMessageId];
+      if (!keepUploadSession) delete replyUi.uploadSessionByMessageId[normalizedMessageId];
+    };
+    const addInlineReplyFiles = async (messageId = "", files = []) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      const list = Array.from(files || []).filter((entry) => !!entry);
+      if (!normalizedMessageId || !list.length) return;
+      const selection = getScopedSelection(root);
+      if (selection?.type !== "sujet") return;
+      const subjectId = String(selection?.item?.id || "").trim();
+      const projectId = String(selection?.item?.project_id || "").trim();
+      if (!subjectId || !projectId || typeof uploadAttachmentFile !== "function") {
+        showError("Projet introuvable pour l’upload des pièces jointes.");
+        return;
+      }
+      const { items, uploadSessionId } = getInlineReplyAttachmentsState(normalizedMessageId, { createIfMissing: true });
+      const effectiveSessionId = uploadSessionId || createUploadSessionId();
+      if (!uploadSessionId) {
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.uploadSessionByMessageId[normalizedMessageId] = effectiveSessionId;
+      }
+      for (const file of list) {
+        const tempId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const localPreview = toObjectUrl(file);
+        const pending = {
+          id: "",
+          tempId,
+          file_name: String(file?.name || "fichier"),
+          mime_type: String(file?.type || ""),
+          size_bytes: Number(file?.size || 0),
+          localPreviewUrl: localPreview,
+          remoteObjectUrl: "",
+          previewUrl: localPreview,
+          isImage: isImageFile(file),
+          uploadStatus: "uploading",
+          previewStatus: localPreview ? "local" : "none",
+          error: ""
+        };
+        items.push(pending);
+        rerenderScope(root);
+        try {
+          const uploaded = await uploadAttachmentFile({
+            subjectId,
+            projectId,
+            uploadSessionId: effectiveSessionId,
+            file,
+            sortOrder: items.length - 1,
+            parentMessageId: normalizedMessageId
+          });
+          pending.id = String(uploaded?.id || "");
+          pending.storage_path = String(uploaded?.storage_path || "");
+          pending.remoteObjectUrl = String(uploaded?.object_url || "");
+          pending.object_url = pending.remoteObjectUrl;
+          pending.uploadStatus = "ready";
+          pending.error = "";
+          if (pending.isImage) {
+            if (pending.remoteObjectUrl) {
+              pending.previewStatus = pending.localPreviewUrl ? "local" : "remote";
+              if (!pending.previewUrl) pending.previewUrl = pending.remoteObjectUrl;
+            } else if (pending.localPreviewUrl) {
+              pending.previewStatus = "local";
+            } else {
+              pending.previewStatus = "none";
+            }
+          } else {
+            pending.previewStatus = "none";
+          }
+        } catch (error) {
+          pending.uploadStatus = "error";
+          pending.previewStatus = pending.localPreviewUrl ? "local" : "none";
+          pending.error = String(error?.message || error || "Erreur d'upload");
+        }
+        rerenderScope(root);
+      }
+    };
+    const removeInlineReplyAttachmentById = async (messageId = "", tempId = "", attachmentId = "") => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const { items } = getInlineReplyAttachmentsState(normalizedMessageId);
+      const normalizedAttachmentId = String(attachmentId || "").trim();
+      const targetIndex = items.findIndex((entry) => String(entry?.tempId || "") === String(tempId || "") || String(entry?.id || "") === normalizedAttachmentId);
+      if (targetIndex < 0) return;
+      const current = items[targetIndex];
+      items.splice(targetIndex, 1);
+      rerenderScope(root);
+      releaseAttachmentPreviewUrls(current);
+      if (!items.length) clearInlineReplyAttachmentsState(normalizedMessageId, { keepUploadSession: true });
+      if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
+        try {
+          await removeTemporaryAttachment({ attachmentId: normalizedAttachmentId });
+        } catch (error) {
+          console.warn("[subject-attachments] remove temporary attachment failed", error);
+        }
+      }
     };
 
     root.querySelectorAll("[data-action='thread-reply-menu-toggle'][data-message-id]").forEach((btn) => {
@@ -1703,7 +1852,7 @@ export function createProjectSubjectsEvents(config) {
         debugThreadReply("menu_action_reply", { messageId, parentMessageLength: parentMessageText.length });
         btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
         const replyUi = resolveInlineReplyUiState();
-        replyUi.draftsByMessageId[messageId] = "";
+        if (!String(replyUi.draftsByMessageId?.[messageId] || "").trim()) replyUi.draftsByMessageId[messageId] = "";
         replyUi.previewByMessageId[messageId] = false;
         replyUi.expandedMessageId = messageId;
         debugThreadReply("reply_opened", {
@@ -1805,6 +1954,55 @@ export function createProjectSubjectsEvents(config) {
         rerenderScope(root);
       };
     });
+    root.querySelectorAll("[data-action='thread-reply-attachments-pick'][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!messageId) return;
+        const input = root.querySelector(`[data-role='thread-reply-file-input'][data-message-id="${selectorValue(messageId)}"]`);
+        input?.click();
+      };
+    });
+    root.querySelectorAll("[data-role='thread-reply-file-input'][data-message-id]").forEach((input) => {
+      input.addEventListener("change", async (event) => {
+        const messageId = String(input.dataset.messageId || "").trim();
+        const files = Array.from(event?.target?.files || []);
+        if (messageId && files.length) await addInlineReplyFiles(messageId, files);
+        input.value = "";
+      });
+    });
+    root.querySelectorAll("[data-inline-reply-editor]").forEach((editor) => {
+      const messageId = String(editor.dataset.inlineReplyEditor || "").trim();
+      if (!messageId) return;
+      const dropzone = editor.querySelector(".comment-composer__editor");
+      if (!dropzone) return;
+      ["dragenter", "dragover"].forEach((eventName) => {
+        dropzone.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dropzone.classList.add("is-dragover");
+        });
+      });
+      ["dragleave", "dragend", "drop"].forEach((eventName) => {
+        dropzone.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dropzone.classList.remove("is-dragover");
+        });
+      });
+      dropzone.addEventListener("drop", async (event) => {
+        const files = Array.from(event?.dataTransfer?.files || []);
+        if (files.length) await addInlineReplyFiles(messageId, files);
+      });
+    });
+    root.querySelectorAll("[data-action='thread-reply-attachment-remove'][data-message-id]").forEach((btn) => {
+      btn.onclick = async () => {
+        await removeInlineReplyAttachmentById(
+          String(btn.dataset.messageId || ""),
+          String(btn.dataset.tempId || ""),
+          String(btn.dataset.attachmentId || "")
+        );
+      };
+    });
 
     root.querySelectorAll("[data-action='thread-reply-cancel'][data-message-id]").forEach((btn) => {
       btn.onclick = () => {
@@ -1813,6 +2011,7 @@ export function createProjectSubjectsEvents(config) {
         const replyUi = resolveInlineReplyUiState();
         if (messageId) replyUi.draftsByMessageId[messageId] = "";
         if (messageId) replyUi.previewByMessageId[messageId] = false;
+        if (messageId) clearInlineReplyAttachmentsState(messageId);
         replyUi.expandedMessageId = "";
         rerenderScope(root);
       };
@@ -1826,17 +2025,23 @@ export function createProjectSubjectsEvents(config) {
         if (!parentMessageId) return;
         const replyUi = resolveInlineReplyUiState();
         const message = String(replyUi.draftsByMessageId?.[parentMessageId] || "").trim();
-        if (!message) return;
+        const inlineAttachmentsState = getInlineReplyAttachmentsState(parentMessageId);
+        const hasReadyAttachment = Array.isArray(inlineAttachmentsState?.items)
+          && inlineAttachmentsState.items.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+        if (!message && !hasReadyAttachment) return;
         const mentions = extractStructuredMentions(message);
+        const uploadSessionId = hasReadyAttachment ? String(inlineAttachmentsState.uploadSessionId || "").trim() : "";
         debugThreadReply("reply_submit", { parentMessageId, messageLength: message.length });
         await addComment("sujet", selection.item.id, message, {
           actor: "Human",
           agent: "human",
           parentMessageId,
+          uploadSessionId,
           mentions
         });
         replyUi.draftsByMessageId[parentMessageId] = "";
         replyUi.previewByMessageId[parentMessageId] = false;
+        clearInlineReplyAttachmentsState(parentMessageId);
         replyUi.expandedMessageId = "";
         rerenderScope(root);
       };

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -200,7 +200,9 @@ export function createProjectSubjectsThread(config = {}) {
       state.inlineReplyUi = {
         expandedMessageId: "",
         draftsByMessageId: {},
-        previewByMessageId: {}
+        previewByMessageId: {},
+        attachmentsByMessageId: {},
+        uploadSessionByMessageId: {}
       };
     }
     if (typeof state.inlineReplyUi.expandedMessageId !== "string") state.inlineReplyUi.expandedMessageId = "";
@@ -209,6 +211,12 @@ export function createProjectSubjectsThread(config = {}) {
     }
     if (!state.inlineReplyUi.previewByMessageId || typeof state.inlineReplyUi.previewByMessageId !== "object") {
       state.inlineReplyUi.previewByMessageId = {};
+    }
+    if (!state.inlineReplyUi.attachmentsByMessageId || typeof state.inlineReplyUi.attachmentsByMessageId !== "object") {
+      state.inlineReplyUi.attachmentsByMessageId = {};
+    }
+    if (!state.inlineReplyUi.uploadSessionByMessageId || typeof state.inlineReplyUi.uploadSessionByMessageId !== "object") {
+      state.inlineReplyUi.uploadSessionByMessageId = {};
     }
     return state.inlineReplyUi;
   }
@@ -689,11 +697,15 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return toolbarButtons.map((button) => renderToolbarButton(button)).join("");
     }
 
+    const attachmentAction = buttonAction === "thread-reply-format"
+      ? "thread-reply-attachments-pick"
+      : "composer-attachments-pick";
     const attachmentButton = `
       <button
         class="comment-toolbar-btn"
         type="button"
-        data-action="composer-attachments-pick"
+        data-action="${escapeHtml(attachmentAction)}"
+        ${extraAttributes}
         title="Pièce jointe"
         aria-label="Pièce jointe"
       >
@@ -719,11 +731,43 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode }) {
+  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [] }) {
     if (!commentId) return "";
     if (!isExpanded) return "";
+    const pendingAttachments = Array.isArray(attachments) ? attachments : [];
     const normalizedDraft = String(draft || "");
-    const canSubmit = !!normalizedDraft.trim();
+    const hasReadyAttachment = pendingAttachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+    const canSubmit = !!normalizedDraft.trim() || hasReadyAttachment;
+    const pendingAttachmentsHtml = pendingAttachments.length
+      ? `
+        <div class="subject-composer-attachments">
+          ${pendingAttachments.map((attachment, index) => `
+            <div class="subject-composer-attachment-item">
+              ${renderAttachmentTile(attachment, {
+                forceImage: !!attachment.isImage,
+                uploadState: attachment.error
+                  ? "Erreur d’upload"
+                  : String(attachment.uploadStatus || "").trim() === "uploading"
+                    ? "Envoi..."
+                    : "Prêt"
+              })}
+              <button
+                class="subject-composer-attachment-remove"
+                type="button"
+                data-action="thread-reply-attachment-remove"
+                data-message-id="${escapeHtml(commentId)}"
+                data-attachment-id="${escapeHtml(normalizeId(attachment.id))}"
+                data-temp-id="${escapeHtml(String(attachment.tempId || index))}"
+                aria-label="Retirer la pièce jointe"
+              >
+                ${svgIcon("x")}
+              </button>
+            </div>
+          `).join("")}
+        </div>
+      `
+      : "";
+
     return `
       <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
         ${renderCommentComposer({
@@ -733,6 +777,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
           textareaId: `threadReplyBox-${commentId}`,
           previewId: `threadReplyPreview-${commentId}`,
           textareaValue: normalizedDraft,
+          textareaAttributes: {
+            "data-thread-reply-draft": commentId
+          },
           placeholder: "Écrire une réponse",
           tabWriteAction: "thread-reply-tab-write",
           tabPreviewAction: "thread-reply-tab-preview",
@@ -742,7 +789,25 @@ priority=${firstNonEmpty(subject.priority, "")}`
             <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
             <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}" ${canSubmit ? "" : "disabled"}>Répondre</button>
           `,
-          previewEmptyHint: "Use Markdown to format your reply"
+          previewEmptyHint: "Use Markdown to format your reply",
+          footerHtml: `
+            <input
+              id="threadReplyAttachmentInput-${escapeHtml(commentId)}"
+              type="file"
+              class="subject-composer-file-input"
+              data-role="thread-reply-file-input"
+              data-message-id="${escapeHtml(commentId)}"
+              multiple
+            />
+            <div
+              class="subject-composer-attachments-preview ${pendingAttachments.length ? "" : "hidden"}"
+              data-role="thread-reply-attachments-preview"
+              data-message-id="${escapeHtml(commentId)}"
+              aria-live="polite"
+            >
+              ${pendingAttachmentsHtml}
+            </div>
+          `
         })}
       </div>
     `;
@@ -875,6 +940,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
         const isExpanded = replyUi.expandedMessageId === commentId;
         const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
         const previewMode = !!replyUi.previewByMessageId?.[commentId];
+        const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
+          ? replyUi.attachmentsByMessageId[commentId]
+          : [];
         const isEditable = !e?.meta?.is_frozen && !e?.meta?.is_deleted;
         const repliesHtml = childReplies.length
           ? `
@@ -932,7 +1000,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
                 commentId,
                 isExpanded,
                 draft,
-                previewMode
+                previewMode,
+                attachments
               })}
             </div>
           `,

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -16,11 +16,22 @@ export function renderCommentComposer({
   footerHtml = "",
   actionsHtml = "",
   toolbarHtml = "",
+  textareaAttributes = {},
   tabWriteAction = "tab-write",
   tabPreviewAction = "tab-preview",
   previewHtml = "",
   previewEmptyHint = "Use Markdown to format your comment"
 } = {}) {
+  const textareaAttributesHtml = Object.entries(
+    textareaAttributes && typeof textareaAttributes === "object" ? textareaAttributes : {}
+  )
+    .map(([key, value]) => {
+      const attrName = String(key || "").trim();
+      if (!attrName || /[\s"'<>/=]/.test(attrName)) return "";
+      return `${escapeHtml(attrName)}="${escapeHtml(String(value ?? ""))}"`;
+    })
+    .filter(Boolean)
+    .join(" ");
   return `
     <div class="human-action comment-composer">
       ${hideAvatar ? "" : `<div class="gh-avatar gh-avatar--human comment-composer__avatar" aria-hidden="true">${avatarHtml}</div>`}
@@ -43,6 +54,7 @@ export function renderCommentComposer({
               id="${escapeHtml(textareaId)}"
               class="textarea comment-composer__textarea"
               placeholder="${escapeHtml(placeholder)}"
+              ${textareaAttributesHtml}
             >${escapeHtml(textareaValue)}</textarea>
           </div>
 


### PR DESCRIPTION
### Motivation
- Les réponses inline ne se publiaient plus car le textarea rendu n’avait pas l’attribut attendu `data-thread-reply-draft`, ce qui empêchait la synchronisation du draft et rendait le submit inopérant.
- Le bouton « pièce jointe » inline ouvrait le picker du composer principal, causant une collision de contexte et empêchant l’attachement propre aux réponses imbriquées.
- L’objectif est de corriger la chaîne rendu/binding minimalement et d’ajouter un flux d’attachments dédié aux replies inline sans toucher au composer principal.

### Description
- `renderCommentComposer()` accepte désormais `textareaAttributes` pour injecter des attributs personnalisés sur le `<textarea>` (implémenté dans `apps/web/js/views/ui/comment-composer.js`).
- Le composer inline injecte `data-thread-reply-draft="<messageId>"` dans le textarea et active la toolbar paperclip dédiée `thread-reply-attachments-pick` (modifications dans `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Ajout d’un état par parent-message (`attachmentsByMessageId`, `uploadSessionByMessageId`) et des helpers d’upload/preview/remove/cleanup pour les replies inline, avec drag & drop et file input dédiés (implémenté dans `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Le submit inline envoie `uploadSessionId` quand au moins une pièce jointe est prête, et le code nettoie draft/preview/attachments au cancel ou après submit; seuls les fichiers listés ci‑dessous ont été modifiés : `apps/web/js/views/ui/comment-composer.js`, `apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`.

### Testing
- Vérification syntaxique JS exécutée avec `node --check apps/web/js/views/ui/comment-composer.js` et elle a réussi.
- Vérification syntaxique JS exécutée avec `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` et elle a réussi.
- Vérification syntaxique JS exécutée avec `node --check apps/web/js/views/project-subjects/project-subjects-events.js` et elle a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b527b5588329af3f35033ad9daa1)