### PR TITLE
Casser la boucle fetch/rerender de la timeline déclenchée par le rendu du thread

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -302,6 +302,7 @@ const {
   getComposerAttachmentsState,
   getThreadForSelection,
   getInlineReplyUiState,
+  ensureTimelineLoadedForSelection,
   renderThreadBlock,
   renderIssueStatusAction,
   renderCommentBox
@@ -786,7 +787,8 @@ const projectSubjectsView = createProjectSubjectsView({
   currentDecisionTarget: (...args) => currentDecisionTarget(...args),
   addComment: (...args) => addComment(...args),
   getScopedSelection: (...args) => getScopedSelection(...args),
-  getInlineReplyUiState: (...args) => getInlineReplyUiState(...args)
+  getInlineReplyUiState: (...args) => getInlineReplyUiState(...args),
+  ensureTimelineLoadedForSelection: (...args) => ensureTimelineLoadedForSelection(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -471,6 +471,7 @@ export function createProjectSubjectsThread(config = {}) {
 
     const force = !!options.force;
     const currentState = subjectTimelineState.get(normalizedSubjectId) || { loading: false, requestId: 0 };
+    if (!force && subjectTimelineCache.has(normalizedSubjectId)) return;
     if (currentState.loading && !force) return;
 
     const requestId = Number(currentState.requestId || 0) + 1;
@@ -512,6 +513,14 @@ export function createProjectSubjectsThread(config = {}) {
         if (Number(latestState.requestId || 0) !== requestId) return;
         subjectTimelineState.set(normalizedSubjectId, { loading: false, requestId });
       });
+  }
+
+  function ensureTimelineLoadedForSelection(selection = null, options = {}) {
+    const currentSelection = selection || getActiveSelection();
+    if (!currentSelection || String(currentSelection.type || "").toLowerCase() !== "sujet") return;
+    const subjectId = normalizeId(currentSelection?.item?.id);
+    if (!subjectId) return;
+    ensureSubjectTimelineLoaded(subjectId, options);
   }
 
   async function addComment(entityType, entityId, message, options = {}) {
@@ -716,7 +725,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const entityKey = (type, id) => `${String(type || "").toLowerCase()}:${String(id || "")}`;
 
     if (subject) {
-      ensureSubjectTimelineLoaded(subject.id);
       allowedComments.add(entityKey("sujet", subject.id));
       allowedActivities.add(entityKey("sujet", subject.id));
       if (situation) allowedActivities.add(entityKey("situation", situation.id));
@@ -1675,6 +1683,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     getSubjectRefUiState,
     getComposerAttachmentsState,
     getInlineReplyUiState,
+    ensureTimelineLoadedForSelection,
     renderThreadBlock,
     renderIssueStatusAction,
     renderCommentBox

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -85,7 +85,8 @@ export function createProjectSubjectsView(deps) {
     setProjectCompactEnabled,
     currentDecisionTarget,
     addComment,
-    getScopedSelection
+    getScopedSelection,
+    ensureTimelineLoadedForSelection
   } = deps;
 
   const {
@@ -2442,6 +2443,7 @@ function renderDetailsDiscussionScopes(detailsHost, options = {}) {
   } = options;
   if (!renderThread && !renderComposer) return;
 
+  ensureTimelineLoadedForSelection();
   const discussion = getProjectSubjectDetail().renderDetailsDiscussionHtml();
   if (renderThread) {
     debugRenderScope("thread", { host: "details-thread-host" });


### PR DESCRIPTION
### Motivation
- Le rendu du thread déclenchait un fetch de timeline (`ensureSubjectTimelineLoaded`) ce qui provoquait un rerender à la fin du fetch et relançait le fetch en boucle, générant un clignotement visible.

### Description
- Retiré l'appel à `ensureSubjectTimelineLoaded(subject.id)` depuis le chemin de rendu du thread pour éviter tout effet de bord pendant la construction HTML (modifié `project-subjects-thread.js`).
- Ajouté un point d'entrée contrôlé `ensureTimelineLoadedForSelection(...)` dans le module thread et exposé via le wiring principal pour déclencher les chargements hors fonctions de rendu (ajouts dans `project-subjects-thread.js`, `project-subjects.js`).
- Déplacé le bootstrapping du chargement de timeline vers l'orchestrateur de scopes `renderDetailsDiscussionScopes(...)`, afin que le fetch soit lancé par le contrôleur et non par la fonction de rendu (modifié `project-subjects-view.js`).
- Ajouté un garde simple dans `ensureSubjectTimelineLoaded(...)` pour éviter de re-fetcher une timeline déjà présente en cache sauf si `force: true` est demandé (modifié `project-subjects-thread.js`).

### Testing
- Vérification de la syntaxe/type-check des fichiers JavaScript avec `node --check` pour les fichiers modifiés: `apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/js/views/project-subjects/project-subjects-view.js`, et `apps/web/js/views/project-subjects.js`, et toutes ont passé la vérification avec succès.
- Aucune autre suite de tests automatisés n'a été ajoutée dans ce changelist; manuellement validé que les points d'entrée de chargement timeline existent et que le rendu du thread ne lance plus de fetchs non sollicités.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e607a1e35c83298f0b4f74560bc8ba)