### PR TITLE
Inline comment editors: toggle visibility and preview with mdToHtml, mention link styling, and details rerender optimization

### DIFF
--- a/apps/web/js/utils/markdown-renderer.js
+++ b/apps/web/js/utils/markdown-renderer.js
@@ -25,7 +25,9 @@ function renderInlineMarkdown(source = "") {
     const href = sanitizeLinkHref(hrefRaw);
     if (!href) return `${label} (lien non autorisé)`;
     const external = /^https?:/i.test(href);
-    return `<a href="${escapeHtml(href)}"${external ? ' target="_blank" rel="noopener noreferrer"' : ""}>${label}</a>`;
+    const isMentionLink = /^\/people\//i.test(href);
+    const className = isMentionLink ? ' class="md-mention-link"' : "";
+    return `<a href="${escapeHtml(href)}"${className}${external ? ' target="_blank" rel="noopener noreferrer"' : ""}>${label}</a>`;
   });
 
   return safe;

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -392,6 +392,7 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   deleteSubjectMessage: (...args) => deleteSubjectMessage(...args),
   getMentionUiState: (...args) => getMentionUiState(...args),
   getComposerAttachmentsState: (...args) => getComposerAttachmentsState(...args),
+  mdToHtml,
   listCollaboratorsForMentions: (...args) => subjectMessagesService.listCollaboratorsForMentions(...args),
   uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args),
   removeTemporaryAttachment: (...args) => subjectMessagesService.removeTemporaryAttachment(...args),

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -66,6 +66,7 @@ export function createProjectSubjectsEvents(config) {
     deleteSubjectMessage,
     getMentionUiState,
     getComposerAttachmentsState,
+    mdToHtml,
     listCollaboratorsForMentions,
     uploadAttachmentFile,
     removeTemporaryAttachment
@@ -1795,6 +1796,24 @@ export function createProjectSubjectsEvents(config) {
       const nextHeight = Math.max(minHeight, textarea.scrollHeight + extraPadding);
       textarea.style.height = `${nextHeight}px`;
     };
+    const toggleInlineReplyEditorVisibility = (messageId = "", visible = false) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const editor = root.querySelector(`[data-inline-reply-editor="${selectorValue(normalizedMessageId)}"]`);
+      if (!editor) return;
+      editor.classList.toggle("hidden", !visible);
+      if (visible) editor.removeAttribute("aria-hidden");
+      else editor.setAttribute("aria-hidden", "true");
+    };
+    const toggleInlineEditEditorVisibility = (messageId = "", visible = false) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const editor = root.querySelector(`[data-inline-edit-editor="${selectorValue(normalizedMessageId)}"]`);
+      if (!editor) return;
+      editor.classList.toggle("hidden", !visible);
+      if (visible) editor.removeAttribute("aria-hidden");
+      else editor.setAttribute("aria-hidden", "true");
+    };
     const clearInlineReplyAttachmentsState = (messageId = "", { keepUploadSession = false } = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -1939,12 +1958,22 @@ export function createProjectSubjectsEvents(config) {
           messageId,
           hasDraft: !!String(replyUi.draftsByMessageId?.[messageId] || "").trim()
         });
-        rerenderScope(root);
-        requestAnimationFrame(() => {
-          const textarea = root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
-          debugThreadReply("reply_editor_presence", { messageId, found: !!textarea });
-          textarea?.focus();
-        });
+        if (previouslyExpandedMessageId && previouslyExpandedMessageId !== messageId) {
+          toggleInlineReplyEditorVisibility(previouslyExpandedMessageId, false);
+        }
+        toggleInlineReplyEditorVisibility(messageId, true);
+        const textarea = root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+        if (textarea) {
+          textarea.value = String(replyUi.draftsByMessageId?.[messageId] || "");
+          syncInlineReplyTextareaHeight(textarea);
+          syncInlineReplySubmitButton(messageId);
+          requestAnimationFrame(() => {
+            debugThreadReply("reply_editor_presence", { messageId, found: true });
+            textarea.focus();
+          });
+        } else {
+          rerenderScope(root);
+        }
       };
     });
 
@@ -1958,13 +1987,22 @@ export function createProjectSubjectsEvents(config) {
         if (!String(replyUi.editDraftsByMessageId?.[messageId] || "").trim()) {
           replyUi.editDraftsByMessageId[messageId] = currentBody;
         }
+        const previousEditMessageId = String(replyUi.editMessageId || "").trim();
         replyUi.editPreviewByMessageId[messageId] = false;
         replyUi.editMessageId = messageId;
-        rerenderScope(root);
-        requestAnimationFrame(() => {
-          const textarea = root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
-          textarea?.focus();
-        });
+        if (previousEditMessageId && previousEditMessageId !== messageId) {
+          toggleInlineEditEditorVisibility(previousEditMessageId, false);
+        }
+        toggleInlineEditEditorVisibility(messageId, true);
+        const textarea = root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+        if (textarea) {
+          textarea.value = String(replyUi.editDraftsByMessageId?.[messageId] || "");
+          syncInlineReplyTextareaHeight(textarea);
+          syncInlineEditSubmitButton(messageId);
+          requestAnimationFrame(() => textarea.focus());
+        } else {
+          rerenderScope(root);
+        }
       };
     });
 
@@ -2031,7 +2069,17 @@ export function createProjectSubjectsEvents(config) {
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.previewByMessageId[messageId] = false;
-        rerenderScope(root);
+        const writeTab = btn.closest(".comment-composer")?.querySelector("[data-action='thread-reply-tab-write']");
+        const previewTab = btn.closest(".comment-composer")?.querySelector("[data-action='thread-reply-tab-preview']");
+        const composerRoot = btn.closest(".comment-composer");
+        const textareaWrap = composerRoot?.querySelector(".comment-composer__editor");
+        const previewWrap = composerRoot?.querySelector(".comment-composer__preview-wrap");
+        writeTab?.classList.add("is-active");
+        previewTab?.classList.remove("is-active");
+        writeTab?.setAttribute("aria-selected", "true");
+        previewTab?.setAttribute("aria-selected", "false");
+        textareaWrap?.classList.remove("hidden");
+        previewWrap?.classList.add("hidden");
       };
     });
 
@@ -2041,7 +2089,22 @@ export function createProjectSubjectsEvents(config) {
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.previewByMessageId[messageId] = true;
-        rerenderScope(root);
+        const composerRoot = btn.closest(".comment-composer");
+        const textarea = composerRoot?.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+        const previewWrap = composerRoot?.querySelector(".comment-composer__preview");
+        const previewWrapContainer = composerRoot?.querySelector(".comment-composer__preview-wrap");
+        const writeTab = composerRoot?.querySelector("[data-action='thread-reply-tab-write']");
+        const previewTab = composerRoot?.querySelector("[data-action='thread-reply-tab-preview']");
+        writeTab?.classList.remove("is-active");
+        previewTab?.classList.add("is-active");
+        writeTab?.setAttribute("aria-selected", "false");
+        previewTab?.setAttribute("aria-selected", "true");
+        composerRoot?.querySelector(".comment-composer__editor")?.classList.add("hidden");
+        previewWrapContainer?.classList.remove("hidden");
+        if (previewWrap) {
+          const markdown = String(textarea?.value || replyUi.draftsByMessageId?.[messageId] || "");
+          previewWrap.innerHTML = markdown.trim() ? mdToHtml(markdown) : `<div class="comment-composer__preview-empty">Use Markdown to format your reply</div>`;
+        }
       };
     });
 
@@ -2051,7 +2114,15 @@ export function createProjectSubjectsEvents(config) {
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.editPreviewByMessageId[messageId] = false;
-        rerenderScope(root);
+        const composerRoot = btn.closest(".comment-composer");
+        const writeTab = composerRoot?.querySelector("[data-action='thread-edit-tab-write']");
+        const previewTab = composerRoot?.querySelector("[data-action='thread-edit-tab-preview']");
+        writeTab?.classList.add("is-active");
+        previewTab?.classList.remove("is-active");
+        writeTab?.setAttribute("aria-selected", "true");
+        previewTab?.setAttribute("aria-selected", "false");
+        composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
+        composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
       };
     });
 
@@ -2061,7 +2132,22 @@ export function createProjectSubjectsEvents(config) {
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.editPreviewByMessageId[messageId] = true;
-        rerenderScope(root);
+        const composerRoot = btn.closest(".comment-composer");
+        const textarea = composerRoot?.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+        const previewWrap = composerRoot?.querySelector(".comment-composer__preview");
+        const previewWrapContainer = composerRoot?.querySelector(".comment-composer__preview-wrap");
+        const writeTab = composerRoot?.querySelector("[data-action='thread-edit-tab-write']");
+        const previewTab = composerRoot?.querySelector("[data-action='thread-edit-tab-preview']");
+        writeTab?.classList.remove("is-active");
+        previewTab?.classList.add("is-active");
+        writeTab?.setAttribute("aria-selected", "false");
+        previewTab?.setAttribute("aria-selected", "true");
+        composerRoot?.querySelector(".comment-composer__editor")?.classList.add("hidden");
+        previewWrapContainer?.classList.remove("hidden");
+        if (previewWrap) {
+          const markdown = String(textarea?.value || replyUi.editDraftsByMessageId?.[messageId] || "");
+          previewWrap.innerHTML = markdown.trim() ? mdToHtml(markdown) : `<div class="comment-composer__preview-empty">Use Markdown to format your comment</div>`;
+        }
       };
     });
 
@@ -2157,7 +2243,7 @@ export function createProjectSubjectsEvents(config) {
         if (messageId) replyUi.previewByMessageId[messageId] = false;
         if (messageId) clearInlineReplyAttachmentsState(messageId);
         replyUi.expandedMessageId = "";
-        rerenderScope(root);
+        toggleInlineReplyEditorVisibility(messageId, false);
       };
     });
 
@@ -2197,7 +2283,7 @@ export function createProjectSubjectsEvents(config) {
         const replyUi = resolveInlineReplyUiState();
         if (messageId) replyUi.editPreviewByMessageId[messageId] = false;
         replyUi.editMessageId = "";
-        rerenderScope(root);
+        toggleInlineEditEditorVisibility(messageId, false);
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -74,14 +74,10 @@ export function createProjectSubjectsThread(config = {}) {
   }
 
   function mapMessageRowToThreadComment(row = {}) {
+    if (row?.deleted_at) return null;
     const authorProfile = resolveAuthorProfile(row);
-    const isDeleted = !!row.deleted_at;
     const isFrozen = !!row.is_frozen;
-    const stateLabel = isDeleted
-      ? "supprimé"
-      : isFrozen
-        ? "figé (vu par un tiers)"
-        : "modifiable";
+    const stateLabel = isFrozen ? "figé (vu par un tiers)" : "modifiable";
     return {
       ts: firstNonEmpty(row.created_at, nowIso()),
       entity_type: "sujet",
@@ -89,7 +85,7 @@ export function createProjectSubjectsThread(config = {}) {
       type: "COMMENT",
       actor: authorProfile.displayName,
       agent: "human",
-      message: String(row.deleted_at ? "[message supprimé]" : row.body_markdown || ""),
+      message: String(row.body_markdown || ""),
       pending: false,
       request_id: null,
       meta: {
@@ -102,7 +98,7 @@ export function createProjectSubjectsThread(config = {}) {
         depth: 0,
         reply_preview: "",
         is_frozen: isFrozen,
-        is_deleted: isDeleted,
+        is_deleted: false,
         state_label: stateLabel,
         mentions: Array.isArray(row?.mentions) ? row.mentions : [],
         attachments: Array.isArray(row?.attachments) ? row.attachments : []
@@ -745,7 +741,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
   function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [], depth = 0 }) {
     if (!commentId) return "";
-    if (!isExpanded) return "";
     const pendingAttachments = Array.isArray(attachments) ? attachments : [];
     const normalizedDraft = String(draft || "");
     const hasReadyAttachment = pendingAttachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
@@ -786,7 +781,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       : "thread-inline-reply-editor thread-inline-reply-editor--root";
 
     return `
-      <div class="${inlineEditorClass}" data-inline-reply-editor="${escapeHtml(commentId)}">
+      <div class="${inlineEditorClass} ${isExpanded ? "" : "hidden"}" data-inline-reply-editor="${escapeHtml(commentId)}" ${isExpanded ? "" : "aria-hidden=\"true\""}>
         ${renderCommentComposer({
           hideAvatar: true,
           hideTitle: true,
@@ -835,7 +830,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
   }
 
   function renderInlineEditComposer({ commentId, depth = 0, isEditing = false, draft = "", previewMode = false, originalMessage = "" } = {}) {
-    if (!commentId || !isEditing) return "";
+    if (!commentId) return "";
     const normalizedDraft = String(draft || "");
     const isNestedReplyEdit = Number(depth || 0) > 0;
     const editModeClass = isNestedReplyEdit
@@ -847,7 +842,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const submitLabel = Number(depth || 0) > 0 ? "Mettre à jour la réponse" : "Mettre à jour le commentaire";
     const canSubmit = !!normalizedDraft.trim();
     return `
-      <div class="thread-inline-edit-editor ${editModeClass}" data-inline-edit-editor="${escapeHtml(commentId)}">
+      <div class="thread-inline-edit-editor ${editModeClass} ${isEditing ? "" : "hidden"}" data-inline-edit-editor="${escapeHtml(commentId)}" ${isEditing ? "" : "aria-hidden=\"true\""}>
         ${renderCommentComposer({
           hideAvatar: true,
           hideTitle: true,
@@ -1114,6 +1109,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
       if (type === "ACTIVITY") {
         const kind = String(e?.kind || "").toLowerCase();
+        if (kind === "message_deleted") return "";
         const agent = e?.agent || "system";
         const activityIdentity = getAuthorIdentity({
           author: e?.actor,
@@ -1179,10 +1175,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
         } else if (kind === "message_edited") {
           iconHtml = `<span class="tl-ico-wrap tl-ico-reopened" aria-hidden="true">${svgIcon("pencil")}</span>`;
           verb = "edited a message on";
-          targetHtml = "this conversation";
-        } else if (kind === "message_deleted") {
-          iconHtml = `<span class="tl-ico-wrap tl-ico-closed" aria-hidden="true">${svgIcon("trash")}</span>`;
-          verb = "deleted a message on";
           targetHtml = "this conversation";
         } else if (kind === "message_frozen") {
           iconHtml = `<span class="tl-ico-wrap tl-ico-closed" aria-hidden="true">${svgIcon("lock")}</span>`;

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2318,7 +2318,41 @@ function rerenderPanels() {
 
 
 function rerenderScope(root) {
-  rerenderPanels();
+  const detailsHost = document.getElementById("situationsDetailsHost");
+  const shouldRerenderDetailsOnly = !!detailsHost
+    && detailsHost.isConnected
+    && !store.situationsView.createSubjectForm?.isOpen
+    && String(store.situationsView.subjectsSubview || "subjects") === "subjects"
+    && !store.situationsView.showTableOnly
+    && !!root?.closest?.("#situationsDetailsHost");
+
+  if (shouldRerenderDetailsOnly) {
+    const detailsScrollState = getScrollableElementScrollState(detailsHost);
+    const details = getProjectSubjectDetail().renderDetailsHtml(null, {
+      showExpand: false,
+      subissuesOptions: {
+        sujetRowClass: "js-modal-drilldown-sujet",
+        sujetToggleClass: "js-modal-toggle-sujet",
+        avisRowClass: "js-modal-drilldown-avis",
+        expandedSujets: store.situationsView.rightExpandedSujets,
+        expandedSubjectIds: store.situationsView.rightSubissuesExpandedSubjectIds,
+        openMenuId: store.situationsView.rightSubissueMenuOpenId,
+        isOpen: store.situationsView.rightSubissuesOpen
+      }
+    });
+    detailsHost.innerHTML = details.bodyHtml;
+    wireDetailsInteractive(detailsHost);
+    bindDetailsScroll(document);
+    restoreScrollableElementScrollState(detailsHost, detailsScrollState);
+    requestAnimationFrame(() => {
+      restoreScrollableElementScrollState(detailsHost, detailsScrollState);
+      const currentDetailsHost = document.getElementById("situationsDetailsHost");
+      currentDetailsHost?.__syncCondensedTitle?.();
+    });
+  } else {
+    rerenderPanels();
+  }
+
   const drilldownBody = document.getElementById("drilldownBody");
   if (root?.closest?.("#drilldownPanel") && drilldownBody) {
     getProjectSubjectDrilldown().updateDrilldownPanel();

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2808,6 +2808,12 @@ body.is-resizing{
 .md-render blockquote{margin:0 0 10px;padding:6px 10px;border-left:3px solid var(--border2);color:var(--muted);}
 .md-render code{background:rgba(110,118,129,.2);border-radius:4px;padding:1px 4px;font-size:12px;}
 .md-render h1,.md-render h2,.md-render h3,.md-render h4,.md-render h5,.md-render h6{margin:0 0 10px;font-size:14px;}
+.md-render .md-mention-link{
+  text-decoration-color:rgb(210,153,34);
+  color:rgb(210,153,34);
+  background-color:rgba(187,128,9,0.15);
+  text-decoration-line:underline;
+}
 .md-task-item{display:flex;align-items:flex-start;gap:6px;list-style:none;margin-left:-18px;}
 .md-task-item input{margin-top:2px;}
 


### PR DESCRIPTION
### Motivation

- Improve inline reply/edit UX by toggling editor visibility instead of triggering full re-renders and provide live Markdown previews. 
- Render mention-style links differently in Markdown and visually emphasize them. 
- Avoid showing deleted messages and redundant activity items in threads. 
- Reduce unnecessary full-panel re-renders by updating the details host in-place when appropriate.

### Description

- Passes `mdToHtml` through project subject views and events and uses it to render composer previews without calling `rerenderScope`. 
- Adds `toggleInlineReplyEditorVisibility` and `toggleInlineEditEditorVisibility` to show/hide inline editors and update `aria-hidden`, and updates reply/edit open/cancel/preview/write handlers to set textarea values, sync heights, and focus the editor when present. 
- Changes `renderInlineReplyComposer` and `renderInlineEditComposer` to render editors with conditional `hidden` class and `aria-hidden` attributes instead of returning early, enabling DOM toggling. 
- Updates markdown renderer to add a `md-mention-link` class for links to `/people/` and adds corresponding CSS styling in `style.css`. 
- Filters out deleted messages in `mapMessageRowToThreadComment` and suppresses `message_deleted` activity entries in thread rendering. 
- Optimizes `rerenderScope` to update only the details host when the details panel is active, preserving scroll state and wiring interactions.

### Testing

- Ran linting with `yarn lint` and the linter passed. 
- Ran the test suite with `yarn test` and unit tests passed. 
- Built the frontend with `yarn build` to validate bundling and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c797a8988329b6e2a49bd63406ff)