### PR TITLE
Sync inline-reply submit button enabled state with draft and attachments

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1719,6 +1719,25 @@ export function createProjectSubjectsEvents(config) {
         uploadSessionId: String(replyUi.uploadSessionByMessageId[normalizedMessageId] || "")
       };
     };
+    const canSubmitInlineReply = (messageId = "") => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return false;
+      const replyUi = resolveInlineReplyUiState();
+      const message = String(replyUi.draftsByMessageId?.[normalizedMessageId] || "").trim();
+      if (message) return true;
+      const inlineAttachmentsState = getInlineReplyAttachmentsState(normalizedMessageId);
+      return Array.isArray(inlineAttachmentsState?.items)
+        && inlineAttachmentsState.items.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+    };
+    const syncInlineReplySubmitButton = (messageId = "") => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const submitButton = root.querySelector(
+        `[data-action='thread-reply-submit'][data-message-id="${selectorValue(normalizedMessageId)}"]`
+      );
+      if (!submitButton) return;
+      submitButton.disabled = !canSubmitInlineReply(normalizedMessageId);
+    };
     const clearInlineReplyAttachmentsState = (messageId = "", { keepUploadSession = false } = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -1911,12 +1930,15 @@ export function createProjectSubjectsEvents(config) {
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
+        syncInlineReplySubmitButton(messageId);
       });
       textarea.addEventListener("keydown", (event) => {
         if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
         event.preventDefault();
         const submitButton = textarea.closest(".thread-inline-reply-editor")?.querySelector("[data-action='thread-reply-submit'][data-message-id]");
-        submitButton?.click();
+        const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
+        if (messageId) syncInlineReplySubmitButton(messageId);
+        if (submitButton && !submitButton.disabled) submitButton.click();
       });
     });
 


### PR DESCRIPTION
### Motivation
- Ensure the inline reply submit button is enabled only when there is text to send or at least one attachment is ready, and prevent submitting when nothing is ready.

### Description
- Add `canSubmitInlineReply(messageId)` to determine if a reply can be submitted based on draft content or ready, non-error attachments.
- Add `syncInlineReplySubmitButton(messageId)` to locate the submit button and set its `disabled` state according to `canSubmitInlineReply`.
- Call `syncInlineReplySubmitButton` from the reply textarea `input` handler and on Ctrl/Cmd+Enter `keydown`, and only perform the `.click()` if the button is not disabled.
- Preserve existing attachment preview revocation and inline-attachment state management helpers.

### Testing
- Ran existing frontend unit tests and linters; all tests passed.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c6c47bd48329979b02959c1c76ee)