### PR TITLE
Localize discussion attachment preview updates to avoid global rerenders

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1379,7 +1379,7 @@ export function createProjectSubjectsEvents(config) {
             error: ""
           };
           state.items.push(pending);
-          rerenderScope(root);
+          renderMainComposerAttachmentsPreview(state.items);
 
           try {
             const uploaded = await uploadAttachmentFile({
@@ -1412,7 +1412,7 @@ export function createProjectSubjectsEvents(config) {
             pending.previewStatus = pending.localPreviewUrl ? "local" : "none";
             pending.error = String(error?.message || error || "Erreur d'upload");
           }
-          rerenderScope(root);
+          renderMainComposerAttachmentsPreview(state.items);
         }
       };
 
@@ -1423,7 +1423,7 @@ export function createProjectSubjectsEvents(config) {
         if (targetIndex < 0) return;
         const current = state.items[targetIndex];
         state.items.splice(targetIndex, 1);
-        rerenderScope(root);
+        renderMainComposerAttachmentsPreview(state.items);
         releaseAttachmentPreviewUrls(current);
         if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
           try {
@@ -1733,15 +1733,6 @@ export function createProjectSubjectsEvents(config) {
           if (files.length) await addComposerFiles(files);
         });
       }
-
-      root.querySelectorAll("[data-action='composer-attachment-remove']").forEach((btn) => {
-        btn.onclick = async () => {
-          await removeComposerAttachmentById(
-            String(btn.dataset.tempId || ""),
-            String(btn.dataset.attachmentId || "")
-          );
-        };
-      });
 
       if (root.dataset.subjectMentionDocumentBound !== "true") {
         document.addEventListener("click", (event) => {
@@ -2368,6 +2359,158 @@ export function createProjectSubjectsEvents(config) {
     });
 
     const selectorValue = (value) => String(value || "").replace(/["\\]/g, "\\$&");
+    const normalizeAttachmentId = (value) => String(value || "").trim();
+    const renderAttachmentTileHtml = (attachment = {}, options = {}) => {
+      const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
+      const mimeType = String(attachment?.mime_type || attachment?.mimeType || "").toLowerCase();
+      const extension = String(fileName.split(".").pop() || "").toLowerCase();
+      const previewUrl = String(attachment?.localPreviewUrl || attachment?.previewUrl || attachment?.object_url || "");
+      const downloadUrl = String(
+        attachment?.remoteObjectUrl
+        || attachment?.download_url
+        || attachment?.signed_url
+        || attachment?.url
+        || attachment?.object_url
+        || previewUrl
+        || ""
+      );
+      const isImage = options.forceImage || mimeType.startsWith("image/");
+      const uploadState = String(options.uploadState || "").trim().toLowerCase();
+      const uploadStateText = String(options.uploadStateText || "").trim();
+      const typeIcon = mimeType === "application/pdf" || extension === "pdf"
+        ? "file-pdf"
+        : mimeType.includes("javascript") || extension === "js" || extension === "ts"
+          ? "file-js"
+          : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
+            ? "file-dwg"
+            : "file-generic";
+      let progressHtml = "";
+      let uploadIndicatorHtml = "";
+      if (uploadState === "uploading") {
+        uploadIndicatorHtml = `
+          <span class="subject-attachment__upload-indicator is-spinning" aria-label="Envoi en cours">
+            ${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner anim-rotate" })}
+          </span>
+        `;
+      } else if (uploadState === "ready") {
+        uploadIndicatorHtml = `
+          <span class="subject-attachment__upload-indicator" aria-label="Pièce jointe prête">
+            ${svgIcon("check-circle-fill", { className: "subject-attachment__spinner" })}
+          </span>
+        `;
+      } else if (uploadState === "error") {
+        progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadStateText || "Erreur d’upload")}</div>`;
+      } else if (uploadState) {
+        progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>`;
+      }
+      const metaLine = [
+        mimeType || "fichier",
+        Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
+          ? `${Math.max(1, Math.round(Number(attachment?.size_bytes || attachment?.sizeBytes) / 1024))} KB`
+          : ""
+      ].filter(Boolean).join(" · ");
+
+      if (isImage && previewUrl) {
+        return `
+          <div class="subject-attachment subject-attachment--image">
+            <a href="${escapeHtml(downloadUrl || previewUrl)}" target="_blank" rel="noopener noreferrer">
+              <img src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
+            </a>
+            <div class="subject-attachment__caption mono-small">
+              <span class="subject-attachment__caption-name">${escapeHtml(fileName)}</span>
+              ${uploadIndicatorHtml}
+            </div>
+            ${progressHtml}
+          </div>
+        `;
+      }
+
+      return `
+        <div class="subject-attachment subject-attachment--file">
+          <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
+          <div class="subject-attachment__file-body">
+            <div class="subject-attachment__file-head">
+              ${downloadUrl
+                ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
+                : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+              ${uploadIndicatorHtml}
+            </div>
+            <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
+            ${progressHtml}
+          </div>
+          ${downloadUrl ? `<a class="subject-attachment__file-link" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">Télécharger</a>` : ""}
+        </div>
+      `;
+    };
+    const renderAttachmentPreviewItemsHtml = ({ attachments = [], removeAction = "", messageId = "" } = {}) => {
+      const list = Array.isArray(attachments) ? attachments : [];
+      if (!list.length) return "";
+      return `
+        <div class="subject-composer-attachments">
+          ${list.map((attachment, index) => `
+            <div class="subject-composer-attachment-item">
+              ${renderAttachmentTileHtml(attachment, {
+                forceImage: !!attachment?.isImage,
+                uploadState: attachment?.error
+                  ? "error"
+                  : String(attachment?.uploadStatus || "").trim() === "uploading"
+                    ? "uploading"
+                    : "ready",
+                uploadStateText: attachment?.error ? "Erreur d’upload" : ""
+              })}
+              <button
+                class="subject-composer-attachment-remove"
+                type="button"
+                data-action="${escapeHtml(removeAction)}"
+                data-message-id="${messageId ? escapeHtml(String(messageId)) : ""}"
+                data-attachment-id="${escapeHtml(normalizeAttachmentId(attachment?.id))}"
+                data-temp-id="${escapeHtml(String(attachment?.tempId || index))}"
+                aria-label="Retirer la pièce jointe"
+              >
+                ${svgIcon("x")}
+              </button>
+            </div>
+          `).join("")}
+        </div>
+      `;
+    };
+    const renderMainComposerAttachmentsPreview = (attachments = []) => {
+      const container = root.querySelector("[data-role='subject-composer-attachments-preview']");
+      if (!container) return;
+      container.innerHTML = renderAttachmentPreviewItemsHtml({
+        attachments,
+        removeAction: "composer-attachment-remove"
+      });
+      container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
+    };
+    const renderInlineReplyAttachmentsPreview = (messageId = "", attachments = []) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const container = root.querySelector(
+        `[data-role='thread-reply-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
+      );
+      if (!container) return;
+      container.innerHTML = renderAttachmentPreviewItemsHtml({
+        attachments,
+        removeAction: "thread-reply-attachment-remove",
+        messageId: normalizedMessageId
+      });
+      container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
+    };
+    const renderInlineEditAttachmentsPreview = (messageId = "", attachments = []) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      const container = root.querySelector(
+        `[data-role='thread-edit-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
+      );
+      if (!container) return;
+      container.innerHTML = renderAttachmentPreviewItemsHtml({
+        attachments,
+        removeAction: "thread-edit-attachment-remove",
+        messageId: normalizedMessageId
+      });
+      container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
+    };
     const threadReplyDebugEnabled = (() => {
       try {
         const search = String(window?.location?.search || "");
@@ -2623,7 +2766,7 @@ export function createProjectSubjectsEvents(config) {
           error: ""
         };
         items.push(pending);
-        rerenderScope(root);
+        renderInlineReplyAttachmentsPreview(normalizedMessageId, items);
         try {
           const uploaded = await uploadAttachmentFile({
             subjectId,
@@ -2656,7 +2799,7 @@ export function createProjectSubjectsEvents(config) {
           pending.previewStatus = pending.localPreviewUrl ? "local" : "none";
           pending.error = String(error?.message || error || "Erreur d'upload");
         }
-        rerenderScope(root);
+        renderInlineReplyAttachmentsPreview(normalizedMessageId, items);
       }
     };
     const addInlineEditFiles = async (messageId = "", files = []) => {
@@ -2695,7 +2838,7 @@ export function createProjectSubjectsEvents(config) {
           error: ""
         };
         items.push(pending);
-        rerenderScope(root);
+        renderInlineEditAttachmentsPreview(normalizedMessageId, items);
         try {
           const uploaded = await uploadAttachmentFile({
             subjectId,
@@ -2728,7 +2871,7 @@ export function createProjectSubjectsEvents(config) {
           pending.previewStatus = pending.localPreviewUrl ? "local" : "none";
           pending.error = String(error?.message || error || "Erreur d'upload");
         }
-        rerenderScope(root);
+        renderInlineEditAttachmentsPreview(normalizedMessageId, items);
       }
     };
     const removeInlineReplyAttachmentById = async (messageId = "", tempId = "", attachmentId = "") => {
@@ -2740,7 +2883,7 @@ export function createProjectSubjectsEvents(config) {
       if (targetIndex < 0) return;
       const current = items[targetIndex];
       items.splice(targetIndex, 1);
-      rerenderScope(root);
+      renderInlineReplyAttachmentsPreview(normalizedMessageId, items);
       releaseAttachmentPreviewUrls(current);
       if (!items.length) clearInlineReplyAttachmentsState(normalizedMessageId, { keepUploadSession: true });
       if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
@@ -2760,7 +2903,7 @@ export function createProjectSubjectsEvents(config) {
       if (targetIndex < 0) return;
       const current = items[targetIndex];
       items.splice(targetIndex, 1);
-      rerenderScope(root);
+      renderInlineEditAttachmentsPreview(normalizedMessageId, items);
       releaseAttachmentPreviewUrls(current);
       if (!items.length) clearInlineEditAttachmentsState(normalizedMessageId, { keepUploadSession: true });
       if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
@@ -2771,6 +2914,40 @@ export function createProjectSubjectsEvents(config) {
         }
       }
     };
+    if (root.dataset.subjectAttachmentPreviewHandlersBound !== "true") {
+      root.addEventListener("click", (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+        const removeButton = target.closest("[data-action='composer-attachment-remove'], [data-action='thread-reply-attachment-remove'], [data-action='thread-edit-attachment-remove']");
+        if (!(removeButton instanceof HTMLElement)) return;
+        const action = String(removeButton.dataset.action || "").trim();
+        if (!action) return;
+        event.preventDefault();
+        if (action === "composer-attachment-remove") {
+          void removeComposerAttachmentById(
+            String(removeButton.dataset.tempId || ""),
+            String(removeButton.dataset.attachmentId || "")
+          );
+          return;
+        }
+        if (action === "thread-reply-attachment-remove") {
+          void removeInlineReplyAttachmentById(
+            String(removeButton.dataset.messageId || ""),
+            String(removeButton.dataset.tempId || ""),
+            String(removeButton.dataset.attachmentId || "")
+          );
+          return;
+        }
+        if (action === "thread-edit-attachment-remove") {
+          void removeInlineEditAttachmentById(
+            String(removeButton.dataset.messageId || ""),
+            String(removeButton.dataset.tempId || ""),
+            String(removeButton.dataset.attachmentId || "")
+          );
+        }
+      });
+      root.dataset.subjectAttachmentPreviewHandlersBound = "true";
+    }
 
     root.querySelectorAll("[data-action='thread-reply-menu-toggle'][data-message-id]").forEach((btn) => {
       btn.onclick = (event) => {
@@ -3556,25 +3733,6 @@ export function createProjectSubjectsEvents(config) {
         if (files.length) await addInlineEditFiles(messageId, files);
       });
     });
-    root.querySelectorAll("[data-action='thread-reply-attachment-remove'][data-message-id]").forEach((btn) => {
-      btn.onclick = async () => {
-        await removeInlineReplyAttachmentById(
-          String(btn.dataset.messageId || ""),
-          String(btn.dataset.tempId || ""),
-          String(btn.dataset.attachmentId || "")
-        );
-      };
-    });
-    root.querySelectorAll("[data-action='thread-edit-attachment-remove'][data-message-id]").forEach((btn) => {
-      btn.onclick = async () => {
-        await removeInlineEditAttachmentById(
-          String(btn.dataset.messageId || ""),
-          String(btn.dataset.tempId || ""),
-          String(btn.dataset.attachmentId || "")
-        );
-      };
-    });
-
     root.querySelectorAll("[data-action='thread-reply-cancel'][data-message-id]").forEach((btn) => {
       btn.onclick = () => {
         const messageId = String(btn.dataset.messageId || "").trim();


### PR DESCRIPTION
### Motivation
- Attachment add/remove/update currently triggers broad `rerenderScope(root)` calls which cause large, non-local rerenders and visual/scroll instability when uploading multiple files. 
- The goal of this change (Step 1 of the plan) is to ensure attachment state updates render only the attachment preview containers and never the full details panel for these local operations.

### Description
- Replaced global `rerenderScope(root)` calls in attachment-only flows with targeted local preview updates by introducing `renderMainComposerAttachmentsPreview(...)`, `renderInlineReplyAttachmentsPreview(...)` and `renderInlineEditAttachmentsPreview(...)` and a shared helper `renderAttachmentTileHtml(...)` that builds tile HTML. 
- Updated attachment flows (`addComposerFiles`, `removeComposerAttachmentById`, `addInlineReplyFiles`, `addInlineEditFiles`, `removeInlineReplyAttachmentById`, `removeInlineEditAttachmentById`) to call the local renderers at `pending` / `ready` / `error` transitions instead of rerendering the whole scope. 
- Replaced individual per-button bindings for remove actions with a single delegated click handler on `root` so remove buttons remain interactive after local DOM updates without requiring global rerenders. 
- File modified: `apps/web/js/views/project-subjects/project-subjects-events.js` (local preview rendering helpers + wiring and attachment-flow changes). 

### Testing
- Ran a static syntax check: `node --check apps/web/js/views/project-subjects/project-subjects-events.js`, which completed successfully. 
- No automated UI tests were added in this change; manual interaction coverage is recommended for drag-and-drop and remove flows in a browser environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fd3e92148329b48077b2ef2a91a6)