### PR TITLE
Ensure subject timeline is loaded and optimize discussion composer rerenders

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -302,6 +302,7 @@ const {
   getComposerAttachmentsState,
   getThreadForSelection,
   getInlineReplyUiState,
+  ensureTimelineLoadedForSelection,
   renderThreadBlock,
   renderIssueStatusAction,
   renderCommentBox
@@ -786,7 +787,8 @@ const projectSubjectsView = createProjectSubjectsView({
   currentDecisionTarget: (...args) => currentDecisionTarget(...args),
   addComment: (...args) => addComment(...args),
   getScopedSelection: (...args) => getScopedSelection(...args),
-  getInlineReplyUiState: (...args) => getInlineReplyUiState(...args)
+  getInlineReplyUiState: (...args) => getInlineReplyUiState(...args),
+  ensureTimelineLoadedForSelection: (...args) => ensureTimelineLoadedForSelection(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -2321,24 +2321,33 @@ export function createProjectSubjectsEvents(config) {
       });
     });
 
+    const rerenderDiscussionComposerScope = (triggerElement = null) => {
+      const composerScopeRoot = triggerElement?.closest?.("[data-details-composer-host]");
+      if (composerScopeRoot) {
+        rerenderScope(composerScopeRoot);
+        return;
+      }
+      rerenderScope(triggerElement || root);
+    };
+
     root.querySelectorAll("[data-action='tab-write']").forEach((btn) => {
       btn.onclick = () => {
         store.situationsView.commentPreviewMode = false;
-        rerenderPanels();
+        rerenderDiscussionComposerScope(btn);
       };
     });
 
     root.querySelectorAll("[data-action='tab-preview']").forEach((btn) => {
       btn.onclick = () => {
         store.situationsView.commentPreviewMode = true;
-        rerenderPanels();
+        rerenderDiscussionComposerScope(btn);
       };
     });
 
     root.querySelectorAll("[data-action='toggle-help']").forEach((btn) => {
       btn.onclick = () => {
         store.situationsView.helpMode = !store.situationsView.helpMode;
-        rerenderPanels();
+        rerenderDiscussionComposerScope(btn);
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -471,6 +471,7 @@ export function createProjectSubjectsThread(config = {}) {
 
     const force = !!options.force;
     const currentState = subjectTimelineState.get(normalizedSubjectId) || { loading: false, requestId: 0 };
+    if (!force && subjectTimelineCache.has(normalizedSubjectId)) return;
     if (currentState.loading && !force) return;
 
     const requestId = Number(currentState.requestId || 0) + 1;
@@ -512,6 +513,14 @@ export function createProjectSubjectsThread(config = {}) {
         if (Number(latestState.requestId || 0) !== requestId) return;
         subjectTimelineState.set(normalizedSubjectId, { loading: false, requestId });
       });
+  }
+
+  function ensureTimelineLoadedForSelection(selection = null, options = {}) {
+    const currentSelection = selection || getActiveSelection();
+    if (!currentSelection || String(currentSelection.type || "").toLowerCase() !== "sujet") return;
+    const subjectId = normalizeId(currentSelection?.item?.id);
+    if (!subjectId) return;
+    ensureSubjectTimelineLoaded(subjectId, options);
   }
 
   async function addComment(entityType, entityId, message, options = {}) {
@@ -716,7 +725,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const entityKey = (type, id) => `${String(type || "").toLowerCase()}:${String(id || "")}`;
 
     if (subject) {
-      ensureSubjectTimelineLoaded(subject.id);
       allowedComments.add(entityKey("sujet", subject.id));
       allowedActivities.add(entityKey("sujet", subject.id));
       if (situation) allowedActivities.add(entityKey("situation", situation.id));
@@ -1675,6 +1683,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     getSubjectRefUiState,
     getComposerAttachmentsState,
     getInlineReplyUiState,
+    ensureTimelineLoadedForSelection,
     renderThreadBlock,
     renderIssueStatusAction,
     renderCommentBox

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -85,7 +85,8 @@ export function createProjectSubjectsView(deps) {
     setProjectCompactEnabled,
     currentDecisionTarget,
     addComment,
-    getScopedSelection
+    getScopedSelection,
+    ensureTimelineLoadedForSelection
   } = deps;
 
   const {
@@ -2442,6 +2443,7 @@ function renderDetailsDiscussionScopes(detailsHost, options = {}) {
   } = options;
   if (!renderThread && !renderComposer) return;
 
+  ensureTimelineLoadedForSelection();
   const discussion = getProjectSubjectDetail().renderDetailsDiscussionHtml();
   if (renderThread) {
     debugRenderScope("thread", { host: "details-thread-host" });


### PR DESCRIPTION
### Motivation

- Ensure subject timeline data is available before rendering the discussion thread/composer to avoid missing messages when viewing a subject.  
- Prevent redundant timeline requests by respecting a timeline cache and current loading state.  
- Reduce full-panel rerenders when toggling the discussion composer modes to improve responsiveness.

### Description

- Added `ensureTimelineLoadedForSelection` in `project-subjects-thread.js` to load the timeline for the current selection and exported it from the thread API.  
- Short-circuited redundant timeline fetches by checking `subjectTimelineCache` in `ensureSubjectTimelineLoaded`.  
- Wired `ensureTimelineLoadedForSelection` into the view (`createProjectSubjectsView`) and invoked it from `renderDetailsDiscussionScopes` to proactively load timeline data before rendering the discussion.  
- Introduced `rerenderDiscussionComposerScope` in `project-subjects-events.js` and replaced calls to `rerenderPanels()` for write/preview/help toggles so only the composer scope is rerendered instead of whole panels.

### Testing

- Ran the project's JavaScript unit tests with `yarn test` and they completed successfully.  
- Ran the linter with `yarn lint` and it succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e607a1e35c83298f0b4f74560bc8ba)