### PR TITLE
Ajouter un scheduler de rendu par scope pour coalescer les rerenders de discussion

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -281,6 +281,7 @@ const projectSubjectsThread = createProjectSubjectsThread({
   getEffectiveSituationStatus,
   subjectMessagesService,
   requestRerender: (...args) => projectSubjectsView.rerenderScope(...args),
+  scheduleThreadRerender: () => projectSubjectsView.scheduleDetailsThreadRerender(),
   entityDisplayLinkHtml: (...args) => projectSubjectsView.entityDisplayLinkHtml(...args),
   inferAgent: (...args) => projectSubjectsView.inferAgent(...args),
   normActorName: (...args) => projectSubjectsView.normActorName(...args),

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -2474,42 +2474,70 @@ export function createProjectSubjectsEvents(config) {
         </div>
       `;
     };
-    const renderMainComposerAttachmentsPreview = (attachments = []) => {
-      const container = root.querySelector("[data-role='subject-composer-attachments-preview']");
-      if (!container) return;
-      container.innerHTML = renderAttachmentPreviewItemsHtml({
-        attachments,
-        removeAction: "composer-attachment-remove"
+    const scheduleScopedDomRender = (scopeKey, callback) => {
+      const normalizedScopeKey = String(scopeKey || "").trim();
+      if (!normalizedScopeKey || typeof callback !== "function") return;
+      if (!root.__subjectScopedDomRenderTasks || typeof root.__subjectScopedDomRenderTasks !== "object") {
+        root.__subjectScopedDomRenderTasks = new Map();
+      }
+      const renderTasks = root.__subjectScopedDomRenderTasks;
+      renderTasks.set(normalizedScopeKey, callback);
+      if (root.__subjectScopedDomRenderFrame) return;
+      root.__subjectScopedDomRenderFrame = requestAnimationFrame(() => {
+        const tasks = Array.from(renderTasks.entries());
+        renderTasks.clear();
+        root.__subjectScopedDomRenderFrame = 0;
+        tasks.forEach(([, task]) => {
+          try {
+            task();
+          } catch (error) {
+            console.warn("[subject-thread] scoped dom render failed", { scopeKey: normalizedScopeKey, error });
+          }
+        });
       });
-      container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
+    };
+    const renderMainComposerAttachmentsPreview = (attachments = []) => {
+      scheduleScopedDomRender("attachments-main-composer-preview", () => {
+        const container = root.querySelector("[data-role='subject-composer-attachments-preview']");
+        if (!container) return;
+        container.innerHTML = renderAttachmentPreviewItemsHtml({
+          attachments,
+          removeAction: "composer-attachment-remove"
+        });
+        container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
+      });
     };
     const renderInlineReplyAttachmentsPreview = (messageId = "", attachments = []) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
-      const container = root.querySelector(
-        `[data-role='thread-reply-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
-      );
-      if (!container) return;
-      container.innerHTML = renderAttachmentPreviewItemsHtml({
-        attachments,
-        removeAction: "thread-reply-attachment-remove",
-        messageId: normalizedMessageId
+      scheduleScopedDomRender(`attachments-inline-reply-preview:${normalizedMessageId}`, () => {
+        const container = root.querySelector(
+          `[data-role='thread-reply-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
+        );
+        if (!container) return;
+        container.innerHTML = renderAttachmentPreviewItemsHtml({
+          attachments,
+          removeAction: "thread-reply-attachment-remove",
+          messageId: normalizedMessageId
+        });
+        container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
       });
-      container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
     };
     const renderInlineEditAttachmentsPreview = (messageId = "", attachments = []) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
-      const container = root.querySelector(
-        `[data-role='thread-edit-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
-      );
-      if (!container) return;
-      container.innerHTML = renderAttachmentPreviewItemsHtml({
-        attachments,
-        removeAction: "thread-edit-attachment-remove",
-        messageId: normalizedMessageId
+      scheduleScopedDomRender(`attachments-inline-edit-preview:${normalizedMessageId}`, () => {
+        const container = root.querySelector(
+          `[data-role='thread-edit-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
+        );
+        if (!container) return;
+        container.innerHTML = renderAttachmentPreviewItemsHtml({
+          attachments,
+          removeAction: "thread-edit-attachment-remove",
+          messageId: normalizedMessageId
+        });
+        container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
       });
-      container.classList.toggle("hidden", !Array.isArray(attachments) || !attachments.length);
     };
     const threadReplyDebugEnabled = (() => {
       try {
@@ -2666,22 +2694,9 @@ export function createProjectSubjectsEvents(config) {
     const toggleInlineReplyEditorVisibility = (messageId = "", visible = false) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
-      const editor = root.querySelector(`[data-inline-reply-editor="${selectorValue(normalizedMessageId)}"]`);
-      if (!editor) return;
-      if (!visible && editor.contains(document.activeElement)) {
-        const activeElement = document.activeElement;
-        if (activeElement && typeof activeElement.blur === "function") activeElement.blur();
-      }
-      editor.classList.toggle("hidden", !visible);
-      if (visible) editor.removeAttribute("aria-hidden");
-      else editor.setAttribute("aria-hidden", "true");
-    };
-    const toggleInlineEditEditorVisibility = (messageId = "", visible = false) => {
-      const normalizedMessageId = String(messageId || "").trim();
-      if (!normalizedMessageId) return;
-      const editor = root.querySelector(`[data-inline-edit-editor="${selectorValue(normalizedMessageId)}"]`);
-      const content = root.querySelector(`[data-thread-comment-content="${selectorValue(normalizedMessageId)}"]`);
-      if (editor) {
+      scheduleScopedDomRender(`inline-reply-editor:${normalizedMessageId}`, () => {
+        const editor = root.querySelector(`[data-inline-reply-editor="${selectorValue(normalizedMessageId)}"]`);
+        if (!editor) return;
         if (!visible && editor.contains(document.activeElement)) {
           const activeElement = document.activeElement;
           if (activeElement && typeof activeElement.blur === "function") activeElement.blur();
@@ -2689,8 +2704,25 @@ export function createProjectSubjectsEvents(config) {
         editor.classList.toggle("hidden", !visible);
         if (visible) editor.removeAttribute("aria-hidden");
         else editor.setAttribute("aria-hidden", "true");
-      }
-      if (content) content.classList.toggle("hidden", !!visible);
+      });
+    };
+    const toggleInlineEditEditorVisibility = (messageId = "", visible = false) => {
+      const normalizedMessageId = String(messageId || "").trim();
+      if (!normalizedMessageId) return;
+      scheduleScopedDomRender(`inline-edit-editor:${normalizedMessageId}`, () => {
+        const editor = root.querySelector(`[data-inline-edit-editor="${selectorValue(normalizedMessageId)}"]`);
+        const content = root.querySelector(`[data-thread-comment-content="${selectorValue(normalizedMessageId)}"]`);
+        if (editor) {
+          if (!visible && editor.contains(document.activeElement)) {
+            const activeElement = document.activeElement;
+            if (activeElement && typeof activeElement.blur === "function") activeElement.blur();
+          }
+          editor.classList.toggle("hidden", !visible);
+          if (visible) editor.removeAttribute("aria-hidden");
+          else editor.setAttribute("aria-hidden", "true");
+        }
+        if (content) content.classList.toggle("hidden", !!visible);
+      });
     };
     const closeInlineReplyEditor = (messageId = "") => {
       const normalizedMessageId = String(messageId || "").trim();

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -32,6 +32,7 @@ export function createProjectSubjectsThread(config = {}) {
     getEffectiveSituationStatus,
     subjectMessagesService,
     requestRerender,
+    scheduleThreadRerender,
     entityDisplayLinkHtml,
     inferAgent,
     normActorName,
@@ -429,6 +430,10 @@ export function createProjectSubjectsThread(config = {}) {
   }
 
   function requestScopeRerender() {
+    if (typeof scheduleThreadRerender === "function") {
+      scheduleThreadRerender();
+      return;
+    }
     if (typeof requestRerender === "function") {
       const detailsHost = document.getElementById("situationsDetailsHost");
       const threadHost = detailsHost?.querySelector?.("[data-details-thread-host]");

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2372,6 +2372,41 @@ function rerenderScope(root) {
   }
 }
 
+const scheduledScopeRenders = new Map();
+let scheduledScopeRendersFrame = 0;
+
+function scheduleScopedRerender(scopeKey, resolveRoot) {
+  const normalizedScopeKey = String(scopeKey || "").trim();
+  if (!normalizedScopeKey) return;
+  const resolver = typeof resolveRoot === "function" ? resolveRoot : () => resolveRoot;
+  scheduledScopeRenders.set(normalizedScopeKey, resolver);
+  if (scheduledScopeRendersFrame) return;
+  scheduledScopeRendersFrame = requestAnimationFrame(() => {
+    const pendingRenders = Array.from(scheduledScopeRenders.entries());
+    scheduledScopeRenders.clear();
+    scheduledScopeRendersFrame = 0;
+    pendingRenders.forEach(([, currentResolver]) => {
+      const root = currentResolver?.();
+      if (!root) return;
+      rerenderScope(root);
+    });
+  });
+}
+
+function scheduleDetailsThreadRerender() {
+  scheduleScopedRerender("details-thread", () => {
+    const detailsHost = document.getElementById("situationsDetailsHost");
+    return detailsHost?.querySelector?.("[data-details-thread-host]") || detailsHost || document;
+  });
+}
+
+function scheduleDetailsComposerRerender() {
+  scheduleScopedRerender("details-composer", () => {
+    const detailsHost = document.getElementById("situationsDetailsHost");
+    return detailsHost?.querySelector?.("[data-details-composer-host]") || detailsHost || document;
+  });
+}
+
 function renderDetailsDiscussionScopes(detailsHost, options = {}) {
   if (!detailsHost || !detailsHost.isConnected) return;
   const {
@@ -2864,6 +2899,9 @@ function getObjectiveById(objectiveId) {
     syncSituationsPrimaryScrollSource,
     rerenderPanels,
     rerenderScope,
+    scheduleScopedRerender,
+    scheduleDetailsThreadRerender,
+    scheduleDetailsComposerRerender,
     syncCommentPreview,
     applyCommentAction
   };


### PR DESCRIPTION
### Motivation
- Les opérations locales de la discussion (attachments, éditeurs inline, refresh timeline) provoquent trop de rerenders successifs et trop larges, entraînant des rebonds de scroll et des rebinding inutiles.

### Description
- Ajout d’un scheduler léger côté détails (`scheduleScopedRerender`) basé sur `requestAnimationFrame` et déduplication par clé de scope, avec deux helpers ciblés `scheduleDetailsThreadRerender` et `scheduleDetailsComposerRerender` pour le thread et le composer. (fichier modifié: `apps/web/js/views/project-subjects/project-subjects-view.js`)
- Le flux de refresh du thread utilise désormais la voie planifiée (`scheduleDetailsThreadRerender`) si disponible, tout en conservant le fallback vers le rerender immédiat existant. (fichier modifié: `apps/web/js/views/project-subjects/project-subjects-thread.js` et intégration dans `apps/web/js/views/project-subjects.js`)
- Ajout d’un scheduler DOM local par scope dans la gestion des events de discussion (`scheduleScopedDomRender`) et remplacement des écritures DOM fréquentes par des tâches planifiées pour: preview attachments du composer principal, preview attachments reply inline, preview attachments edit inline, toggle éditeur reply inline et toggle éditeur edit inline. (fichier modifié: `apps/web/js/views/project-subjects/project-subjects-events.js`)
- Exposition des helpers de scheduling via l’API view existante pour une intégration propre et progressive; comportement existant conservé en fallback.
- Points à surveiller: le scheduler DOM local utilise des propriétés attachées au `root` (`__subjectScopedDomRenderTasks`, `__subjectScopedDomRenderFrame`) — choix volontaire pour rester simple et local.

### Testing
- Vérification de syntaxe avec `node --check` sur les fichiers modifiés: commande exécutée et sans erreur. (succès)
- Exécution des tests ciblés `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs` (5 tests) et tous sont passés. (succès)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60270efec83299ea7e33aba651716)