### PR TITLE
Add '#' subject autocomplete and clickable subject refs

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -41,6 +41,7 @@
 <div id="subject-autocomplete-layer" aria-hidden="true">
   <div id="subject-mention-popup-root" class="subject-autocomplete-popup-root hidden"></div>
   <div id="subject-emoji-popup-root" class="subject-autocomplete-popup-root hidden"></div>
+  <div id="subject-ref-popup-root" class="subject-autocomplete-popup-root hidden"></div>
 </div>
 
 <script>

--- a/apps/web/js/utils/markdown-renderer.js
+++ b/apps/web/js/utils/markdown-renderer.js
@@ -49,7 +49,7 @@ function flushList(state, html) {
   state.items = [];
 }
 
-export function renderMarkdownToHtml(markdown = "") {
+export function renderMarkdownToHtml(markdown = "", options = {}) {
   const source = String(markdown || "").replace(/\r\n?/g, "\n");
   if (!source.trim()) return "";
 
@@ -120,5 +120,10 @@ export function renderMarkdownToHtml(markdown = "") {
   flushParagraph(paragraphLines, html);
   flushList(listState, html);
 
-  return `<div class="md-render">${html.join("")}</div>`;
+  const rendered = `<div class="md-render">${html.join("")}</div>`;
+  const postProcessHtml = options && typeof options.postProcessHtml === "function"
+    ? options.postProcessHtml
+    : null;
+  if (!postProcessHtml) return rendered;
+  return String(postProcessHtml(rendered) || rendered);
 }

--- a/apps/web/js/utils/subject-links.js
+++ b/apps/web/js/utils/subject-links.js
@@ -1,0 +1,145 @@
+function normalizeNumber(value) {
+  const parsed = Number.parseInt(String(value || "").trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export function resolveSubjectRefTriggerContext(text = "", cursorIndex = 0) {
+  const source = String(text || "");
+  const caret = Math.max(0, Math.min(Number(cursorIndex || 0), source.length));
+  const before = source.slice(0, caret);
+  const triggerStart = before.lastIndexOf("#");
+  if (triggerStart < 0) return null;
+
+  const previousChar = triggerStart === 0 ? "" : before[triggerStart - 1];
+  if (triggerStart > 0 && /[A-Za-z0-9_]/.test(previousChar)) return null;
+
+  const token = before.slice(triggerStart + 1);
+  if (/[\s\r\n\t]/.test(token)) return null;
+  if (token.includes("#")) return null;
+
+  return {
+    triggerStart,
+    triggerEnd: caret,
+    query: token
+  };
+}
+
+function scoreSubjectSuggestion(subject, normalizedQuery) {
+  const title = String(subject?.title || "").trim().toLowerCase();
+  const numberText = String(subject?.subjectNumber || "");
+  if (!normalizedQuery) return 100;
+
+  if (/^\d+$/.test(normalizedQuery) && numberText === normalizedQuery) return 0;
+  if (numberText.startsWith(normalizedQuery)) return 10;
+  if (title.startsWith(normalizedQuery)) return 20;
+  if (numberText.includes(normalizedQuery)) return 30;
+  if (title.includes(normalizedQuery)) return 40;
+  return Number.POSITIVE_INFINITY;
+}
+
+export function searchSubjectRefSuggestions(subjects = [], query = "", limit = 8) {
+  const normalizedQuery = String(query || "").trim().toLowerCase();
+  const max = Math.max(1, Number(limit || 8));
+  const rows = Array.isArray(subjects) ? subjects : [];
+  return rows
+    .map((subject) => ({
+      ...subject,
+      score: scoreSubjectSuggestion(subject, normalizedQuery)
+    }))
+    .filter((subject) => Number.isFinite(subject.score))
+    .sort((a, b) => {
+      if (a.score !== b.score) return a.score - b.score;
+      const numA = Number(a.subjectNumber || 0);
+      const numB = Number(b.subjectNumber || 0);
+      if (numA && numB && numA !== numB) return numA - numB;
+      return String(a.title || "").localeCompare(String(b.title || ""), "fr", { sensitivity: "base" });
+    })
+    .slice(0, max);
+}
+
+export function applySubjectRefSuggestion(text = "", context = {}, suggestion = {}) {
+  const source = String(text || "");
+  const triggerStart = Math.max(0, Math.min(Number(context?.triggerStart || 0), source.length));
+  const triggerEnd = Math.max(triggerStart, Math.min(Number(context?.triggerEnd || triggerStart), source.length));
+  const subjectNumber = normalizeNumber(suggestion?.subjectNumber);
+  if (!subjectNumber) return { nextText: source, nextCursorIndex: triggerEnd };
+
+  const nextChar = source[triggerEnd] || "";
+  const needsTrailingSpace = nextChar && !/[\s),.!?;:\]}]/.test(nextChar);
+  const insertion = `#${subjectNumber}${needsTrailingSpace ? " " : ""}`;
+  const nextText = `${source.slice(0, triggerStart)}${insertion}${source.slice(triggerEnd)}`;
+  return {
+    nextText,
+    nextCursorIndex: triggerStart + insertion.length
+  };
+}
+
+function shouldSkipSubjectRefNode(node) {
+  if (!(node instanceof Text)) return true;
+  const parent = node.parentElement;
+  if (!parent) return true;
+  if (parent.closest("a, code, pre, h1, h2, h3, h4, h5, h6")) return true;
+  return false;
+}
+
+export function linkifySubjectRefsInHtml(html = "", { resolveSubjectByNumber } = {}) {
+  const source = String(html || "");
+  if (!source.trim()) return source;
+  if (typeof document === "undefined" || typeof resolveSubjectByNumber !== "function") return source;
+
+  const template = document.createElement("template");
+  template.innerHTML = source;
+
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT);
+  const replacements = [];
+  let node = walker.nextNode();
+  while (node) {
+    if (!shouldSkipSubjectRefNode(node)) {
+      const text = String(node.nodeValue || "");
+      const pattern = /(^|[^\w/])#(\d{1,7})(?!\w)/g;
+      let cursor = 0;
+      let changed = false;
+      const fragment = document.createDocumentFragment();
+      let match = pattern.exec(text);
+      while (match) {
+        const full = String(match[0] || "");
+        const prefix = String(match[1] || "");
+        const numberText = String(match[2] || "");
+        const number = normalizeNumber(numberText);
+        const subject = number ? resolveSubjectByNumber(number) : null;
+        if (!subject?.id) {
+          match = pattern.exec(text);
+          continue;
+        }
+        const start = Number(match.index || 0);
+        const tokenStart = start + prefix.length;
+        const tokenEnd = start + full.length;
+        if (tokenStart > cursor) {
+          fragment.appendChild(document.createTextNode(text.slice(cursor, tokenStart)));
+        }
+        const anchor = document.createElement("a");
+        anchor.setAttribute("href", "#");
+        anchor.className = "md-subject-link";
+        anchor.dataset.subjectId = String(subject.id || "");
+        anchor.dataset.subjectNumber = String(number);
+        anchor.textContent = `#${number}`;
+        fragment.appendChild(anchor);
+        cursor = tokenEnd;
+        changed = true;
+        match = pattern.exec(text);
+      }
+      if (changed) {
+        if (cursor < text.length) fragment.appendChild(document.createTextNode(text.slice(cursor)));
+        replacements.push({ node, fragment });
+      }
+    }
+    node = walker.nextNode();
+  }
+
+  replacements.forEach(({ node: textNode, fragment }) => {
+    textNode.parentNode?.replaceChild(fragment, textNode);
+  });
+
+  return template.innerHTML;
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -78,6 +78,7 @@ import {
 } from "./ui/status-badges.js";
 import { escapeHtml } from "../utils/escape-html.js";
 import { renderMarkdownToHtml } from "../utils/markdown-renderer.js";
+import { linkifySubjectRefsInHtml } from "../utils/subject-links.js";
 import { renderSelectMenuSection } from "./ui/select-menu.js";
 import {
   formatSharedDateInputValue,
@@ -295,6 +296,7 @@ const {
   getDecision,
   getMentionUiState,
   getEmojiUiState,
+  getSubjectRefUiState,
   getComposerAttachmentsState,
   getThreadForSelection,
   getInlineReplyUiState,
@@ -395,11 +397,15 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   toggleSubjectMessageReaction: (...args) => toggleSubjectMessageReaction(...args),
   getMentionUiState: (...args) => getMentionUiState(...args),
   getEmojiUiState: (...args) => getEmojiUiState(...args),
+  getSubjectRefUiState: (...args) => getSubjectRefUiState(...args),
   getComposerAttachmentsState: (...args) => getComposerAttachmentsState(...args),
   mdToHtml,
   listCollaboratorsForMentions: (...args) => subjectMessagesService.listCollaboratorsForMentions(...args),
   uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args),
   removeTemporaryAttachment: (...args) => subjectMessagesService.removeTemporaryAttachment(...args),
+  getNestedSujet: (...args) => getNestedSujet(...args),
+  getEffectiveSujetStatus: (...args) => getEffectiveSujetStatus(...args),
+  svgIcon,
   getSubjectsCurrentRoot: () => subjectsCurrentRoot,
   resolveCurrentUserAssigneeId: () => resolveCurrentUserDirectoryPersonId({
     email: store.user?.email || "",
@@ -666,7 +672,39 @@ function rerenderSubjectsPanelsWhenConnected(root, remainingAttempts = 12) {
 
 
 function mdToHtml(text) {
-  return renderMarkdownToHtml(text || "");
+  const subjectRows = Array.isArray(store.projectSubjectsView?.subjectsData)
+    ? store.projectSubjectsView.subjectsData
+    : [];
+  const byNumber = new Map();
+  const registerSubject = (entry) => {
+    const number = Number.parseInt(String(entry?.subject_number ?? entry?.subjectNumber ?? ""), 10);
+    const subjectId = String(entry?.id || "").trim();
+    if (!Number.isFinite(number) || number <= 0 || !subjectId || byNumber.has(number)) return;
+    byNumber.set(number, {
+      id: subjectId,
+      subjectNumber: number
+    });
+  };
+  subjectRows.forEach((situation) => {
+    const queue = Array.isArray(situation?.sujets) ? [...situation.sujets] : [];
+    while (queue.length) {
+      const sujet = queue.shift();
+      registerSubject(sujet);
+      const children = Array.isArray(sujet?.sujets)
+        ? sujet.sujets
+        : Array.isArray(sujet?.childSujets)
+          ? sujet.childSujets
+          : Array.isArray(sujet?.children)
+            ? sujet.children
+            : [];
+      if (children.length) queue.push(...children);
+    }
+  });
+  return renderMarkdownToHtml(text || "", {
+    postProcessHtml: (html) => linkifySubjectRefsInHtml(html, {
+      resolveSubjectByNumber: (number) => byNumber.get(Number(number)) || null
+    })
+  });
 }
 
 function firstNonEmpty(...values) {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -9,6 +9,11 @@ import {
   resolveEmojiTriggerContext,
   searchEmojiSuggestions
 } from "../../utils/emoji-autocomplete.js";
+import {
+  applySubjectRefSuggestion,
+  resolveSubjectRefTriggerContext,
+  searchSubjectRefSuggestions
+} from "../../utils/subject-links.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
 
 export function createProjectSubjectsEvents(config) {
@@ -75,11 +80,15 @@ export function createProjectSubjectsEvents(config) {
     toggleSubjectMessageReaction,
     getMentionUiState,
     getEmojiUiState,
+    getSubjectRefUiState,
     getComposerAttachmentsState,
     mdToHtml,
     listCollaboratorsForMentions,
     uploadAttachmentFile,
-    removeTemporaryAttachment
+    removeTemporaryAttachment,
+    getNestedSujet,
+    getEffectiveSujetStatus,
+    svgIcon
   } = config;
 
   let detachDropdownDocumentEvents = null;
@@ -701,6 +710,25 @@ export function createProjectSubjectsEvents(config) {
       return store.situationsView.emojiUi;
     };
 
+    const getSubjectRefState = () => {
+      if (typeof getSubjectRefUiState === "function") return getSubjectRefUiState();
+      if (!store.situationsView.subjectRefUi || typeof store.situationsView.subjectRefUi !== "object") {
+        store.situationsView.subjectRefUi = {
+          open: false,
+          query: "",
+          activeIndex: 0,
+          triggerStart: -1,
+          triggerEnd: -1,
+          suggestions: [],
+          composerKey: ""
+        };
+      }
+      if (typeof store.situationsView.subjectRefUi.composerKey !== "string") {
+        store.situationsView.subjectRefUi.composerKey = "";
+      }
+      return store.situationsView.subjectRefUi;
+    };
+
     const escapeHtml = (value) => String(value || "")
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
@@ -719,6 +747,19 @@ export function createProjectSubjectsEvents(config) {
       emojiState.triggerEnd = -1;
       emojiState.suggestions = [];
       emojiState.composerKey = "";
+      if (rerender) rerenderAutocompleteUi();
+      else syncAutocompletePopups();
+    };
+
+    const closeSubjectRefPopup = ({ rerender = true } = {}) => {
+      const subjectRefState = getSubjectRefState();
+      subjectRefState.open = false;
+      subjectRefState.query = "";
+      subjectRefState.activeIndex = 0;
+      subjectRefState.triggerStart = -1;
+      subjectRefState.triggerEnd = -1;
+      subjectRefState.suggestions = [];
+      subjectRefState.composerKey = "";
       if (rerender) rerenderAutocompleteUi();
       else syncAutocompletePopups();
     };
@@ -755,8 +796,9 @@ export function createProjectSubjectsEvents(config) {
       if (!layer) return null;
       const mentionRoot = layer.querySelector("#subject-mention-popup-root");
       const emojiRoot = layer.querySelector("#subject-emoji-popup-root");
-      if (!mentionRoot || !emojiRoot) return null;
-      return { layer, mentionRoot, emojiRoot };
+      const subjectRefRoot = layer.querySelector("#subject-ref-popup-root");
+      if (!mentionRoot || !emojiRoot || !subjectRefRoot) return null;
+      return { layer, mentionRoot, emojiRoot, subjectRefRoot };
     };
 
     const renderMentionPopupHtml = () => {
@@ -826,12 +868,57 @@ export function createProjectSubjectsEvents(config) {
       `;
     };
 
+    const resolveSubjectStatusIcon = (status = "open") => {
+      const normalized = String(status || "open").trim().toLowerCase();
+      if (normalized === "reopened") return svgIcon("issue-reopened", { className: "octicon octicon-issue-reopened" });
+      if (normalized.startsWith("closed")) return svgIcon("check-circle", { className: "octicon octicon-check-circle" });
+      return svgIcon("issue-opened", { className: "octicon octicon-issue-opened" });
+    };
+
+    const renderSubjectRefPopupHtml = () => {
+      const subjectRefState = getSubjectRefState();
+      if (!subjectRefState?.open) return "";
+      const suggestions = Array.isArray(subjectRefState.suggestions) ? subjectRefState.suggestions : [];
+      return `
+        <div class="subject-mention-popup subject-ref-popup" data-autocomplete-popup="subject-ref" data-composer-key="${escapeHtml(String(subjectRefState.composerKey || ""))}" role="listbox" aria-label="Suggestions de sujet">
+          ${suggestions.length
+    ? suggestions.map((suggestion, index) => {
+      const isActive = Number(subjectRefState.activeIndex || 0) === index;
+      const subjectId = String(suggestion?.subjectId || "").trim();
+      const subjectNumber = Number(suggestion?.subjectNumber || 0);
+      const status = String(suggestion?.status || "open");
+      const iconHtml = resolveSubjectStatusIcon(status);
+      return `
+              <button
+                class="subject-mention-popup__item subject-ref-popup__item ${isActive ? "is-active" : ""}"
+                type="button"
+                role="option"
+                aria-selected="${isActive ? "true" : "false"}"
+                data-action="subject-ref-pick"
+                data-composer-key="${escapeHtml(String(subjectRefState.composerKey || ""))}"
+                data-subject-id="${escapeHtml(subjectId)}"
+                data-subject-number="${escapeHtml(String(subjectNumber || ""))}"
+              >
+                <span class="subject-ref-popup__line">
+                  <span class="subject-ref-popup__status" aria-hidden="true">${iconHtml}</span>
+                  <span class="subject-ref-popup__title">${escapeHtml(String(suggestion?.title || ""))}</span>
+                  <span class="subject-ref-popup__number">#${escapeHtml(String(subjectNumber || ""))}</span>
+                </span>
+              </button>
+            `;
+    }).join("")
+    : `<div class="subject-mention-popup__empty">Aucun sujet trouvé</div>`}
+        </div>
+      `;
+    };
+
     const positionAutocompletePopup = (textarea, popup, popupRoot) => {
       if (!textarea || !popup || !popup.isConnected) return;
       const caretRect = computeTextareaCaretRect(textarea, textarea.selectionStart || 0);
       if (!caretRect) return;
       popup.style.maxWidth = "min(360px, calc(100vw - 16px))";
-      if (String(popup.dataset.autocompletePopup || "") === "mention") {
+      const popupType = String(popup.dataset.autocompletePopup || "");
+      if (popupType === "mention" || popupType === "subject-ref") {
         popup.style.width = "min(340px, calc(100vw - 16px))";
       } else {
         popup.style.width = "";
@@ -860,8 +947,10 @@ export function createProjectSubjectsEvents(config) {
       if (!autocompleteLayer) return;
       const mentionState = getMentionState();
       const emojiState = getEmojiState();
+      const subjectRefState = getSubjectRefState();
       const mentionPopup = autocompleteLayer.mentionRoot.querySelector(".subject-mention-popup");
       const emojiPopup = autocompleteLayer.emojiRoot.querySelector(".subject-mention-popup");
+      const subjectRefPopup = autocompleteLayer.subjectRefRoot.querySelector(".subject-mention-popup");
       if (mentionState.open && mentionPopup) {
         const mentionTextarea = getTextareaForComposerKey(String(mentionState.composerKey || ""));
         if (mentionTextarea) positionAutocompletePopup(mentionTextarea, mentionPopup, autocompleteLayer.mentionRoot);
@@ -872,6 +961,11 @@ export function createProjectSubjectsEvents(config) {
         if (emojiTextarea) positionAutocompletePopup(emojiTextarea, emojiPopup, autocompleteLayer.emojiRoot);
         else autocompleteLayer.emojiRoot.classList.add("hidden");
       }
+      if (subjectRefState.open && subjectRefPopup) {
+        const subjectRefTextarea = getTextareaForComposerKey(String(subjectRefState.composerKey || ""));
+        if (subjectRefTextarea) positionAutocompletePopup(subjectRefTextarea, subjectRefPopup, autocompleteLayer.subjectRefRoot);
+        else autocompleteLayer.subjectRefRoot.classList.add("hidden");
+      }
     };
 
     const syncAutocompletePopups = () => {
@@ -879,6 +973,7 @@ export function createProjectSubjectsEvents(config) {
       if (!autocompleteLayer) return;
       const mentionState = getMentionState();
       const emojiState = getEmojiState();
+      const subjectRefState = getSubjectRefState();
 
       if (mentionState.open) {
         autocompleteLayer.mentionRoot.innerHTML = renderMentionPopupHtml();
@@ -893,6 +988,13 @@ export function createProjectSubjectsEvents(config) {
       } else {
         autocompleteLayer.emojiRoot.innerHTML = "";
         autocompleteLayer.emojiRoot.classList.add("hidden");
+      }
+      if (subjectRefState.open) {
+        autocompleteLayer.subjectRefRoot.innerHTML = renderSubjectRefPopupHtml();
+        autocompleteLayer.subjectRefRoot.classList.remove("hidden");
+      } else {
+        autocompleteLayer.subjectRefRoot.innerHTML = "";
+        autocompleteLayer.subjectRefRoot.classList.add("hidden");
       }
 
       positionAllAutocompletePopups();
@@ -1063,6 +1165,111 @@ export function createProjectSubjectsEvents(config) {
       const selector = getTextareaSelector({ composerKey: mode, messageId });
       rerenderAutocompleteUi({
         selector,
+        shouldFocus: true,
+        caretStart: result.nextCursorIndex,
+        caretEnd: result.nextCursorIndex
+      });
+    };
+
+    const listSubjectRefSuggestions = (query = "") => {
+      const subjectsData = Array.isArray(store.projectSubjectsView?.subjectsData)
+        ? store.projectSubjectsView.subjectsData
+        : [];
+      const seen = new Set();
+      const allSubjects = [];
+      subjectsData.forEach((situation) => {
+        const queue = Array.isArray(situation?.sujets) ? [...situation.sujets] : [];
+        while (queue.length) {
+          const sujet = queue.shift();
+          const subjectId = String(sujet?.id || "").trim();
+          const subjectNumber = Number.parseInt(String(sujet?.subject_number ?? sujet?.subjectNumber ?? ""), 10);
+          if (subjectId && Number.isFinite(subjectNumber) && subjectNumber > 0 && !seen.has(subjectId)) {
+            seen.add(subjectId);
+            const canonicalSujet = typeof getNestedSujet === "function" ? getNestedSujet(subjectId) : sujet;
+            const status = typeof getEffectiveSujetStatus === "function"
+              ? getEffectiveSujetStatus(canonicalSujet || sujet)
+              : String((canonicalSujet || sujet)?.status || "open");
+            allSubjects.push({
+              subjectId,
+              subjectNumber: Math.floor(subjectNumber),
+              title: String((canonicalSujet || sujet)?.title || "").trim() || `Sujet #${subjectNumber}`,
+              status
+            });
+          }
+          const children = Array.isArray(sujet?.sujets)
+            ? sujet.sujets
+            : Array.isArray(sujet?.childSujets)
+              ? sujet.childSujets
+              : Array.isArray(sujet?.children)
+                ? sujet.children
+                : [];
+          if (children.length) queue.push(...children);
+        }
+      });
+      return searchSubjectRefSuggestions(allSubjects, query, 8);
+    };
+
+    const syncSubjectRefPopupForTextarea = (textarea, composerKey) => {
+      if (!textarea) return;
+      const subjectRefState = getSubjectRefState();
+      const context = resolveSubjectRefTriggerContext(textarea.value || "", textarea.selectionStart || 0);
+      if (!context) {
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+          closeSubjectRefPopup({ rerender: false });
+        }
+        return;
+      }
+      const query = String(context?.query || "").trim().toLowerCase();
+      const suggestions = listSubjectRefSuggestions(query);
+      subjectRefState.triggerStart = Number(context?.triggerStart ?? -1);
+      subjectRefState.triggerEnd = Number(context?.triggerEnd ?? -1);
+      subjectRefState.query = query;
+      subjectRefState.suggestions = suggestions;
+      subjectRefState.composerKey = composerKey;
+      subjectRefState.open = true;
+      subjectRefState.activeIndex = Math.max(0, Math.min(Number(subjectRefState.activeIndex || 0), Math.max(0, suggestions.length - 1)));
+      const { mode, messageId = "" } = splitComposerKey(composerKey);
+      rerenderAutocompleteUi({
+        selector: getTextareaSelector({ composerKey: mode, messageId }),
+        shouldFocus: true,
+        caretStart: Number(textarea.selectionStart || 0),
+        caretEnd: Number(textarea.selectionEnd || 0)
+      });
+    };
+
+    const pickSubjectRefSuggestion = (suggestion = {}, composerKey = "main") => {
+      const textarea = getTextareaForComposerKey(composerKey);
+      if (!textarea) return;
+      const subjectRefState = getSubjectRefState();
+      const context = {
+        triggerStart: subjectRefState.triggerStart,
+        triggerEnd: Number(textarea.selectionStart || subjectRefState.triggerEnd || 0)
+      };
+      const result = applySubjectRefSuggestion(textarea.value || "", context, suggestion);
+      textarea.value = String(result.nextText || "");
+      const { mode, messageId = "" } = splitComposerKey(composerKey);
+      if (mode === "main") {
+        store.situationsView.commentDraft = String(result.nextText || "");
+      } else {
+        const replyUi = resolveInlineReplyUiState();
+        if (mode === "reply") {
+          replyUi.draftsByMessageId[messageId] = String(result.nextText || "");
+          syncInlineReplySubmitButton(messageId);
+        } else if (mode === "edit") {
+          replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
+          syncInlineEditSubmitButton(messageId);
+        }
+        syncInlineReplyTextareaHeight(textarea);
+      }
+      textarea.focus();
+      textarea.selectionStart = result.nextCursorIndex;
+      textarea.selectionEnd = result.nextCursorIndex;
+      closeSubjectRefPopup({ rerender: false });
+      closeMentionPopup({ rerender: false });
+      closeEmojiPopup({ rerender: false });
+      if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
+      rerenderAutocompleteUi({
+        selector: getTextareaSelector({ composerKey: mode, messageId }),
         shouldFocus: true,
         caretStart: result.nextCursorIndex,
         caretEnd: result.nextCursorIndex
@@ -1273,10 +1480,19 @@ export function createProjectSubjectsEvents(config) {
         const mentionContext = resolveMentionTriggerContext(commentTextarea.value || "", commentTextarea.selectionStart || 0);
         if (mentionContext) {
           await syncMentionPopup();
+          closeSubjectRefPopup({ rerender: false });
+          closeEmojiPopup({ rerender: false });
+          return;
+        }
+        const subjectRefContext = resolveSubjectRefTriggerContext(commentTextarea.value || "", commentTextarea.selectionStart || 0);
+        if (subjectRefContext) {
+          if (getMentionState().open) closeMentionPopup({ rerender: false });
+          syncSubjectRefPopupForTextarea(commentTextarea, "main");
           closeEmojiPopup({ rerender: false });
           return;
         }
         if (getMentionState().open) closeMentionPopup({ rerender: false });
+        if (getSubjectRefState().open) closeSubjectRefPopup({ rerender: false });
         syncMainEmojiPopup({ composerKey: "main" });
       };
 
@@ -1303,6 +1519,7 @@ export function createProjectSubjectsEvents(config) {
       commentTextarea.addEventListener("keydown", (ev) => {
         const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
         if (ev.key === "Escape") {
           if (mentionState.open && String(mentionState.composerKey || "") === "main") {
             ev.preventDefault();
@@ -1322,6 +1539,11 @@ export function createProjectSubjectsEvents(config) {
               caretStart: Number(commentTextarea.selectionStart || 0),
               caretEnd: Number(commentTextarea.selectionEnd || 0)
             });
+            return;
+          }
+          if (subjectRefState.open && String(subjectRefState.composerKey || "") === "main") {
+            ev.preventDefault();
+            closeSubjectRefPopup();
             return;
           }
         }
@@ -1402,6 +1624,25 @@ export function createProjectSubjectsEvents(config) {
           if (ev.key === "Enter") {
             ev.preventDefault();
             pickEmojiSuggestion(emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
+            return;
+          }
+        }
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === "main" && Array.isArray(subjectRefState.suggestions) && subjectRefState.suggestions.length) {
+          if (ev.key === "ArrowDown" || ev.key === "ArrowUp") {
+            ev.preventDefault();
+            const delta = ev.key === "ArrowDown" ? 1 : -1;
+            subjectRefState.activeIndex = (Number(subjectRefState.activeIndex || 0) + delta + subjectRefState.suggestions.length) % subjectRefState.suggestions.length;
+            rerenderAutocompleteUi({
+              selector: "#humanCommentBox",
+              shouldFocus: true,
+              caretStart: Number(commentTextarea.selectionStart || 0),
+              caretEnd: Number(commentTextarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (ev.key === "Enter") {
+            ev.preventDefault();
+            pickSubjectRefSuggestion(subjectRefState.suggestions[Number(subjectRefState.activeIndex || 0)] || subjectRefState.suggestions[0], "main");
             return;
           }
         }
@@ -2061,6 +2302,16 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    root.querySelectorAll(".md-subject-link[data-subject-id]").forEach((link) => {
+      link.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectId = String(link.dataset.subjectId || "").trim();
+        if (!subjectId) return;
+        (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(subjectId);
+      });
+    });
+
     root.querySelectorAll("[data-action='tab-write']").forEach((btn) => {
       btn.onclick = () => {
         store.situationsView.commentPreviewMode = false;
@@ -2527,12 +2778,27 @@ export function createProjectSubjectsEvents(config) {
       const mentionContext = resolveMentionTriggerContext(textarea.value || "", textarea.selectionStart || 0);
       if (mentionContext) {
         await syncMentionPopupForTextarea(textarea, composerKey);
+        closeSubjectRefPopup({ rerender: false });
+        closeEmojiPopup({ rerender: false });
+        return;
+      }
+      const subjectRefContext = resolveSubjectRefTriggerContext(textarea.value || "", textarea.selectionStart || 0);
+      if (subjectRefContext) {
+        const mentionState = getMentionState();
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+          closeMentionPopup({ rerender: false });
+        }
+        syncSubjectRefPopupForTextarea(textarea, composerKey);
         closeEmojiPopup({ rerender: false });
         return;
       }
       const mentionState = getMentionState();
       if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
         closeMentionPopup({ rerender: false });
+      }
+      const subjectRefState = getSubjectRefState();
+      if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+        closeSubjectRefPopup({ rerender: false });
       }
       syncInlineEmojiPopup(textarea, composerKey);
     };
@@ -2612,6 +2878,7 @@ export function createProjectSubjectsEvents(config) {
         const composerKey = `reply:${messageId}`;
         const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
         if (event.key === "Escape") {
           if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
             event.preventDefault();
@@ -2631,6 +2898,11 @@ export function createProjectSubjectsEvents(config) {
               caretStart: Number(textarea.selectionStart || 0),
               caretEnd: Number(textarea.selectionEnd || 0)
             });
+            return;
+          }
+          if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeSubjectRefPopup();
             return;
           }
         }
@@ -2708,6 +2980,25 @@ export function createProjectSubjectsEvents(config) {
             return;
           }
         }
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey && Array.isArray(subjectRefState.suggestions) && subjectRefState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            subjectRefState.activeIndex = (Number(subjectRefState.activeIndex || 0) + delta + subjectRefState.suggestions.length) % subjectRefState.suggestions.length;
+            rerenderAutocompleteUi({
+              selector: getTextareaSelector({ composerKey: "reply", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickSubjectRefSuggestion(subjectRefState.suggestions[Number(subjectRefState.activeIndex || 0)] || subjectRefState.suggestions[0], composerKey);
+            return;
+          }
+        }
         if (CARET_NAVIGATION_KEYS.has(event.key)) {
           requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
         }
@@ -2739,6 +3030,7 @@ export function createProjectSubjectsEvents(config) {
         const composerKey = `edit:${messageId}`;
         const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
         if (event.key === "Escape") {
           if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
             event.preventDefault();
@@ -2758,6 +3050,11 @@ export function createProjectSubjectsEvents(config) {
               caretStart: Number(textarea.selectionStart || 0),
               caretEnd: Number(textarea.selectionEnd || 0)
             });
+            return;
+          }
+          if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeSubjectRefPopup();
             return;
           }
         }
@@ -2832,6 +3129,25 @@ export function createProjectSubjectsEvents(config) {
             if (messageId) replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
             syncInlineReplyTextareaHeight(textarea);
             syncInlineEditSubmitButton(messageId);
+            return;
+          }
+        }
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey && Array.isArray(subjectRefState.suggestions) && subjectRefState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            subjectRefState.activeIndex = (Number(subjectRefState.activeIndex || 0) + delta + subjectRefState.suggestions.length) % subjectRefState.suggestions.length;
+            rerenderAutocompleteUi({
+              selector: getTextareaSelector({ composerKey: "edit", messageId }),
+              shouldFocus: true,
+              caretStart: Number(textarea.selectionStart || 0),
+              caretEnd: Number(textarea.selectionEnd || 0)
+            });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickSubjectRefSuggestion(subjectRefState.suggestions[Number(subjectRefState.activeIndex || 0)] || subjectRefState.suggestions[0], composerKey);
             return;
           }
         }
@@ -3130,7 +3446,7 @@ export function createProjectSubjectsEvents(config) {
       autocompleteLayer.layer.addEventListener("mousedown", (event) => {
         const target = event.target;
         if (!(target instanceof Element)) return;
-        if (target.closest("[data-action='mention-pick'], [data-action='emoji-pick']")) {
+        if (target.closest("[data-action='mention-pick'], [data-action='emoji-pick'], [data-action='subject-ref-pick']")) {
           event.preventDefault();
         }
       });
@@ -3146,13 +3462,21 @@ export function createProjectSubjectsEvents(config) {
           return;
         }
         const emojiBtn = target.closest("[data-action='emoji-pick'][data-composer-key]");
-        if (!(emojiBtn instanceof HTMLElement)) return;
-        const composerKey = String(emojiBtn.dataset.composerKey || "").trim();
-        if (!composerKey) return;
-        applyEmojiSuggestionByComposerKey(composerKey, {
-          emoji: String(emojiBtn.dataset.emoji || "").trim(),
-          shortcode: String(emojiBtn.dataset.shortcode || "").trim()
-        });
+        if (emojiBtn instanceof HTMLElement) {
+          const composerKey = String(emojiBtn.dataset.composerKey || "").trim();
+          if (!composerKey) return;
+          applyEmojiSuggestionByComposerKey(composerKey, {
+            emoji: String(emojiBtn.dataset.emoji || "").trim(),
+            shortcode: String(emojiBtn.dataset.shortcode || "").trim()
+          });
+          return;
+        }
+        const subjectRefBtn = target.closest("[data-action='subject-ref-pick'][data-subject-id][data-subject-number]");
+        if (!(subjectRefBtn instanceof HTMLElement)) return;
+        pickSubjectRefSuggestion({
+          subjectId: String(subjectRefBtn.dataset.subjectId || "").trim(),
+          subjectNumber: Number(subjectRefBtn.dataset.subjectNumber || 0)
+        }, String(subjectRefBtn.dataset.composerKey || "main"));
       });
       autocompleteLayer.layer.dataset.subjectAutocompleteBound = "true";
     }
@@ -3169,8 +3493,11 @@ export function createProjectSubjectsEvents(config) {
           return;
         }
         const emojiState = getEmojiState();
-        if (!emojiState.open) return;
-        closeEmojiPopup();
+        const subjectRefState = getSubjectRefState();
+        if (!emojiState.open && !subjectRefState.open) return;
+        closeEmojiPopup({ rerender: false });
+        closeSubjectRefPopup({ rerender: false });
+        rerenderAutocompleteUi();
       });
       root.dataset.subjectEmojiDocumentBound = "true";
     }
@@ -3194,13 +3521,16 @@ export function createProjectSubjectsEvents(config) {
         if (event.key !== "Escape" || event.defaultPrevented) return;
         const mentionState = getMentionState();
         const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
         const mentionOpen = !!mentionState.open;
         const emojiOpen = !!emojiState.open;
-        if (!mentionOpen && !emojiOpen) return;
+        const subjectRefOpen = !!subjectRefState.open;
+        if (!mentionOpen && !emojiOpen && !subjectRefOpen) return;
         event.preventDefault();
-        const fallbackComposerKey = String(mentionState.composerKey || emojiState.composerKey || "main");
+        const fallbackComposerKey = String(mentionState.composerKey || subjectRefState.composerKey || emojiState.composerKey || "main");
         closeMentionPopup({ rerender: false });
         closeEmojiPopup({ rerender: false });
+        closeSubjectRefPopup({ rerender: false });
         rerenderAutocompleteUi();
         focusComposerTextarea(fallbackComposerKey);
       });

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -180,6 +180,24 @@ export function createProjectSubjectsThread(config = {}) {
     return state.emojiUi;
   }
 
+  function getSubjectRefUiState() {
+    ensureViewUiState();
+    const state = store.situationsView;
+    if (!state.subjectRefUi || typeof state.subjectRefUi !== "object") {
+      state.subjectRefUi = {
+        open: false,
+        query: "",
+        activeIndex: 0,
+        triggerStart: -1,
+        triggerEnd: -1,
+        suggestions: [],
+        composerKey: ""
+      };
+    }
+    if (typeof state.subjectRefUi.composerKey !== "string") state.subjectRefUi.composerKey = "";
+    return state.subjectRefUi;
+  }
+
   function getReplyContextState() {
     ensureViewUiState();
     const state = store.situationsView;
@@ -1539,6 +1557,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     buildReplyPreview,
     getMentionUiState,
     getEmojiUiState,
+    getSubjectRefUiState,
     getComposerAttachmentsState,
     getInlineReplyUiState,
     renderThreadBlock,

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2701,6 +2701,35 @@ body.is-resizing{
   border-color:rgba(56,139,253,.45);
   background:rgba(56,139,253,.18);
 }
+.subject-ref-popup__item{
+  justify-content:flex-start;
+}
+.subject-ref-popup__line{
+  min-width:0;
+  width:100%;
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+.subject-ref-popup__status{
+  display:inline-flex;
+  align-items:center;
+  color:var(--muted);
+  flex:0 0 auto;
+}
+.subject-ref-popup__title{
+  min-width:0;
+  flex:1 1 auto;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  font-size:13px;
+}
+.subject-ref-popup__number{
+  flex:0 0 auto;
+  font-size:12px;
+  color:var(--muted);
+}
 .comment-composer__editor.is-dragover{
   border-color:rgba(56,139,253,.95);
 }
@@ -2856,6 +2885,11 @@ body.is-resizing{
   color:rgb(210,153,34);
   background-color:rgba(187,128,9,0.15);
   text-decoration-line:underline;
+}
+.md-render .md-subject-link{
+  color:var(--accent, #2f81f7);
+  text-decoration:underline;
+  text-decoration-color:rgba(47,129,247,.75);
 }
 .md-task-item{display:flex;align-items:flex-start;gap:6px;list-style:none;margin-left:-18px;}
 .md-task-item input{margin-top:2px;}


### PR DESCRIPTION
### Motivation
- Provide a third inline autocomplete channel triggered by `#` in subject composers (main composer, inline reply, inline edit) matching existing `@` and `:` UX.
- Insert a simple plain-text reference like `#126` in the textarea (no heavy markdown) and make those `#num` tokens clickable in previews/messages to open the drilldown.
- Reuse the existing global autocomplete layer/positioning/focus/caret infra to avoid regressions with mentions and emoji.

### Description
- Added a new utility `apps/web/js/utils/subject-links.js` implementing `resolveSubjectRefTriggerContext`, `searchSubjectRefSuggestions`, `applySubjectRefSuggestion` and `linkifySubjectRefsInHtml` to detect `#` triggers, rank/filter suggestions, insert plain `#123`, and post-process HTML into `<a class="md-subject-link" data-subject-id="...">#123</a>` while skipping headings/links/code.
- Extended the markdown renderer `renderMarkdownToHtml` to accept an optional `postProcessHtml` hook and enabled it in the subjects view by updating `mdToHtml()` in `apps/web/js/views/project-subjects.js` to run `linkifySubjectRefsInHtml` using the current project subjects map.
- Integrated a full subject-ref popup into the existing autocomplete flow in `apps/web/js/views/project-subjects/project-subjects-events.js` by adding `subjectRefUi` state, rendering a `subject-ref` popup root and items (status icon + title + `#num`), wiring keyboard navigation (`ArrowUp`/`ArrowDown`/`Enter`/`Escape`), positioning via the shared caret logic, and click selection through the shared autocomplete layer.
- Hooked clicks on rendered `.md-subject-link` to reuse existing drilldown opening (`openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel`), and ensured clicks from the drilldown will behave consistently (replace/refresh drilldown as per existing drilldown logic).
- Added `#subject-ref-popup-root` to `apps/web/index.html` and styles for the popup and rendered links in `apps/web/style.css` (class `.subject-ref-popup__*` and `.md-subject-link`).
- Minimal, localized changes to thread code to expose `getSubjectRefUiState` and to propagate `getNestedSujet`, `getEffectiveSujetStatus` and `svgIcon` where needed; no large refactor and `@` / `:` paths preserved.

Modified files (high level): `apps/web/index.html`, `apps/web/style.css`, `apps/web/js/utils/markdown-renderer.js`, `apps/web/js/utils/subject-links.js` (new), `apps/web/js/views/project-subjects.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/project-subjects/project-subjects-thread.js`.

### Testing
- Performed static checks with `node --check` on modified modules; result: success.
- Ran existing automated tests: `node apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` and `node apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs`; both suites passed.
- No UI manual tests were run here; manual checks recommended: `#` in main composer/reply/edit, keyboard navigation, `Escape` to close, and clicking `#123` in preview/published message and from drilldown.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cdcc64248329bbf7be77241a8a3a)