### PR TITLE
Add inline-edit attachment support and uploadSession handling for subject messages

### DIFF
--- a/apps/web/js/services/subject-messages-service.js
+++ b/apps/web/js/services/subject-messages-service.js
@@ -83,10 +83,20 @@ export function createSubjectMessagesService({ repository } = {}) {
     return provider.canEditMessage({ messageId });
   }
 
-  async function editMessage(messageId, patch = {}) {
+  async function editMessage(messageIdOrPayload, patch = {}) {
+    if (messageIdOrPayload && typeof messageIdOrPayload === "object" && !Array.isArray(messageIdOrPayload)) {
+      return provider.editMessage({
+        messageId: messageIdOrPayload.messageId,
+        subjectId: messageIdOrPayload.subjectId,
+        bodyMarkdown: messageIdOrPayload.bodyMarkdown,
+        uploadSessionId: messageIdOrPayload.uploadSessionId
+      });
+    }
     return provider.editMessage({
-      messageId,
-      bodyMarkdown: patch.bodyMarkdown
+      messageId: messageIdOrPayload,
+      bodyMarkdown: patch.bodyMarkdown,
+      subjectId: patch.subjectId,
+      uploadSessionId: patch.uploadSessionId
     });
   }
 

--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -635,25 +635,52 @@ export function createSubjectMessagesSupabaseRepository() {
       return !!result;
     },
 
-    async editMessage({ messageId, bodyMarkdown }) {
+    async editMessage({ messageId, subjectId, bodyMarkdown, uploadSessionId } = {}) {
       const normalizedMessageId = normalizeId(messageId);
-      const nextBody = String(bodyMarkdown || "").trim();
+      const rawBody = String(bodyMarkdown || "");
+      const nextBody = rawBody.trim();
+      const normalizedSubjectId = normalizeId(subjectId);
+      const normalizedUploadSessionId = normalizeId(uploadSessionId);
       if (!normalizedMessageId) throw new Error("messageId is required");
-      if (!nextBody) throw new Error("bodyMarkdown is required");
+      if (!nextBody && !normalizedUploadSessionId) throw new Error("bodyMarkdown or uploadSessionId is required");
 
       const params = new URLSearchParams();
       params.set("id", `eq.${normalizedMessageId}`);
 
-      const rows = await restFetch("/rest/v1/subject_messages", params, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Prefer: "return=representation"
-        },
-        body: JSON.stringify({ body_markdown: nextBody })
-      });
+      let rows = null;
+      try {
+        rows = await restFetch("/rest/v1/subject_messages", params, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Prefer: "return=representation"
+          },
+          body: JSON.stringify({ body_markdown: nextBody })
+        });
+      } catch (error) {
+        if (nextBody || !normalizedUploadSessionId) throw error;
+        rows = await restFetch("/rest/v1/subject_messages", params, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Prefer: "return=representation"
+          },
+          body: JSON.stringify({ body_markdown: "\u200B" })
+        });
+      }
 
-      return (Array.isArray(rows) ? rows[0] : rows) || null;
+      const updatedMessage = (Array.isArray(rows) ? rows[0] : rows) || null;
+      if (normalizedUploadSessionId) {
+        const targetSubjectId = normalizedSubjectId || normalizeId(updatedMessage?.subject_id);
+        if (!targetSubjectId) throw new Error("subjectId is required when uploadSessionId is provided");
+        await this.linkAttachmentsToMessage({
+          subjectId: targetSubjectId,
+          messageId: normalizedMessageId,
+          uploadSessionId: normalizedUploadSessionId
+        });
+      }
+
+      return updatedMessage;
     },
 
     async deleteMessage({ messageId }) {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -2399,7 +2399,9 @@ export function createProjectSubjectsEvents(config) {
           uploadSessionByMessageId: {},
           editMessageId: "",
           editDraftsByMessageId: {},
-          editPreviewByMessageId: {}
+          editPreviewByMessageId: {},
+          editAttachmentsByMessageId: {},
+          editUploadSessionByMessageId: {}
         };
       }
       if (!store.situationsView.inlineReplyUi.previewByMessageId || typeof store.situationsView.inlineReplyUi.previewByMessageId !== "object") {
@@ -2419,6 +2421,12 @@ export function createProjectSubjectsEvents(config) {
       }
       if (!store.situationsView.inlineReplyUi.editPreviewByMessageId || typeof store.situationsView.inlineReplyUi.editPreviewByMessageId !== "object") {
         store.situationsView.inlineReplyUi.editPreviewByMessageId = {};
+      }
+      if (!store.situationsView.inlineReplyUi.editAttachmentsByMessageId || typeof store.situationsView.inlineReplyUi.editAttachmentsByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.editAttachmentsByMessageId = {};
+      }
+      if (!store.situationsView.inlineReplyUi.editUploadSessionByMessageId || typeof store.situationsView.inlineReplyUi.editUploadSessionByMessageId !== "object") {
+        store.situationsView.inlineReplyUi.editUploadSessionByMessageId = {};
       }
       debugThreadReply("reply_state_fallback", { hasAccessor: typeof getInlineReplyUiState === "function" });
       return store.situationsView.inlineReplyUi;
@@ -2471,6 +2479,8 @@ export function createProjectSubjectsEvents(config) {
       return Array.isArray(inlineAttachmentsState?.items)
         && inlineAttachmentsState.items.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
     };
+    const hasReadyInlineAttachments = (attachmentsState = null) => Array.isArray(attachmentsState?.items)
+      && attachmentsState.items.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
     const syncInlineReplySubmitButton = (messageId = "") => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -2484,7 +2494,10 @@ export function createProjectSubjectsEvents(config) {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return false;
       const replyUi = resolveInlineReplyUiState();
-      return !!String(replyUi.editDraftsByMessageId?.[normalizedMessageId] || "").trim();
+      const message = String(replyUi.editDraftsByMessageId?.[normalizedMessageId] || "").trim();
+      if (message) return true;
+      const inlineAttachmentsState = getInlineEditAttachmentsState(normalizedMessageId);
+      return hasReadyInlineAttachments(inlineAttachmentsState);
     };
     const syncInlineEditSubmitButton = (messageId = "") => {
       const normalizedMessageId = String(messageId || "").trim();
@@ -2546,6 +2559,33 @@ export function createProjectSubjectsEvents(config) {
       items.forEach((attachment) => releaseAttachmentPreviewUrls(attachment));
       delete replyUi.attachmentsByMessageId[normalizedMessageId];
       if (!keepUploadSession) delete replyUi.uploadSessionByMessageId[normalizedMessageId];
+    };
+    const getInlineEditAttachmentsState = (messageId = "", { createIfMissing = false } = {}) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      const replyUi = resolveInlineReplyUiState();
+      if (!normalizedMessageId) return { replyUi, items: [], uploadSessionId: "" };
+      if (!Array.isArray(replyUi.editAttachmentsByMessageId[normalizedMessageId])) {
+        if (createIfMissing) replyUi.editAttachmentsByMessageId[normalizedMessageId] = [];
+      }
+      if (createIfMissing && !String(replyUi.editUploadSessionByMessageId[normalizedMessageId] || "")) {
+        replyUi.editUploadSessionByMessageId[normalizedMessageId] = createUploadSessionId();
+      }
+      return {
+        replyUi,
+        items: Array.isArray(replyUi.editAttachmentsByMessageId[normalizedMessageId]) ? replyUi.editAttachmentsByMessageId[normalizedMessageId] : [],
+        uploadSessionId: String(replyUi.editUploadSessionByMessageId[normalizedMessageId] || "")
+      };
+    };
+    const clearInlineEditAttachmentsState = (messageId = "", { keepUploadSession = false } = {}) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const replyUi = resolveInlineReplyUiState();
+      const items = Array.isArray(replyUi.editAttachmentsByMessageId?.[normalizedMessageId])
+        ? replyUi.editAttachmentsByMessageId[normalizedMessageId]
+        : [];
+      items.forEach((attachment) => releaseAttachmentPreviewUrls(attachment));
+      delete replyUi.editAttachmentsByMessageId[normalizedMessageId];
+      if (!keepUploadSession) delete replyUi.editUploadSessionByMessageId[normalizedMessageId];
     };
     const addInlineReplyFiles = async (messageId = "", files = []) => {
       const normalizedMessageId = String(messageId || "").trim();
@@ -2619,6 +2659,78 @@ export function createProjectSubjectsEvents(config) {
         rerenderScope(root);
       }
     };
+    const addInlineEditFiles = async (messageId = "", files = []) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      const list = Array.from(files || []).filter((entry) => !!entry);
+      if (!normalizedMessageId || !list.length) return;
+      const selection = getScopedSelection(root);
+      if (selection?.type !== "sujet") return;
+      const subjectId = String(selection?.item?.id || "").trim();
+      const projectId = String(selection?.item?.project_id || "").trim();
+      if (!subjectId || !projectId || typeof uploadAttachmentFile !== "function") {
+        showError("Projet introuvable pour l’upload des pièces jointes.");
+        return;
+      }
+      const { items, uploadSessionId } = getInlineEditAttachmentsState(normalizedMessageId, { createIfMissing: true });
+      const effectiveSessionId = uploadSessionId || createUploadSessionId();
+      if (!uploadSessionId) {
+        const replyUi = resolveInlineReplyUiState();
+        replyUi.editUploadSessionByMessageId[normalizedMessageId] = effectiveSessionId;
+      }
+      for (const file of list) {
+        const tempId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const localPreview = toObjectUrl(file);
+        const pending = {
+          id: "",
+          tempId,
+          file_name: String(file?.name || "fichier"),
+          mime_type: String(file?.type || ""),
+          size_bytes: Number(file?.size || 0),
+          localPreviewUrl: localPreview,
+          remoteObjectUrl: "",
+          previewUrl: localPreview,
+          isImage: isImageFile(file),
+          uploadStatus: "uploading",
+          previewStatus: localPreview ? "local" : "none",
+          error: ""
+        };
+        items.push(pending);
+        rerenderScope(root);
+        try {
+          const uploaded = await uploadAttachmentFile({
+            subjectId,
+            projectId,
+            uploadSessionId: effectiveSessionId,
+            file,
+            sortOrder: items.length - 1,
+            parentMessageId: normalizedMessageId
+          });
+          pending.id = String(uploaded?.id || "");
+          pending.storage_path = String(uploaded?.storage_path || "");
+          pending.remoteObjectUrl = String(uploaded?.object_url || "");
+          pending.object_url = pending.remoteObjectUrl;
+          pending.uploadStatus = "ready";
+          pending.error = "";
+          if (pending.isImage) {
+            if (pending.remoteObjectUrl) {
+              pending.previewStatus = pending.localPreviewUrl ? "local" : "remote";
+              if (!pending.previewUrl) pending.previewUrl = pending.remoteObjectUrl;
+            } else if (pending.localPreviewUrl) {
+              pending.previewStatus = "local";
+            } else {
+              pending.previewStatus = "none";
+            }
+          } else {
+            pending.previewStatus = "none";
+          }
+        } catch (error) {
+          pending.uploadStatus = "error";
+          pending.previewStatus = pending.localPreviewUrl ? "local" : "none";
+          pending.error = String(error?.message || error || "Erreur d'upload");
+        }
+        rerenderScope(root);
+      }
+    };
     const removeInlineReplyAttachmentById = async (messageId = "", tempId = "", attachmentId = "") => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -2631,6 +2743,26 @@ export function createProjectSubjectsEvents(config) {
       rerenderScope(root);
       releaseAttachmentPreviewUrls(current);
       if (!items.length) clearInlineReplyAttachmentsState(normalizedMessageId, { keepUploadSession: true });
+      if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
+        try {
+          await removeTemporaryAttachment({ attachmentId: normalizedAttachmentId });
+        } catch (error) {
+          console.warn("[subject-attachments] remove temporary attachment failed", error);
+        }
+      }
+    };
+    const removeInlineEditAttachmentById = async (messageId = "", tempId = "", attachmentId = "") => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const { items } = getInlineEditAttachmentsState(normalizedMessageId);
+      const normalizedAttachmentId = String(attachmentId || "").trim();
+      const targetIndex = items.findIndex((entry) => String(entry?.tempId || "") === String(tempId || "") || String(entry?.id || "") === normalizedAttachmentId);
+      if (targetIndex < 0) return;
+      const current = items[targetIndex];
+      items.splice(targetIndex, 1);
+      rerenderScope(root);
+      releaseAttachmentPreviewUrls(current);
+      if (!items.length) clearInlineEditAttachmentsState(normalizedMessageId, { keepUploadSession: true });
       if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
         try {
           await removeTemporaryAttachment({ attachmentId: normalizedAttachmentId });
@@ -2713,6 +2845,7 @@ export function createProjectSubjectsEvents(config) {
         replyUi.editPreviewByMessageId[messageId] = false;
         replyUi.editMessageId = messageId;
         if (previousEditMessageId && previousEditMessageId !== messageId) {
+          clearInlineEditAttachmentsState(previousEditMessageId);
           toggleInlineEditEditorVisibility(previousEditMessageId, false);
         }
         toggleInlineEditEditorVisibility(messageId, true);
@@ -3351,11 +3484,27 @@ export function createProjectSubjectsEvents(config) {
         input?.click();
       };
     });
+    root.querySelectorAll("[data-action='thread-edit-attachments-pick'][data-message-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const messageId = String(btn.dataset.messageId || "").trim();
+        if (!messageId) return;
+        const input = root.querySelector(`[data-role='thread-edit-file-input'][data-message-id="${selectorValue(messageId)}"]`);
+        input?.click();
+      };
+    });
     root.querySelectorAll("[data-role='thread-reply-file-input'][data-message-id]").forEach((input) => {
       input.addEventListener("change", async (event) => {
         const messageId = String(input.dataset.messageId || "").trim();
         const files = Array.from(event?.target?.files || []);
         if (messageId && files.length) await addInlineReplyFiles(messageId, files);
+        input.value = "";
+      });
+    });
+    root.querySelectorAll("[data-role='thread-edit-file-input'][data-message-id]").forEach((input) => {
+      input.addEventListener("change", async (event) => {
+        const messageId = String(input.dataset.messageId || "").trim();
+        const files = Array.from(event?.target?.files || []);
+        if (messageId && files.length) await addInlineEditFiles(messageId, files);
         input.value = "";
       });
     });
@@ -3383,9 +3532,42 @@ export function createProjectSubjectsEvents(config) {
         if (files.length) await addInlineReplyFiles(messageId, files);
       });
     });
+    root.querySelectorAll("[data-inline-edit-editor]").forEach((editor) => {
+      const messageId = String(editor.dataset.inlineEditEditor || "").trim();
+      if (!messageId) return;
+      const dropzone = editor.querySelector(".comment-composer__editor");
+      if (!dropzone) return;
+      ["dragenter", "dragover"].forEach((eventName) => {
+        dropzone.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dropzone.classList.add("is-dragover");
+        });
+      });
+      ["dragleave", "dragend", "drop"].forEach((eventName) => {
+        dropzone.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dropzone.classList.remove("is-dragover");
+        });
+      });
+      dropzone.addEventListener("drop", async (event) => {
+        const files = Array.from(event?.dataTransfer?.files || []);
+        if (files.length) await addInlineEditFiles(messageId, files);
+      });
+    });
     root.querySelectorAll("[data-action='thread-reply-attachment-remove'][data-message-id]").forEach((btn) => {
       btn.onclick = async () => {
         await removeInlineReplyAttachmentById(
+          String(btn.dataset.messageId || ""),
+          String(btn.dataset.tempId || ""),
+          String(btn.dataset.attachmentId || "")
+        );
+      };
+    });
+    root.querySelectorAll("[data-action='thread-edit-attachment-remove'][data-message-id]").forEach((btn) => {
+      btn.onclick = async () => {
+        await removeInlineEditAttachmentById(
           String(btn.dataset.messageId || ""),
           String(btn.dataset.tempId || ""),
           String(btn.dataset.attachmentId || "")
@@ -3441,6 +3623,7 @@ export function createProjectSubjectsEvents(config) {
         const messageId = String(btn.dataset.messageId || "").trim();
         const replyUi = resolveInlineReplyUiState();
         if (messageId) replyUi.editPreviewByMessageId[messageId] = false;
+        if (messageId) clearInlineEditAttachmentsState(messageId);
         replyUi.editMessageId = "";
         toggleInlineEditEditorVisibility(messageId, false);
       };
@@ -3455,17 +3638,28 @@ export function createProjectSubjectsEvents(config) {
         const replyUi = resolveInlineReplyUiState();
         const nextBody = String(replyUi.editDraftsByMessageId?.[messageId] || "");
         const normalized = nextBody.trim();
-        if (!normalized) return;
+        const inlineAttachmentsState = getInlineEditAttachmentsState(messageId);
+        const hasReadyAttachment = hasReadyInlineAttachments(inlineAttachmentsState);
+        if (!normalized && !hasReadyAttachment) return;
+        const uploadSessionId = hasReadyAttachment
+          ? String(inlineAttachmentsState.uploadSessionId || "").trim()
+          : "";
         const currentBody = String(btn.dataset.originalBody || "");
-        if (normalized === currentBody.trim()) {
+        const hasBodyChanged = normalized !== currentBody.trim();
+        if (!hasBodyChanged && !uploadSessionId) {
           replyUi.editPreviewByMessageId[messageId] = false;
+          clearInlineEditAttachmentsState(messageId);
           replyUi.editMessageId = "";
           rerenderScope(root);
           return;
         }
         try {
-          await editSubjectMessage?.(selection.item.id, messageId, normalized);
+          await editSubjectMessage?.(selection.item.id, messageId, {
+            bodyMarkdown: nextBody,
+            uploadSessionId
+          });
           replyUi.editPreviewByMessageId[messageId] = false;
+          clearInlineEditAttachmentsState(messageId);
           replyUi.editMessageId = "";
         } catch (error) {
           showError(`Modification impossible : ${String(error?.message || error || "Erreur inconnue")}`);

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -50,7 +50,15 @@ export function createProjectSubjectsState({ store }) {
     if (!v.inlineReplyUi || typeof v.inlineReplyUi !== "object") {
       v.inlineReplyUi = {
         expandedMessageId: "",
-        draftsByMessageId: {}
+        draftsByMessageId: {},
+        previewByMessageId: {},
+        attachmentsByMessageId: {},
+        uploadSessionByMessageId: {},
+        editMessageId: "",
+        editDraftsByMessageId: {},
+        editPreviewByMessageId: {},
+        editAttachmentsByMessageId: {},
+        editUploadSessionByMessageId: {}
       };
     }
     if (typeof v.showTableOnly !== "boolean") v.showTableOnly = true;
@@ -233,7 +241,15 @@ export function createProjectSubjectsState({ store }) {
     };
     v.inlineReplyUi = {
       expandedMessageId: "",
-      draftsByMessageId: {}
+      draftsByMessageId: {},
+      previewByMessageId: {},
+      attachmentsByMessageId: {},
+      uploadSessionByMessageId: {},
+      editMessageId: "",
+      editDraftsByMessageId: {},
+      editPreviewByMessageId: {},
+      editAttachmentsByMessageId: {},
+      editUploadSessionByMessageId: {}
     };
     return v;
   }

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -296,6 +296,12 @@ export function createProjectSubjectsThread(config = {}) {
     if (!state.inlineReplyUi.editPreviewByMessageId || typeof state.inlineReplyUi.editPreviewByMessageId !== "object") {
       state.inlineReplyUi.editPreviewByMessageId = {};
     }
+    if (!state.inlineReplyUi.editAttachmentsByMessageId || typeof state.inlineReplyUi.editAttachmentsByMessageId !== "object") {
+      state.inlineReplyUi.editAttachmentsByMessageId = {};
+    }
+    if (!state.inlineReplyUi.editUploadSessionByMessageId || typeof state.inlineReplyUi.editUploadSessionByMessageId !== "object") {
+      state.inlineReplyUi.editUploadSessionByMessageId = {};
+    }
     return state.inlineReplyUi;
   }
 
@@ -526,12 +532,18 @@ export function createProjectSubjectsThread(config = {}) {
     return null;
   }
 
-  async function editSubjectMessage(subjectId, messageId, bodyMarkdown) {
+  async function editSubjectMessage(subjectId, messageId, { bodyMarkdown = "", uploadSessionId = "" } = {}) {
     const normalizedSubjectId = normalizeId(subjectId);
     const normalizedMessageId = normalizeId(messageId);
-    const nextBody = String(bodyMarkdown || "").trim();
-    if (!normalizedSubjectId || !normalizedMessageId || !nextBody || !subjectMessagesService) return null;
-    const updated = await subjectMessagesService.editMessage(normalizedMessageId, { bodyMarkdown: nextBody });
+    const nextBody = String(bodyMarkdown || "");
+    const normalizedUploadSessionId = normalizeId(uploadSessionId);
+    if (!normalizedSubjectId || !normalizedMessageId || !subjectMessagesService) return null;
+    const updated = await subjectMessagesService.editMessage({
+      messageId: normalizedMessageId,
+      subjectId: normalizedSubjectId,
+      bodyMarkdown: nextBody,
+      uploadSessionId: normalizedUploadSessionId || undefined
+    });
     ensureSubjectTimelineLoaded(normalizedSubjectId, { force: true });
     return updated;
   }
@@ -794,9 +806,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return toolbarButtons.map((button) => renderToolbarButton(button)).join("");
     }
 
-    const attachmentAction = buttonAction === "thread-reply-format" || buttonAction === "thread-edit-format"
-      ? "thread-reply-attachments-pick"
-      : "composer-attachments-pick";
+    const attachmentAction = buttonAction === "thread-edit-format"
+      ? "thread-edit-attachments-pick"
+      : buttonAction === "thread-reply-format"
+        ? "thread-reply-attachments-pick"
+        : "composer-attachments-pick";
     const attachmentButton = `
       <button
         class="comment-toolbar-btn"
@@ -920,9 +934,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
-  function renderInlineEditComposer({ commentId, depth = 0, isEditing = false, draft = "", previewMode = false, originalMessage = "" } = {}) {
+  function renderInlineEditComposer({ commentId, depth = 0, isEditing = false, draft = "", previewMode = false, originalMessage = "", attachments = [] } = {}) {
     if (!commentId) return "";
     const normalizedDraft = String(draft || "");
+    const pendingAttachments = Array.isArray(attachments) ? attachments : [];
+    const hasReadyAttachment = pendingAttachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
     const isNestedReplyEdit = Number(depth || 0) > 0;
     const editModeClass = isNestedReplyEdit
       ? "thread-inline-edit-editor--nested"
@@ -931,7 +947,37 @@ priority=${firstNonEmpty(subject.priority, "")}`
       ? "comment-composer--thread-edit-nested"
       : "comment-composer--thread-edit-root";
     const submitLabel = Number(depth || 0) > 0 ? "Mettre à jour la réponse" : "Mettre à jour le commentaire";
-    const canSubmit = !!normalizedDraft.trim();
+    const canSubmit = !!normalizedDraft.trim() || hasReadyAttachment;
+    const pendingAttachmentsHtml = pendingAttachments.length
+      ? `
+        <div class="subject-composer-attachments">
+          ${pendingAttachments.map((attachment, index) => `
+            <div class="subject-composer-attachment-item">
+              ${renderAttachmentTile(attachment, {
+                forceImage: !!attachment.isImage,
+                uploadState: attachment.error
+                  ? "error"
+                  : String(attachment.uploadStatus || "").trim() === "uploading"
+                    ? "uploading"
+                    : "ready",
+                uploadStateText: attachment.error ? "Erreur d’upload" : ""
+              })}
+              <button
+                class="subject-composer-attachment-remove"
+                type="button"
+                data-action="thread-edit-attachment-remove"
+                data-message-id="${escapeHtml(commentId)}"
+                data-attachment-id="${escapeHtml(normalizeId(attachment.id))}"
+                data-temp-id="${escapeHtml(String(attachment.tempId || index))}"
+                aria-label="Retirer la pièce jointe"
+              >
+                ${svgIcon("x")}
+              </button>
+            </div>
+          `).join("")}
+        </div>
+      `
+      : "";
     return `
       <div class="thread-inline-edit-editor ${editModeClass} ${isEditing ? "" : "hidden"}" data-inline-edit-editor="${escapeHtml(commentId)}" ${isEditing ? "" : "aria-hidden=\"true\""}>
         ${renderCommentComposer({
@@ -944,7 +990,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           textareaAttributes: {
             "data-thread-edit-draft": commentId
           },
-          placeholder: "Modifier le message...",
+          placeholder: "Modifier le message, glisser-déposer une pièce jointe...",
           tabWriteAction: "thread-edit-tab-write",
           tabPreviewAction: "thread-edit-tab-preview",
           tabsClassName: "comment-composer__tabs--thread-reply",
@@ -960,7 +1006,24 @@ priority=${firstNonEmpty(subject.priority, "")}`
             </div>
           `,
           previewEmptyHint: "Use Markdown to format your comment",
-          footerHtml: ""
+          footerHtml: `
+            <input
+              id="threadEditAttachmentInput-${escapeHtml(commentId)}"
+              type="file"
+              class="subject-composer-file-input"
+              data-role="thread-edit-file-input"
+              data-message-id="${escapeHtml(commentId)}"
+              multiple
+            />
+            <div
+              class="subject-composer-attachments-preview ${pendingAttachments.length ? "" : "hidden"}"
+              data-role="thread-edit-attachments-preview"
+              data-message-id="${escapeHtml(commentId)}"
+              aria-live="polite"
+            >
+              ${pendingAttachmentsHtml}
+            </div>
+          `
         })}
       </div>
     `;
@@ -1052,10 +1115,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const isEditing = replyUi.editMessageId === commentId;
     const draft = String(replyUi.draftsByMessageId?.[commentId] || "");
     const previewMode = !!replyUi.previewByMessageId?.[commentId];
-    const editDraft = String(replyUi.editDraftsByMessageId?.[commentId] || "");
+    const hasExplicitEditDraft = !!replyUi.editDraftsByMessageId
+      && Object.prototype.hasOwnProperty.call(replyUi.editDraftsByMessageId, commentId);
+    const editDraft = hasExplicitEditDraft
+      ? String(replyUi.editDraftsByMessageId?.[commentId] || "")
+      : String(entry?.message || "");
     const editPreviewMode = !!replyUi.editPreviewByMessageId?.[commentId];
     const attachments = Array.isArray(replyUi.attachmentsByMessageId?.[commentId])
       ? replyUi.attachmentsByMessageId[commentId]
+      : [];
+    const editAttachments = Array.isArray(replyUi.editAttachmentsByMessageId?.[commentId])
+      ? replyUi.editAttachmentsByMessageId[commentId]
       : [];
     const messageReactionSummary = buildMessageReactionSummary(entry?.meta?.reactions || []);
     const reactionsSummaryList = THREAD_REACTION_CHOICES
@@ -1087,9 +1157,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
           commentId,
           depth,
           isEditing,
-          draft: editDraft || String(entry?.message || ""),
+          draft: editDraft,
           previewMode: editPreviewMode,
-          originalMessage: String(entry?.message || "")
+          originalMessage: String(entry?.message || ""),
+          attachments: editAttachments
         })}
         ${(Array.isArray(entry?.meta?.attachments) && entry.meta.attachments.length)
           ? `<div class="subject-attachment-grid">${entry.meta.attachments.map((attachment) => renderAttachmentTile(attachment)).join("")}</div>`


### PR DESCRIPTION
### Motivation

- Allow attaching files when editing an existing subject message and support edits that only add attachments without changing text.
- Make the subject message edit API more flexible to accept structured payloads including `subjectId` and `uploadSessionId`.
- Persist and manage inline edit attachment UI state (pick, drag-drop, preview, remove) similarly to inline reply attachments.

### Description

- Updated `subject-messages-service.js` so `editMessage` accepts either a `messageId` or a payload object and forwards `subjectId` and `uploadSessionId` when provided.
- Enhanced Supabase repository `editMessage` to accept `subjectId` and `uploadSessionId`, allow empty message bodies when an `uploadSessionId` is present (uses a zero-width-space fallback on PATCH errors) and call `linkAttachmentsToMessage` to attach uploaded files to the message after patching.
- Added inline-edit attachment state and utilities in `project-subjects-events.js`, including `getInlineEditAttachmentsState`, `clearInlineEditAttachmentsState`, `addInlineEditFiles`, `removeInlineEditAttachmentById`, drag-and-drop handlers, file input handlers, submit-button sync logic and cleanup on cancel or switching edits.
- Initialized new inline edit attachment fields in `project-subjects-state.js` and updated `project-subjects-thread.js` to render inline edit composer attachments, consider attachments for submit enabling, default edit draft fallback to existing message, and pass `uploadSessionId` into `editSubjectMessage`.
- Minor adjustment to toolbar attachment action mapping to support edit vs reply composer file pick actions.

### Testing

- Ran `yarn lint` and the JavaScript linter checks which completed successfully.
- Ran frontend unit tests via `yarn test` and the test suite passed locally.
- Performed automated build (`yarn build`) to ensure the client bundle compiles without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f0e294e88329aa14cebc57d2c610)