### PR TITLE
Add `preserveMessageLineBreaks` option to markdown renderer and enable it in comment composers

### DIFF
--- a/apps/web/js/utils/markdown-renderer.js
+++ b/apps/web/js/utils/markdown-renderer.js
@@ -33,12 +33,13 @@ function renderInlineMarkdown(source = "") {
   return safe;
 }
 
-function flushParagraph(paragraphLines = [], html = []) {
+function flushParagraph(paragraphLines = [], html = [], options = {}) {
   if (!paragraphLines.length) return;
+  const preserveMessageLineBreaks = !!options.preserveMessageLineBreaks;
   const renderedLines = paragraphLines
     .map((line) => renderInlineMarkdown(String(line || "")))
     .join("<br>");
-  if (!renderedLines.trim()) return;
+  if (!preserveMessageLineBreaks && !renderedLines.trim()) return;
   html.push(`<p>${renderedLines}</p>`);
   paragraphLines.length = 0;
 }
@@ -54,6 +55,7 @@ function flushList(state, html) {
 export function renderMarkdownToHtml(markdown = "", options = {}) {
   const source = String(markdown || "").replace(/\r\n?/g, "\n");
   if (!source.trim()) return "";
+  const preserveMessageLineBreaks = !!options.preserveMessageLineBreaks;
 
   const html = [];
   const paragraphLines = [];
@@ -66,7 +68,7 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
 
     const headingMatch = line.match(HEADING_PATTERN);
     if (headingMatch) {
-      flushParagraph(paragraphLines, html);
+      flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
       flushList(listState, html);
       const level = Math.min(6, headingMatch[1].length);
       html.push(`<h${level}>${renderInlineMarkdown(headingMatch[2])}</h${level}>`);
@@ -75,7 +77,7 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
 
     const blockquoteMatch = line.match(BLOCKQUOTE_PATTERN);
     if (blockquoteMatch) {
-      flushParagraph(paragraphLines, html);
+      flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
       flushList(listState, html);
       html.push(`<blockquote>${renderInlineMarkdown(blockquoteMatch[1])}</blockquote>`);
       return;
@@ -83,7 +85,7 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
 
     const checklistMatch = line.match(CHECKLIST_PATTERN);
     if (checklistMatch) {
-      flushParagraph(paragraphLines, html);
+      flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
       if (listState.type && listState.type !== "unordered") flushList(listState, html);
       listState.type = "unordered";
       const checked = String(checklistMatch[1] || "").toLowerCase() === "x";
@@ -93,7 +95,7 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
 
     const unorderedMatch = line.match(LIST_ITEM_PATTERN);
     if (unorderedMatch) {
-      flushParagraph(paragraphLines, html);
+      flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
       if (listState.type && listState.type !== "unordered") flushList(listState, html);
       listState.type = "unordered";
       listState.items.push(`<li>${renderInlineMarkdown(unorderedMatch[2])}</li>`);
@@ -102,7 +104,7 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
 
     const orderedMatch = line.match(ORDERED_LIST_PATTERN);
     if (orderedMatch) {
-      flushParagraph(paragraphLines, html);
+      flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
       if (listState.type && listState.type !== "ordered") flushList(listState, html);
       listState.type = "ordered";
       listState.items.push(`<li>${renderInlineMarkdown(orderedMatch[1])}</li>`);
@@ -110,7 +112,14 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
     }
 
     if (!trimmed) {
-      flushParagraph(paragraphLines, html);
+      // Message mode preserves user-entered line breaks in plain text blocks
+      // by keeping empty lines inside the current paragraph instead of forcing
+      // a new paragraph split.
+      if (preserveMessageLineBreaks && !listState.type) {
+        paragraphLines.push("");
+        return;
+      }
+      flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
       flushList(listState, html);
       return;
     }
@@ -119,7 +128,7 @@ export function renderMarkdownToHtml(markdown = "", options = {}) {
     paragraphLines.push(line);
   });
 
-  flushParagraph(paragraphLines, html);
+  flushParagraph(paragraphLines, html, { preserveMessageLineBreaks });
   flushList(listState, html);
 
   const rendered = `<div class="md-render">${html.join("")}</div>`;

--- a/apps/web/js/utils/markdown-renderer.test.mjs
+++ b/apps/web/js/utils/markdown-renderer.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderMarkdownToHtml } from './markdown-renderer.js';
+
+test('renderer garde le découpage en paragraphes par défaut', () => {
+  const html = renderMarkdownToHtml('ligne 1\n\nligne 2');
+  assert.match(html, /<p>ligne 1<\/p><p>ligne 2<\/p>/);
+});
+
+test('renderer peut préserver les retours à la ligne des messages', () => {
+  const html = renderMarkdownToHtml('ligne 1\n\nligne 2', { preserveMessageLineBreaks: true });
+  assert.match(html, /<p>ligne 1<br><br>ligne 2<\/p>/);
+});
+
+test('renderer en mode message reste sécurisé sur le HTML brut', () => {
+  const html = renderMarkdownToHtml('bonjour <br> test', { preserveMessageLineBreaks: true });
+  assert.match(html, /bonjour &lt;br&gt; test/);
+  assert.doesNotMatch(html, /bonjour <br> test/);
+});
+
+test('renderer en mode message conserve titres, citations et listes markdown', () => {
+  const markdown = '# Titre\n\n> Citation\n\n- élément';
+  const html = renderMarkdownToHtml(markdown, { preserveMessageLineBreaks: true });
+  assert.match(html, /<h1>Titre<\/h1>/);
+  assert.match(html, /<blockquote>Citation<\/blockquote>/);
+  assert.match(html, /<ul><li>élément<\/li><\/ul>/);
+});

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -672,8 +672,9 @@ function rerenderSubjectsPanelsWhenConnected(root, remainingAttempts = 12) {
 ========================================================= */
 
 
-function mdToHtml(text) {
+function mdToHtml(text, options = {}) {
   return renderMarkdownToHtml(text || "", {
+    preserveMessageLineBreaks: !!options.preserveMessageLineBreaks,
     postProcessHtml: (html) => linkifySubjectRefsInHtml(html, {
       resolveSubjectByNumber: (number) => getSubjectRefByNumber(store.projectSubjectsView, number)
     })

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -3224,7 +3224,9 @@ export function createProjectSubjectsEvents(config) {
         previewWrapContainer?.classList.remove("hidden");
         if (previewWrap) {
           const markdown = String(textarea?.value || replyUi.draftsByMessageId?.[messageId] || "");
-          previewWrap.innerHTML = markdown.trim() ? mdToHtml(markdown) : `<div class="comment-composer__preview-empty">Use Markdown to format your reply</div>`;
+          previewWrap.innerHTML = markdown.trim()
+            ? mdToHtml(markdown, { preserveMessageLineBreaks: true })
+            : `<div class="comment-composer__preview-empty">Use Markdown to format your reply</div>`;
         }
       };
     });
@@ -3267,7 +3269,9 @@ export function createProjectSubjectsEvents(config) {
         previewWrapContainer?.classList.remove("hidden");
         if (previewWrap) {
           const markdown = String(textarea?.value || replyUi.editDraftsByMessageId?.[messageId] || "");
-          previewWrap.innerHTML = markdown.trim() ? mdToHtml(markdown) : `<div class="comment-composer__preview-empty">Use Markdown to format your comment</div>`;
+          previewWrap.innerHTML = markdown.trim()
+            ? mdToHtml(markdown, { preserveMessageLineBreaks: true })
+            : `<div class="comment-composer__preview-empty">Use Markdown to format your comment</div>`;
         }
       };
     });

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -763,7 +763,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
       { action: "ordered-list", icon: "markdown-list-ordered", label: "Liste numérotée" },
       { action: "bullet-list", icon: "markdown-list-unordered", label: "Liste à puces" },
       { action: "checklist", icon: "markdown-tasklist", label: "Checklist" },
-      { action: "heading", icon: "markdown-heading", label: "Titre (H3)" },
       { action: "mention", icon: "markdown-mention", label: "Mention" },
       { action: "subject-ref", icon: "cross-reference", label: "Référence sujet" }
     ];
@@ -788,12 +787,14 @@ priority=${firstNonEmpty(subject.priority, "")}`
       </button>
     `;
 
-    const shouldUseComposerLayout = buttonAction === "composer-format" || buttonAction === "thread-reply-format";
+    const shouldUseComposerLayout = buttonAction === "composer-format"
+      || buttonAction === "thread-reply-format"
+      || buttonAction === "thread-edit-format";
     if (!shouldUseComposerLayout) {
       return toolbarButtons.map((button) => renderToolbarButton(button)).join("");
     }
 
-    const attachmentAction = buttonAction === "thread-reply-format"
+    const attachmentAction = buttonAction === "thread-reply-format" || buttonAction === "thread-edit-format"
       ? "thread-reply-attachments-pick"
       : "composer-attachments-pick";
     const attachmentButton = `
@@ -886,7 +887,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
           tabsClassName: "comment-composer__tabs--thread-reply",
           composerClassName: "comment-composer--thread-reply-editor",
           toolbarHtml: renderMarkdownToolbar("thread-reply-format", { messageId: commentId }),
-          previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
+          previewHtml: normalizedDraft.trim()
+            ? mdToHtml(normalizedDraft, { preserveMessageLineBreaks: true })
+            : "",
           actionsHtml: `
             <div class="thread-inline-reply-editor__actions">
               <button class="gh-btn" type="button" data-action="thread-reply-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
@@ -947,7 +950,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
           tabsClassName: "comment-composer__tabs--thread-reply",
           composerClassName: `comment-composer--thread-reply-editor ${composerEditClass}`,
           toolbarHtml: renderMarkdownToolbar("thread-edit-format", { messageId: commentId }),
-          previewHtml: normalizedDraft.trim() ? mdToHtml(normalizedDraft) : "",
+          previewHtml: normalizedDraft.trim()
+            ? mdToHtml(normalizedDraft, { preserveMessageLineBreaks: true })
+            : "",
           actionsHtml: `
             <div class="thread-inline-reply-editor__actions">
               <button class="gh-btn" type="button" data-action="thread-edit-cancel" data-message-id="${escapeHtml(commentId)}">Annuler</button>
@@ -1076,7 +1081,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       headerRightHtml: renderThreadCommentActions(entry),
       bodyHtml: `
         <div class="thread-comment-content-capsule ${isEditing ? "hidden" : ""}" data-thread-comment-content="${escapeHtml(commentId)}">
-          ${mdToHtml(entry?.message || "")}
+          ${mdToHtml(entry?.message || "", { preserveMessageLineBreaks: true })}
         </div>
         ${renderInlineEditComposer({
           commentId,
@@ -1539,7 +1544,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       toolbarHtml,
       tabsClassName: "comment-composer__tabs--main",
       previewHtml: previewMode && String(store.situationsView.commentDraft || "").trim()
-        ? mdToHtml(String(store.situationsView.commentDraft || ""))
+        ? mdToHtml(String(store.situationsView.commentDraft || ""), { preserveMessageLineBreaks: true })
         : "",
       previewEmptyHint: "Utilisez le Markdown pour formater votre commentaire",
       footerHtml: composerAttachmentsHtml


### PR DESCRIPTION
### Motivation

- Improve rendering of user messages by preserving user-entered line breaks in composer previews and message displays.
- Keep existing security and post-processing (linkification) intact while changing paragraph splitting behavior for message mode.

### Description

- Add a `preserveMessageLineBreaks` option to `renderMarkdownToHtml` and thread it through `flushParagraph` to avoid dropping empty lines when enabled.
- Change paragraph handling so empty lines are kept inside the current paragraph in message mode instead of forcing new paragraph splits, while preserving sanitization of raw HTML.
- Update `mdToHtml` wrapper in `project-subjects.js` and all composer/preview call sites to pass `{ preserveMessageLineBreaks: true }` for reply/edit/main comment previews and rendered message bodies.
- Tweak the markdown toolbar to include `thread-edit-format` in composer layouts and attachment actions, and remove a duplicate toolbar button entry.
- Add unit tests in `apps/web/js/utils/markdown-renderer.test.mjs` covering default paragraph splitting, message-mode line-break preservation, XSS safety in message mode, and preservation of markdown constructs (headings, blockquotes, lists) while in message mode.

### Testing

- Ran the new unit tests with `node --test apps/web/js/utils/markdown-renderer.test.mjs`, and all tests passed.
- Confirmed the renderer still escapes raw HTML and that `postProcessHtml` (linkification) remains applied when `preserveMessageLineBreaks` is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e82fc2108329b273a3094506e077)