### PR TITLE
Finalize timeline refresh scoping + add render-scope instrumentation

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -2500,6 +2500,7 @@ export function createProjectSubjectsEvents(config) {
       scheduleScopedDomRender("attachments-main-composer-preview", () => {
         const container = root.querySelector("[data-role='subject-composer-attachments-preview']");
         if (!container) return;
+        debugRenderScope("attachments-main-composer-preview", { count: Array.isArray(attachments) ? attachments.length : 0 });
         container.innerHTML = renderAttachmentPreviewItemsHtml({
           attachments,
           removeAction: "composer-attachment-remove"
@@ -2515,6 +2516,10 @@ export function createProjectSubjectsEvents(config) {
           `[data-role='thread-reply-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
         );
         if (!container) return;
+        debugRenderScope("attachments-inline-reply-preview", {
+          messageId: normalizedMessageId,
+          count: Array.isArray(attachments) ? attachments.length : 0
+        });
         container.innerHTML = renderAttachmentPreviewItemsHtml({
           attachments,
           removeAction: "thread-reply-attachment-remove",
@@ -2531,6 +2536,10 @@ export function createProjectSubjectsEvents(config) {
           `[data-role='thread-edit-attachments-preview'][data-message-id="${selectorValue(normalizedMessageId)}"]`
         );
         if (!container) return;
+        debugRenderScope("attachments-inline-edit-preview", {
+          messageId: normalizedMessageId,
+          count: Array.isArray(attachments) ? attachments.length : 0
+        });
         container.innerHTML = renderAttachmentPreviewItemsHtml({
           attachments,
           removeAction: "thread-edit-attachment-remove",
@@ -2552,6 +2561,27 @@ export function createProjectSubjectsEvents(config) {
     const debugThreadReply = (eventName, payload = {}) => {
       if (!threadReplyDebugEnabled) return;
       console.log("[subject-thread-reply]", eventName, payload);
+    };
+    const renderScopeDebugEnabled = (() => {
+      try {
+        const search = String(window?.location?.search || "");
+        if (search.includes("debugRenderScopes=1")) return true;
+        const localValue = String(window?.localStorage?.getItem?.("mdall:debug-render-scopes") || "").trim().toLowerCase();
+        const sessionValue = String(window?.sessionStorage?.getItem?.("mdall:debug-render-scopes") || "").trim().toLowerCase();
+        const globalValue = String(window?.__MDALL_DEBUG_RENDER_SCOPES__ || "").trim().toLowerCase();
+        return localValue === "1"
+          || localValue === "true"
+          || sessionValue === "1"
+          || sessionValue === "true"
+          || globalValue === "1"
+          || globalValue === "true";
+      } catch {
+        return false;
+      }
+    })();
+    const debugRenderScope = (scope, payload = {}) => {
+      if (!renderScopeDebugEnabled) return;
+      console.log("[subject-render-scope]", String(scope || "unknown"), payload);
     };
     const resolveInlineReplyUiState = () => {
       if (typeof getInlineReplyUiState === "function") {
@@ -2697,6 +2727,7 @@ export function createProjectSubjectsEvents(config) {
       scheduleScopedDomRender(`inline-reply-editor:${normalizedMessageId}`, () => {
         const editor = root.querySelector(`[data-inline-reply-editor="${selectorValue(normalizedMessageId)}"]`);
         if (!editor) return;
+        debugRenderScope("inline-reply-editor", { messageId: normalizedMessageId, visible: !!visible });
         if (!visible && editor.contains(document.activeElement)) {
           const activeElement = document.activeElement;
           if (activeElement && typeof activeElement.blur === "function") activeElement.blur();
@@ -2712,6 +2743,7 @@ export function createProjectSubjectsEvents(config) {
       scheduleScopedDomRender(`inline-edit-editor:${normalizedMessageId}`, () => {
         const editor = root.querySelector(`[data-inline-edit-editor="${selectorValue(normalizedMessageId)}"]`);
         const content = root.querySelector(`[data-thread-comment-content="${selectorValue(normalizedMessageId)}"]`);
+        debugRenderScope("inline-edit-editor", { messageId: normalizedMessageId, visible: !!visible });
         if (editor) {
           if (!visible && editor.contains(document.activeElement)) {
             const activeElement = document.activeElement;

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -42,6 +42,23 @@ export function createProjectSubjectsThread(config = {}) {
   const subjectTimelineCache = new Map();
   const subjectTimelineState = new Map();
   const subjectReadMarkState = new Map();
+  const renderScopeDebugEnabled = (() => {
+    try {
+      const search = String(window?.location?.search || "");
+      if (search.includes("debugRenderScopes=1")) return true;
+      const localValue = String(window?.localStorage?.getItem?.("mdall:debug-render-scopes") || "").trim().toLowerCase();
+      const sessionValue = String(window?.sessionStorage?.getItem?.("mdall:debug-render-scopes") || "").trim().toLowerCase();
+      const globalValue = String(window?.__MDALL_DEBUG_RENDER_SCOPES__ || "").trim().toLowerCase();
+      return localValue === "1"
+        || localValue === "true"
+        || sessionValue === "1"
+        || sessionValue === "true"
+        || globalValue === "1"
+        || globalValue === "true";
+    } catch {
+      return false;
+    }
+  })();
   const MAX_REPLY_VISUAL_DEPTH = 2;
   const THREAD_REACTION_CHOICES = [
     { code: "thumbs_up", label: "J'aime", emoji: "👍", assetPath: "assets/images/reactions/thumbs-up.png" },
@@ -56,6 +73,11 @@ export function createProjectSubjectsThread(config = {}) {
 
   function normalizeId(value) {
     return String(value || "").trim();
+  }
+
+  function debugRenderScope(scope, payload = {}) {
+    if (!renderScopeDebugEnabled) return;
+    console.log("[subject-render-scope]", String(scope || "unknown"), payload);
   }
 
   function getProjectCollaborators() {
@@ -431,12 +453,14 @@ export function createProjectSubjectsThread(config = {}) {
 
   function requestScopeRerender() {
     if (typeof scheduleThreadRerender === "function") {
+      debugRenderScope("thread", { source: "timeline-refresh", mode: "scheduled" });
       scheduleThreadRerender();
       return;
     }
     if (typeof requestRerender === "function") {
       const detailsHost = document.getElementById("situationsDetailsHost");
       const threadHost = detailsHost?.querySelector?.("[data-details-thread-host]");
+      debugRenderScope("thread", { source: "timeline-refresh", mode: "fallback-request-rerender" });
       requestRerender(threadHost || detailsHost || document);
     }
   }
@@ -472,6 +496,10 @@ export function createProjectSubjectsThread(config = {}) {
           comments: nestedComments,
           activities: events.map((row) => mapEventRowToThreadActivity(row)),
           conversation: timeline?.conversation || null
+        });
+        debugRenderScope("thread-timeline-refresh", {
+          subjectId: normalizedSubjectId,
+          rowsCount: mappedRows.length
         });
         queueSubjectMessageReadMarking(normalizedSubjectId, messages);
         requestScopeRerender();

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2332,12 +2332,14 @@ function rerenderScope(root) {
 
   if (shouldRerenderDetailsOnly) {
     if (isThreadScopeRoot || isComposerScopeRoot) {
+      debugRenderScope(isThreadScopeRoot ? "thread" : "composer", { mode: "scoped-rerender" });
       renderDetailsDiscussionScopes(detailsHost, {
         renderThread: isThreadScopeRoot,
         renderComposer: isComposerScopeRoot
       });
       return;
     }
+    debugRenderScope("details-shell", { mode: "full-details-rerender" });
     const detailsScrollState = getScrollableElementScrollState(detailsHost);
     const details = getProjectSubjectDetail().renderDetailsHtml(null, {
       showExpand: false,
@@ -2375,19 +2377,44 @@ function rerenderScope(root) {
 const scheduledScopeRenders = new Map();
 let scheduledScopeRendersFrame = 0;
 
+function isRenderScopeDebugEnabled() {
+  try {
+    const search = String(window?.location?.search || "");
+    if (search.includes("debugRenderScopes=1")) return true;
+    const localValue = String(window?.localStorage?.getItem?.("mdall:debug-render-scopes") || "").trim().toLowerCase();
+    const sessionValue = String(window?.sessionStorage?.getItem?.("mdall:debug-render-scopes") || "").trim().toLowerCase();
+    const globalValue = String(window?.__MDALL_DEBUG_RENDER_SCOPES__ || "").trim().toLowerCase();
+    return localValue === "1"
+      || localValue === "true"
+      || sessionValue === "1"
+      || sessionValue === "true"
+      || globalValue === "1"
+      || globalValue === "true";
+  } catch {
+    return false;
+  }
+}
+
+function debugRenderScope(scope, payload = {}) {
+  if (!isRenderScopeDebugEnabled()) return;
+  console.log("[subject-render-scope]", String(scope || "unknown"), payload);
+}
+
 function scheduleScopedRerender(scopeKey, resolveRoot) {
   const normalizedScopeKey = String(scopeKey || "").trim();
   if (!normalizedScopeKey) return;
   const resolver = typeof resolveRoot === "function" ? resolveRoot : () => resolveRoot;
   scheduledScopeRenders.set(normalizedScopeKey, resolver);
+  debugRenderScope(`${normalizedScopeKey}:scheduled`);
   if (scheduledScopeRendersFrame) return;
   scheduledScopeRendersFrame = requestAnimationFrame(() => {
     const pendingRenders = Array.from(scheduledScopeRenders.entries());
     scheduledScopeRenders.clear();
     scheduledScopeRendersFrame = 0;
-    pendingRenders.forEach(([, currentResolver]) => {
+    pendingRenders.forEach(([pendingScopeKey, currentResolver]) => {
       const root = currentResolver?.();
       if (!root) return;
+      debugRenderScope(`${pendingScopeKey}:flushed`);
       rerenderScope(root);
     });
   });
@@ -2417,6 +2444,7 @@ function renderDetailsDiscussionScopes(detailsHost, options = {}) {
 
   const discussion = getProjectSubjectDetail().renderDetailsDiscussionHtml();
   if (renderThread) {
+    debugRenderScope("thread", { host: "details-thread-host" });
     const threadHost = detailsHost.querySelector("[data-details-thread-host]");
     if (threadHost) {
       threadHost.innerHTML = discussion.threadHtml;
@@ -2424,6 +2452,7 @@ function renderDetailsDiscussionScopes(detailsHost, options = {}) {
     }
   }
   if (renderComposer) {
+    debugRenderScope("composer", { host: "details-composer-host" });
     const composerHost = detailsHost.querySelector("[data-details-composer-host]");
     if (composerHost) {
       composerHost.innerHTML = discussion.composerHtml;
@@ -2494,7 +2523,14 @@ async function applyCommentAction(root) {
     store.situationsView.subjectComposerAttachments.uploadSessionId = "";
     store.situationsView.subjectComposerAttachments.items = [];
   }
-  rerenderScope(root);
+  const detailsHost = document.getElementById("situationsDetailsHost");
+  const composerHost = root?.closest?.("[data-details-composer-host]")
+    || detailsHost?.querySelector?.("[data-details-composer-host]");
+  if (composerHost) {
+    scheduleDetailsComposerRerender();
+  } else {
+    rerenderScope(root);
+  }
 
 }
 


### PR DESCRIPTION
### Motivation
- Empêcher le rerender global du panneau de détail lors du refresh serveur de la timeline et rendre observables les scopes de rendu pour éviter les régressions de scroll visuel.

### Description
- Restreint le rerender post-commentaire pour cibler le `composer` quand possible en utilisant `scheduleDetailsComposerRerender()` au lieu d'un `rerenderScope(root)` large (modifié dans `project-subjects-view.js`).
- Ajout d'une instrumentation discrète activable (`?debugRenderScopes=1` / `localStorage/sessionStorage` / `window.__MDALL_DEBUG_RENDER_SCOPES__`) qui logge les scopes `details-shell`, `thread`, `composer` et les événements `scheduled`/`flushed` du scheduler (implémentée dans `project-subjects-view.js`).
- Instrumentation côté thread pour tracer les refreshs de timeline serveur et le chemin fallback du rerender thread (ajouts dans `project-subjects-thread.js`).
- Ajout de traces de debug pour les rendus locaux importants (previews attachments et toggles d'éditeurs inline) via `debugRenderScope` sans impact en production (modifications dans `project-subjects-events.js`).

### Testing
- Exécution des checks de syntaxe avec `node --check` sur `project-subjects-view.js`, `project-subjects-events.js` et `project-subjects-thread.js` : OK.
- Exécution des tests d'import `node apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` : 2 tests passés, 0 échec.
- Le commit a été créé localement avec le message: `Scope timeline refresh to thread and add render-scope debug traces`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6045a666083299fdb2b3233dc4601)