### PR TITLE
Composer/UI: autosize textareas, inline-reply refactor, upload indicators, and scroll preservation

### DIFF
--- a/apps/web/assets/icons.svg
+++ b/apps/web/assets/icons.svg
@@ -395,5 +395,13 @@
     <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
     <path d="M4.3 11.8V8h1.2c1.11 0 1.86.72 1.86 1.9s-.75 1.9-1.86 1.9Zm1-.8h.2c.63 0 .95-.35.95-1.1s-.32-1.1-.95-1.1h-.2Zm2.44.8L6.95 8h1.03l.43 2.25h.02L8.94 8h.83l.5 2.25h.02L10.72 8h.99l-.8 3.8h-.93L9.39 9.5h-.02L8.73 11.8Zm4.02-.2c-.27.18-.62.28-.99.28-1.16 0-1.9-.75-1.9-1.94 0-1.19.76-1.96 1.94-1.96.48 0 .88.14 1.2.45l-.56.62a.9.9 0 0 0-.64-.26c-.63 0-1 .44-1 .99 0 .56.34 1 .97 1 .13 0 .24-.02.33-.06v-.5h-.54v-.75h1.39v1.13c-.06 0-.13.01-.2.01Z"></path>
   </symbol>
+  <symbol id="attachment-upload-spinner" viewBox="0 0 16 16">
+    <path fill="none" stroke="currentColor" stroke-width="2" d="M3.05 3.05a7 7 0 1 1 9.9 9.9 7 7 0 0 1-9.9-9.9Z" opacity=".5"></path>
+    <path fill="currentColor" fill-rule="evenodd" d="M8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" clip-rule="evenodd"></path>
+    <path fill="currentColor" d="M14 8a6 6 0 0 0-6-6V0a8 8 0 0 1 8 8h-2Z"></path>
+  </symbol>
+  <symbol id="attachment-upload-dot" viewBox="0 0 16 16">
+    <path fill="currentColor" fill-rule="evenodd" d="M8 4a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" clip-rule="evenodd"></path>
+  </symbol>
 
 </svg>

--- a/apps/web/js/utils/markdown-composer.js
+++ b/apps/web/js/utils/markdown-composer.js
@@ -38,6 +38,8 @@ function prefixSelectedLines(text, start, end, marker) {
 
 export function applyMarkdownComposerAction(textarea, action = "") {
   if (!textarea) return false;
+  const previousScrollTop = Number(textarea.scrollTop || 0);
+  const previousScrollLeft = Number(textarea.scrollLeft || 0);
   const value = String(textarea.value || "");
   const start = Number(textarea.selectionStart || 0);
   const end = Number(textarea.selectionEnd || 0);
@@ -83,6 +85,8 @@ export function applyMarkdownComposerAction(textarea, action = "") {
 
   if (!result) return false;
   textarea.value = result.next;
+  textarea.scrollTop = previousScrollTop;
+  textarea.scrollLeft = previousScrollLeft;
   setSelectionAndFocus(textarea, result.selectionStart, result.selectionEnd);
   return true;
 }

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -928,8 +928,23 @@ export function createProjectSubjectsEvents(config) {
         rerenderScope(root);
       };
 
+      const syncMainComposerTextareaHeight = () => {
+        const computedStyle = window.getComputedStyle(commentTextarea);
+        const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
+        const minHeight = Math.max(170, Math.round(parseFloat(computedStyle.minHeight) || 170));
+        const comfortExtraLines = 3;
+        const extraPadding = lineHeight * comfortExtraLines;
+        commentTextarea.style.overflowY = "hidden";
+        commentTextarea.style.height = "auto";
+        const nextHeight = Math.max(minHeight, commentTextarea.scrollHeight + extraPadding);
+        commentTextarea.style.height = `${nextHeight}px`;
+      };
+
+      syncMainComposerTextareaHeight();
+
       commentTextarea.addEventListener("input", () => {
         store.situationsView.commentDraft = String(commentTextarea.value || "");
+        syncMainComposerTextareaHeight();
         void syncMentionPopup();
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
       });
@@ -974,6 +989,7 @@ export function createProjectSubjectsEvents(config) {
           if (action === "mention") void syncMentionPopup({ forceOpen: true });
           else closeMentionPopup({ rerender: false });
           store.situationsView.commentDraft = String(commentTextarea.value || "");
+          syncMainComposerTextareaHeight();
           if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
         };
       });
@@ -987,8 +1003,10 @@ export function createProjectSubjectsEvents(config) {
         };
       });
 
-      const attachmentInput = root.querySelector("[data-role='subject-composer-file-input']");
-      const attachmentDropzone = root.querySelector(".comment-composer__editor");
+      const mainComposerRoot = commentTextarea.closest(".comment-composer");
+      const attachmentInput = mainComposerRoot?.querySelector("[data-role='subject-composer-file-input']")
+        || root.querySelector("[data-role='subject-composer-file-input']");
+      const attachmentDropzone = mainComposerRoot?.querySelector(".comment-composer__editor");
       root.querySelectorAll("[data-action='composer-attachments-pick']").forEach((btn) => {
         btn.onclick = () => attachmentInput?.click();
       });
@@ -1738,6 +1756,18 @@ export function createProjectSubjectsEvents(config) {
       if (!submitButton) return;
       submitButton.disabled = !canSubmitInlineReply(normalizedMessageId);
     };
+    const syncInlineReplyTextareaHeight = (textarea) => {
+      if (!textarea) return;
+      const computedStyle = window.getComputedStyle(textarea);
+      const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
+      const minHeight = Math.max(110, Math.round(parseFloat(computedStyle.minHeight) || 110));
+      const comfortExtraLines = 3;
+      const extraPadding = lineHeight * comfortExtraLines;
+      textarea.style.overflowY = "hidden";
+      textarea.style.height = "auto";
+      const nextHeight = Math.max(minHeight, textarea.scrollHeight + extraPadding);
+      textarea.style.height = `${nextHeight}px`;
+    };
     const clearInlineReplyAttachmentsState = (messageId = "", { keepUploadSession = false } = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -1871,6 +1901,10 @@ export function createProjectSubjectsEvents(config) {
         debugThreadReply("menu_action_reply", { messageId, parentMessageLength: parentMessageText.length });
         btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
         const replyUi = resolveInlineReplyUiState();
+        const previouslyExpandedMessageId = String(replyUi.expandedMessageId || "").trim();
+        if (previouslyExpandedMessageId && previouslyExpandedMessageId !== messageId) {
+          clearInlineReplyAttachmentsState(previouslyExpandedMessageId);
+        }
         if (!String(replyUi.draftsByMessageId?.[messageId] || "").trim()) replyUi.draftsByMessageId[messageId] = "";
         replyUi.previewByMessageId[messageId] = false;
         replyUi.expandedMessageId = messageId;
@@ -1925,11 +1959,13 @@ export function createProjectSubjectsEvents(config) {
     });
 
     root.querySelectorAll("[data-thread-reply-draft]").forEach((textarea) => {
+      syncInlineReplyTextareaHeight(textarea);
       textarea.addEventListener("input", () => {
         const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
+        syncInlineReplyTextareaHeight(textarea);
         syncInlineReplySubmitButton(messageId);
       });
       textarea.addEventListener("keydown", (event) => {
@@ -1973,7 +2009,9 @@ export function createProjectSubjectsEvents(config) {
         if (!didApply) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
-        rerenderScope(root);
+        syncInlineReplyTextareaHeight(textarea);
+        syncInlineReplySubmitButton(messageId);
+        textarea.focus();
       };
     });
     root.querySelectorAll("[data-action='thread-reply-attachments-pick'][data-message-id]").forEach((btn) => {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -735,7 +735,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [] }) {
+  function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [], depth = 0 }) {
     if (!commentId) return "";
     if (!isExpanded) return "";
     const pendingAttachments = Array.isArray(attachments) ? attachments : [];
@@ -750,10 +750,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
               ${renderAttachmentTile(attachment, {
                 forceImage: !!attachment.isImage,
                 uploadState: attachment.error
-                  ? "Erreur d’upload"
+                  ? "error"
                   : String(attachment.uploadStatus || "").trim() === "uploading"
-                    ? "Envoi..."
-                    : "Prêt"
+                    ? "uploading"
+                    : "ready",
+                uploadStateText: attachment.error ? "Erreur d’upload" : ""
               })}
               <button
                 class="subject-composer-attachment-remove"
@@ -772,8 +773,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
       `
       : "";
 
+    const inlineEditorClass = Number(depth || 0) > 0
+      ? "thread-inline-reply-editor thread-inline-reply-editor--nested"
+      : "thread-inline-reply-editor thread-inline-reply-editor--root";
+
     return `
-      <div class="thread-inline-reply-editor" data-inline-reply-editor="${escapeHtml(commentId)}">
+      <div class="${inlineEditorClass}" data-inline-reply-editor="${escapeHtml(commentId)}">
         ${renderCommentComposer({
           hideAvatar: true,
           hideTitle: true,
@@ -784,14 +789,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
           textareaAttributes: {
             "data-thread-reply-draft": commentId
           },
-          placeholder: "Écrire une réponse",
+          placeholder: "Écrire une réponse, glisser-déposer une pièce jointe...",
           tabWriteAction: "thread-reply-tab-write",
           tabPreviewAction: "thread-reply-tab-preview",
+          tabsClassName: "comment-composer__tabs--thread-reply",
           toolbarHtml: renderMarkdownToolbar("thread-reply-format", { messageId: commentId }),
           previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
           actionsHtml: `
-            <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
-            <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}" ${canSubmit ? "" : "disabled"}>Répondre</button>
+            <div class="thread-inline-reply-editor__actions">
+              <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
+              <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-reply-submit" data-message-id="${escapeHtml(commentId)}" ${canSubmit ? "" : "disabled"}>Répondre</button>
+            </div>
           `,
           previewEmptyHint: "Use Markdown to format your reply",
           footerHtml: `
@@ -817,12 +825,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderNestedReplyComment(entry, idx) {
+  function resolveThreadCommentIdentity(entry) {
     const currentUserId = normalizeId(store?.user?.id);
     const authorUserId = normalizeId(entry?.meta?.author_user_id);
     const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
     const agent = isCurrentUserAuthor ? "human" : "member";
-    const identity = getAuthorIdentity({
+    const isRapso = agent === "specialist_ps";
+    if (isRapso) {
+      return { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" };
+    }
+    return getAuthorIdentity({
       author: entry?.actor,
       agent,
       avatarUrl: entry?.meta?.author_avatar_url || "",
@@ -830,25 +842,101 @@ priority=${firstNonEmpty(subject.priority, "")}`
       humanAvatarHtml: SVG_AVATAR_HUMAN,
       fallbackName: "System"
     });
+  }
+
+  function renderThreadCommentActions(entry) {
+    const commentId = normalizeId(entry?.meta?.id);
+    if (!commentId) return "";
+    const isEditable = !entry?.meta?.is_frozen && !entry?.meta?.is_deleted;
+    return `
+      <div class="thread-comment-menu">
+        <button
+          class="thread-comment-menu__trigger"
+          type="button"
+          aria-label="Actions du message"
+          data-action="thread-reply-menu-toggle"
+          data-message-id="${escapeHtml(commentId)}"
+        >
+          ${svgIcon("kebab-horizontal")}
+        </button>
+        <div class="thread-comment-menu__dropdown">
+          ${isEditable
+            ? `
+              <button class="gh-menu__item" type="button" data-action="thread-message-edit" data-message-id="${escapeHtml(commentId)}" data-message-body="${escapeHtml(String(entry?.message || ""))}">Modifier le message</button>
+              <button class="gh-menu__item" type="button" data-action="thread-message-delete" data-message-id="${escapeHtml(commentId)}">Supprimer le message</button>
+              <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
+            `
+            : ""}
+          <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderThreadCommentNode(entry, { idx = 0, depth = 0, childrenByParentId = new Map(), replyUi = {} } = {}) {
+    const commentId = normalizeId(entry?.meta?.id);
+    if (!commentId) return "";
+    const identity = resolveThreadCommentIdentity(entry);
     const tsHtml = entry?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(entry.ts))}</div>` : "";
+    const childReplies = childrenByParentId.get(commentId) || [];
+    const nestedDepth = Math.min(MAX_REPLY_VISUAL_DEPTH, Math.max(1, Number(depth || 0)));
+    const classes = depth > 0
+      ? `message-thread__comment--nested message-thread__comment--reply-item message-thread__comment--depth-${nestedDepth}`
+      : "";
+    const isExpanded = replyUi.expandedMessageId === commentId;
+    const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
+    const previewMode = !!replyUi.previewByMessageId?.[commentId];
+    const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
+      ? replyUi.attachmentsByMessageId[commentId]
+      : [];
+    const repliesHtml = childReplies.length
+      ? `
+        <div class="thread-comment-replies thread-comment-replies--github">
+          ${childReplies.map((reply, replyIdx) => renderThreadCommentNode(reply, {
+            idx: idx + replyIdx + 1,
+            depth: depth + 1,
+            childrenByParentId,
+            replyUi
+          })).join("")}
+        </div>
+      `
+      : "";
 
     return renderMessageThreadComment({
       idx,
       author: identity.displayName,
       tsHtml,
+      headerRightHtml: renderThreadCommentActions(entry),
       bodyHtml: `
         <div class="thread-comment-content-capsule">
-          <div class="mono-small color-fg-muted">${escapeHtml(String(entry?.stateLabel || "modifiable"))}</div>
           ${mdToHtml(entry?.message || "")}
         </div>
         ${(Array.isArray(entry?.meta?.attachments) && entry.meta.attachments.length)
           ? `<div class="subject-attachment-grid">${entry.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
           : ""}
+        ${childReplies.length
+          ? `
+            <div class="thread-comment-footer">
+              <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
+            </div>
+          `
+          : ""}
+        ${repliesHtml}
+        <div class="thread-comment-reply-box">
+          ${renderInlineReplyComposer({
+            commentId,
+            isExpanded,
+            draft,
+            previewMode,
+            attachments,
+            depth
+          })}
+        </div>
       `,
       avatarType: identity.avatarType,
       avatarHtml: identity.avatarHtml,
       avatarInitial: identity.avatarInitial,
-      className: "message-thread__comment--nested message-thread__comment--reply-item"
+      className: classes
     });
   }
 
@@ -867,7 +955,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
       || ""
     );
     const isImage = options.forceImage || mimeType.startsWith("image/");
-    const uploadState = String(options.uploadState || "").trim();
+    const uploadState = String(options.uploadState || "").trim().toLowerCase();
+    const uploadStateText = String(options.uploadStateText || "").trim();
     const typeIcon = mimeType === "application/pdf" || extension === "pdf"
       ? "file-pdf"
       : mimeType.includes("javascript") || extension === "js" || extension === "ts"
@@ -875,7 +964,25 @@ priority=${firstNonEmpty(subject.priority, "")}`
         : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
           ? "file-dwg"
           : "file-generic";
-    const progressHtml = uploadState ? `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>` : "";
+    let progressHtml = "";
+    let uploadIndicatorHtml = "";
+    if (uploadState === "uploading") {
+      uploadIndicatorHtml = `
+        <span class="subject-attachment__upload-indicator is-spinning" aria-label="Envoi en cours">
+          ${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner anim-rotate" })}
+        </span>
+      `;
+    } else if (uploadState === "ready") {
+      uploadIndicatorHtml = `
+        <span class="subject-attachment__upload-indicator" aria-label="Pièce jointe prête">
+          ${svgIcon("attachment-upload-dot", { className: "subject-attachment__spinner" })}
+        </span>
+      `;
+    } else if (uploadState === "error") {
+      progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadStateText || "Erreur d’upload")}</div>`;
+    } else if (uploadState) {
+      progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>`;
+    }
     const metaLine = [
       mimeType || "fichier",
       Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
@@ -889,7 +996,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
           <a href="${escapeHtml(downloadUrl || previewUrl)}" target="_blank" rel="noopener noreferrer">
             <img src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
           </a>
-          <div class="subject-attachment__caption mono-small">${escapeHtml(fileName)}</div>
+          <div class="subject-attachment__caption mono-small">
+            <span class="subject-attachment__caption-name">${escapeHtml(fileName)}</span>
+            ${uploadIndicatorHtml}
+          </div>
           ${progressHtml}
         </div>
       `;
@@ -899,9 +1009,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
       <div class="subject-attachment subject-attachment--file">
         <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
         <div class="subject-attachment__file-body">
-          ${downloadUrl
-            ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
-            : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+          <div class="subject-attachment__file-head">
+            ${downloadUrl
+              ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
+              : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+            ${uploadIndicatorHtml}
+          </div>
           <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
           ${progressHtml}
         </div>
@@ -915,107 +1028,22 @@ priority=${firstNonEmpty(subject.priority, "")}`
     if (!thread.length) return "";
     const replyUi = getInlineReplyUiState();
     const { childrenByParentId } = groupThreadReplies(thread);
+    let commentRenderIdx = 0;
 
     const itemsHtml = thread.map((e, idx) => {
       const type = String(e?.type || "").toUpperCase();
 
       if (type === "COMMENT") {
-        const commentId = normalizeId(e?.meta?.id);
         const parentId = normalizeId(e?.meta?.parent_message_id);
         if (parentId) return "";
-
-        const currentUserId = normalizeId(store?.user?.id);
-        const authorUserId = normalizeId(e?.meta?.author_user_id);
-        const isCurrentUserAuthor = !!authorUserId && !!currentUserId && authorUserId === currentUserId;
-        const agent = isCurrentUserAuthor ? "human" : "member";
-        const isRapso = agent === "specialist_ps";
-        const identity = isRapso
-          ? { displayName: "Agent specialist_ps", avatarType: "agent", avatarHtml: "", avatarInitial: "AS" }
-          : getAuthorIdentity({
-              author: e?.actor,
-              agent,
-              avatarUrl: e?.meta?.author_avatar_url || "",
-              currentUserAvatar: isCurrentUserAuthor ? store?.user?.avatar : "",
-              humanAvatarHtml: SVG_AVATAR_HUMAN,
-              fallbackName: "System"
-            });
-        const tsHtml = e?.ts ? `<div class="mono-small">${escapeHtml(fmtTs(e.ts))}</div>` : "";
-        const childReplies = childrenByParentId.get(commentId) || [];
-        const isExpanded = replyUi.expandedMessageId === commentId;
-        const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
-        const previewMode = !!replyUi.previewByMessageId?.[commentId];
-        const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
-          ? replyUi.attachmentsByMessageId[commentId]
-          : [];
-        const isEditable = !e?.meta?.is_frozen && !e?.meta?.is_deleted;
-        const repliesHtml = childReplies.length
-          ? `
-            <div class="thread-comment-replies thread-comment-replies--github">
-              ${childReplies.map((reply, replyIdx) => renderNestedReplyComment(reply, idx + replyIdx + 1)).join("")}
-            </div>
-          `
-          : "";
-
-        return renderMessageThreadComment({
-          idx,
-          author: identity.displayName,
-          tsHtml,
-          headerRightHtml: `
-            <div class="thread-comment-menu">
-              <button
-                class="thread-comment-menu__trigger"
-                type="button"
-                aria-label="Actions du message"
-                data-action="thread-reply-menu-toggle"
-                data-message-id="${escapeHtml(commentId)}"
-              >
-                ${svgIcon("kebab-horizontal")}
-              </button>
-              <div class="thread-comment-menu__dropdown">
-                ${isEditable
-                  ? `
-                    <button class="gh-menu__item" type="button" data-action="thread-message-edit" data-message-id="${escapeHtml(commentId)}" data-message-body="${escapeHtml(String(e?.message || ""))}">Modifier le message</button>
-                    <button class="gh-menu__item" type="button" data-action="thread-message-delete" data-message-id="${escapeHtml(commentId)}">Supprimer le message</button>
-                    <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
-                  `
-                  : ""}
-                <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
-              </div>
-            </div>
-          `,
-          bodyHtml: `
-            <div class="thread-comment-content-capsule">
-              <div class="mono-small color-fg-muted">${escapeHtml(String(e?.stateLabel || "modifiable"))}</div>
-              ${mdToHtml(e?.message || "")}
-            </div>
-            ${(Array.isArray(e?.meta?.attachments) && e.meta.attachments.length)
-              ? `<div class="subject-attachment-grid">${e.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
-              : ""}
-            ${childReplies.length
-              ? `
-                <div class="thread-comment-footer">
-                  <span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>
-                </div>
-              `
-              : ""}
-            ${repliesHtml}
-            <div class="thread-comment-reply-box">
-              ${renderInlineReplyComposer({
-                commentId,
-                isExpanded,
-                draft,
-                previewMode,
-                attachments
-              })}
-            </div>
-          `,
-          avatarType: identity.avatarType,
-          avatarHtml: identity.avatarHtml,
-          avatarInitial: identity.avatarInitial,
-          className: Number(e?.meta?.depth || 0) > 0
-            ? `message-thread__comment--nested message-thread__comment--depth-${Math.min(MAX_REPLY_VISUAL_DEPTH, Number(e?.meta?.depth || 0))}`
-            : ""
+        const rendered = renderThreadCommentNode(e, {
+          idx: commentRenderIdx,
+          depth: 0,
+          childrenByParentId,
+          replyUi
         });
+        commentRenderIdx += 1;
+        return rendered;
       }
 
       if (type === "ACTIVITY") {
@@ -1223,14 +1251,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const previewMode = !!store.situationsView.commentPreviewMode;
     const helpMode = !!store.situationsView.helpMode;
 
-    const hintHtml = type === "sujet"
-      ? `
-        <button class="subject-composer-attachments-pick-btn" type="button" data-action="composer-attachments-pick">
-          <span class="subject-composer-attachments-pick-btn__icon" aria-hidden="true">${svgIcon("image")}</span>
-          <span>Ajouter un fichier</span>
-        </button>
-      `
-      : "";
+    const hintHtml = "";
 
     const issueStatusActionHtml = renderIssueStatusAction(selection);
     const replyContext = type === "sujet" ? getReplyContextForSubject(item?.id) : null;
@@ -1295,10 +1316,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
               ${renderAttachmentTile(attachment, {
                 forceImage: !!attachment.isImage,
                 uploadState: attachment.error
-                  ? "Erreur d’upload"
+                  ? "error"
                   : String(attachment.uploadStatus || "").trim() === "uploading"
-                    ? "Envoi..."
-                    : "Prêt"
+                    ? "uploading"
+                    : "ready",
+                uploadStateText: attachment.error ? "Erreur d’upload" : ""
               })}
               <button
                 class="subject-composer-attachment-remove"
@@ -1330,7 +1352,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       : "";
 
     return renderCommentComposer({
-      title: "Add a comment",
+      title: "Ajouter un commentaire",
       avatarHtml: getAuthorIdentity({
         author: store?.user?.name,
         agent: "human",
@@ -1345,11 +1367,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
       textareaValue: String(store.situationsView.commentDraft || ""),
       placeholder: helpMode
         ? "Help (éphémère) — décrivez l’écran / l’action souhaitée."
-        : `Réponse humaine (Markdown) sur ce ${type === "sujet" ? "sujet" : "regroupement"} — mentionne @rapso pour solliciter l’agent.`,
+        : "Ecrire une réponse, glisser-déposer une pièce jointe...",
       hintHtml,
       contextHtml,
       actionsHtml,
       toolbarHtml,
+      tabsClassName: "comment-composer__tabs--main",
       footerHtml: `${mentionPopupHtml}${composerAttachmentsHtml}`
     });
   }

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -16,6 +16,7 @@ export function renderCommentComposer({
   footerHtml = "",
   actionsHtml = "",
   toolbarHtml = "",
+  tabsClassName = "",
   textareaAttributes = {},
   tabWriteAction = "tab-write",
   tabPreviewAction = "tab-preview",
@@ -41,10 +42,10 @@ export function renderCommentComposer({
 
         <div class="comment-box gh-comment-boxwrap comment-composer__box ${helpMode ? "gh-comment-box--help" : ""}">
           ${contextHtml || ""}
-          <div class="comment-tabs comment-composer__tabs ${helpMode ? "gh-comment-header--help" : ""}" role="tablist" aria-label="Comment tabs">
+          <div class="comment-composer__tabs light-tabs ${escapeHtml(tabsClassName)} ${helpMode ? "gh-comment-header--help" : ""}" role="tablist" aria-label="Onglets du commentaire">
             <div class="comment-composer__tabs-left">
-              <button class="comment-tab ${!previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabWriteAction)}" type="button">Write</button>
-              <button class="comment-tab ${previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabPreviewAction)}" type="button">Preview</button>
+              <button class="comment-tab light-tabs__item ${!previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabWriteAction)}" type="button" role="tab" aria-selected="${!previewMode ? "true" : "false"}"><span class="light-tabs__label">Écrire</span></button>
+              <button class="comment-tab light-tabs__item ${previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabPreviewAction)}" type="button" role="tab" aria-selected="${previewMode ? "true" : "false"}"><span class="light-tabs__label">Aperçu</span></button>
             </div>
             ${toolbarHtml ? `<div class="comment-composer__toolbar" role="toolbar" aria-label="Markdown toolbar">${toolbarHtml}</div>` : ""}
           </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2527,6 +2527,8 @@ body.is-resizing{
 .message-thread{display:block;}
 .message-thread__item{width:calc(100% + 52px);}
 .message-thread__comment{padding-left:var(--discussion-content-inset);}
+.message-thread .thread-item--comment{overflow:visible;}
+.message-thread .gh-comment-box{overflow:visible;}
 .comment-composer{display:flex;gap:12px;align-items:flex-start;margin-top:10px;}
 .comment-composer__main{flex:1 1 auto;min-width:0;}
 .comment-composer__box{width:100%;}
@@ -2547,6 +2549,20 @@ body.is-resizing{
 }
 .comment-composer__tabs{display:flex;align-items:center;justify-content:space-between;gap:8px;padding-right:8px;}
 .comment-composer__tabs-left{display:flex;align-items:center;gap:0;}
+.comment-composer__tabs.light-tabs{
+  margin:0;
+  border-bottom:1px solid var(--border2);
+  background:rgba(22,27,34,.6);
+}
+.comment-composer__tabs.light-tabs::before{
+  border-bottom:1px solid var(--border2);
+}
+.comment-composer__tabs.light-tabs .light-tabs__item{
+  padding:8px 12px;
+  font-size:13px;
+}
+.comment-composer__tabs--main{}
+.comment-composer__tabs--thread-reply{}
 .comment-composer__toolbar{display:flex;align-items:center;justify-content:flex-end;}
 .comment-toolbar-layout{
   display:grid;
@@ -2704,7 +2720,12 @@ body.is-resizing{
 .subject-attachment__caption{
   padding:6px 8px;
   color:var(--muted);
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
 }
+.subject-attachment__caption-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .subject-attachment--file{
   display:flex;
   align-items:center;
@@ -2721,11 +2742,18 @@ body.is-resizing{
   color:var(--muted);
 }
 .subject-attachment__file-body{flex:1 1 auto;min-width:0;}
+.subject-attachment__file-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+}
 .subject-attachment__file-name{
   color:var(--text);
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
+  min-width:0;
 }
 .subject-attachment__file-link--name{
   text-decoration:none;
@@ -2737,6 +2765,19 @@ body.is-resizing{
 .subject-attachment__file-meta{color:var(--muted);}
 .subject-attachment__file-link{font-size:12px;}
 .subject-attachment__state{padding:0 8px 8px;color:var(--muted);}
+.subject-attachment__upload-indicator{
+  display:inline-flex;
+  width:16px;
+  height:16px;
+  color:var(--fgColor-attention);
+  flex:0 0 auto;
+}
+.subject-attachment__spinner{width:16px;height:16px;}
+.anim-rotate{animation:thread-attachment-spin 1s linear infinite;transform-origin:center;}
+@keyframes thread-attachment-spin{
+  from{transform:rotate(0deg);}
+  to{transform:rotate(360deg);}
+}
 .md-render p{margin:0 0 10px;}
 .md-render p:last-child{margin-bottom:0;}
 .md-render ul,.md-render ol{margin:0 0 10px 20px;padding:0;}
@@ -2824,6 +2865,20 @@ body.is-resizing{
   padding:12px;
   background-color:var(--bg-input);
 }
+.thread-inline-reply-editor--root{
+  border-bottom-left-radius:var(--radius);
+  border-bottom-right-radius:var(--radius);
+}
+.thread-inline-reply-editor--nested{
+  border:1px solid var(--border2);
+  border-top-left-radius:var(--radius);
+  border-bottom-left-radius:var(--radius);
+}
+.thread-inline-reply-editor__actions{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+}
 .thread-inline-reply-editor .comment-composer__textarea{
   min-height:110px;
   background:var(--bgAssistPanel);
@@ -2834,6 +2889,8 @@ body.is-resizing{
   border-top:1px solid var(--border2);
   padding-top:8px;
   background-color:var(--bgAssistPanel);
+  border-bottom-left-radius:var(--radius);
+  border-bottom-right-radius:var(--radius);
 }
 .thread-comment-replies--github .gh-comment-box{
   border:none;
@@ -3450,7 +3507,7 @@ body.is-resizing{
 .actions-row--details{
   gap:10px;
   justify-content:flex-end;
-  padding:0 12px;
+  padding:0px;
 }
 .actions-row--details .rapso-mention-hint{margin-right:auto;}
 .actions-row--details .actions-row__right{width:100%;}


### PR DESCRIPTION
### Motivation
- Improve the comment/inline-reply composer UX by auto-resizing textareas to fit content and keep focus/selection stable when applying formatting actions. 
- Surface attachment upload state in the composer with visual indicators and consistent upload-state values. 
- Refactor thread comment rendering to support nested replies, per-editor attachments, and clearer action menus.

### Description
- Preserve textarea scroll position when applying markdown actions by saving/restoring `scrollTop`/`scrollLeft` in `applyMarkdownComposerAction`.
- Add autosize helpers `syncMainComposerTextareaHeight` and `syncInlineReplyTextareaHeight` and call them on relevant `input` events and after formatting actions to dynamically adjust textarea heights.
- Scope attachment inputs/dropzones to the composer instance by resolving the main composer root and use that for attach/pick actions.
- When opening an inline reply, clear attachments state from any previously expanded reply to avoid leaking attachments between editors.
- Normalize attachment `uploadState` values to lowercase canonical states (`uploading`, `ready`, `error`) and add `uploadStateText` to pass human-readable error text.
- Add two new SVG icons (`attachment-upload-spinner`, `attachment-upload-dot`) and render upload indicators (spinning icon for uploads, dot for ready) inside `renderAttachmentTile` with fallback progress text for errors or other states.
- Refactor thread rendering by extracting `resolveThreadCommentIdentity`, `renderThreadCommentActions`, and `renderThreadCommentNode` to handle nested replies, depth classes, reply counts, and inline reply composer placement with a `depth` parameter.
- Update `renderInlineReplyComposer` and `renderCommentComposer` to provide improved placeholders, tab classes, small layout adjustments, and action grouping for inline editors.
- Add CSS rules for tabs, attachment captions, upload indicators, spinner animation, and inline-reply editor variants to support the new UI elements and behaviors.

### Testing
- No automated tests were added or modified for this change and no automated test run was included with the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e478a7aa548329a1f3a3574bad762b)