### PR TITLE
Corrige l’affichage “Bloqué par” dans le head pour ne compter que les bloqueurs ouverts

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProjectSubjectsView } from "./project-subjects-view.js";
+
+function buildView(overrides = {}) {
+  const base = {
+    getProjectSubjectLabels: () => ({
+      getSubjectLabelDefinition: () => null,
+      renderSubjectLabelBadge: () => ""
+    }),
+    firstNonEmpty: (...values) => values.find((value) => value !== undefined && value !== null && value !== "") || "",
+    normalizeReviewState: (value = "") => String(value || "").toLowerCase(),
+    normalizeVerdict: (value = "") => String(value || "").toLowerCase(),
+    getEntityDisplayRef: (_entityType, entityId) => `#${entityId || ""}`,
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: (name) => `<svg>${name}</svg>`,
+    getBlockedBySubjects: () => [],
+    getNestedSujet: () => ({ status: "open" }),
+    getDecision: () => null,
+    store: { user: null, projectForm: { collaborators: [] }, projectSubjectsView: {} }
+  };
+
+  const deps = new Proxy({ ...base, ...overrides }, {
+    get(target, prop) {
+      if (prop in target) return target[prop];
+      return () => "";
+    }
+  });
+
+  return createProjectSubjectsView(deps);
+}
+
+test("head: sujet ouvert bloqué par sujet ouvert affiche le badge Bloqué par", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [{ id: "A", title: "Sujet A" }],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: false });
+
+  assert.match(html, /Bloqué par/);
+  assert.match(html, /Sujet A/);
+});
+
+test("head: sujet ouvert bloqué uniquement par sujet fermé n'affiche pas le badge", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [{ id: "A", title: "Sujet A" }],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: subjectId === "A" ? "closed" : "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: false });
+
+  assert.equal(html, "");
+});
+
+test("head: sujet ouvert avec bloqueurs ouverts/fermés affiche un compteur basé sur les ouverts", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [
+      { id: "A", title: "Sujet A" },
+      { id: "C", title: "Sujet C" },
+      { id: "D", title: "Sujet D" }
+    ],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: subjectId === "A" ? "closed_done" : "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: true });
+
+  assert.match(html, /details-blocked-badge/);
+  assert.match(html, />2</);
+  assert.match(html, /Bloqué par 2 sujets/);
+});
+
+test("head: sujet fermé bloqué par sujet ouvert n'affiche jamais le badge", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [{ id: "A", title: "Sujet A" }],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: subjectId === "B" ? "closed_review" : "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: false });
+
+  assert.equal(html, "");
+});

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1347,11 +1347,26 @@ function renderSubjectRelationsCards(subjectId) {
   return `<div class="subject-meta-relations-cards">${groups.join('<div class="subject-meta-relations-divider" aria-hidden="true"></div>')}</div>`;
 }
 
+function getHeadVisibleBlockedBySubjects(subjectId) {
+  const normalizedSubjectId = firstNonEmpty(subjectId?.id, subjectId);
+  if (!normalizedSubjectId) return [];
+
+  const subjectStatus = normalizeIssueLifecycleStatus(getEffectiveSujetStatus(normalizedSubjectId));
+  if (subjectStatus === "closed") return [];
+
+  const blockedBySubjects = Array.isArray(getBlockedBySubjects(normalizedSubjectId))
+    ? getBlockedBySubjects(normalizedSubjectId)
+    : [];
+
+  return blockedBySubjects.filter((blocker) => {
+    const blockerStatus = normalizeIssueLifecycleStatus(getEffectiveSujetStatus(blocker?.id));
+    return blockerStatus === "open";
+  });
+}
+
 function renderSubjectBlockedByHeadHtml(subject, options = {}) {
   const compact = options.compact === true;
-  const blockedBySubjects = Array.isArray(getBlockedBySubjects(subject?.id || subject))
-    ? getBlockedBySubjects(subject?.id || subject)
-    : [];
+  const blockedBySubjects = getHeadVisibleBlockedBySubjects(subject?.id || subject);
   if (!blockedBySubjects.length) return "";
 
   const iconHtml = `<span class="details-blocked-badge__icon">${svgIcon("blocked", { className: "octicon octicon-blocked fgColor-danger" })}</span>`;
@@ -2910,6 +2925,7 @@ function getObjectiveById(objectiveId) {
     matchSearch,
     reloadSubjectsFromSupabase,
     getEffectiveSujetStatus,
+    getHeadVisibleBlockedBySubjects,
     getEffectiveAvisVerdict,
     getEffectiveSituationStatus,
     problemsCountsHtml,


### PR DESCRIPTION
### Motivation

- Le head du détail affichait le badge « Bloqué par » dès qu’il existait une relation `blocked_by`, sans tenir compte du statut effectif du sujet courant ni des bloqueurs, entraînant des alertes incorrectes.

### Description

- Ajout d’un helper dédié `getHeadVisibleBlockedBySubjects(subjectId)` qui retourne `[]` si le sujet courant est effectivement fermé et sinon filtre les bloqueurs pour ne garder que ceux avec un statut effectif `open` en réutilisant `getEffectiveSujetStatus` et `normalizeIssueLifecycleStatus`.
- `renderSubjectBlockedByHeadHtml` a été branchée sur ce helper afin que les variantes head (compact/expanded) respectent la nouvelle règle métier sans modifier les panneaux de relations ni la logique des sélecteurs globaux.
- Le helper est exposé via l’API retournée par `createProjectSubjectsView` pour faciliter les tests ciblés.
- Fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-view.js` et ajout de `apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs`.

### Testing

- Exécution du test ciblé avec `node --test apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs` : succès (4/4 tests passés).
- Exécution de la suite `project-subjects` avec `node --test apps/web/js/views/project-subjects/*.test.mjs` : succès (tous les tests de la suite passés).
- Les tests couvrent les 4 cas métier demandés : sujet ouvert bloqué par ouvert (badge affiché), sujet ouvert bloqué uniquement par fermés (pas de badge), mélange ouvert/fermé (compteur sur ouverts uniquement), et sujet fermé (pas de badge).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e613d0054083299b3b1db839560ffc)