### PR TITLE
fix(subjects): reduce parasitic rerenders in subject discussion panel

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2318,7 +2318,41 @@ function rerenderPanels() {
 
 
 function rerenderScope(root) {
-  rerenderPanels();
+  const detailsHost = document.getElementById("situationsDetailsHost");
+  const shouldRerenderDetailsOnly = !!detailsHost
+    && detailsHost.isConnected
+    && !store.situationsView.createSubjectForm?.isOpen
+    && String(store.situationsView.subjectsSubview || "subjects") === "subjects"
+    && !store.situationsView.showTableOnly
+    && !!root?.closest?.("#situationsDetailsHost");
+
+  if (shouldRerenderDetailsOnly) {
+    const detailsScrollState = getScrollableElementScrollState(detailsHost);
+    const details = getProjectSubjectDetail().renderDetailsHtml(null, {
+      showExpand: false,
+      subissuesOptions: {
+        sujetRowClass: "js-modal-drilldown-sujet",
+        sujetToggleClass: "js-modal-toggle-sujet",
+        avisRowClass: "js-modal-drilldown-avis",
+        expandedSujets: store.situationsView.rightExpandedSujets,
+        expandedSubjectIds: store.situationsView.rightSubissuesExpandedSubjectIds,
+        openMenuId: store.situationsView.rightSubissueMenuOpenId,
+        isOpen: store.situationsView.rightSubissuesOpen
+      }
+    });
+    detailsHost.innerHTML = details.bodyHtml;
+    wireDetailsInteractive(detailsHost);
+    bindDetailsScroll(document);
+    restoreScrollableElementScrollState(detailsHost, detailsScrollState);
+    requestAnimationFrame(() => {
+      restoreScrollableElementScrollState(detailsHost, detailsScrollState);
+      const currentDetailsHost = document.getElementById("situationsDetailsHost");
+      currentDetailsHost?.__syncCondensedTitle?.();
+    });
+  } else {
+    rerenderPanels();
+  }
+
   const drilldownBody = document.getElementById("drilldownBody");
   if (root?.closest?.("#drilldownPanel") && drilldownBody) {
     getProjectSubjectDrilldown().updateDrilldownPanel();


### PR DESCRIPTION
### Motivation
- Thread interactions (reply, edit, attachments, timeline refresh) invoked a generic rerender path that often performed a full panel re-render, causing avatars/images to repaint and producing visible scroll jumps/vibration.
- The goal is to scope rerenders to the discussion details when the action originates there to eliminate the parasitic DOM re-injections and UX vibration.

### Description
- Modify `rerenderScope(root)` in `apps/web/js/views/project-subjects/project-subjects-view.js` to detect when the interaction originates from `#situationsDetailsHost` and perform a targeted re-render of that host instead of calling `rerenderPanels()`.
- Preserve and restore the details host scroll using `getScrollableElementScrollState` / `restoreScrollableElementScrollState` and rebind interactions with `wireDetailsInteractive` and `bindDetailsScroll` after the partial update.
- Use `requestAnimationFrame` to reapply scroll restoration and call `__syncCondensedTitle` on the refreshed host, and fall back to the original `rerenderPanels()` when the scoped update is not applicable.

### Testing
- Ran `node --check apps/web/js/views/project-subjects/project-subjects-view.js`, which completed without errors.
- No automated browser/integration tests were available in this environment to validate visual jitter, so runtime verification should be performed in a browser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c797a8988329b6e2a49bd63406ff)