### PR TITLE
Fix subject icon state after reopening dismissed/duplicate issues

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -865,6 +865,7 @@ export function createProjectSubjectsActions(config) {
       subject.closure_reason = null;
       subject.closed_at = null;
       setDecision("sujet", subjectId, "REOPENED", "", { actor: "Human", agent: "human" });
+      setEntityReviewState("sujet", subjectId, "pending");
       if (subject.raw && typeof subject.raw === "object") {
         subject.raw.status = "open";
         subject.raw.closure_reason = null;
@@ -878,6 +879,7 @@ export function createProjectSubjectsActions(config) {
       subject.closure_reason = "realized";
       subject.closed_at = nowIso();
       setDecision("sujet", subjectId, "CLOSED", "", { actor: "Human", agent: "human" });
+      setEntityReviewState("sujet", subjectId, "pending");
       if (subject.raw && typeof subject.raw === "object") {
         subject.raw.status = "closed";
         subject.raw.closure_reason = "realized";
@@ -926,6 +928,7 @@ export function createProjectSubjectsActions(config) {
     subject.status = previous.status;
     subject.closure_reason = previous.closure_reason;
     subject.closed_at = previous.closed_at;
+    subject.review_state = previous.review_state;
     if (subject.raw && typeof subject.raw === "object") {
       subject.raw.status = previous.raw?.status;
       subject.raw.closure_reason = previous.raw?.closure_reason;


### PR DESCRIPTION
### Motivation
- Reopened subjects that had been closed as "non pertinent" or "duplicate" kept the `skip` (rejected) icon because their `review_state` remained `rejected`/`dismissed` in local optimistic state.
- The UI (main subjects table and lists) must show an open icon (`issue-opened`) after a subject is reopened, so local review metadata must be reset accordingly.

### Description
- In `apps/web/js/views/project-subjects/project-subjects-actions.js` the optimistic handler `applyOptimisticSubjectIssueAction` now calls `setEntityReviewState("sujet", subjectId, "pending")` when handling `issue:reopen` to clear a previously rejected/dismissed review state.
- The same `setEntityReviewState(..., "pending")` call was added for the `issue:close:realized` branch to avoid leaving a stale rejected/dismissed review state that could affect icons.
- The optimistic rollback `revertOptimisticSubjectIssueAction` now restores `subject.review_state` from the saved `previous` snapshot to keep local state fully consistent after failures.

### Testing
- Ran `node --check apps/web/js/views/project-subjects/project-subjects-actions.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60e305b8c83299e9d9f7456058f30)