### PR TITLE
Inline reply UX: attachment indicators, auto-resize, nested thread rendering and icons

### DIFF
--- a/apps/web/assets/icons.svg
+++ b/apps/web/assets/icons.svg
@@ -395,5 +395,13 @@
     <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
     <path d="M4.3 11.8V8h1.2c1.11 0 1.86.72 1.86 1.9s-.75 1.9-1.86 1.9Zm1-.8h.2c.63 0 .95-.35.95-1.1s-.32-1.1-.95-1.1h-.2Zm2.44.8L6.95 8h1.03l.43 2.25h.02L8.94 8h.83l.5 2.25h.02L10.72 8h.99l-.8 3.8h-.93L9.39 9.5h-.02L8.73 11.8Zm4.02-.2c-.27.18-.62.28-.99.28-1.16 0-1.9-.75-1.9-1.94 0-1.19.76-1.96 1.94-1.96.48 0 .88.14 1.2.45l-.56.62a.9.9 0 0 0-.64-.26c-.63 0-1 .44-1 .99 0 .56.34 1 .97 1 .13 0 .24-.02.33-.06v-.5h-.54v-.75h1.39v1.13c-.06 0-.13.01-.2.01Z"></path>
   </symbol>
+  <symbol id="attachment-upload-spinner" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" d="M3.05 3.05a7 7 0 1 1 9.9 9.9 7 7 0 0 1-9.9-9.9Z" opacity=".5"></path>
+    <path fill="currentColor" fill-rule="evenodd" d="M8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" clip-rule="evenodd"></path>
+    <path fill="currentColor" d="M14 8a6 6 0 0 0-6-6V0a8 8 0 0 1 8 8h-2Z"></path>
+  </symbol>
+  <symbol id="attachment-upload-dot" viewBox="0 0 16 16">
+    <path fill="currentColor" fill-rule="evenodd" d="M8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" clip-rule="evenodd"></path>
+  </symbol>
 
 </svg>

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -987,8 +987,10 @@ export function createProjectSubjectsEvents(config) {
         };
       });
 
-      const attachmentInput = root.querySelector("[data-role='subject-composer-file-input']");
-      const attachmentDropzone = root.querySelector(".comment-composer__editor");
+      const mainComposerRoot = commentTextarea.closest(".comment-composer");
+      const attachmentInput = mainComposerRoot?.querySelector("[data-role='subject-composer-file-input']")
+        || root.querySelector("[data-role='subject-composer-file-input']");
+      const attachmentDropzone = mainComposerRoot?.querySelector(".comment-composer__editor");
       root.querySelectorAll("[data-action='composer-attachments-pick']").forEach((btn) => {
         btn.onclick = () => attachmentInput?.click();
       });
@@ -1738,6 +1740,18 @@ export function createProjectSubjectsEvents(config) {
       if (!submitButton) return;
       submitButton.disabled = !canSubmitInlineReply(normalizedMessageId);
     };
+    const syncInlineReplyTextareaHeight = (textarea) => {
+      if (!textarea) return;
+      const computedStyle = window.getComputedStyle(textarea);
+      const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
+      const minHeight = Math.max(110, Math.round(parseFloat(computedStyle.minHeight) || 110));
+      const comfortExtraLines = 6;
+      const extraPadding = lineHeight * comfortExtraLines;
+      textarea.style.overflowY = "hidden";
+      textarea.style.height = "auto";
+      const nextHeight = Math.max(minHeight, textarea.scrollHeight + extraPadding);
+      textarea.style.height = `${nextHeight}px`;
+    };
     const clearInlineReplyAttachmentsState = (messageId = "", { keepUploadSession = false } = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -1871,6 +1885,10 @@ export function createProjectSubjectsEvents(config) {
         debugThreadReply("menu_action_reply", { messageId, parentMessageLength: parentMessageText.length });
         btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
         const replyUi = resolveInlineReplyUiState();
+        const previouslyExpandedMessageId = String(replyUi.expandedMessageId || "").trim();
+        if (previouslyExpandedMessageId && previouslyExpandedMessageId !== messageId) {
+          clearInlineReplyAttachmentsState(previouslyExpandedMessageId);
+        }
         if (!String(replyUi.draftsByMessageId?.[messageId] || "").trim()) replyUi.draftsByMessageId[messageId] = "";
         replyUi.previewByMessageId[messageId] = false;
         replyUi.expandedMessageId = messageId;
@@ -1925,11 +1943,13 @@ export function createProjectSubjectsEvents(config) {
     });
 
     root.querySelectorAll("[data-thread-reply-draft]").forEach((textarea) => {
+      syncInlineReplyTextareaHeight(textarea);
       textarea.addEventListener("input", () => {
         const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
+        syncInlineReplyTextareaHeight(textarea);
         syncInlineReplySubmitButton(messageId);
       });
       textarea.addEventListener("keydown", (event) => {
@@ -1973,7 +1993,9 @@ export function createProjectSubjectsEvents(config) {
         if (!didApply) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
-        rerenderScope(root);
+        syncInlineReplyTextareaHeight(textarea);
+        syncInlineReplySubmitButton(messageId);
+        textarea.focus();
       };
     });
     root.querySelectorAll("[data-action='thread-reply-attachments-pick'][data-message-id]").forEach((btn) => {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -735,7 +735,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [] }) {
+  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [], depth = 0 }) {
     if (!commentId) return "";
     if (!isExpanded) return "";
     const pendingAttachments = Array.isArray(attachments) ? attachments : [];
@@ -750,10 +750,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
               ${renderAttachmentTile(attachment, {
                 forceImage: !!attachment.isImage,
                 uploadState: attachment.error
-                  ? "Erreur d’upload"
+                  ? "error"
                   : String(attachment.uploadStatus || "").trim() === "uploading"
-                    ? "Envoi..."
-                    : "Prêt"
+                    ? "uploading"
+                    : "ready",
+                uploadStateText: attachment.error ? "Erreur d’upload" : ""
               })}
               <button
                 class="subject-composer-attachment-remove"
@@ -772,8 +773,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
       `
       : "";
 
+    const inlineEditorClass = Number(depth || 0) > 0
+      ? "thread-inline-reply-editor thread-inline-reply-editor--nested"
+      : "thread-inline-reply-editor thread-inline-reply-editor--root";
+
     return `
-      <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
+      <div class="${inlineEditorClass}" data-inline-reply-editor="${escapeHtml(commentId)}">
         ${renderCommentComposer({
           hideAvatar: true,
           hideTitle: true,
@@ -784,14 +789,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
           textareaAttributes: {
             "data-thread-reply-draft": commentId
           },
-          placeholder: "Écrire une réponse",
+          placeholder: "écrire une réponse, glisser-déposer une pièce jointe...",
           tabWriteAction: "thread-reply-tab-write",
           tabPreviewAction: "thread-reply-tab-preview",
           toolbarHtml: renderMarkdownToolbar("thread-reply-format", { messageId: commentId }),
           previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
           actionsHtml: `
-            <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
-            <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}" ${canSubmit ? "" : "disabled"}>Répondre</button>
+            <div class="thread-inline-reply-editor__actions">
+              <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
+              <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}" ${canSubmit ? "" : "disabled"}>Répondre</button>
+            </div>
           `,
           previewEmptyHint: "Use Markdown to format your reply",
           footerHtml: `
@@ -817,12 +824,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderNestedReplyComment(entry, idx) {
+  function resolveThreadCommentIdentity(entry) {
     const currentUserId = normalizeId(store?.user?.id);
     const authorUserId = normalizeId(entry?.meta?.author_user_id);
     const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
     const agent = isCurrentUserAuthor ? "human" : "member";
-    const identity = getAuthorIdentity({
+    const isRapso = agent === "specialist_ps";
+    if (isRapso) {
+      return { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" };
+    }
+    return getAuthorIdentity({
       author: entry?.actor,
       agent,
       avatarUrl: entry?.meta?.author_avatar_url || "",
@@ -830,25 +841,101 @@ priority=${firstNonEmpty(subject.priority, "")}`
       humanAvatarHtml: SVG_AVATAR_HUMAN,
       fallbackName: "System"
     });
+  }
+
+  function renderThreadCommentActions(entry) {
+    const commentId = normalizeId(entry?.meta?.id);
+    if (!commentId) return "";
+    const isEditable = !entry?.meta?.is_frozen && !entry?.meta?.is_deleted;
+    return `
+      <div class="thread-comment-menu">
+        <button
+          class="thread-comment-menu__trigger"
+          type="button"
+          aria-label="Actions du message"
+          data-action="thread-reply-menu-toggle"
+          data-message-id="${escapeHtml(commentId)}"
+        >
+          ${svgIcon("kebab-horizontal")}
+        </button>
+        <div class="thread-comment-menu__dropdown">
+          ${isEditable
+            ? `
+              <button class="gh-menu__item" type="button" data-action="thread-message-edit" data-message-id="${escapeHtml(commentId)}" data-message-body="${escapeHtml(String(entry?.message || ""))}">Modifier le message</button>
+              <button class="gh-menu__item" type="button" data-action="thread-message-delete" data-message-id="${escapeHtml(commentId)}">Supprimer le message</button>
+              <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
+            `
+            : ""}
+          <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderThreadCommentNode(entry, { idx = 0, depth = 0, childrenByParentId = new Map(), replyUi = {} } = {}) {
+    const commentId = normalizeId(entry?.meta?.id);
+    if (!commentId) return "";
+    const identity = resolveThreadCommentIdentity(entry);
     const tsHtml = entry?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(entry.ts))}</div>` : "";
+    const childReplies = childrenByParentId.get(commentId) || [];
+    const nestedDepth = Math.min(MAX_REPLY_VISUAL_DEPTH, Math.max(1, Number(depth || 0)));
+    const classes = depth > 0
+      ? `message-thread__comment--nested message-thread__comment--reply-item message-thread__comment--depth-${nestedDepth}`
+      : "";
+    const isExpanded = replyUi.expandedMessageId === commentId;
+    const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
+    const previewMode = !!replyUi.previewByMessageId?.[commentId];
+    const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
+      ? replyUi.attachmentsByMessageId[commentId]
+      : [];
+    const repliesHtml = childReplies.length
+      ? `
+        <div class="thread-comment-replies thread-comment-replies--github">
+          ${childReplies.map((reply, replyIdx) => renderThreadCommentNode(reply, {
+            idx: idx + replyIdx + 1,
+            depth: depth + 1,
+            childrenByParentId,
+            replyUi
+          })).join("")}
+        </div>
+      `
+      : "";
 
     return renderMessageThreadComment({
       idx,
       author: identity.displayName,
       tsHtml,
+      headerRightHtml: renderThreadCommentActions(entry),
       bodyHtml: `
         <div class="thread-comment-content-capsule">
-          <div class="mono-small color-fg-muted">${escapeHtml(String(entry?.stateLabel || "modifiable"))}</div>
           ${mdToHtml(entry?.message || "")}
         </div>
         ${(Array.isArray(entry?.meta?.attachments) && entry.meta.attachments.length)
           ? `<div class="subject-attachment-grid">${entry.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
           : ""}
+        ${childReplies.length
+          ? `
+            <div class="thread-comment-footer">
+              <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
+            </div>
+          `
+          : ""}
+        ${repliesHtml}
+        <div class="thread-comment-reply-box">
+          ${renderInlineReplyComposer({
+            commentId,
+            isExpanded,
+            draft,
+            previewMode,
+            attachments,
+            depth
+          })}
+        </div>
       `,
       avatarType: identity.avatarType,
       avatarHtml: identity.avatarHtml,
       avatarInitial: identity.avatarInitial,
-      className: "message-thread__comment--nested message-thread__comment--reply-item"
+      className: classes
     });
   }
 
@@ -867,7 +954,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
       || ""
     );
     const isImage = options.forceImage || mimeType.startsWith("image/");
-    const uploadState = String(options.uploadState || "").trim();
+    const uploadState = String(options.uploadState || "").trim().toLowerCase();
+    const uploadStateText = String(options.uploadStateText || "").trim();
     const typeIcon = mimeType === "application/pdf" || extension === "pdf"
       ? "file-pdf"
       : mimeType.includes("javascript") || extension === "js" || extension === "ts"
@@ -875,7 +963,25 @@ priority=${firstNonEmpty(subject.priority, "")}`
         : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
           ? "file-dwg"
           : "file-generic";
-    const progressHtml = uploadState ? `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>` : "";
+    let progressHtml = "";
+    let uploadIndicatorHtml = "";
+    if (uploadState === "uploading") {
+      uploadIndicatorHtml = `
+        <span class="subject-attachment__upload-indicator is-spinning" aria-label="Envoi en cours">
+          ${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner anim-rotate" })}
+        </span>
+      `;
+    } else if (uploadState === "ready") {
+      uploadIndicatorHtml = `
+        <span class="subject-attachment__upload-indicator" aria-label="Pièce jointe prête">
+          ${svgIcon("attachment-upload-dot", { className: "subject-attachment__spinner" })}
+        </span>
+      `;
+    } else if (uploadState === "error") {
+      progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadStateText || "Erreur d’upload")}</div>`;
+    } else if (uploadState) {
+      progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>`;
+    }
     const metaLine = [
       mimeType || "fichier",
       Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
@@ -889,7 +995,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
           <a href="${escapeHtml(downloadUrl || previewUrl)}" target="_blank" rel="noopener noreferrer">
             <img src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
           </a>
-          <div class="subject-attachment__caption mono-small">${escapeHtml(fileName)}</div>
+          <div class="subject-attachment__caption mono-small">
+            <span class="subject-attachment__caption-name">${escapeHtml(fileName)}</span>
+            ${uploadIndicatorHtml}
+          </div>
           ${progressHtml}
         </div>
       `;
@@ -899,9 +1008,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
       <div class="subject-attachment subject-attachment--file">
         <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
         <div class="subject-attachment__file-body">
-          ${downloadUrl
-            ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
-            : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+          <div class="subject-attachment__file-head">
+            ${downloadUrl
+              ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
+              : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+            ${uploadIndicatorHtml}
+          </div>
           <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
           ${progressHtml}
         </div>
@@ -915,107 +1027,22 @@ priority=${firstNonEmpty(subject.priority, "")}`
     if (!thread.length) return "";
     const replyUi = getInlineReplyUiState();
     const { childrenByParentId } = groupThreadReplies(thread);
+    let commentRenderIdx = 0;
 
     const itemsHtml = thread.map((e, idx) => {
       const type = String(e?.type || "").toUpperCase();
 
       if (type === "COMMENT") {
-        const commentId = normalizeId(e?.meta?.id);
         const parentId = normalizeId(e?.meta?.parent_message_id);
         if (parentId) return "";
-
-        const currentUserId = normalizeId(store?.user?.id);
-        const authorUserId = normalizeId(e?.meta?.author_user_id);
-        const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
-        const agent = isCurrentUserAuthor ? "human" : "member";
-        const isRapso = agent === "specialist_ps";
-        const identity = isRapso
-          ? { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" }
-          : getAuthorIdentity({
-              author: e?.actor,
-              agent,
-              avatarUrl: e?.meta?.author_avatar_url || "",
-              currentUserAvatar: isCurrentUserAuthor ? store?.user?.avatar : "",
-              humanAvatarHtml: SVG_AVATAR_HUMAN,
-              fallbackName: "System"
-            });
-        const tsHtml = e?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(e.ts))}</div>` : "";
-        const childReplies = childrenByParentId.get(commentId) || [];
-        const isExpanded = replyUi.expandedMessageId === commentId;
-        const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
-        const previewMode = !!replyUi.previewByMessageId?.[commentId];
-        const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
-          ? replyUi.attachmentsByMessageId[commentId]
-          : [];
-        const isEditable = !e?.meta?.is_frozen && !e?.meta?.is_deleted;
-        const repliesHtml = childReplies.length
-          ? `
-            <div class="thread-comment-replies thread-comment-replies--github">
-              ${childReplies.map((reply, replyIdx) => renderNestedReplyComment(reply, idx + replyIdx + 1)).join("")}
-            </div>
-          `
-          : "";
-
-        return renderMessageThreadComment({
-          idx,
-          author: identity.displayName,
-          tsHtml,
-          headerRightHtml: `
-            <div class="thread-comment-menu">
-              <button
-                class="thread-comment-menu__trigger"
-                type="button"
-                aria-label="Actions du message"
-                data-action="thread-reply-menu-toggle"
-                data-message-id="${escapeHtml(commentId)}"
-              >
-                ${svgIcon("kebab-horizontal")}
-              </button>
-              <div class="thread-comment-menu__dropdown">
-                ${isEditable
-                  ? `
-                    <button class="gh-menu__item" type="button" data-action="thread-message-edit" data-message-id="${escapeHtml(commentId)}" data-message-body="${escapeHtml(String(e?.message || ""))}">Modifier le message</button>
-                    <button class="gh-menu__item" type="button" data-action="thread-message-delete" data-message-id="${escapeHtml(commentId)}">Supprimer le message</button>
-                    <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
-                  `
-                  : ""}
-                <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
-              </div>
-            </div>
-          `,
-          bodyHtml: `
-            <div class="thread-comment-content-capsule">
-              <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
-              ${mdToHtml(e?.message || "")}
-            </div>
-            ${(Array.isArray(e?.meta?.attachments) && e.meta.attachments.length)
-              ? `<div class="subject-attachment-grid">${e.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
-              : ""}
-            ${childReplies.length
-              ? `
-                <div class="thread-comment-footer">
-                  <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
-                </div>
-              `
-              : ""}
-            ${repliesHtml}
-            <div class="thread-comment-reply-box">
-              ${renderInlineReplyComposer({
-                commentId,
-                isExpanded,
-                draft,
-                previewMode,
-                attachments
-              })}
-            </div>
-          `,
-          avatarType: identity.avatarType,
-          avatarHtml: identity.avatarHtml,
-          avatarInitial: identity.avatarInitial,
-          className: Number(e?.meta?.depth || 0) > 0
-            ? `message-thread__comment--nested message-thread__comment--depth-${Math.min(MAX_REPLY_VISUAL_DEPTH, Number(e?.meta?.depth || 0))}`
-            : ""
+        const rendered = renderThreadCommentNode(e, {
+          idx: commentRenderIdx,
+          depth: 0,
+          childrenByParentId,
+          replyUi
         });
+        commentRenderIdx += 1;
+        return rendered;
       }
 
       if (type === "ACTIVITY") {
@@ -1295,10 +1322,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
               ${renderAttachmentTile(attachment, {
                 forceImage: !!attachment.isImage,
                 uploadState: attachment.error
-                  ? "Erreur d’upload"
+                  ? "error"
                   : String(attachment.uploadStatus || "").trim() === "uploading"
-                    ? "Envoi..."
-                    : "Prêt"
+                    ? "uploading"
+                    : "ready",
+                uploadStateText: attachment.error ? "Erreur d’upload" : ""
               })}
               <button
                 class="subject-composer-attachment-remove"

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2527,6 +2527,8 @@ body.is-resizing{
 .message-thread{display:block;}
 .message-thread__item{width:calc(100% + 52px);}
 .message-thread__comment{padding-left:var(--discussion-content-inset);}
+.message-thread .thread-item--comment{overflow:visible;}
+.message-thread .gh-comment-box{overflow:visible;}
 .comment-composer{display:flex;gap:12px;align-items:flex-start;margin-top:10px;}
 .comment-composer__main{flex:1 1 auto;min-width:0;}
 .comment-composer__box{width:100%;}
@@ -2704,7 +2706,12 @@ body.is-resizing{
 .subject-attachment__caption{
   padding:6px 8px;
   color:var(--muted);
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
 }
+.subject-attachment__caption-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .subject-attachment--file{
   display:flex;
   align-items:center;
@@ -2721,11 +2728,18 @@ body.is-resizing{
   color:var(--muted);
 }
 .subject-attachment__file-body{flex:1 1 auto;min-width:0;}
+.subject-attachment__file-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+}
 .subject-attachment__file-name{
   color:var(--text);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
+  min-width:0;
 }
 .subject-attachment__file-link--name{
   text-decoration:none;
@@ -2737,6 +2751,19 @@ body.is-resizing{
 .subject-attachment__file-meta{color:var(--muted);}
 .subject-attachment__file-link{font-size:12px;}
 .subject-attachment__state{padding:0 8px 8px;color:var(--muted);}
+.subject-attachment__upload-indicator{
+  display:inline-flex;
+  width:16px;
+  height:16px;
+  color:var(--fgColor-attention);
+  flex:0 0 auto;
+}
+.subject-attachment__spinner{width:16px;height:16px;}
+.anim-rotate{animation:thread-attachment-spin 1s linear infinite;transform-origin:center;}
+@keyframes thread-attachment-spin{
+  from{transform:rotate(0deg);}
+  to{transform:rotate(360deg);}
+}
 .md-render p{margin:0 0 10px;}
 .md-render p:last-child{margin-bottom:0;}
 .md-render ul,.md-render ol{margin:0 0 10px 20px;padding:0;}
@@ -2824,6 +2851,19 @@ body.is-resizing{
   padding:12px;
   background-color:var(--bg-input);
 }
+.thread-inline-reply-editor--root{
+  border-bottom-left-radius:var(--radius);
+  border-bottom-right-radius:var(--radius);
+}
+.thread-inline-reply-editor--nested{
+  border:1px solid var(--border2);
+  border-bottom-left-radius:var(--radius);
+}
+.thread-inline-reply-editor__actions{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+}
 .thread-inline-reply-editor .comment-composer__textarea{
   min-height:110px;
   background:var(--bgAssistPanel);
@@ -2834,6 +2874,8 @@ body.is-resizing{
   border-top:1px solid var(--border2);
   padding-top:8px;
   background-color:var(--bgAssistPanel);
+  border-bottom-left-radius:var(--radius);
+  border-bottom-right-radius:var(--radius);
 }
 .thread-comment-replies--github .gh-comment-box{
   border:none;


### PR DESCRIPTION
### Motivation
- Improve the inline reply experience by showing upload state indicators for attachments, supporting nested reply visuals, and making reply textareas auto-resize for better usability.
- Unify attachment upload state values and ensure per-reply attachment sessions are isolated and cleared when switching editors to avoid stale previews or sessions.

### Description
- Added two new SVG icons `attachment-upload-spinner` and `attachment-upload-dot` to `apps/web/assets/icons.svg` for upload indicators. 
- Normalized attachment upload state semantics to `"uploading"`, `"ready"`, and `"error"` and added an optional `uploadStateText` to surface error messages in `renderAttachmentTile` in `project-subjects-thread.js`.
- Introduced visual upload indicators (spinner / dot) and conditional progress/error text in attachment tiles, and moved file name / indicator into compact `file-head` layout with truncated names; corresponding styles added to `apps/web/style.css` (`.subject-attachment__upload-indicator`, `.anim-rotate`, layout tweaks, and nested editor styles).
- Refactored threaded comment rendering by splitting identity resolution into `resolveThreadCommentIdentity`, action menu into `renderThreadCommentActions`, and a recursive `renderThreadCommentNode` that supports child replies, reply composer embedding and depth-aware classes; replaced prior inline rendering logic in `project-subjects-thread.js`.
- Extended the inline reply composer to accept `depth` and produce different classes for root vs nested editors, adjusted placeholder text, and wrapped action buttons in a new container for layout consistency.
- In `project-subjects-events.js` added composer scoping to prefer the nearest `.comment-composer` for attachment inputs, implemented `syncInlineReplyTextareaHeight` to auto-resize reply textareas (used on init and on `input`), and clear inline attachments when opening a different reply editor.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e478a7aa548329a1f3a3574bad762b)