### PR TITLE
Fix mention/emoji popup behavior and thread menu/footer layout

### DIFF
--- a/apps/web/js/utils/subject-mentions.js
+++ b/apps/web/js/utils/subject-mentions.js
@@ -30,21 +30,16 @@ export function resolveMentionTriggerContext(text = "", cursorIndex = 0) {
   const source = String(text || "");
   const caret = Math.max(0, Math.min(Number(cursorIndex || 0), source.length));
   const before = source.slice(0, caret);
-
-  let index = before.length - 1;
-  while (index >= 0) {
-    const char = before[index];
-    if (char === "\n" || char === "\r" || char === "\t" || char === " ") break;
-    index -= 1;
-  }
-
-  const tokenStart = index + 1;
-  const token = before.slice(tokenStart);
-  if (!token.startsWith("@")) return null;
+  const triggerStart = before.lastIndexOf("@");
+  if (triggerStart < 0) return null;
+  const previousChar = triggerStart === 0 ? "" : before[triggerStart - 1];
+  if (triggerStart > 0 && /[A-Za-z0-9_]/.test(previousChar)) return null;
+  const token = before.slice(triggerStart);
+  if (/[\s\r\n\t]/.test(token)) return null;
   if (token.length >= 2 && token[1] === "[") return null;
 
   return {
-    triggerStart: tokenStart,
+    triggerStart,
     triggerEnd: caret,
     query: token.slice(1)
   };

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -770,7 +770,6 @@ export function createProjectSubjectsEvents(config) {
 
     const positionAutocompletePopup = (textarea, popup) => {
       if (!textarea || !popup || !popup.isConnected) return;
-      if (document.activeElement !== textarea) return;
       const caretRect = computeTextareaCaretRect(textarea, textarea.selectionStart || 0);
       if (!caretRect) return;
       popup.style.position = "fixed";

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1024,7 +1024,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
             `
             : ""}
           <button class="gh-menu__item" type="button" data-action="thread-reply-open" data-message-id="${escapeHtml(commentId)}">Répondre au message</button>
-          <div class="thread-comment-menu__reactions-label">Réagir</div>
+          <div class="thread-comment-menu__divider" role="separator" aria-hidden="true"></div>
+          <div class="thread-comment-menu__reactions-label">Réagir au message</div>
           <div class="thread-comment-menu__reactions-grid">
             ${THREAD_REACTION_CHOICES.map((choice) => `
               <button
@@ -1110,9 +1111,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
         ${(childReplies.length || reactionsSummaryList.length)
           ? `
             <div class="thread-comment-footer">
-              ${childReplies.length
-                ? `<span class="mono-small color-fg-muted">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>`
-                : ""}
               ${reactionsSummaryList.length
                 ? `
                   <div class="thread-comment-footer__reactions">
@@ -1130,6 +1128,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
                     `).join("")}
                   </div>
                 `
+                : ""}
+              ${childReplies.length
+                ? `<span class="mono-small color-fg-muted thread-comment-footer__replies-count">${childReplies.length} réponse${childReplies.length > 1 ? "s" : ""}</span>`
                 : ""}
             </div>
           `

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2922,7 +2922,7 @@ body.is-resizing{
 }
 .thread-comment-footer{
   display:flex;
-  justify-content:flex-start;
+  justify-content:space-between;
   align-items:center;
   gap:8px;
   margin-top:8px;
@@ -2933,6 +2933,12 @@ body.is-resizing{
   display:flex;
   flex-wrap:wrap;
   gap:6px;
+  min-width:0;
+}
+.thread-comment-footer__replies-count{
+  margin-left:auto;
+  text-align:right;
+  white-space:nowrap;
 }
 .thread-comment-reaction-chip{
   cursor:default;


### PR DESCRIPTION
### Motivation
- Le menu de mention (`@`) n’apparaissait pas dans certains contextes de saisie et le menu d’emoji (`:`) rebondissait à sa position précédente, rendant l’autocomplétion peu fiable.
- Il faut aussi améliorer l’ergonomie du menu kebab et aligner proprement le compteur de réponses à droite pour correspondre au design demandé.

### Description
- Amélioration de la détection du trigger `@` en `resolveMentionTriggerContext` pour utiliser `lastIndexOf` et valider le caractère précédent afin d’ouvrir les suggestions dans plus de contextes de saisie (`apps/web/js/utils/subject-mentions.js`).
- Stabilisation du positionnement des popups d’autocomplétion en retirant la restriction qui testait `document.activeElement` dans `positionAutocompletePopup`, forçant ainsi le recalcul de la position au bon moment (`apps/web/js/views/project-subjects/project-subjects-events.js`).
- Mise à jour du dropdown kebab : ajout d’un divider sous « Répondre au message » et renommage de l’étiquette « Réagir » en « Réagir au message » (`apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Réorganisation du footer des commentaires pour utiliser `flex` avec `justify-content: space-between`, déplacement du compteur de réponses vers la droite via la classe `.thread-comment-footer__replies-count` et ajustements CSS pour garder les réactions à gauche (`apps/web/style.css`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check apps/web/js/utils/subject-mentions.js && node --check apps/web/js/views/project-subjects/project-subjects-thread.js && node --check apps/web/js/views/project-subjects/project-subjects-events.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f542d00c8329a26ccbdbdbcc930f)