### PR TITLE
Fix emoji/mention autocomplete positioning and inline parity in subject composers

### DIFF
--- a/apps/web/js/utils/textarea-caret-position.js
+++ b/apps/web/js/utils/textarea-caret-position.js
@@ -1,0 +1,93 @@
+function px(value) {
+  const parsed = Number.parseFloat(String(value || "0"));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+const MIRROR_STYLE_PROPS = [
+  "boxSizing",
+  "width",
+  "height",
+  "overflowX",
+  "overflowY",
+  "borderTopWidth",
+  "borderRightWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "fontStyle",
+  "fontVariant",
+  "fontWeight",
+  "fontStretch",
+  "fontSize",
+  "fontSizeAdjust",
+  "lineHeight",
+  "fontFamily",
+  "textAlign",
+  "textTransform",
+  "textIndent",
+  "textDecoration",
+  "letterSpacing",
+  "wordSpacing",
+  "tabSize",
+  "MozTabSize",
+  "whiteSpace",
+  "wordBreak",
+  "overflowWrap",
+  "direction"
+];
+
+export function computeTextareaCaretRect(textarea, caretIndex = 0) {
+  if (!textarea || !textarea.isConnected) return null;
+  const source = String(textarea.value || "");
+  const caret = Math.max(0, Math.min(Number(caretIndex || 0), source.length));
+  const computed = window.getComputedStyle(textarea);
+  const textareaRect = textarea.getBoundingClientRect();
+
+  const mirror = document.createElement("div");
+  const mirrorStyle = mirror.style;
+  mirrorStyle.position = "fixed";
+  mirrorStyle.left = "-9999px";
+  mirrorStyle.top = "0";
+  mirrorStyle.visibility = "hidden";
+  mirrorStyle.pointerEvents = "none";
+  mirrorStyle.whiteSpace = "pre-wrap";
+  mirrorStyle.wordWrap = "break-word";
+
+  MIRROR_STYLE_PROPS.forEach((property) => {
+    mirrorStyle[property] = computed[property];
+  });
+
+  mirrorStyle.width = `${textarea.clientWidth}px`;
+  mirrorStyle.height = "auto";
+  mirrorStyle.overflow = "hidden";
+
+  const beforeText = source.slice(0, caret).replace(/\n$/g, "\n\u200b");
+  mirror.textContent = beforeText;
+
+  const marker = document.createElement("span");
+  marker.textContent = source.slice(caret, caret + 1) || "\u200b";
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const markerRect = marker.getBoundingClientRect();
+  const mirrorRect = mirror.getBoundingClientRect();
+  mirror.remove();
+
+  const lineHeight = Math.max(16, Math.round(px(computed.lineHeight) || px(computed.fontSize) * 1.2 || 20));
+
+  const relativeTop = markerRect.top - mirrorRect.top;
+  const relativeLeft = markerRect.left - mirrorRect.left;
+
+  const top = textareaRect.top + relativeTop - textarea.scrollTop;
+  const left = textareaRect.left + relativeLeft - textarea.scrollLeft;
+
+  return {
+    top,
+    left,
+    bottom: top + lineHeight,
+    lineHeight
+  };
+}

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -9,6 +9,7 @@ import {
   resolveEmojiTriggerContext,
   searchEmojiSuggestions
 } from "../../utils/emoji-autocomplete.js";
+import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
 
 export function createProjectSubjectsEvents(config) {
   const EMOJI_GRID_COLUMNS = 6;
@@ -730,42 +731,17 @@ export function createProjectSubjectsEvents(config) {
       return "";
     };
 
-    const computeTextareaCaretRect = (textarea, caretIndex = 0) => {
-      if (!textarea || !textarea.isConnected) return null;
-      const computed = window.getComputedStyle(textarea);
-      const mirror = document.createElement("div");
-      const mirrorStyle = mirror.style;
-      mirrorStyle.position = "fixed";
-      mirrorStyle.top = "0";
-      mirrorStyle.left = "-9999px";
-      mirrorStyle.whiteSpace = "pre-wrap";
-      mirrorStyle.wordWrap = "break-word";
-      mirrorStyle.visibility = "hidden";
-      mirrorStyle.overflow = "hidden";
-      [
-        "fontFamily", "fontSize", "fontWeight", "fontStyle", "letterSpacing", "lineHeight",
-        "textTransform", "textIndent", "textDecoration", "paddingTop", "paddingRight",
-        "paddingBottom", "paddingLeft", "borderTopWidth", "borderRightWidth",
-        "borderBottomWidth", "borderLeftWidth", "boxSizing"
-      ].forEach((key) => {
-        mirrorStyle[key] = computed[key];
-      });
-      mirrorStyle.width = `${textarea.clientWidth}px`;
-      mirror.textContent = String(textarea.value || "").slice(0, Math.max(0, Number(caretIndex || 0)));
-      const marker = document.createElement("span");
-      marker.textContent = "\u200b";
-      mirror.appendChild(marker);
-      document.body.appendChild(mirror);
-      const markerRect = marker.getBoundingClientRect();
-      const textareaRect = textarea.getBoundingClientRect();
-      const top = textareaRect.top + (markerRect.top - mirror.getBoundingClientRect().top) - textarea.scrollTop;
-      const left = textareaRect.left + (markerRect.left - mirror.getBoundingClientRect().left) - textarea.scrollLeft;
-      document.body.removeChild(mirror);
-      return {
-        top,
-        left,
-        bottom: top + Math.max(16, parseFloat(computed.lineHeight) || 20)
-      };
+    const splitComposerKey = (composerKey = "") => {
+      const normalized = String(composerKey || "").trim();
+      if (!normalized || normalized === "main") return { mode: "main", messageId: "" };
+      const [mode = "", messageId = ""] = normalized.split(":");
+      return { mode, messageId };
+    };
+
+    const getTextareaForComposerKey = (composerKey = "") => {
+      const { mode, messageId } = splitComposerKey(composerKey);
+      const selector = getTextareaSelector({ composerKey: mode, messageId });
+      return selector ? root.querySelector(selector) : null;
     };
 
     const positionAutocompletePopup = (textarea, popup) => {
@@ -994,13 +970,17 @@ export function createProjectSubjectsEvents(config) {
             activeIndex: 0,
             triggerStart: -1,
             triggerEnd: -1,
-            suggestions: []
+            suggestions: [],
+            composerKey: ""
           };
+        }
+        if (typeof store.situationsView.mentionUi.composerKey !== "string") {
+          store.situationsView.mentionUi.composerKey = "";
         }
         return store.situationsView.mentionUi;
       };
 
-      const closeMentionPopup = ({ rerender = true } = {}) => {
+      const closeMentionPopup = ({ rerender = true, selector = "#humanCommentBox", shouldFocus = false, caretStart = 0, caretEnd = 0 } = {}) => {
         const mentionState = getMentionState();
         mentionState.open = false;
         mentionState.query = "";
@@ -1008,13 +988,9 @@ export function createProjectSubjectsEvents(config) {
         mentionState.triggerStart = -1;
         mentionState.triggerEnd = -1;
         mentionState.suggestions = [];
+        mentionState.composerKey = "";
         if (rerender) {
-          rerenderAutocompleteUi({
-            selector: "#humanCommentBox",
-            shouldFocus: document.activeElement === commentTextarea,
-            caretStart: Number(commentTextarea.selectionStart || 0),
-            caretEnd: Number(commentTextarea.selectionEnd || 0)
-          });
+          rerenderAutocompleteUi({ selector, shouldFocus, caretStart, caretEnd });
         }
       };
       const syncMainEmojiPopup = ({ composerKey = "main" } = {}) => {
@@ -1068,14 +1044,25 @@ export function createProjectSubjectsEvents(config) {
         return mentionLoadPromise;
       };
 
-      const syncMentionPopup = async ({ forceOpen = false } = {}) => {
+      const syncMentionPopupForTextarea = async (textarea, composerKey, { forceOpen = false } = {}) => {
+        if (!textarea) return;
         const mentionState = getMentionState();
-        const context = resolveMentionTriggerContext(commentTextarea.value || "", commentTextarea.selectionStart || 0);
+        const context = resolveMentionTriggerContext(textarea.value || "", textarea.selectionStart || 0);
         if (!context && !forceOpen) {
-          if (mentionState.open) closeMentionPopup();
+          if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+            const { mode, messageId } = splitComposerKey(composerKey);
+            closeMentionPopup({
+              selector: getTextareaSelector({ composerKey: mode, messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+          }
           return;
         }
         const query = String(context?.query || "").trim().toLowerCase();
+        const { mode, messageId } = splitComposerKey(composerKey);
+        const selector = getTextareaSelector({ composerKey: mode, messageId });
         if (!mentionCollaboratorsLoaded) {
           mentionState.triggerStart = Number(context?.triggerStart ?? -1);
           mentionState.triggerEnd = Number(context?.triggerEnd ?? -1);
@@ -1083,14 +1070,16 @@ export function createProjectSubjectsEvents(config) {
           mentionState.suggestions = [];
           mentionState.open = true;
           mentionState.activeIndex = 0;
+          mentionState.composerKey = composerKey;
           rerenderAutocompleteUi({
-            selector: "#humanCommentBox",
+            selector,
             shouldFocus: true,
-            caretStart: Number(commentTextarea.selectionStart || 0),
-            caretEnd: Number(commentTextarea.selectionEnd || 0)
+            caretStart: Number(textarea.selectionStart || 0),
+            caretEnd: Number(textarea.selectionEnd || 0)
           });
           void ensureMentionCollaboratorsLoaded().then(() => {
-            void syncMainComposerAutocomplete();
+            const activeTextarea = getTextareaForComposerKey(composerKey);
+            if (activeTextarea) void syncMentionPopupForTextarea(activeTextarea, composerKey, { forceOpen: true });
           });
           return;
         }
@@ -1111,31 +1100,52 @@ export function createProjectSubjectsEvents(config) {
         mentionState.suggestions = suggestions;
         mentionState.open = !!context || forceOpen;
         mentionState.activeIndex = Math.max(0, Math.min(Number(mentionState.activeIndex || 0), Math.max(0, suggestions.length - 1)));
+        mentionState.composerKey = composerKey;
         rerenderAutocompleteUi({
-          selector: "#humanCommentBox",
+          selector,
           shouldFocus: true,
-          caretStart: Number(commentTextarea.selectionStart || 0),
-          caretEnd: Number(commentTextarea.selectionEnd || 0)
+          caretStart: Number(textarea.selectionStart || 0),
+          caretEnd: Number(textarea.selectionEnd || 0)
         });
       };
 
-      const pickMentionSuggestion = (suggestion) => {
+      const syncMentionPopup = async ({ forceOpen = false } = {}) => {
+        await syncMentionPopupForTextarea(commentTextarea, "main", { forceOpen });
+      };
+
+      const pickMentionSuggestion = (suggestion, composerKey = "main") => {
+        const textarea = getTextareaForComposerKey(composerKey);
+        if (!textarea) return;
         const mentionState = getMentionState();
         const context = {
           triggerStart: mentionState.triggerStart,
-          triggerEnd: Number(commentTextarea.selectionStart || mentionState.triggerEnd || 0)
+          triggerEnd: Number(textarea.selectionStart || mentionState.triggerEnd || 0)
         };
-        const result = applyMentionSuggestion(commentTextarea.value || "", context, suggestion);
-        commentTextarea.value = result.nextText;
-        store.situationsView.commentDraft = String(result.nextText || "");
-        commentTextarea.focus();
-        commentTextarea.selectionStart = result.nextCursorIndex;
-        commentTextarea.selectionEnd = result.nextCursorIndex;
+        const result = applyMentionSuggestion(textarea.value || "", context, suggestion);
+        textarea.value = result.nextText;
+        const { mode, messageId = "" } = splitComposerKey(composerKey);
+        if (mode === "main") {
+          store.situationsView.commentDraft = String(result.nextText || "");
+        } else {
+          const replyUi = resolveInlineReplyUiState();
+          if (mode === "reply") {
+            replyUi.draftsByMessageId[messageId] = String(result.nextText || "");
+            syncInlineReplySubmitButton(messageId);
+          } else if (mode === "edit") {
+            replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
+            syncInlineEditSubmitButton(messageId);
+          }
+          syncInlineReplyTextareaHeight(textarea);
+        }
+        textarea.focus();
+        textarea.selectionStart = result.nextCursorIndex;
+        textarea.selectionEnd = result.nextCursorIndex;
         closeMentionPopup({ rerender: false });
         closeEmojiPopup({ rerender: false });
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
+        const selector = getTextareaSelector({ composerKey: mode, messageId });
         rerenderAutocompleteUi({
-          selector: "#humanCommentBox",
+          selector,
           shouldFocus: true,
           caretStart: result.nextCursorIndex,
           caretEnd: result.nextCursorIndex
@@ -1197,6 +1207,28 @@ export function createProjectSubjectsEvents(config) {
       commentTextarea.addEventListener("keydown", (ev) => {
         const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        if (ev.key === "Escape") {
+          if (mentionState.open && String(mentionState.composerKey || "") === "main") {
+            ev.preventDefault();
+            closeMentionPopup({
+              selector: "#humanCommentBox",
+              shouldFocus: true,
+              caretStart: Number(commentTextarea.selectionStart || 0),
+              caretEnd: Number(commentTextarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (emojiState.open && String(emojiState.composerKey || "") === "main") {
+            ev.preventDefault();
+            closeEmojiPopup({
+              selector: "#humanCommentBox",
+              shouldFocus: true,
+              caretStart: Number(commentTextarea.selectionStart || 0),
+              caretEnd: Number(commentTextarea.selectionEnd || 0)
+            });
+            return;
+          }
+        }
         if (mentionState.open && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length) {
           if (ev.key === "ArrowDown") {
             ev.preventDefault();
@@ -1223,11 +1255,6 @@ export function createProjectSubjectsEvents(config) {
           if (ev.key === "Enter") {
             ev.preventDefault();
             pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0]);
-            return;
-          }
-          if (ev.key === "Escape") {
-            ev.preventDefault();
-            closeMentionPopup();
             return;
           }
         }
@@ -1281,21 +1308,19 @@ export function createProjectSubjectsEvents(config) {
             pickEmojiSuggestion(emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
             return;
           }
-          if (ev.key === "Escape") {
-            ev.preventDefault();
-            closeEmojiPopup({
-              selector: "#humanCommentBox",
-              shouldFocus: true,
-              caretStart: Number(commentTextarea.selectionStart || 0),
-              caretEnd: Number(commentTextarea.selectionEnd || 0)
-            });
-            return;
-          }
         }
         if (ev.key === "Enter" && (ev.ctrlKey || ev.metaKey)) {
           ev.preventDefault();
           applyCommentAction(root);
         }
+      });
+      const syncMainAutocompleteFromCaret = () => {
+        void syncMainComposerAutocomplete();
+      };
+      commentTextarea.addEventListener("click", syncMainAutocompleteFromCaret);
+      commentTextarea.addEventListener("keyup", syncMainAutocompleteFromCaret);
+      commentTextarea.addEventListener("scroll", () => {
+        positionAllAutocompletePopups();
       });
 
       root.querySelectorAll("[data-action='composer-format'][data-format]").forEach((btn) => {
@@ -1320,7 +1345,7 @@ export function createProjectSubjectsEvents(config) {
           pickMentionSuggestion({
             personId: String(btn.dataset.personId || "").trim(),
             label: String(btn.dataset.label || "").trim()
-          });
+          }, String(btn.dataset.composerKey || "main"));
         };
       });
       root.querySelectorAll("[data-action='emoji-pick'][data-composer-key='main']").forEach((btn) => {
@@ -1381,7 +1406,14 @@ export function createProjectSubjectsEvents(config) {
         document.addEventListener("click", (event) => {
           const target = event?.target;
           if (!target || !(target instanceof Element)) return;
-          if (target.closest(".subject-mention-popup") || target.closest("#humanCommentBox")) return;
+          if (
+            target.closest(".subject-mention-popup")
+            || target.closest("#humanCommentBox")
+            || target.closest("[data-thread-reply-draft]")
+            || target.closest("[data-thread-edit-draft]")
+          ) {
+            return;
+          }
           const mentionState = getMentionState();
           if (!mentionState.open) return;
           closeMentionPopup();
@@ -2378,7 +2410,7 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
-      const syncInlineEmojiPopup = (textarea, composerKey) => {
+    const syncInlineEmojiPopup = (textarea, composerKey) => {
       const emojiState = getEmojiState();
       const mentionContext = resolveMentionTriggerContext(textarea.value || "", textarea.selectionStart || 0);
       if (mentionContext) {
@@ -2399,7 +2431,7 @@ export function createProjectSubjectsEvents(config) {
       emojiState.triggerEnd = Number(context?.triggerEnd ?? -1);
       emojiState.suggestions = suggestions;
       emojiState.composerKey = composerKey;
-      const [mode, messageId = ""] = String(composerKey || "").split(":");
+      const { mode, messageId = "" } = splitComposerKey(composerKey);
       const selector = getTextareaSelector({ composerKey: mode, messageId });
       rerenderAutocompleteUi({
         selector,
@@ -2407,6 +2439,20 @@ export function createProjectSubjectsEvents(config) {
         caretStart: Number(textarea.selectionStart || 0),
         caretEnd: Number(textarea.selectionEnd || 0)
       });
+    };
+
+    const syncInlineAutocomplete = async (textarea, composerKey) => {
+      const mentionContext = resolveMentionTriggerContext(textarea.value || "", textarea.selectionStart || 0);
+      if (mentionContext) {
+        await syncMentionPopupForTextarea(textarea, composerKey);
+        closeEmojiPopup({ rerender: false });
+        return;
+      }
+      const mentionState = getMentionState();
+      if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+        closeMentionPopup({ rerender: false });
+      }
+      syncInlineEmojiPopup(textarea, composerKey);
     };
 
     const applyInlineEmojiSuggestion = (textarea, suggestion = {}) => {
@@ -2433,12 +2479,54 @@ export function createProjectSubjectsEvents(config) {
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
         syncInlineReplyTextareaHeight(textarea);
         syncInlineReplySubmitButton(messageId);
-        syncInlineEmojiPopup(textarea, `reply:${messageId}`);
+        void syncInlineAutocomplete(textarea, `reply:${messageId}`);
       });
       textarea.addEventListener("keydown", (event) => {
         const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
         const composerKey = `reply:${messageId}`;
+        const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        if (event.key === "Escape") {
+          if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeMentionPopup({
+              selector: getTextareaSelector({ composerKey: "reply", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (emojiState.open && String(emojiState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeEmojiPopup({
+              selector: getTextareaSelector({ composerKey: "reply", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            mentionState.activeIndex = (Number(mentionState.activeIndex || 0) + delta + mentionState.suggestions.length) % mentionState.suggestions.length;
+            rerenderAutocompleteUi({
+              selector: getTextareaSelector({ composerKey: "reply", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0], composerKey);
+            return;
+          }
+        }
         if (emojiState.open && String(emojiState.composerKey || "") === composerKey && Array.isArray(emojiState.suggestions) && emojiState.suggestions.length) {
           if (event.key === "ArrowDown") {
             event.preventDefault();
@@ -2493,16 +2581,6 @@ export function createProjectSubjectsEvents(config) {
             syncInlineReplySubmitButton(messageId);
             return;
           }
-          if (event.key === "Escape") {
-            event.preventDefault();
-            closeEmojiPopup({
-              selector: getTextareaSelector({ composerKey: "reply", messageId }),
-              shouldFocus: true,
-              caretStart: Number(textarea.selectionStart || 0),
-              caretEnd: Number(textarea.selectionEnd || 0)
-            });
-            return;
-          }
         }
         if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
         event.preventDefault();
@@ -2510,6 +2588,10 @@ export function createProjectSubjectsEvents(config) {
         if (messageId) syncInlineReplySubmitButton(messageId);
         if (submitButton && !submitButton.disabled) submitButton.click();
       });
+      const composerKey = `reply:${String(textarea.dataset.threadReplyDraft || "").trim()}`;
+      textarea.addEventListener("click", () => { void syncInlineAutocomplete(textarea, composerKey); });
+      textarea.addEventListener("keyup", () => { void syncInlineAutocomplete(textarea, composerKey); });
+      textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
     });
 
     root.querySelectorAll("[data-thread-edit-draft]").forEach((textarea) => {
@@ -2521,12 +2603,54 @@ export function createProjectSubjectsEvents(config) {
         replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
         syncInlineReplyTextareaHeight(textarea);
         syncInlineEditSubmitButton(messageId);
-        syncInlineEmojiPopup(textarea, `edit:${messageId}`);
+        void syncInlineAutocomplete(textarea, `edit:${messageId}`);
       });
       textarea.addEventListener("keydown", (event) => {
         const messageId = String(textarea.dataset.threadEditDraft || "").trim();
         const composerKey = `edit:${messageId}`;
+        const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        if (event.key === "Escape") {
+          if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeMentionPopup({
+              selector: getTextareaSelector({ composerKey: "edit", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (emojiState.open && String(emojiState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeEmojiPopup({
+              selector: getTextareaSelector({ composerKey: "edit", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            mentionState.activeIndex = (Number(mentionState.activeIndex || 0) + delta + mentionState.suggestions.length) % mentionState.suggestions.length;
+            rerenderAutocompleteUi({
+              selector: getTextareaSelector({ composerKey: "edit", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0], composerKey);
+            return;
+          }
+        }
         if (emojiState.open && String(emojiState.composerKey || "") === composerKey && Array.isArray(emojiState.suggestions) && emojiState.suggestions.length) {
           if (event.key === "ArrowDown") {
             event.preventDefault();
@@ -2581,16 +2705,6 @@ export function createProjectSubjectsEvents(config) {
             syncInlineEditSubmitButton(messageId);
             return;
           }
-          if (event.key === "Escape") {
-            event.preventDefault();
-            closeEmojiPopup({
-              selector: getTextareaSelector({ composerKey: "edit", messageId }),
-              shouldFocus: true,
-              caretStart: Number(textarea.selectionStart || 0),
-              caretEnd: Number(textarea.selectionEnd || 0)
-            });
-            return;
-          }
         }
         if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
         event.preventDefault();
@@ -2598,6 +2712,10 @@ export function createProjectSubjectsEvents(config) {
         if (messageId) syncInlineEditSubmitButton(messageId);
         if (submitButton && !submitButton.disabled) submitButton.click();
       });
+      const composerKey = `edit:${String(textarea.dataset.threadEditDraft || "").trim()}`;
+      textarea.addEventListener("click", () => { void syncInlineAutocomplete(textarea, composerKey); });
+      textarea.addEventListener("keyup", () => { void syncInlineAutocomplete(textarea, composerKey); });
+      textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
     });
 
     root.querySelectorAll("[data-action='thread-reply-tab-write']").forEach((btn) => {
@@ -2701,6 +2819,11 @@ export function createProjectSubjectsEvents(config) {
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
         syncInlineReplyTextareaHeight(textarea);
         syncInlineReplySubmitButton(messageId);
+        if (action === "mention") void syncMentionPopupForTextarea(textarea, `reply:${messageId}`, { forceOpen: true });
+        else {
+          closeMentionPopup({ rerender: false });
+          closeEmojiPopup({ rerender: false });
+        }
         textarea.focus();
       };
     });
@@ -2718,6 +2841,11 @@ export function createProjectSubjectsEvents(config) {
         replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
         syncInlineReplyTextareaHeight(textarea);
         syncInlineEditSubmitButton(messageId);
+        if (action === "mention") void syncMentionPopupForTextarea(textarea, `edit:${messageId}`, { forceOpen: true });
+        else {
+          closeMentionPopup({ rerender: false });
+          closeEmojiPopup({ rerender: false });
+        }
         textarea.focus();
       };
     });
@@ -2914,6 +3042,12 @@ export function createProjectSubjectsEvents(config) {
       };
       window.addEventListener("resize", syncPopupPositions);
       window.addEventListener("scroll", syncPopupPositions);
+      document.addEventListener("selectionchange", () => {
+        const activeElement = document.activeElement;
+        if (!(activeElement instanceof HTMLTextAreaElement)) return;
+        if (!root.contains(activeElement)) return;
+        positionAllAutocompletePopups();
+      });
       root.dataset.subjectAutocompletePositionBound = "true";
     }
     requestAnimationFrame(() => positionAllAutocompletePopups());

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -155,9 +155,11 @@ export function createProjectSubjectsThread(config = {}) {
         activeIndex: 0,
         triggerStart: -1,
         triggerEnd: -1,
-        suggestions: []
+        suggestions: [],
+        composerKey: ""
       };
     }
+    if (typeof state.mentionUi.composerKey !== "string") state.mentionUi.composerKey = "";
     return state.mentionUi;
   }
 
@@ -839,6 +841,36 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
+  function renderMentionPopup(mentionUi, composerKey) {
+    if (!mentionUi?.open || String(mentionUi.composerKey || "") !== String(composerKey || "")) return "";
+    const suggestions = Array.isArray(mentionUi.suggestions) ? mentionUi.suggestions : [];
+    return `
+      <div class="subject-mention-popup" data-autocomplete-popup="mention" data-composer-key="${escapeHtml(String(composerKey || ""))}" role="listbox" aria-label="Suggestions de mention">
+        ${suggestions.length
+    ? suggestions.map((suggestion, index) => {
+      const personId = normalizeId(suggestion?.personId);
+      const isActive = Number(mentionUi.activeIndex || 0) === index;
+      return `
+            <button
+              class="subject-mention-popup__item ${isActive ? "is-active" : ""}"
+              type="button"
+              role="option"
+              aria-selected="${isActive ? "true" : "false"}"
+              data-action="mention-pick"
+              data-composer-key="${escapeHtml(String(composerKey || ""))}"
+              data-person-id="${escapeHtml(personId)}"
+              data-label="${escapeHtml(String(suggestion?.label || ""))}"
+            >
+              <span class="subject-mention-popup__name">${escapeHtml(String(suggestion?.label || ""))}</span>
+              <span class="subject-mention-popup__meta">${escapeHtml(String(suggestion?.email || ""))}</span>
+            </button>
+          `;
+    }).join("")
+    : `<div class="subject-mention-popup__empty">Aucun collaborateur trouvé</div>`}
+      </div>
+    `;
+  }
+
   function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [], depth = 0 }) {
     if (!commentId) return "";
     const pendingAttachments = Array.isArray(attachments) ? attachments : [];
@@ -880,8 +912,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
       ? "thread-inline-reply-editor thread-inline-reply-editor--nested"
       : "thread-inline-reply-editor thread-inline-reply-editor--root";
     const emojiUi = getEmojiUiState();
+    const mentionUi = getMentionUiState();
     const replyComposerKey = `reply:${commentId}`;
     const inlineReplyEmojiPopupHtml = renderEmojiPopup(emojiUi, replyComposerKey);
+    const inlineReplyMentionPopupHtml = renderMentionPopup(mentionUi, replyComposerKey);
 
     return `
       <div class="${inlineEditorClass} ${isExpanded ? "" : "hidden"}" data-inline-reply-editor="${escapeHtml(commentId)}" ${isExpanded ? "" : "aria-hidden=\"true\""}>
@@ -910,6 +944,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           `,
           previewEmptyHint: "Use Markdown to format your reply",
           footerHtml: `
+            ${inlineReplyMentionPopupHtml}
             ${inlineReplyEmojiPopupHtml}
             <input
               id="threadReplyAttachmentInput-${escapeHtml(commentId)}"
@@ -946,8 +981,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const submitLabel = Number(depth || 0) > 0 ? "Mettre à jour la réponse" : "Mettre à jour le commentaire";
     const canSubmit = !!normalizedDraft.trim();
     const emojiUi = getEmojiUiState();
+    const mentionUi = getMentionUiState();
     const editComposerKey = `edit:${commentId}`;
     const inlineEditEmojiPopupHtml = renderEmojiPopup(emojiUi, editComposerKey);
+    const inlineEditMentionPopupHtml = renderMentionPopup(mentionUi, editComposerKey);
     return `
       <div class="thread-inline-edit-editor ${editModeClass} ${isEditing ? "" : "hidden"}" data-inline-edit-editor="${escapeHtml(commentId)}" ${isEditing ? "" : "aria-hidden=\"true\""}>
         ${renderCommentComposer({
@@ -974,7 +1011,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
             </div>
           `,
           previewEmptyHint: "Use Markdown to format your comment",
-          footerHtml: inlineEditEmojiPopupHtml
+          footerHtml: `${inlineEditMentionPopupHtml}${inlineEditEmojiPopupHtml}`
         })}
       </div>
     `;
@@ -1493,32 +1530,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
       <button class="gh-btn gh-action__main gh-btn--primary gh-btn--md" data-action="add-comment" type="button">Commenter</button>
     `;
-    const mentionPopupHtml = mentionUi.open
-      ? `
-        <div class="subject-mention-popup" data-autocomplete-popup="mention" data-composer-key="main" role="listbox" aria-label="Suggestions de mention">
-          ${(Array.isArray(mentionUi.suggestions) ? mentionUi.suggestions : []).length
-            ? mentionUi.suggestions.map((suggestion, index) => {
-            const personId = normalizeId(suggestion?.personId);
-            const isActive = Number(mentionUi.activeIndex || 0) === index;
-            return `
-              <button
-                class="subject-mention-popup__item ${isActive ? "is-active" : ""}"
-                type="button"
-                role="option"
-                aria-selected="${isActive ? "true" : "false"}"
-                data-action="mention-pick"
-                data-person-id="${escapeHtml(personId)}"
-                data-label="${escapeHtml(String(suggestion?.label || ""))}"
-              >
-                <span class="subject-mention-popup__name">${escapeHtml(String(suggestion?.label || ""))}</span>
-                <span class="subject-mention-popup__meta">${escapeHtml(String(suggestion?.email || ""))}</span>
-              </button>
-            `;
-          }).join("")
-            : `<div class="subject-mention-popup__empty">Aucun collaborateur trouvé</div>`}
-        </div>
-      `
-      : "";
+    const mentionPopupHtml = renderMentionPopup(mentionUi, "main");
     const mainEmojiPopupHtml = renderEmojiPopup(emojiUi, "main");
 
     const pendingAttachmentsHtml = pendingAttachments.length


### PR DESCRIPTION
### Motivation
- Corriger le positionnement instable de la popup autocomplete qui « saute » au coin du textarea à cause d’un calcul caret fragile. 
- Faire en sorte que `:` et `@` ouvrent des popups ancrées au caret et qui suivent correctement la saisie / déplacement du caret / scroll / resize. 
- Uniformiser le support des mentions entre le composer principal, les réponses inline et l’édition inline sans toucher à la logique métier des suggestions ni aux flows d’envoi/preview/attachments.

### Description
- Ajout d’un helper `computeTextareaCaretRect` (`apps/web/js/utils/textarea-caret-position.js`) basé sur la technique mirror pour mesurer la position réelle du caret et gérer wrapping, scroll, padding/border et retours à la ligne. 
- Reprise du positionnement des popups pour utiliser le helper et centralisation de la gestion par `composerKey` (`main`, `reply:<id>`, `edit:<id>`) pour éviter les duplications et collisions d’état. 
- Extension de la gestion des mentions pour rendre et gérer la popup de mentions dans les composers inline (reply/edit) de la même manière que les emojis, en passant `data-composer-key` et en routant la sélection vers le bon textarea et état. 
- Améliorations clavier et repositionnement : `Escape` ferme la popup ouverte même si la liste de suggestions est vide, les flèches/Entrée conservent leur comportement, et la popup se repositionne sur `click`/`keyup`/`scroll`/`selectionchange`/`resize` pour rester ancrée au caret. 
- Fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/js/utils/textarea-caret-position.js`.

### Testing
- Exécution des vérifications de syntaxe JS : `node --check apps/web/js/views/project-subjects/project-subjects-events.js`, `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` et `node --check apps/web/js/utils/textarea-caret-position.js`, toutes réussies.
- Aucune autre suite automatisée disponible dans cet environnement ; changements limités au DOM/UX JS et sans modification CSS ou logique métier des messages/attachments/markdown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f97543208329b9ed56e6f560e2e5)