### PR TITLE
feat(thread): éditeur inline Markdown pour la modification des messages

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1684,7 +1684,10 @@ export function createProjectSubjectsEvents(config) {
           draftsByMessageId: {},
           previewByMessageId: {},
           attachmentsByMessageId: {},
-          uploadSessionByMessageId: {}
+          uploadSessionByMessageId: {},
+          editMessageId: "",
+          editDraftsByMessageId: {},
+          editPreviewByMessageId: {}
         };
       }
       if (!store.situationsView.inlineReplyUi.previewByMessageId || typeof store.situationsView.inlineReplyUi.previewByMessageId !== "object") {
@@ -1695,6 +1698,15 @@ export function createProjectSubjectsEvents(config) {
       }
       if (!store.situationsView.inlineReplyUi.uploadSessionByMessageId || typeof store.situationsView.inlineReplyUi.uploadSessionByMessageId !== "object") {
         store.situationsView.inlineReplyUi.uploadSessionByMessageId = {};
+      }
+      if (typeof store.situationsView.inlineReplyUi.editMessageId !== "string") {
+        store.situationsView.inlineReplyUi.editMessageId = "";
+      }
+      if (!store.situationsView.inlineReplyUi.editDraftsByMessageId || typeof store.situationsView.inlineReplyUi.editDraftsByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.editDraftsByMessageId = {};
+      }
+      if (!store.situationsView.inlineReplyUi.editPreviewByMessageId || typeof store.situationsView.inlineReplyUi.editPreviewByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.editPreviewByMessageId = {};
       }
       debugThreadReply("reply_state_fallback", { hasAccessor: typeof getInlineReplyUiState === "function" });
       return store.situationsView.inlineReplyUi;
@@ -1755,6 +1767,21 @@ export function createProjectSubjectsEvents(config) {
       );
       if (!submitButton) return;
       submitButton.disabled = !canSubmitInlineReply(normalizedMessageId);
+    };
+    const canSubmitInlineEdit = (messageId = "") => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return false;
+      const replyUi = resolveInlineReplyUiState();
+      return !!String(replyUi.editDraftsByMessageId?.[normalizedMessageId] || "").trim();
+    };
+    const syncInlineEditSubmitButton = (messageId = "") => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const submitButton = root.querySelector(
+        `[data-action='thread-edit-submit'][data-message-id="${selectorValue(normalizedMessageId)}"]`
+      );
+      if (!submitButton) return;
+      submitButton.disabled = !canSubmitInlineEdit(normalizedMessageId);
     };
     const syncInlineReplyTextareaHeight = (textarea) => {
       if (!textarea) return;
@@ -1922,22 +1949,22 @@ export function createProjectSubjectsEvents(config) {
     });
 
     root.querySelectorAll("[data-action='thread-message-edit'][data-message-id]").forEach((btn) => {
-      btn.onclick = async () => {
-        const selection = getScopedSelection(root);
-        if (selection?.type !== "sujet") return;
+      btn.onclick = () => {
         const messageId = String(btn.dataset.messageId || "").trim();
         if (!messageId) return;
-        const currentBody = String(btn.dataset.messageBody || "").trim();
-        const nextBody = window.prompt("Modifier le message", currentBody);
-        if (nextBody == null) return;
-        const normalized = String(nextBody || "").trim();
-        if (!normalized || normalized === currentBody) return;
         btn.closest(".thread-comment-menu__dropdown")?.classList.remove("is-open");
-        try {
-          await editSubjectMessage?.(selection.item.id, messageId, normalized);
-        } catch (error) {
-          showError(`Modification impossible : ${String(error?.message || error || "Erreur inconnue")}`);
+        const replyUi = resolveInlineReplyUiState();
+        const currentBody = String(btn.dataset.messageBody || "");
+        if (!String(replyUi.editDraftsByMessageId?.[messageId] || "").trim()) {
+          replyUi.editDraftsByMessageId[messageId] = currentBody;
         }
+        replyUi.editPreviewByMessageId[messageId] = false;
+        replyUi.editMessageId = messageId;
+        rerenderScope(root);
+        requestAnimationFrame(() => {
+          const textarea = root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+          textarea?.focus();
+        });
       };
     });
 
@@ -1978,6 +2005,26 @@ export function createProjectSubjectsEvents(config) {
       });
     });
 
+    root.querySelectorAll("[data-thread-edit-draft]").forEach((textarea) => {
+      syncInlineReplyTextareaHeight(textarea);
+      textarea.addEventListener("input", () => {
+        const messageId = String(textarea.dataset.threadEditDraft || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
+        syncInlineReplyTextareaHeight(textarea);
+        syncInlineEditSubmitButton(messageId);
+      });
+      textarea.addEventListener("keydown", (event) => {
+        if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
+        event.preventDefault();
+        const submitButton = textarea.closest(".thread-inline-edit-editor")?.querySelector("[data-action='thread-edit-submit'][data-message-id]");
+        const messageId = String(textarea.dataset.threadEditDraft || "").trim();
+        if (messageId) syncInlineEditSubmitButton(messageId);
+        if (submitButton && !submitButton.disabled) submitButton.click();
+      });
+    });
+
     root.querySelectorAll("[data-action='thread-reply-tab-write']").forEach((btn) => {
       btn.onclick = () => {
         const messageId = String(btn.closest("[data-inline-reply-editor]")?.dataset.inlineReplyEditor || "").trim();
@@ -1998,6 +2045,26 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    root.querySelectorAll("[data-action='thread-edit-tab-write']").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.closest("[data-inline-edit-editor]")?.dataset.inlineEditEditor || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.editPreviewByMessageId[messageId] = false;
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-edit-tab-preview']").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.closest("[data-inline-edit-editor]")?.dataset.inlineEditEditor || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.editPreviewByMessageId[messageId] = true;
+        rerenderScope(root);
+      };
+    });
+
     root.querySelectorAll("[data-action='thread-reply-format'][data-format][data-message-id]").forEach((btn) => {
       btn.onclick = () => {
         const action = String(btn.dataset.format || "").trim();
@@ -2011,6 +2078,23 @@ export function createProjectSubjectsEvents(config) {
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
         syncInlineReplyTextareaHeight(textarea);
         syncInlineReplySubmitButton(messageId);
+        textarea.focus();
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-edit-format'][data-format][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const action = String(btn.dataset.format || "").trim();
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!action || !messageId) return;
+        const textarea = root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+        if (!textarea) return;
+        const didApply = applyMarkdownComposerAction(textarea, action);
+        if (!didApply) return;
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
+        syncInlineReplyTextareaHeight(textarea);
+        syncInlineEditSubmitButton(messageId);
         textarea.focus();
       };
     });
@@ -2104,6 +2188,45 @@ export function createProjectSubjectsEvents(config) {
         clearInlineReplyAttachmentsState(parentMessageId);
         replyUi.expandedMessageId = "";
         rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-edit-cancel'][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.dataset.messageId || "").trim();
+        const replyUi = resolveInlineReplyUiState();
+        if (messageId) replyUi.editPreviewByMessageId[messageId] = false;
+        replyUi.editMessageId = "";
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='thread-edit-submit'][data-message-id]").forEach((btn) => {
+      btn.onclick = async () => {
+        const selection = getScopedSelection(root);
+        if (selection?.type !== "sujet") return;
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!messageId) return;
+        const replyUi = resolveInlineReplyUiState();
+        const nextBody = String(replyUi.editDraftsByMessageId?.[messageId] || "");
+        const normalized = nextBody.trim();
+        if (!normalized) return;
+        const currentBody = String(btn.dataset.originalBody || "");
+        if (normalized === currentBody.trim()) {
+          replyUi.editPreviewByMessageId[messageId] = false;
+          replyUi.editMessageId = "";
+          rerenderScope(root);
+          return;
+        }
+        try {
+          await editSubjectMessage?.(selection.item.id, messageId, normalized);
+          replyUi.editPreviewByMessageId[messageId] = false;
+          replyUi.editMessageId = "";
+        } catch (error) {
+          showError(`Modification impossible : ${String(error?.message || error || "Erreur inconnue")}`);
+        } finally {
+          rerenderScope(root);
+        }
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -218,6 +218,13 @@ export function createProjectSubjectsThread(config = {}) {
     if (!state.inlineReplyUi.uploadSessionByMessageId || typeof state.inlineReplyUi.uploadSessionByMessageId !== "object") {
       state.inlineReplyUi.uploadSessionByMessageId = {};
     }
+    if (typeof state.inlineReplyUi.editMessageId !== "string") state.inlineReplyUi.editMessageId = "";
+    if (!state.inlineReplyUi.editDraftsByMessageId || typeof state.inlineReplyUi.editDraftsByMessageId !== "object") {
+      state.inlineReplyUi.editDraftsByMessageId = {};
+    }
+    if (!state.inlineReplyUi.editPreviewByMessageId || typeof state.inlineReplyUi.editPreviewByMessageId !== "object") {
+      state.inlineReplyUi.editPreviewByMessageId = {};
+    }
     return state.inlineReplyUi;
   }
 
@@ -827,6 +834,42 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
+  function renderInlineEditComposer({ commentId, depth = 0, isEditing = false, draft = "", previewMode = false, originalMessage = "" } = {}) {
+    if (!commentId || !isEditing) return "";
+    const normalizedDraft = String(draft || "");
+    const submitLabel = Number(depth || 0) > 0 ? "Mettre à jour la réponse" : "Mettre à jour le commentaire";
+    const canSubmit = !!normalizedDraft.trim();
+    return `
+      <div class="thread-inline-edit-editor" data-inline-edit-editor="${escapeHtml(commentId)}">
+        ${renderCommentComposer({
+          hideAvatar: true,
+          hideTitle: true,
+          previewMode,
+          textareaId: `threadEditBox-${commentId}`,
+          previewId: `threadEditPreview-${commentId}`,
+          textareaValue: normalizedDraft,
+          textareaAttributes: {
+            "data-thread-edit-draft": commentId
+          },
+          placeholder: "Modifier le message...",
+          tabWriteAction: "thread-edit-tab-write",
+          tabPreviewAction: "thread-edit-tab-preview",
+          tabsClassName: "comment-composer__tabs--thread-reply",
+          composerClassName: "comment-composer--thread-reply-editor",
+          toolbarHtml: renderMarkdownToolbar("thread-edit-format", { messageId: commentId }),
+          previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
+          actionsHtml: `
+            <div class="thread-inline-reply-editor__actions">
+              <button class="gh-btn" type="button" data-action="thread-edit-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
+              <button class="gh-btn gh-btn--comment gh-btn--primary" type="button" data-action="thread-edit-submit" data-message-id="${escapeHtml(commentId)}" data-original-body="${escapeHtml(String(originalMessage || ""))}" ${canSubmit ? "" : "disabled"}>${submitLabel}</button>
+            </div>
+          `,
+          previewEmptyHint: "Use Markdown to format your comment"
+        })}
+      </div>
+    `;
+  }
+
   function resolveThreadCommentIdentity(entry) {
     const currentUserId = normalizeId(store?.user?.id);
     const authorUserId = normalizeId(entry?.meta?.author_user_id);
@@ -886,8 +929,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
       ? `message-thread__comment--nested message-thread__comment--reply-item message-thread__comment--depth-${nestedDepth}`
       : "";
     const isExpanded = replyUi.expandedMessageId === commentId;
+    const isEditing = replyUi.editMessageId === commentId;
     const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
     const previewMode = !!replyUi.previewByMessageId?.[commentId];
+    const editDraft = String(replyUi.editDraftsByMessageId?.[commentId] || "");
+    const editPreviewMode = !!replyUi.editPreviewByMessageId?.[commentId];
     const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
       ? replyUi.attachmentsByMessageId[commentId]
       : [];
@@ -910,9 +956,20 @@ priority=${firstNonEmpty(subject.priority, "")}`
       tsHtml,
       headerRightHtml: renderThreadCommentActions(entry),
       bodyHtml: `
-        <div class="thread-comment-content-capsule">
-          ${mdToHtml(entry?.message || "")}
-        </div>
+        ${isEditing
+          ? renderInlineEditComposer({
+            commentId,
+            depth,
+            isEditing,
+            draft: editDraft || String(entry?.message || ""),
+            previewMode: editPreviewMode,
+            originalMessage: String(entry?.message || "")
+          })
+          : `
+            <div class="thread-comment-content-capsule">
+              ${mdToHtml(entry?.message || "")}
+            </div>
+          `}
         ${(Array.isArray(entry?.meta?.attachments) && entry.meta.attachments.length)
           ? `<div class="subject-attachment-grid">${entry.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`
           : ""}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2873,6 +2873,12 @@ body.is-resizing{
 .thread-comment-content-capsule{
   padding:12px;
 }
+.thread-inline-edit-editor{
+  padding:12px;
+}
+.thread-inline-edit-editor .comment-composer__actions{
+  margin-bottom:0;
+}
 .thread-comment-footer{
   display:flex;
   justify-content:flex-end;


### PR DESCRIPTION
### Motivation
- Remplacer le flux d’édition actuel basé sur `window.prompt` qui ne permet pas de voir/mettre en forme le message complet et offre une mauvaise UX pour modifier un commentaire principal ou une réponse imbriquée. 
- Réutiliser les composants existants pour afficher un véritable éditeur Write/Aperçu/toolbar directement à la place du `thread-comment-content-capsule` lors de l’action “Modifier le message”.

### Description
- Ajout d’un état d’édition dans `inlineReplyUi` (`editMessageId`, `editDraftsByMessageId`, `editPreviewByMessageId`) dans `apps/web/js/views/project-subjects/project-subjects-thread.js` et `apps/web/js/views/project-subjects/project-subjects-events.js` pour piloter l’édition inline. 
- Création de `renderInlineEditComposer` qui réutilise `renderCommentComposer` et `renderMarkdownToolbar` pour fournir Write/Aperçu, toolbar markdown et actions, avec libellés contextuels (`Mettre à jour le commentaire` ou `Mettre à jour la réponse`).
- Intégration de l’éditeur inline dans `renderThreadCommentNode` pour afficher l’éditeur à la place du `thread-comment-content-capsule` quand `editMessageId` est actif, et propagation des drafts/preview par message.
- Remplacement du `window.prompt` par des handlers d’ouverture, format, write/preview tabs, `Ctrl/Cmd+Enter`, annulation et soumission dans `apps/web/js/views/project-subjects/project-subjects-events.js`, et ajout de styles CSS légers dans `apps/web/style.css` pour l’éditeur inline.

### Testing
- Exécution de la vérification de syntaxe JS avec `node --check apps/web/js/views/project-subjects/project-subjects-thread.js && node --check apps/web/js/views/project-subjects/project-subjects-events.js`, qui a réussi. 
- Aucun test unitaire additionnel automatisé n’a été exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c356419c832985fdb05a2968dd10)