### PR TITLE
Add subject reference index and integrate fast subject-ref lookup/search

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -3,6 +3,7 @@ import { buildSubjectHierarchyIndexes } from "./subject-hierarchy.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./project-situations-supabase.js";
 import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 
 const SUPABASE_URL = getSupabaseUrl();
@@ -1096,6 +1097,7 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
         }
       };
       store.projectSubjectsView.rawResult = store.projectSubjectsView.rawSubjectsResult;
+      invalidateSubjectRefIndex(store.projectSubjectsView);
       store.projectSubjectsView.loading = false;
       store.projectSubjectsView.loaded = true;
       return [];
@@ -1177,6 +1179,7 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
     store.projectSubjectsView.subjectsData = result.subjects;
     store.projectSubjectsView.rawSubjectsResult = result;
     store.projectSubjectsView.rawResult = result;
+    invalidateSubjectRefIndex(store.projectSubjectsView);
     store.projectSubjectsView.projectScopeId = currentProjectScopeId;
     store.projectSubjectsView.page = previousPage;
     store.projectSubjectsView.pagination = {
@@ -1221,6 +1224,7 @@ export function resetFlatSubjectsForCurrentProject() {
   store.projectSubjectsView.subjectsData = [];
   store.projectSubjectsView.rawSubjectsResult = null;
   store.projectSubjectsView.rawResult = null;
+  invalidateSubjectRefIndex(store.projectSubjectsView);
   store.projectSubjectsView.projectScopeId = String(store.currentProjectId || "").trim() || null;
   store.projectSubjectsView.loading = false;
   store.projectSubjectsView.loaded = false;

--- a/apps/web/js/utils/subject-ref-index.js
+++ b/apps/web/js/utils/subject-ref-index.js
@@ -1,0 +1,148 @@
+function normalizeSearchValue(value = "") {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+function parsePositiveInt(value) {
+  const parsed = Number.parseInt(String(value ?? "").trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function resolveCanonicalSource(view = {}) {
+  const rawSubjectsResult = view?.rawSubjectsResult;
+  const subjectsById = rawSubjectsResult?.subjectsById;
+  if (subjectsById && typeof subjectsById === "object" && !Array.isArray(subjectsById)) {
+    return {
+      sourceType: "subjectsById",
+      sourceRef: subjectsById,
+      rows: Object.values(subjectsById)
+    };
+  }
+
+  const flatSubjects = Array.isArray(view?.subjectsData) ? view.subjectsData : [];
+  return {
+    sourceType: "subjectsData",
+    sourceRef: flatSubjects,
+    rows: flatSubjects
+  };
+}
+
+function normalizeSubjectEntry(subject = {}, { statusResolver } = {}) {
+  const id = String(subject?.id || "").trim();
+  if (!id) return null;
+
+  const subjectNumber = parsePositiveInt(subject?.subject_number ?? subject?.subjectNumber);
+  if (!subjectNumber) return null;
+
+  const title = String(subject?.title || "").trim() || `Sujet #${subjectNumber}`;
+  const resolvedStatus = typeof statusResolver === "function" ? statusResolver(subject) : subject?.status;
+  const status = String(resolvedStatus || "open").trim().toLowerCase() || "open";
+
+  return {
+    id,
+    subjectId: id,
+    subjectNumber,
+    title,
+    status,
+    searchTitleNormalized: normalizeSearchValue(title),
+    searchNumberNormalized: String(subjectNumber)
+  };
+}
+
+function buildIndex(view = {}, options = {}) {
+  const { sourceType, sourceRef, rows } = resolveCanonicalSource(view);
+  const entries = [];
+  const byId = new Map();
+  const byNumber = new Map();
+
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const normalized = normalizeSubjectEntry(row, options);
+    if (!normalized?.id || byId.has(normalized.id)) continue;
+    byId.set(normalized.id, normalized);
+    if (!byNumber.has(normalized.subjectNumber)) byNumber.set(normalized.subjectNumber, normalized);
+    entries.push(normalized);
+  }
+
+  entries.sort((left, right) => {
+    if (left.subjectNumber !== right.subjectNumber) return left.subjectNumber - right.subjectNumber;
+    return left.title.localeCompare(right.title, "fr", { sensitivity: "base" });
+  });
+
+  return {
+    sourceType,
+    sourceRef,
+    entries,
+    byId,
+    byNumber
+  };
+}
+
+function ensureCache(view = {}, options = {}) {
+  const cached = view?.subjectRefIndexCache;
+  const { sourceType, sourceRef } = resolveCanonicalSource(view);
+  if (cached && cached.sourceType === sourceType && cached.sourceRef === sourceRef) {
+    return cached;
+  }
+  const next = buildIndex(view, options);
+  if (view && typeof view === "object") {
+    view.subjectRefIndexCache = next;
+  }
+  return next;
+}
+
+export function invalidateSubjectRefIndex(view = {}) {
+  if (!view || typeof view !== "object") return;
+  view.subjectRefIndexCache = null;
+}
+
+export function getAllSubjectRefEntries(view = {}, options = {}) {
+  return ensureCache(view, options).entries;
+}
+
+export function getSubjectRefById(view = {}, subjectId, options = {}) {
+  const id = String(subjectId || "").trim();
+  if (!id) return null;
+  return ensureCache(view, options).byId.get(id) || null;
+}
+
+export function getSubjectRefByNumber(view = {}, subjectNumber, options = {}) {
+  const num = parsePositiveInt(subjectNumber);
+  if (!num) return null;
+  return ensureCache(view, options).byNumber.get(num) || null;
+}
+
+export function searchSubjectRefs(view = {}, query = "", limit = 8, options = {}) {
+  const index = ensureCache(view, options);
+  const normalizedQuery = normalizeSearchValue(query);
+  const max = Math.max(1, Number(limit || 8));
+  if (!normalizedQuery) return index.entries.slice(0, max);
+
+  const isNumericQuery = /^\d+$/.test(normalizedQuery);
+  const results = [];
+
+  if (isNumericQuery) {
+    const exact = index.byNumber.get(Number(normalizedQuery));
+    if (exact) results.push(exact);
+    for (const entry of index.entries) {
+      if (results.length >= max) break;
+      if (exact && entry.id === exact.id) continue;
+      if (entry.searchNumberNormalized.startsWith(normalizedQuery)) {
+        results.push(entry);
+      }
+    }
+    return results.slice(0, max);
+  }
+
+  for (const entry of index.entries) {
+    if (results.length >= max) break;
+    if (entry.searchTitleNormalized.includes(normalizedQuery)) {
+      results.push(entry);
+    }
+  }
+
+  return results;
+}

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -79,6 +79,7 @@ import {
 import { escapeHtml } from "../utils/escape-html.js";
 import { renderMarkdownToHtml } from "../utils/markdown-renderer.js";
 import { linkifySubjectRefsInHtml } from "../utils/subject-links.js";
+import { getSubjectRefByNumber } from "../utils/subject-ref-index.js";
 import { renderSelectMenuSection } from "./ui/select-menu.js";
 import {
   formatSharedDateInputValue,
@@ -672,37 +673,9 @@ function rerenderSubjectsPanelsWhenConnected(root, remainingAttempts = 12) {
 
 
 function mdToHtml(text) {
-  const subjectRows = Array.isArray(store.projectSubjectsView?.subjectsData)
-    ? store.projectSubjectsView.subjectsData
-    : [];
-  const byNumber = new Map();
-  const registerSubject = (entry) => {
-    const number = Number.parseInt(String(entry?.subject_number ?? entry?.subjectNumber ?? ""), 10);
-    const subjectId = String(entry?.id || "").trim();
-    if (!Number.isFinite(number) || number <= 0 || !subjectId || byNumber.has(number)) return;
-    byNumber.set(number, {
-      id: subjectId,
-      subjectNumber: number
-    });
-  };
-  subjectRows.forEach((situation) => {
-    const queue = Array.isArray(situation?.sujets) ? [...situation.sujets] : [];
-    while (queue.length) {
-      const sujet = queue.shift();
-      registerSubject(sujet);
-      const children = Array.isArray(sujet?.sujets)
-        ? sujet.sujets
-        : Array.isArray(sujet?.childSujets)
-          ? sujet.childSujets
-          : Array.isArray(sujet?.children)
-            ? sujet.children
-            : [];
-      if (children.length) queue.push(...children);
-    }
-  });
   return renderMarkdownToHtml(text || "", {
     postProcessHtml: (html) => linkifySubjectRefsInHtml(html, {
-      resolveSubjectByNumber: (number) => byNumber.get(Number(number)) || null
+      resolveSubjectByNumber: (number) => getSubjectRefByNumber(store.projectSubjectsView, number)
     })
   });
 }

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -11,9 +11,9 @@ import {
 } from "../../utils/emoji-autocomplete.js";
 import {
   applySubjectRefSuggestion,
-  resolveSubjectRefTriggerContext,
-  searchSubjectRefSuggestions
+  resolveSubjectRefTriggerContext
 } from "../../utils/subject-links.js";
+import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
 
 export function createProjectSubjectsEvents(config) {
@@ -870,9 +870,22 @@ export function createProjectSubjectsEvents(config) {
 
     const resolveSubjectStatusIcon = (status = "open") => {
       const normalized = String(status || "open").trim().toLowerCase();
-      if (normalized === "reopened") return svgIcon("issue-reopened", { className: "octicon octicon-issue-reopened" });
-      if (normalized.startsWith("closed")) return svgIcon("check-circle", { className: "octicon octicon-check-circle" });
-      return svgIcon("issue-opened", { className: "octicon octicon-issue-opened" });
+      if (normalized === "closed_invalid" || normalized === "closed_duplicate") {
+        return svgIcon("skip", {
+          className: "octicon octicon-skip",
+          style: "color: rgb(145, 152, 161)"
+        });
+      }
+      if (normalized.startsWith("closed")) {
+        return svgIcon("check-circle", {
+          className: "octicon octicon-check-circle",
+          style: "color: var(--fgColor-done)"
+        });
+      }
+      return svgIcon("issue-opened", {
+        className: "octicon octicon-issue-opened",
+        style: "color: var(--fgColor-open)"
+      });
     };
 
     const renderSubjectRefPopupHtml = () => {
@@ -1172,41 +1185,20 @@ export function createProjectSubjectsEvents(config) {
     };
 
     const listSubjectRefSuggestions = (query = "") => {
-      const subjectsData = Array.isArray(store.projectSubjectsView?.subjectsData)
-        ? store.projectSubjectsView.subjectsData
-        : [];
-      const seen = new Set();
-      const allSubjects = [];
-      subjectsData.forEach((situation) => {
-        const queue = Array.isArray(situation?.sujets) ? [...situation.sujets] : [];
-        while (queue.length) {
-          const sujet = queue.shift();
-          const subjectId = String(sujet?.id || "").trim();
-          const subjectNumber = Number.parseInt(String(sujet?.subject_number ?? sujet?.subjectNumber ?? ""), 10);
-          if (subjectId && Number.isFinite(subjectNumber) && subjectNumber > 0 && !seen.has(subjectId)) {
-            seen.add(subjectId);
-            const canonicalSujet = typeof getNestedSujet === "function" ? getNestedSujet(subjectId) : sujet;
-            const status = typeof getEffectiveSujetStatus === "function"
-              ? getEffectiveSujetStatus(canonicalSujet || sujet)
-              : String((canonicalSujet || sujet)?.status || "open");
-            allSubjects.push({
-              subjectId,
-              subjectNumber: Math.floor(subjectNumber),
-              title: String((canonicalSujet || sujet)?.title || "").trim() || `Sujet #${subjectNumber}`,
-              status
-            });
+      const projectSubjectsView = store.projectSubjectsView && typeof store.projectSubjectsView === "object"
+        ? store.projectSubjectsView
+        : {};
+      return searchSubjectRefs(projectSubjectsView, query, 8, {
+        statusResolver: (subject) => {
+          const canonicalSujet = typeof getNestedSujet === "function"
+            ? (getNestedSujet(subject?.id) || subject)
+            : subject;
+          if (typeof getEffectiveSujetStatus === "function") {
+            return getEffectiveSujetStatus(canonicalSujet);
           }
-          const children = Array.isArray(sujet?.sujets)
-            ? sujet.sujets
-            : Array.isArray(sujet?.childSujets)
-              ? sujet.childSujets
-              : Array.isArray(sujet?.children)
-                ? sujet.children
-                : [];
-          if (children.length) queue.push(...children);
+          return String(canonicalSujet?.status || subject?.status || "open");
         }
       });
-      return searchSubjectRefSuggestions(allSubjects, query, 8);
     };
 
     const syncSubjectRefPopupForTextarea = (textarea, composerKey) => {


### PR DESCRIPTION
### Motivation
- Provide a canonical, cached index for subjects to enable fast and consistent resolution of subject references by id or number across the UI. 
- Replace repeated ad-hoc traversal code with a single utility to simplify autocomplete, linkification and other subject-ref lookups. 
- Ensure the subject-ref cache is invalidated whenever the project subjects view is reset or reloaded to keep lookups up-to-date.

### Description
- Add new utility `apps/web/js/utils/subject-ref-index.js` that builds a canonical index from the subjects data, supports caching, invalidation, and exposes `getAllSubjectRefEntries`, `getSubjectRefById`, `getSubjectRefByNumber`, `searchSubjectRefs`, and `invalidateSubjectRefIndex` functions. 
- Integrate the new index into subject loading lifecycle by importing `invalidateSubjectRefIndex` in `project-subjects-supabase.js` and calling it when the flat subjects view is populated or reset. 
- Replace manual tree traversal and bespoke suggestion logic in `project-subjects.js` and `project-subjects-events.js` with calls to `getSubjectRefByNumber` and `searchSubjectRefs` respectively. 
- Improve subject status icon rendering in `project-subjects-events.js` to handle `closed_invalid` and `closed_duplicate` states with appropriate icons and colors.

### Testing
- Ran the frontend lint and test suite via `npm run lint` and `npm test`, and the suite completed without failures. 
- Exercised the subject reference autocomplete and inline linkification flows in the app to verify suggestions, number lookups and cache invalidation behave as expected under reloads. 
- Verified there are no regressions in subject list rendering and subject loading flows after integrating the new index.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d4889a808329aae6489899a1bab6)