### PR TITLE
Composer: center toolbar actions, hide toolbar in preview, style nested reply editor

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -794,6 +794,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           tabWriteAction: "thread-reply-tab-write",
           tabPreviewAction: "thread-reply-tab-preview",
           tabsClassName: "comment-composer__tabs--thread-reply",
+          composerClassName: "comment-composer--thread-reply-editor",
           toolbarHtml: renderMarkdownToolbar("thread-reply-format", { messageId: commentId }),
           previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
           actionsHtml: `

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -17,6 +17,7 @@ export function renderCommentComposer({
   actionsHtml = "",
   toolbarHtml = "",
   tabsClassName = "",
+  composerClassName = "",
   textareaAttributes = {},
   tabWriteAction = "tab-write",
   tabPreviewAction = "tab-preview",
@@ -34,7 +35,7 @@ export function renderCommentComposer({
     .filter(Boolean)
     .join(" ");
   return `
-    <div class="human-action comment-composer">
+    <div class="human-action comment-composer ${escapeHtml(composerClassName)}">
       ${hideAvatar ? "" : `<div class="gh-avatar gh-avatar--human comment-composer__avatar" aria-hidden="true">${avatarHtml}</div>`}
 
       <div class="comment-general-block comment-composer__main">
@@ -47,7 +48,7 @@ export function renderCommentComposer({
               <button class="comment-tab light-tabs__item ${!previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabWriteAction)}" type="button" role="tab" aria-selected="${!previewMode ? "true" : "false"}"><span class="light-tabs__label">Écrire</span></button>
               <button class="comment-tab light-tabs__item ${previewMode ? "is-active" : ""}" data-action="${escapeHtml(tabPreviewAction)}" type="button" role="tab" aria-selected="${previewMode ? "true" : "false"}"><span class="light-tabs__label">Aperçu</span></button>
             </div>
-            ${toolbarHtml ? `<div class="comment-composer__toolbar" role="toolbar" aria-label="Markdown toolbar">${toolbarHtml}</div>` : ""}
+            ${toolbarHtml && !previewMode ? `<div class="comment-composer__toolbar" role="toolbar" aria-label="Markdown toolbar">${toolbarHtml}</div>` : ""}
           </div>
 
           <div class="comment-editor comment-composer__editor ${previewMode ? "hidden" : ""}">

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2569,11 +2569,20 @@ body.is-resizing{
 }
 .comment-composer__tabs--main{}
 .comment-composer__tabs--thread-reply{}
-.comment-composer__toolbar{display:flex;align-items:center;justify-content:flex-end;}
+
+.comment-composer--thread-reply-editor .comment-editor{
+  background:var(--bgAssistPanel);
+}
+.comment-composer--thread-reply-editor .comment-composer__tabs.light-tabs .light-tabs__item.is-active{
+  background:var(--bgAssistPanel);
+}
+.comment-composer__toolbar{display:flex;align-items:center;justify-content:flex-end;min-height:39px;}
 .comment-toolbar-layout{
   display:grid;
   grid-template-columns:auto auto auto;
   align-items:center;
+  align-content:center;
+  height:100%;
   gap:0;
 }
 .comment-toolbar-layout__group{


### PR DESCRIPTION
### Motivation
- Améliorer l’alignement vertical des boutons d’action Markdown (gras/italique/...) dans la barre d’outils pour un rendu visuel centré. 
- Masquer les boutons d’actions lorsque l’utilisateur bascule en mode Aperçu pour éviter des contrôles inutiles. 
- Appliquer un style d’arrière-plan spécifique aux éditeurs de réponse imbriquée afin d’uniformiser l’apparence du panneau d’assistance.

### Description
- Ajout du paramètre `composerClassName` à la fonction `renderCommentComposer` et injection de cette classe sur la racine du composer afin de cibler les variantes (fichier modifié : `apps/web/js/views/ui/comment-composer.js`).
- Conditionnement de l’affichage de la toolbar Markdown pour ne l’afficher que lorsque `toolbarHtml` est présent ET que `previewMode` est `false` (fichier modifié : `apps/web/js/views/ui/comment-composer.js`).
- Passage de `composerClassName: "comment-composer--thread-reply-editor"` lors du rendu de l’éditeur de réponse imbriquée pour pouvoir le styler séparément (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Ajout de règles CSS pour la classe dédiée : mise du `background: var(--bgAssistPanel)` sur `.comment-editor` et sur l’onglet actif, et ajustement de la hauteur/centrage de la toolbar pour centrer verticalement les actions (fichier modifié : `apps/web/style.css`).

### Testing
- Vérification de la syntaxe JavaScript avec `node --check apps/web/js/views/ui/comment-composer.js` qui a réussi. 
- Vérification de la syntaxe JavaScript avec `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b8aba3548329982f06e8515918ea)