### PR TITLE
Extract subject autocomplete popups to a global fixed layer

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -38,6 +38,10 @@
 <div id="nativeDragPreviewRoot" aria-hidden="true">
   <div id="nativeDragPreviewCard"></div>
 </div>
+<div id="subject-autocomplete-layer" aria-hidden="true">
+  <div id="subject-mention-popup-root" class="subject-autocomplete-popup-root hidden"></div>
+  <div id="subject-emoji-popup-root" class="subject-autocomplete-popup-root hidden"></div>
+</div>
 
 <script>
  window.MDALL_CONFIG = window.MDALL_CONFIG || {};

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -13,6 +13,7 @@ import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js
 
 export function createProjectSubjectsEvents(config) {
   const EMOJI_GRID_COLUMNS = 6;
+  const CARET_NAVIGATION_KEYS = new Set(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "PageUp", "PageDown"]);
   const {
     store,
     PROJECT_TAB_RESELECTED_EVENT,
@@ -700,12 +701,15 @@ export function createProjectSubjectsEvents(config) {
       return store.situationsView.emojiUi;
     };
 
+    const escapeHtml = (value) => String(value || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
     const closeEmojiPopup = ({
-      rerender = true,
-      selector = "",
-      shouldFocus = false,
-      caretStart = 0,
-      caretEnd = 0
+      rerender = true
     } = {}) => {
       const emojiState = getEmojiState();
       emojiState.open = false;
@@ -715,13 +719,7 @@ export function createProjectSubjectsEvents(config) {
       emojiState.triggerEnd = -1;
       emojiState.suggestions = [];
       emojiState.composerKey = "";
-      if (rerender) {
-        if (selector) {
-          rerenderAutocompleteUi({ selector, shouldFocus, caretStart, caretEnd });
-        } else {
-          rerenderScope(root);
-        }
-      }
+      if (rerender) rerenderAutocompleteUi();
     };
 
     const getTextareaSelector = ({ composerKey = "main", messageId = "" } = {}) => {
@@ -744,12 +742,86 @@ export function createProjectSubjectsEvents(config) {
       return selector ? root.querySelector(selector) : null;
     };
 
-    const positionAutocompletePopup = (textarea, popup) => {
+    const getAutocompleteLayer = () => {
+      const layer = document.querySelector("#subject-autocomplete-layer");
+      if (!layer) return null;
+      const mentionRoot = layer.querySelector("#subject-mention-popup-root");
+      const emojiRoot = layer.querySelector("#subject-emoji-popup-root");
+      if (!mentionRoot || !emojiRoot) return null;
+      return { layer, mentionRoot, emojiRoot };
+    };
+
+    const renderMentionPopupHtml = () => {
+      const mentionState = getMentionState();
+      if (!mentionState?.open) return "";
+      const suggestions = Array.isArray(mentionState.suggestions) ? mentionState.suggestions : [];
+      return `
+        <div class="subject-mention-popup" data-autocomplete-popup="mention" data-composer-key="${escapeHtml(String(mentionState.composerKey || ""))}" role="listbox" aria-label="Suggestions de mention">
+          ${suggestions.length
+    ? suggestions.map((suggestion, index) => {
+      const personId = String(suggestion?.personId || "").trim();
+      const isActive = Number(mentionState.activeIndex || 0) === index;
+      return `
+              <button
+                class="subject-mention-popup__item ${isActive ? "is-active" : ""}"
+                type="button"
+                role="option"
+                aria-selected="${isActive ? "true" : "false"}"
+                data-action="mention-pick"
+                data-composer-key="${escapeHtml(String(mentionState.composerKey || ""))}"
+                data-person-id="${escapeHtml(personId)}"
+                data-label="${escapeHtml(String(suggestion?.label || ""))}"
+              >
+                <span class="subject-mention-popup__name">${escapeHtml(String(suggestion?.label || ""))}</span>
+                <span class="subject-mention-popup__meta">${escapeHtml(String(suggestion?.email || ""))}</span>
+              </button>
+            `;
+    }).join("")
+    : `<div class="subject-mention-popup__empty">Aucun collaborateur trouvé</div>`}
+        </div>
+      `;
+    };
+
+    const renderEmojiPopupHtml = () => {
+      const emojiState = getEmojiState();
+      if (!emojiState?.open) return "";
+      const suggestions = Array.isArray(emojiState.suggestions) ? emojiState.suggestions : [];
+      return `
+        <div class="subject-mention-popup subject-emoji-popup" data-autocomplete-popup="emoji" data-composer-key="${escapeHtml(String(emojiState.composerKey || ""))}" role="listbox" aria-label="Suggestions d’emoji">
+          ${suggestions.length
+    ? `
+              <div class="subject-emoji-popup__grid">
+                ${suggestions.map((suggestion, index) => {
+      const isActive = Number(emojiState.activeIndex || 0) === index;
+      const shortcode = String(suggestion?.shortcode || "").trim();
+      return `
+                    <button
+                      class="subject-emoji-popup__cell ${isActive ? "is-active" : ""}"
+                      type="button"
+                      role="option"
+                      aria-selected="${isActive ? "true" : "false"}"
+                      aria-label="${escapeHtml(shortcode ? `:${shortcode}:` : "emoji")}"
+                      title="${escapeHtml(shortcode ? `:${shortcode}:` : "emoji")}"
+                      data-action="emoji-pick"
+                      data-composer-key="${escapeHtml(String(emojiState.composerKey || ""))}"
+                      data-emoji="${escapeHtml(String(suggestion?.emoji || ""))}"
+                      data-shortcode="${escapeHtml(shortcode)}"
+                    >
+                      ${escapeHtml(String(suggestion?.emoji || ""))}
+                    </button>
+                  `;
+    }).join("")}
+              </div>
+            `
+    : `<div class="subject-mention-popup__empty">Aucun emoji trouvé</div>`}
+        </div>
+      `;
+    };
+
+    const positionAutocompletePopup = (textarea, popup, popupRoot) => {
       if (!textarea || !popup || !popup.isConnected) return;
       const caretRect = computeTextareaCaretRect(textarea, textarea.selectionStart || 0);
       if (!caretRect) return;
-      popup.style.position = "fixed";
-      popup.style.margin = "0";
       popup.style.maxWidth = "min(360px, calc(100vw - 16px))";
       if (String(popup.dataset.autocompletePopup || "") === "mention") {
         popup.style.width = "min(340px, calc(100vw - 16px))";
@@ -769,41 +841,57 @@ export function createProjectSubjectsEvents(config) {
         Math.max(8, caretRect.left),
         Math.max(8, viewportW - popupRect.width - 8)
       );
-      popup.style.top = `${Math.round(top)}px`;
-      popup.style.left = `${Math.round(left)}px`;
+      if (popupRoot) {
+        popupRoot.style.top = `${Math.round(top)}px`;
+        popupRoot.style.left = `${Math.round(left)}px`;
+      }
     };
 
     const positionAllAutocompletePopups = () => {
-      const popups = root.querySelectorAll(".subject-mention-popup[data-composer-key]");
-      popups.forEach((popup) => {
-        const popupKey = String(popup.dataset.composerKey || "");
-        if (!popupKey) return;
-        const [mode, messageId = ""] = popupKey.includes(":") ? popupKey.split(":") : [popupKey, ""];
-        const popupSelector = getTextareaSelector({ composerKey: mode, messageId });
-        const popupTextarea = popupSelector ? root.querySelector(popupSelector) : null;
-        if (!popupTextarea) return;
-        positionAutocompletePopup(popupTextarea, popup);
-      });
+      const autocompleteLayer = getAutocompleteLayer();
+      if (!autocompleteLayer) return;
+      const mentionState = getMentionState();
+      const emojiState = getEmojiState();
+      const mentionPopup = autocompleteLayer.mentionRoot.querySelector(".subject-mention-popup");
+      const emojiPopup = autocompleteLayer.emojiRoot.querySelector(".subject-mention-popup");
+      if (mentionState.open && mentionPopup) {
+        const mentionTextarea = getTextareaForComposerKey(String(mentionState.composerKey || ""));
+        if (mentionTextarea) positionAutocompletePopup(mentionTextarea, mentionPopup, autocompleteLayer.mentionRoot);
+        else autocompleteLayer.mentionRoot.classList.add("hidden");
+      }
+      if (emojiState.open && emojiPopup) {
+        const emojiTextarea = getTextareaForComposerKey(String(emojiState.composerKey || ""));
+        if (emojiTextarea) positionAutocompletePopup(emojiTextarea, emojiPopup, autocompleteLayer.emojiRoot);
+        else autocompleteLayer.emojiRoot.classList.add("hidden");
+      }
     };
 
-    const restoreComposerViewport = ({ selector = "", caretStart = 0, caretEnd = 0, shouldFocus = false } = {}) => {
-      const textarea = selector ? root.querySelector(selector) : null;
-      if (textarea && shouldFocus) {
-        textarea.focus({ preventScroll: true });
-        textarea.selectionStart = caretStart;
-        textarea.selectionEnd = caretEnd;
+    const syncAutocompletePopups = () => {
+      const autocompleteLayer = getAutocompleteLayer();
+      if (!autocompleteLayer) return;
+      const mentionState = getMentionState();
+      const emojiState = getEmojiState();
+
+      if (mentionState.open) {
+        autocompleteLayer.mentionRoot.innerHTML = renderMentionPopupHtml();
+        autocompleteLayer.mentionRoot.classList.remove("hidden");
+      } else {
+        autocompleteLayer.mentionRoot.innerHTML = "";
+        autocompleteLayer.mentionRoot.classList.add("hidden");
       }
+      if (emojiState.open) {
+        autocompleteLayer.emojiRoot.innerHTML = renderEmojiPopupHtml();
+        autocompleteLayer.emojiRoot.classList.remove("hidden");
+      } else {
+        autocompleteLayer.emojiRoot.innerHTML = "";
+        autocompleteLayer.emojiRoot.classList.add("hidden");
+      }
+
       positionAllAutocompletePopups();
     };
 
-    const rerenderAutocompleteUi = ({ selector = "", shouldFocus = false, caretStart = 0, caretEnd = 0 } = {}) => {
-      const scrollX = window.scrollX;
-      const scrollY = window.scrollY;
-      rerenderScope(root);
-      requestAnimationFrame(() => {
-        window.scrollTo(scrollX, scrollY);
-        restoreComposerViewport({ selector, shouldFocus, caretStart, caretEnd });
-      });
+    const rerenderAutocompleteUi = () => {
+      syncAutocompletePopups();
     };
 
     let mentionCollaborators = [];
@@ -829,7 +917,7 @@ export function createProjectSubjectsEvents(config) {
       return store.situationsView.mentionUi;
     };
 
-    const closeMentionPopup = ({ rerender = true, selector = "#humanCommentBox", shouldFocus = false, caretStart = 0, caretEnd = 0 } = {}) => {
+    const closeMentionPopup = ({ rerender = true } = {}) => {
       const mentionState = getMentionState();
       mentionState.open = false;
       mentionState.query = "";
@@ -838,7 +926,7 @@ export function createProjectSubjectsEvents(config) {
       mentionState.triggerEnd = -1;
       mentionState.suggestions = [];
       mentionState.composerKey = "";
-      if (rerender) rerenderAutocompleteUi({ selector, shouldFocus, caretStart, caretEnd });
+      if (rerender) rerenderAutocompleteUi();
     };
 
     const ensureMentionCollaboratorsLoaded = async () => {
@@ -1308,6 +1396,9 @@ export function createProjectSubjectsEvents(config) {
             return;
           }
         }
+        if (CARET_NAVIGATION_KEYS.has(ev.key)) {
+          requestAnimationFrame(() => { void syncMainComposerAutocomplete(); });
+        }
         if (ev.key === "Enter" && (ev.ctrlKey || ev.metaKey)) {
           ev.preventDefault();
           applyCommentAction(root);
@@ -1336,23 +1427,6 @@ export function createProjectSubjectsEvents(config) {
           store.situationsView.commentDraft = String(commentTextarea.value || "");
           syncMainComposerTextareaHeight();
           if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
-        };
-      });
-
-      root.querySelectorAll("[data-action='mention-pick'][data-person-id]").forEach((btn) => {
-        btn.onclick = () => {
-          pickMentionSuggestion({
-            personId: String(btn.dataset.personId || "").trim(),
-            label: String(btn.dataset.label || "").trim()
-          }, String(btn.dataset.composerKey || "main"));
-        };
-      });
-      root.querySelectorAll("[data-action='emoji-pick'][data-composer-key='main']").forEach((btn) => {
-        btn.onclick = () => {
-          pickEmojiSuggestion({
-            emoji: String(btn.dataset.emoji || "").trim(),
-            shortcode: String(btn.dataset.shortcode || "").trim()
-          });
         };
       });
 
@@ -1406,7 +1480,7 @@ export function createProjectSubjectsEvents(config) {
           const target = event?.target;
           if (!target || !(target instanceof Element)) return;
           if (
-            target.closest(".subject-mention-popup")
+            target.closest("#subject-autocomplete-layer")
             || target.closest("#humanCommentBox")
             || target.closest("[data-thread-reply-draft]")
             || target.closest("[data-thread-edit-draft]")
@@ -2581,6 +2655,9 @@ export function createProjectSubjectsEvents(config) {
             return;
           }
         }
+        if (CARET_NAVIGATION_KEYS.has(event.key)) {
+          requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
+        }
         if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
         event.preventDefault();
         const submitButton = textarea.closest(".thread-inline-reply-editor")?.querySelector("[data-action='thread-reply-submit'][data-message-id]");
@@ -2704,6 +2781,9 @@ export function createProjectSubjectsEvents(config) {
             syncInlineEditSubmitButton(messageId);
             return;
           }
+        }
+        if (CARET_NAVIGATION_KEYS.has(event.key)) {
+          requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
         }
         if (!(event.ctrlKey || event.metaKey) || event.key !== "Enter") return;
         event.preventDefault();
@@ -2846,31 +2926,6 @@ export function createProjectSubjectsEvents(config) {
           closeEmojiPopup({ rerender: false });
         }
         textarea.focus();
-      };
-    });
-    root.querySelectorAll("[data-action='emoji-pick'][data-composer-key]").forEach((btn) => {
-      btn.onclick = () => {
-        const composerKey = String(btn.dataset.composerKey || "").trim();
-        if (!composerKey || composerKey === "main") return;
-        const [mode, messageId] = composerKey.split(":");
-        if (!mode || !messageId) return;
-        const textarea = mode === "reply"
-          ? root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`)
-          : root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
-        if (!textarea) return;
-        const result = applyInlineEmojiSuggestion(textarea, {
-          emoji: String(btn.dataset.emoji || "").trim(),
-          shortcode: String(btn.dataset.shortcode || "").trim()
-        });
-        const replyUi = resolveInlineReplyUiState();
-        if (mode === "reply") {
-          replyUi.draftsByMessageId[messageId] = String(result.nextText || "");
-          syncInlineReplySubmitButton(messageId);
-        } else {
-          replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
-          syncInlineEditSubmitButton(messageId);
-        }
-        syncInlineReplyTextareaHeight(textarea);
       };
     });
     root.querySelectorAll("[data-action='thread-reply-attachments-pick'][data-message-id]").forEach((btn) => {
@@ -3017,11 +3072,62 @@ export function createProjectSubjectsEvents(config) {
       });
       root.dataset.threadReplyDropdownDocumentBound = "true";
     }
+    const autocompleteLayer = getAutocompleteLayer();
+    if (autocompleteLayer && autocompleteLayer.layer.dataset.subjectAutocompleteBound !== "true") {
+      autocompleteLayer.layer.addEventListener("mousedown", (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+        if (target.closest("[data-action='mention-pick'], [data-action='emoji-pick']")) {
+          event.preventDefault();
+        }
+      });
+      autocompleteLayer.layer.addEventListener("click", (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+        const mentionBtn = target.closest("[data-action='mention-pick'][data-person-id]");
+        if (mentionBtn instanceof HTMLElement) {
+          pickMentionSuggestion({
+            personId: String(mentionBtn.dataset.personId || "").trim(),
+            label: String(mentionBtn.dataset.label || "").trim()
+          }, String(mentionBtn.dataset.composerKey || "main"));
+          return;
+        }
+        const emojiBtn = target.closest("[data-action='emoji-pick'][data-composer-key]");
+        if (!(emojiBtn instanceof HTMLElement)) return;
+        const composerKey = String(emojiBtn.dataset.composerKey || "").trim();
+        if (!composerKey) return;
+        const textarea = getTextareaForComposerKey(composerKey);
+        if (!textarea) return;
+        if (composerKey === "main") {
+          pickEmojiSuggestion({
+            emoji: String(emojiBtn.dataset.emoji || "").trim(),
+            shortcode: String(emojiBtn.dataset.shortcode || "").trim()
+          });
+          return;
+        }
+        const [mode, messageId] = composerKey.split(":");
+        if (!mode || !messageId) return;
+        const result = applyInlineEmojiSuggestion(textarea, {
+          emoji: String(emojiBtn.dataset.emoji || "").trim(),
+          shortcode: String(emojiBtn.dataset.shortcode || "").trim()
+        });
+        const replyUi = resolveInlineReplyUiState();
+        if (mode === "reply") {
+          replyUi.draftsByMessageId[messageId] = String(result.nextText || "");
+          syncInlineReplySubmitButton(messageId);
+        } else {
+          replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
+          syncInlineEditSubmitButton(messageId);
+        }
+        syncInlineReplyTextareaHeight(textarea);
+      });
+      autocompleteLayer.layer.dataset.subjectAutocompleteBound = "true";
+    }
     if (root.dataset.subjectEmojiDocumentBound !== "true") {
       document.addEventListener("click", (event) => {
         const target = event?.target;
         if (!target || !(target instanceof Element)) return;
-        if (target.closest(".subject-emoji-popup")) return;
+        if (target.closest("#subject-autocomplete-layer")) return;
         if (
           target.closest("#humanCommentBox")
           || target.closest("[data-thread-reply-draft]")

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -806,71 +806,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderEmojiPopup(emojiUi, composerKey) {
-    if (!emojiUi?.open || String(emojiUi.composerKey || "") !== String(composerKey || "")) return "";
-    const suggestions = Array.isArray(emojiUi.suggestions) ? emojiUi.suggestions : [];
-    return `
-      <div class="subject-mention-popup subject-emoji-popup" data-autocomplete-popup="emoji" data-composer-key="${escapeHtml(String(composerKey || ""))}" role="listbox" aria-label="Suggestions d’emoji">
-        ${suggestions.length
-    ? `
-            <div class="subject-emoji-popup__grid">
-              ${suggestions.map((suggestion, index) => {
-      const isActive = Number(emojiUi.activeIndex || 0) === index;
-      const shortcode = String(suggestion?.shortcode || "").trim();
-      return `
-                  <button
-                    class="subject-emoji-popup__cell ${isActive ? "is-active" : ""}"
-                    type="button"
-                    role="option"
-                    aria-selected="${isActive ? "true" : "false"}"
-                    aria-label="${escapeHtml(shortcode ? `:${shortcode}:` : "emoji")}"
-                    title="${escapeHtml(shortcode ? `:${shortcode}:` : "emoji")}"
-                    data-action="emoji-pick"
-                    data-composer-key="${escapeHtml(String(composerKey || ""))}"
-                    data-emoji="${escapeHtml(String(suggestion?.emoji || ""))}"
-                    data-shortcode="${escapeHtml(shortcode)}"
-                  >
-                    ${escapeHtml(String(suggestion?.emoji || ""))}
-                  </button>
-                `;
-    }).join("")}
-            </div>
-          `
-    : `<div class="subject-mention-popup__empty">Aucun emoji trouvé</div>`}
-      </div>
-    `;
-  }
-
-  function renderMentionPopup(mentionUi, composerKey) {
-    if (!mentionUi?.open || String(mentionUi.composerKey || "") !== String(composerKey || "")) return "";
-    const suggestions = Array.isArray(mentionUi.suggestions) ? mentionUi.suggestions : [];
-    return `
-      <div class="subject-mention-popup" data-autocomplete-popup="mention" data-composer-key="${escapeHtml(String(composerKey || ""))}" role="listbox" aria-label="Suggestions de mention">
-        ${suggestions.length
-    ? suggestions.map((suggestion, index) => {
-      const personId = normalizeId(suggestion?.personId);
-      const isActive = Number(mentionUi.activeIndex || 0) === index;
-      return `
-            <button
-              class="subject-mention-popup__item ${isActive ? "is-active" : ""}"
-              type="button"
-              role="option"
-              aria-selected="${isActive ? "true" : "false"}"
-              data-action="mention-pick"
-              data-composer-key="${escapeHtml(String(composerKey || ""))}"
-              data-person-id="${escapeHtml(personId)}"
-              data-label="${escapeHtml(String(suggestion?.label || ""))}"
-            >
-              <span class="subject-mention-popup__name">${escapeHtml(String(suggestion?.label || ""))}</span>
-              <span class="subject-mention-popup__meta">${escapeHtml(String(suggestion?.email || ""))}</span>
-            </button>
-          `;
-    }).join("")
-    : `<div class="subject-mention-popup__empty">Aucun collaborateur trouvé</div>`}
-      </div>
-    `;
-  }
-
   function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [], depth = 0 }) {
     if (!commentId) return "";
     const pendingAttachments = Array.isArray(attachments) ? attachments : [];
@@ -911,12 +846,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const inlineEditorClass = Number(depth || 0) > 0
       ? "thread-inline-reply-editor thread-inline-reply-editor--nested"
       : "thread-inline-reply-editor thread-inline-reply-editor--root";
-    const emojiUi = getEmojiUiState();
-    const mentionUi = getMentionUiState();
-    const replyComposerKey = `reply:${commentId}`;
-    const inlineReplyEmojiPopupHtml = renderEmojiPopup(emojiUi, replyComposerKey);
-    const inlineReplyMentionPopupHtml = renderMentionPopup(mentionUi, replyComposerKey);
-
     return `
       <div class="${inlineEditorClass} ${isExpanded ? "" : "hidden"}" data-inline-reply-editor="${escapeHtml(commentId)}" ${isExpanded ? "" : "aria-hidden=\"true\""}>
         ${renderCommentComposer({
@@ -944,8 +873,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
           `,
           previewEmptyHint: "Use Markdown to format your reply",
           footerHtml: `
-            ${inlineReplyMentionPopupHtml}
-            ${inlineReplyEmojiPopupHtml}
             <input
               id="threadReplyAttachmentInput-${escapeHtml(commentId)}"
               type="file"
@@ -980,11 +907,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
       : "comment-composer--thread-edit-root";
     const submitLabel = Number(depth || 0) > 0 ? "Mettre à jour la réponse" : "Mettre à jour le commentaire";
     const canSubmit = !!normalizedDraft.trim();
-    const emojiUi = getEmojiUiState();
-    const mentionUi = getMentionUiState();
-    const editComposerKey = `edit:${commentId}`;
-    const inlineEditEmojiPopupHtml = renderEmojiPopup(emojiUi, editComposerKey);
-    const inlineEditMentionPopupHtml = renderMentionPopup(mentionUi, editComposerKey);
     return `
       <div class="thread-inline-edit-editor ${editModeClass} ${isEditing ? "" : "hidden"}" data-inline-edit-editor="${escapeHtml(commentId)}" ${isEditing ? "" : "aria-hidden=\"true\""}>
         ${renderCommentComposer({
@@ -1011,7 +933,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
             </div>
           `,
           previewEmptyHint: "Use Markdown to format your comment",
-          footerHtml: `${inlineEditMentionPopupHtml}${inlineEditEmojiPopupHtml}`
+          footerHtml: ""
         })}
       </div>
     `;
@@ -1516,8 +1438,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     const toolbarHtml = renderMarkdownToolbar("composer-format");
 
-    const mentionUi = getMentionUiState();
-    const emojiUi = getEmojiUiState();
     const attachmentState = getComposerAttachmentsState();
     const normalizedSubjectId = type === "sujet" ? normalizeId(item.id) : "";
     const pendingAttachments = normalizedSubjectId && normalizeId(attachmentState.subjectId) === normalizedSubjectId
@@ -1530,8 +1450,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
       <button class="gh-btn gh-action__main gh-btn--primary gh-btn--md" data-action="add-comment" type="button">Commenter</button>
     `;
-    const mentionPopupHtml = renderMentionPopup(mentionUi, "main");
-    const mainEmojiPopupHtml = renderEmojiPopup(emojiUi, "main");
 
     const pendingAttachmentsHtml = pendingAttachments.length
       ? `
@@ -1602,7 +1520,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
         ? mdToHtml(String(store.situationsView.commentDraft || ""))
         : "",
       previewEmptyHint: "Utilisez le Markdown pour formater votre commentaire",
-      footerHtml: `${mentionPopupHtml}${mainEmojiPopupHtml}${composerAttachmentsHtml}`
+      footerHtml: composerAttachmentsHtml
     });
   }
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2630,6 +2630,22 @@ body.is-resizing{
 .comment-toolbar-btn .ui-icon{width:16px;height:16px;}
 .comment-composer__preview{min-height:170px;padding:12px;background:var(--bg);}
 .comment-composer__preview-empty{color:var(--muted);font-size:14px;}
+#subject-autocomplete-layer{
+  position:fixed;
+  inset:0;
+  z-index:900;
+  pointer-events:none;
+}
+.subject-autocomplete-popup-root{
+  position:fixed;
+  top:0;
+  left:0;
+  pointer-events:none;
+}
+.subject-autocomplete-popup-root .subject-mention-popup{
+  margin:0;
+  pointer-events:auto;
+}
 .subject-mention-popup{
   margin:0 10px 10px;
   border:1px solid var(--border2);


### PR DESCRIPTION
### Motivation
- Éviter que les popups d’autocomplete (emoji / mention) soient recreées et repositionnées via les rerenders locaux des composers, ce qui provoquait des sauts visuels et la perte de focus du textarea.
- Fournir une couche globale stable dans le shell applicatif pour piloter l’affichage, la position et les interactions des popups uniquement depuis JS.

### Description
- Ajout d’un conteneur global pré-monté dans le shell HTML `#subject-autocomplete-layer` avec deux roots distincts `#subject-mention-popup-root` et `#subject-emoji-popup-root` pour les popups (hors du flux, masqués par défaut). (apps/web/index.html, apps/web/style.css)
- Suppression du rendu HTML des popups depuis les templates des composers (main / inline reply / inline edit) pour ne plus injecter les popups dans le footer des composers. (apps/web/js/views/project-subjects/project-subjects-thread.js)
- Implémentation d’un pilotage centralisé dans `project-subjects-events.js` qui rend le HTML des suggestions dans les roots globaux, positionne les popups en `fixed` à partir du caret (via `computeTextareaCaretRect`), et met à jour/masque les popups sans rerender des composers. (apps/web/js/views/project-subjects/project-subjects-events.js)
- Délégué la gestion des clics/choix sur la couche globale (avec `mousedown.preventDefault()` pour préserver le focus du textarea actif) et maintenu le support clavier (`Escape`, `Arrow*`, `Enter`) et le repositionnement sur `input`, `keydown`, `click`, `selectionchange`, `scroll` et `resize`. (apps/web/js/views/project-subjects/project-subjects-events.js, apps/web/style.css)

### Testing
- Exécution de la vérification de syntaxe JS : `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` — succès.
- Exécution de la vérification de syntaxe JS : `node --check apps/web/js/views/project-subjects/project-subjects-events.js` — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ffadc1e88329999007ec28db836a)