### PR TITLE
Refactor thread comment rendering; add actions menu, nested reply rendering, and inline reply UI

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -817,12 +817,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderNestedReplyComment(entry, idx) {
+  function resolveThreadCommentIdentity(entry) {
     const currentUserId = normalizeId(store?.user?.id);
     const authorUserId = normalizeId(entry?.meta?.author_user_id);
     const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
     const agent = isCurrentUserAuthor ? "human" : "member";
-    const identity = getAuthorIdentity({
+    const isRapso = agent === "specialist_ps";
+    if (isRapso) {
+      return { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" };
+    }
+    return getAuthorIdentity({
       author: entry?.actor,
       agent,
       avatarUrl: entry?.meta?.author_avatar_url || "",
@@ -830,12 +834,71 @@ priority=${firstNonEmpty(subject.priority, "")}`
       humanAvatarHtml: SVG_AVATAR_HUMAN,
       fallbackName: "System"
     });
+  }
+
+  function renderThreadCommentActions(entry) {
+    const commentId = normalizeId(entry?.meta?.id);
+    if (!commentId) return "";
+    const isEditable = !entry?.meta?.is_frozen && !entry?.meta?.is_deleted;
+    return `
+      <div class="thread-comment-menu">
+        <button
+          class="thread-comment-menu__trigger"
+          type="button"
+          aria-label="Actions du message"
+          data-action="thread-reply-menu-toggle"
+          data-message-id="${escapeHtml(commentId)}"
+        >
+          ${svgIcon("kebab-horizontal")}
+        </button>
+        <div class="thread-comment-menu__dropdown">
+          ${isEditable
+            ? `
+              <button class="gh-menu__item" type="button" data-action="thread-message-edit" data-message-id="${escapeHtml(commentId)}" data-message-body="${escapeHtml(String(entry?.message || ""))}">Modifier le message</button>
+              <button class="gh-menu__item" type="button" data-action="thread-message-delete" data-message-id="${escapeHtml(commentId)}">Supprimer le message</button>
+              <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
+            `
+            : ""}
+          <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderThreadCommentNode(entry, { idx = 0, depth = 0, childrenByParentId = new Map(), replyUi = {} } = {}) {
+    const commentId = normalizeId(entry?.meta?.id);
+    if (!commentId) return "";
+    const identity = resolveThreadCommentIdentity(entry);
     const tsHtml = entry?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(entry.ts))}</div>` : "";
+    const childReplies = childrenByParentId.get(commentId) || [];
+    const nestedDepth = Math.min(MAX_REPLY_VISUAL_DEPTH, Math.max(1, Number(depth || 0)));
+    const classes = depth > 0
+      ? `message-thread__comment--nested message-thread__comment--reply-item message-thread__comment--depth-${nestedDepth}`
+      : "";
+    const isExpanded = replyUi.expandedMessageId === commentId;
+    const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
+    const previewMode = !!replyUi.previewByMessageId?.[commentId];
+    const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
+      ? replyUi.attachmentsByMessageId[commentId]
+      : [];
+    const repliesHtml = childReplies.length
+      ? `
+        <div class="thread-comment-replies thread-comment-replies--github">
+          ${childReplies.map((reply, replyIdx) => renderThreadCommentNode(reply, {
+            idx: idx + replyIdx + 1,
+            depth: depth + 1,
+            childrenByParentId,
+            replyUi
+          })).join("")}
+        </div>
+      `
+      : "";
 
     return renderMessageThreadComment({
       idx,
       author: identity.displayName,
       tsHtml,
+      headerRightHtml: renderThreadCommentActions(entry),
       bodyHtml: `
         <div class="thread-comment-content-capsule">
           <div class="mono-small color-fg-muted">${escapeHtml(String(entry?.stateLabel || "modifiable"))}</div>
@@ -844,11 +907,28 @@ priority=${firstNonEmpty(subject.priority, "")}`
         ${(Array.isArray(entry?.meta?.attachments) && entry.meta.attachments.length)
           ? `<div class="subject-attachment-grid">${entry.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
           : ""}
+        ${childReplies.length
+          ? `
+            <div class="thread-comment-footer">
+              <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
+            </div>
+          `
+          : ""}
+        ${repliesHtml}
+        <div class="thread-comment-reply-box">
+          ${renderInlineReplyComposer({
+            commentId,
+            isExpanded,
+            draft,
+            previewMode,
+            attachments
+          })}
+        </div>
       `,
       avatarType: identity.avatarType,
       avatarHtml: identity.avatarHtml,
       avatarInitial: identity.avatarInitial,
-      className: "message-thread__comment--nested message-thread__comment--reply-item"
+      className: classes
     });
   }
 
@@ -915,107 +995,22 @@ priority=${firstNonEmpty(subject.priority, "")}`
     if (!thread.length) return "";
     const replyUi = getInlineReplyUiState();
     const { childrenByParentId } = groupThreadReplies(thread);
+    let commentRenderIdx = 0;
 
     const itemsHtml = thread.map((e, idx) => {
       const type = String(e?.type || "").toUpperCase();
 
       if (type === "COMMENT") {
-        const commentId = normalizeId(e?.meta?.id);
         const parentId = normalizeId(e?.meta?.parent_message_id);
         if (parentId) return "";
-
-        const currentUserId = normalizeId(store?.user?.id);
-        const authorUserId = normalizeId(e?.meta?.author_user_id);
-        const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
-        const agent = isCurrentUserAuthor ? "human" : "member";
-        const isRapso = agent === "specialist_ps";
-        const identity = isRapso
-          ? { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" }
-          : getAuthorIdentity({
-              author: e?.actor,
-              agent,
-              avatarUrl: e?.meta?.author_avatar_url || "",
-              currentUserAvatar: isCurrentUserAuthor ? store?.user?.avatar : "",
-              humanAvatarHtml: SVG_AVATAR_HUMAN,
-              fallbackName: "System"
-            });
-        const tsHtml = e?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(e.ts))}</div>` : "";
-        const childReplies = childrenByParentId.get(commentId) || [];
-        const isExpanded = replyUi.expandedMessageId === commentId;
-        const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
-        const previewMode = !!replyUi.previewByMessageId?.[commentId];
-        const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
-          ? replyUi.attachmentsByMessageId[commentId]
-          : [];
-        const isEditable = !e?.meta?.is_frozen && !e?.meta?.is_deleted;
-        const repliesHtml = childReplies.length
-          ? `
-            <div class="thread-comment-replies thread-comment-replies--github">
-              ${childReplies.map((reply, replyIdx) => renderNestedReplyComment(reply, idx + replyIdx + 1)).join("")}
-            </div>
-          `
-          : "";
-
-        return renderMessageThreadComment({
-          idx,
-          author: identity.displayName,
-          tsHtml,
-          headerRightHtml: `
-            <div class="thread-comment-menu">
-              <button
-                class="thread-comment-menu__trigger"
-                type="button"
-                aria-label="Actions du message"
-                data-action="thread-reply-menu-toggle"
-                data-message-id="${escapeHtml(commentId)}"
-              >
-                ${svgIcon("kebab-horizontal")}
-              </button>
-              <div class="thread-comment-menu__dropdown">
-                ${isEditable
-                  ? `
-                    <button class="gh-menu__item" type="button" data-action="thread-message-edit" data-message-id="${escapeHtml(commentId)}" data-message-body="${escapeHtml(String(e?.message || ""))}">Modifier le message</button>
-                    <button class="gh-menu__item" type="button" data-action="thread-message-delete" data-message-id="${escapeHtml(commentId)}">Supprimer le message</button>
-                    <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
-                  `
-                  : ""}
-                <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
-              </div>
-            </div>
-          `,
-          bodyHtml: `
-            <div class="thread-comment-content-capsule">
-              <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
-              ${mdToHtml(e?.message || "")}
-            </div>
-            ${(Array.isArray(e?.meta?.attachments) && e.meta.attachments.length)
-              ? `<div class="subject-attachment-grid">${e.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
-              : ""}
-            ${childReplies.length
-              ? `
-                <div class="thread-comment-footer">
-                  <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
-                </div>
-              `
-              : ""}
-            ${repliesHtml}
-            <div class="thread-comment-reply-box">
-              ${renderInlineReplyComposer({
-                commentId,
-                isExpanded,
-                draft,
-                previewMode,
-                attachments
-              })}
-            </div>
-          `,
-          avatarType: identity.avatarType,
-          avatarHtml: identity.avatarHtml,
-          avatarInitial: identity.avatarInitial,
-          className: Number(e?.meta?.depth || 0) > 0
-            ? `message-thread__comment--nested message-thread__comment--depth-${Math.min(MAX_REPLY_VISUAL_DEPTH, Number(e?.meta?.depth || 0))}`
-            : ""
+        const rendered = renderThreadCommentNode(e, {
+          idx: commentRenderIdx,
+          depth: 0,
+          childrenByParentId,
+          replyUi
         });
+        commentRenderIdx += 1;
+        return rendered;
       }
 
       if (type === "ACTIVITY") {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2527,6 +2527,8 @@ body.is-resizing{
 .message-thread{display:block;}
 .message-thread__item{width:calc(100% + 52px);}
 .message-thread__comment{padding-left:var(--discussion-content-inset);}
+.message-thread .thread-item--comment{overflow:visible;}
+.message-thread .gh-comment-box{overflow:visible;}
 .comment-composer{display:flex;gap:12px;align-items:flex-start;margin-top:10px;}
 .comment-composer__main{flex:1 1 auto;min-width:0;}
 .comment-composer__box{width:100%;}


### PR DESCRIPTION
### Motivation

- Simplify and modularize the message thread rendering logic to make nested replies, actions, and identity resolution easier to maintain.
- Add per-comment actions (edit/delete/reply) and an inline reply composer so users can act on thread comments directly.
- Fix overflow/visual clipping issues for thread comments in the UI.

### Description

- Extracted identity resolution into `resolveThreadCommentIdentity` and centralized author/avatar handling, including a special-case for agent identities like `specialist_ps`.
- Introduced `renderThreadCommentActions` to render the kebab menu with edit, delete, and reply actions and `renderThreadCommentNode` to recursively render a comment node with its nested replies and inline reply composer; removed the older `renderNestedReplyComment` duplication.
- Updated `renderThreadBlock` to use the new node renderer and maintain a `commentRenderIdx` counter when mapping top-level comments.
- Kept existing attachment rendering in `renderAttachmentTile` and integrated attachment previews and draft/preview states into the inline reply UI rendering.
- CSS: added rules to avoid clipping by setting `overflow: visible` on `.message-thread .thread-item--comment` and `.message-thread .gh-comment-box`.

### Testing

- Ran linting with `npm run lint` and the linter completed without errors.
- Executed unit tests with `npm test` and all tests passed.
- Verified the front-end build with `npm run build` and the bundle compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e478a7aa548329a1f3a3574bad762b)