### PR TITLE
Fix empty '#' subject autocomplete by adding canonical subject-ref index

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -3,6 +3,7 @@ import { buildSubjectHierarchyIndexes } from "./subject-hierarchy.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./project-situations-supabase.js";
 import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 
 const SUPABASE_URL = getSupabaseUrl();
@@ -1096,6 +1097,7 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
         }
       };
       store.projectSubjectsView.rawResult = store.projectSubjectsView.rawSubjectsResult;
+      invalidateSubjectRefIndex(store.projectSubjectsView);
       store.projectSubjectsView.loading = false;
       store.projectSubjectsView.loaded = true;
       return [];
@@ -1177,6 +1179,7 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
     store.projectSubjectsView.subjectsData = result.subjects;
     store.projectSubjectsView.rawSubjectsResult = result;
     store.projectSubjectsView.rawResult = result;
+    invalidateSubjectRefIndex(store.projectSubjectsView);
     store.projectSubjectsView.projectScopeId = currentProjectScopeId;
     store.projectSubjectsView.page = previousPage;
     store.projectSubjectsView.pagination = {
@@ -1221,6 +1224,7 @@ export function resetFlatSubjectsForCurrentProject() {
   store.projectSubjectsView.subjectsData = [];
   store.projectSubjectsView.rawSubjectsResult = null;
   store.projectSubjectsView.rawResult = null;
+  invalidateSubjectRefIndex(store.projectSubjectsView);
   store.projectSubjectsView.projectScopeId = String(store.currentProjectId || "").trim() || null;
   store.projectSubjectsView.loading = false;
   store.projectSubjectsView.loaded = false;

--- a/apps/web/js/utils/subject-ref-index.js
+++ b/apps/web/js/utils/subject-ref-index.js
@@ -1,0 +1,148 @@
+function normalizeSearchValue(value = "") {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+function parsePositiveInt(value) {
+  const parsed = Number.parseInt(String(value ?? "").trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function resolveCanonicalSource(view = {}) {
+  const rawSubjectsResult = view?.rawSubjectsResult;
+  const subjectsById = rawSubjectsResult?.subjectsById;
+  if (subjectsById && typeof subjectsById === "object" && !Array.isArray(subjectsById)) {
+    return {
+      sourceType: "subjectsById",
+      sourceRef: subjectsById,
+      rows: Object.values(subjectsById)
+    };
+  }
+
+  const flatSubjects = Array.isArray(view?.subjectsData) ? view.subjectsData : [];
+  return {
+    sourceType: "subjectsData",
+    sourceRef: flatSubjects,
+    rows: flatSubjects
+  };
+}
+
+function normalizeSubjectEntry(subject = {}, { statusResolver } = {}) {
+  const id = String(subject?.id || "").trim();
+  if (!id) return null;
+
+  const subjectNumber = parsePositiveInt(subject?.subject_number ?? subject?.subjectNumber);
+  if (!subjectNumber) return null;
+
+  const title = String(subject?.title || "").trim() || `Sujet #${subjectNumber}`;
+  const resolvedStatus = typeof statusResolver === "function" ? statusResolver(subject) : subject?.status;
+  const status = String(resolvedStatus || "open").trim().toLowerCase() || "open";
+
+  return {
+    id,
+    subjectId: id,
+    subjectNumber,
+    title,
+    status,
+    searchTitleNormalized: normalizeSearchValue(title),
+    searchNumberNormalized: String(subjectNumber)
+  };
+}
+
+function buildIndex(view = {}, options = {}) {
+  const { sourceType, sourceRef, rows } = resolveCanonicalSource(view);
+  const entries = [];
+  const byId = new Map();
+  const byNumber = new Map();
+
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const normalized = normalizeSubjectEntry(row, options);
+    if (!normalized?.id || byId.has(normalized.id)) continue;
+    byId.set(normalized.id, normalized);
+    if (!byNumber.has(normalized.subjectNumber)) byNumber.set(normalized.subjectNumber, normalized);
+    entries.push(normalized);
+  }
+
+  entries.sort((left, right) => {
+    if (left.subjectNumber !== right.subjectNumber) return left.subjectNumber - right.subjectNumber;
+    return left.title.localeCompare(right.title, "fr", { sensitivity: "base" });
+  });
+
+  return {
+    sourceType,
+    sourceRef,
+    entries,
+    byId,
+    byNumber
+  };
+}
+
+function ensureCache(view = {}, options = {}) {
+  const cached = view?.subjectRefIndexCache;
+  const { sourceType, sourceRef } = resolveCanonicalSource(view);
+  if (cached && cached.sourceType === sourceType && cached.sourceRef === sourceRef) {
+    return cached;
+  }
+  const next = buildIndex(view, options);
+  if (view && typeof view === "object") {
+    view.subjectRefIndexCache = next;
+  }
+  return next;
+}
+
+export function invalidateSubjectRefIndex(view = {}) {
+  if (!view || typeof view !== "object") return;
+  view.subjectRefIndexCache = null;
+}
+
+export function getAllSubjectRefEntries(view = {}, options = {}) {
+  return ensureCache(view, options).entries;
+}
+
+export function getSubjectRefById(view = {}, subjectId, options = {}) {
+  const id = String(subjectId || "").trim();
+  if (!id) return null;
+  return ensureCache(view, options).byId.get(id) || null;
+}
+
+export function getSubjectRefByNumber(view = {}, subjectNumber, options = {}) {
+  const num = parsePositiveInt(subjectNumber);
+  if (!num) return null;
+  return ensureCache(view, options).byNumber.get(num) || null;
+}
+
+export function searchSubjectRefs(view = {}, query = "", limit = 8, options = {}) {
+  const index = ensureCache(view, options);
+  const normalizedQuery = normalizeSearchValue(query);
+  const max = Math.max(1, Number(limit || 8));
+  if (!normalizedQuery) return index.entries.slice(0, max);
+
+  const isNumericQuery = /^\d+$/.test(normalizedQuery);
+  const results = [];
+
+  if (isNumericQuery) {
+    const exact = index.byNumber.get(Number(normalizedQuery));
+    if (exact) results.push(exact);
+    for (const entry of index.entries) {
+      if (results.length >= max) break;
+      if (exact && entry.id === exact.id) continue;
+      if (entry.searchNumberNormalized.startsWith(normalizedQuery)) {
+        results.push(entry);
+      }
+    }
+    return results.slice(0, max);
+  }
+
+  for (const entry of index.entries) {
+    if (results.length >= max) break;
+    if (entry.searchTitleNormalized.includes(normalizedQuery)) {
+      results.push(entry);
+    }
+  }
+
+  return results;
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -79,6 +79,7 @@ import {
 import { escapeHtml } from "../utils/escape-html.js";
 import { renderMarkdownToHtml } from "../utils/markdown-renderer.js";
 import { linkifySubjectRefsInHtml } from "../utils/subject-links.js";
+import { getSubjectRefByNumber } from "../utils/subject-ref-index.js";
 import { renderSelectMenuSection } from "./ui/select-menu.js";
 import {
   formatSharedDateInputValue,
@@ -672,37 +673,9 @@ function rerenderSubjectsPanelsWhenConnected(root, remainingAttempts = 12) {
 
 
 function mdToHtml(text) {
-  const subjectRows = Array.isArray(store.projectSubjectsView?.subjectsData)
-    ? store.projectSubjectsView.subjectsData
-    : [];
-  const byNumber = new Map();
-  const registerSubject = (entry) => {
-    const number = Number.parseInt(String(entry?.subject_number ?? entry?.subjectNumber ?? ""), 10);
-    const subjectId = String(entry?.id || "").trim();
-    if (!Number.isFinite(number) || number <= 0 || !subjectId || byNumber.has(number)) return;
-    byNumber.set(number, {
-      id: subjectId,
-      subjectNumber: number
-    });
-  };
-  subjectRows.forEach((situation) => {
-    const queue = Array.isArray(situation?.sujets) ? [...situation.sujets] : [];
-    while (queue.length) {
-      const sujet = queue.shift();
-      registerSubject(sujet);
-      const children = Array.isArray(sujet?.sujets)
-        ? sujet.sujets
-        : Array.isArray(sujet?.childSujets)
-          ? sujet.childSujets
-          : Array.isArray(sujet?.children)
-            ? sujet.children
-            : [];
-      if (children.length) queue.push(...children);
-    }
-  });
   return renderMarkdownToHtml(text || "", {
     postProcessHtml: (html) => linkifySubjectRefsInHtml(html, {
-      resolveSubjectByNumber: (number) => byNumber.get(Number(number)) || null
+      resolveSubjectByNumber: (number) => getSubjectRefByNumber(store.projectSubjectsView, number)
     })
   });
 }

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -11,9 +11,9 @@ import {
 } from "../../utils/emoji-autocomplete.js";
 import {
   applySubjectRefSuggestion,
-  resolveSubjectRefTriggerContext,
-  searchSubjectRefSuggestions
+  resolveSubjectRefTriggerContext
 } from "../../utils/subject-links.js";
+import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
 
 export function createProjectSubjectsEvents(config) {
@@ -1172,41 +1172,20 @@ export function createProjectSubjectsEvents(config) {
     };
 
     const listSubjectRefSuggestions = (query = "") => {
-      const subjectsData = Array.isArray(store.projectSubjectsView?.subjectsData)
-        ? store.projectSubjectsView.subjectsData
-        : [];
-      const seen = new Set();
-      const allSubjects = [];
-      subjectsData.forEach((situation) => {
-        const queue = Array.isArray(situation?.sujets) ? [...situation.sujets] : [];
-        while (queue.length) {
-          const sujet = queue.shift();
-          const subjectId = String(sujet?.id || "").trim();
-          const subjectNumber = Number.parseInt(String(sujet?.subject_number ?? sujet?.subjectNumber ?? ""), 10);
-          if (subjectId && Number.isFinite(subjectNumber) && subjectNumber > 0 && !seen.has(subjectId)) {
-            seen.add(subjectId);
-            const canonicalSujet = typeof getNestedSujet === "function" ? getNestedSujet(subjectId) : sujet;
-            const status = typeof getEffectiveSujetStatus === "function"
-              ? getEffectiveSujetStatus(canonicalSujet || sujet)
-              : String((canonicalSujet || sujet)?.status || "open");
-            allSubjects.push({
-              subjectId,
-              subjectNumber: Math.floor(subjectNumber),
-              title: String((canonicalSujet || sujet)?.title || "").trim() || `Sujet #${subjectNumber}`,
-              status
-            });
+      const projectSubjectsView = store.projectSubjectsView && typeof store.projectSubjectsView === "object"
+        ? store.projectSubjectsView
+        : {};
+      return searchSubjectRefs(projectSubjectsView, query, 8, {
+        statusResolver: (subject) => {
+          const canonicalSujet = typeof getNestedSujet === "function"
+            ? (getNestedSujet(subject?.id) || subject)
+            : subject;
+          if (typeof getEffectiveSujetStatus === "function") {
+            return getEffectiveSujetStatus(canonicalSujet);
           }
-          const children = Array.isArray(sujet?.sujets)
-            ? sujet.sujets
-            : Array.isArray(sujet?.childSujets)
-              ? sujet.childSujets
-              : Array.isArray(sujet?.children)
-                ? sujet.children
-                : [];
-          if (children.length) queue.push(...children);
+          return String(canonicalSujet?.status || subject?.status || "open");
         }
       });
-      return searchSubjectRefSuggestions(allSubjects, query, 8);
     };
 
     const syncSubjectRefPopupForTextarea = (textarea, composerKey) => {


### PR DESCRIPTION
### Motivation
- The `#` autocomplete and `#123` markdown resolution were broken because code iterated `store.projectSubjectsView.subjectsData` as if it were a nested situation tree, while it is a flat list provided by Supabase, producing an empty candidate list. 
- The goal was to fix the root cause and provide a shared, efficient in-memory index usable by autocomplete and the markdown renderer, robust for large projects (e.g. 10k subjects). 
- The index must be built from the canonical source and only rebuilt when the underlying subjects payload changes to avoid per-keystroke rebuilds.

### Description
- Added a new indexing utility `apps/web/js/utils/subject-ref-index.js` that builds and caches a canonical in-memory subject ref index with maps by id/number and sorted entries, and exports `getAllSubjectRefEntries()`, `getSubjectRefById()`, `getSubjectRefByNumber()` and `searchSubjectRefs()`. 
- The index prefers `projectSubjectsView.rawSubjectsResult.subjectsById` as the canonical source with fallback to `projectSubjectsView.subjectsData` (flat), and precomputes normalized search fields and `status` via an optional `statusResolver`. 
- Replaced the broken traversal in `listSubjectRefSuggestions()` (in `apps/web/js/views/project-subjects/project-subjects-events.js`) to call the shared `searchSubjectRefs()` and preserved existing business logic for resolving status (`getEffectiveSujetStatus`) and popup rendering. 
- Replaced the local `byNumber` build in `mdToHtml()` (in `apps/web/js/views/project-subjects.js`) with `getSubjectRefByNumber(store.projectSubjectsView, number)` so markdown linkification and autocomplete share the same canonical source. 
- In `apps/web/js/services/project-subjects-supabase.js` the subject index cache is invalidated when subjects are loaded or reset via `invalidateSubjectRefIndex()` to ensure freshness after Supabase payload changes. 
- Search behavior optimized for scale: cached index rebuilds only when source reference changes, numeric queries try exact match then number-prefix, text queries use pre-normalized title substring matching, and sorting is done at index build time. 

### Testing
- Ran static/node syntax checks: `node --check apps/web/js/utils/subject-ref-index.js` succeeded. 
- Ran static/node syntax checks: `node --check apps/web/js/views/project-subjects.js` succeeded. 
- Ran static/node syntax checks: `node --check apps/web/js/views/project-subjects/project-subjects-events.js` succeeded. 
- Ran static/node syntax checks: `node --check apps/web/js/services/project-subjects-supabase.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d4889a808329aae6489899a1bab6)