### PR TITLE
Only show 'Bloqué' head/pill for open blockers and add unit tests

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProjectSubjectsView } from "./project-subjects-view.js";
+
+function buildView(overrides = {}) {
+  const base = {
+    getProjectSubjectLabels: () => ({
+      getSubjectLabelDefinition: () => null,
+      renderSubjectLabelBadge: () => ""
+    }),
+    firstNonEmpty: (...values) => values.find((value) => value !== undefined && value !== null && value !== "") || "",
+    normalizeReviewState: (value = "") => String(value || "").toLowerCase(),
+    normalizeVerdict: (value = "") => String(value || "").toLowerCase(),
+    getEntityDisplayRef: (_entityType, entityId) => `#${entityId || ""}`,
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: (name) => `<svg>${name}</svg>`,
+    getBlockedBySubjects: () => [],
+    getNestedSujet: () => ({ status: "open" }),
+    getDecision: () => null,
+    store: { user: null, projectForm: { collaborators: [] }, projectSubjectsView: {} }
+  };
+
+  const deps = new Proxy({ ...base, ...overrides }, {
+    get(target, prop) {
+      if (prop in target) return target[prop];
+      return () => "";
+    }
+  });
+
+  return createProjectSubjectsView(deps);
+}
+
+test("head: sujet ouvert bloqué par sujet ouvert affiche le badge Bloqué par", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [{ id: "A", title: "Sujet A" }],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: false });
+
+  assert.match(html, /Bloqué par/);
+  assert.match(html, /Sujet A/);
+});
+
+test("head: sujet ouvert bloqué uniquement par sujet fermé n'affiche pas le badge", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [{ id: "A", title: "Sujet A" }],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: subjectId === "A" ? "closed" : "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: false });
+
+  assert.equal(html, "");
+});
+
+test("head: sujet ouvert avec bloqueurs ouverts/fermés affiche un compteur basé sur les ouverts", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [
+      { id: "A", title: "Sujet A" },
+      { id: "C", title: "Sujet C" },
+      { id: "D", title: "Sujet D" }
+    ],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: subjectId === "A" ? "closed_done" : "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: true });
+
+  assert.match(html, /details-blocked-badge/);
+  assert.match(html, />2</);
+  assert.match(html, /Bloqué par 2 sujets/);
+});
+
+test("head: sujet fermé bloqué par sujet ouvert n'affiche jamais le badge", () => {
+  const view = buildView({
+    getBlockedBySubjects: () => [{ id: "A", title: "Sujet A" }],
+    getNestedSujet: (subjectId) => ({ id: subjectId, status: subjectId === "B" ? "closed_review" : "open" })
+  });
+
+  const html = view.renderSubjectBlockedByHeadHtml({ id: "B", title: "Sujet B" }, { compact: false });
+
+  assert.equal(html, "");
+});

--- a/apps/web/js/views/project-subjects/project-subjects-table-blocked-pill.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-table-blocked-pill.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderFlatSujetRow } from "./project-subjects-table.js";
+
+function buildDeps(overrides = {}) {
+  return {
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    issueIcon: () => "",
+    getEffectiveSujetStatus: () => "open",
+    getEntityReviewMeta: () => ({ review_state: "", is_seen: true }),
+    getReviewTitleStateClass: () => "",
+    getEntityDisplayRef: () => "S-1",
+    getEntityDescriptionState: () => ({ author: "System", agent: "system" }),
+    formatRelativeTimeLabel: () => "opened now",
+    getEntityListTimestamp: () => Date.now(),
+    getSubjectSidebarMeta: () => ({ labels: [], objectiveIds: [] }),
+    getSubjectLabelDefinition: () => null,
+    renderSubjectLabelBadge: () => "",
+    getObjectiveById: () => null,
+    getChildSubjects: () => [],
+    getBlockedBySubjects: () => [{ id: "A" }],
+    getHeadVisibleBlockedBySubjects: () => [],
+    firstNonEmpty: (...values) => values.find((value) => value !== undefined && value !== null && value !== "") || "",
+    store: { user: null, projectForm: { collaborators: [] } },
+    ...overrides
+  };
+}
+
+test("renderFlatSujetRow masque le pill Bloqué si le head Bloqué par est masqué", () => {
+  const html = renderFlatSujetRow({ id: "B", title: "Sujet B", status: "open" }, "sit-1", {
+    deps: buildDeps({
+      getBlockedBySubjects: () => [{ id: "A" }],
+      getHeadVisibleBlockedBySubjects: () => []
+    })
+  });
+
+  assert.doesNotMatch(html, /issue-row-blocked-pill/);
+  assert.doesNotMatch(html, />Bloqué</);
+});
+
+test("renderFlatSujetRow affiche le pill Bloqué quand le head Bloqué par est visible", () => {
+  const html = renderFlatSujetRow({ id: "B", title: "Sujet B", status: "open" }, "sit-1", {
+    deps: buildDeps({
+      getHeadVisibleBlockedBySubjects: () => [{ id: "D" }]
+    })
+  });
+
+  assert.match(html, /issue-row-blocked-pill/);
+  assert.match(html, />Bloqué</);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -173,6 +173,7 @@ export function renderFlatSujetRow(sujet, situationId, options = {}) {
     getObjectiveById,
     getChildSubjects,
     getBlockedBySubjects,
+    getHeadVisibleBlockedBySubjects,
     firstNonEmpty
   } = deps;
 
@@ -195,7 +196,10 @@ export function renderFlatSujetRow(sujet, situationId, options = {}) {
   const objectiveLabel = objective
     ? ` - <button type="button" class="issue-row-subject-objective" data-row-objective-id="${escapeHtml(objective.id)}"><span class="issue-row-subject-objective__icon" aria-hidden="true">${svgIcon("milestone", { className: "octicon octicon-milestone" })}</span><span class="issue-row-subject-objective__text">${escapeHtml(firstNonEmpty(objective.title, objective.id, "Objectif"))}</span></button>`
     : "";
-  const isBlocked = (Array.isArray(getBlockedBySubjects?.(sujet.id)) ? getBlockedBySubjects(sujet.id) : []).length > 0;
+  const headVisibleBlockedBySubjects = Array.isArray(getHeadVisibleBlockedBySubjects?.(sujet.id))
+    ? getHeadVisibleBlockedBySubjects(sujet.id)
+    : (Array.isArray(getBlockedBySubjects?.(sujet.id)) ? getBlockedBySubjects(sujet.id) : []);
+  const isBlocked = headVisibleBlockedBySubjects.length > 0;
   const blockedBadge = isBlocked
     ? `<span class="issue-row-blocked-pill" aria-label="Sujet bloqué">${svgIcon("blocked", { className: "octicon octicon-blocked fgColor-danger" })}<span>Bloqué</span></span>`
     : "";

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -928,6 +928,7 @@ function getSubjectsTableDeps() {
     getObjectiveById,
     getChildSubjects,
     getBlockedBySubjects,
+    getHeadVisibleBlockedBySubjects,
     issueIcon,
     priorityBadge,
     firstNonEmpty
@@ -1347,11 +1348,26 @@ function renderSubjectRelationsCards(subjectId) {
   return `<div class="subject-meta-relations-cards">${groups.join('<div class="subject-meta-relations-divider" aria-hidden="true"></div>')}</div>`;
 }
 
+function getHeadVisibleBlockedBySubjects(subjectId) {
+  const normalizedSubjectId = firstNonEmpty(subjectId?.id, subjectId);
+  if (!normalizedSubjectId) return [];
+
+  const subjectStatus = normalizeIssueLifecycleStatus(getEffectiveSujetStatus(normalizedSubjectId));
+  if (subjectStatus === "closed") return [];
+
+  const blockedBySubjects = Array.isArray(getBlockedBySubjects(normalizedSubjectId))
+    ? getBlockedBySubjects(normalizedSubjectId)
+    : [];
+
+  return blockedBySubjects.filter((blocker) => {
+    const blockerStatus = normalizeIssueLifecycleStatus(getEffectiveSujetStatus(blocker?.id));
+    return blockerStatus === "open";
+  });
+}
+
 function renderSubjectBlockedByHeadHtml(subject, options = {}) {
   const compact = options.compact === true;
-  const blockedBySubjects = Array.isArray(getBlockedBySubjects(subject?.id || subject))
-    ? getBlockedBySubjects(subject?.id || subject)
-    : [];
+  const blockedBySubjects = getHeadVisibleBlockedBySubjects(subject?.id || subject);
   if (!blockedBySubjects.length) return "";
 
   const iconHtml = `<span class="details-blocked-badge__icon">${svgIcon("blocked", { className: "octicon octicon-blocked fgColor-danger" })}</span>`;
@@ -2910,6 +2926,7 @@ function getObjectiveById(objectiveId) {
     matchSearch,
     reloadSubjectsFromSupabase,
     getEffectiveSujetStatus,
+    getHeadVisibleBlockedBySubjects,
     getEffectiveAvisVerdict,
     getEffectiveSituationStatus,
     problemsCountsHtml,


### PR DESCRIPTION
### Motivation

- Ensure the subject "blocked" indicators only appear when there are open blocker subjects and hide them for closed subjects to avoid misleading UI state.
- Make the table pill consistent with the head badge visibility so the list view matches the details view.
- Add unit tests to cover head badge and table pill visibility rules.

### Description

- Introduce `getHeadVisibleBlockedBySubjects` in `project-subjects-view.js` that normalizes the subject id, skips closed subjects, and filters blockers to only include those with an open lifecycle status.
- Use `getHeadVisibleBlockedBySubjects` in `renderSubjectBlockedByHeadHtml` to drive the head badge rendering logic so the head only shows when there are open blockers.
- In `project-subjects-table.js`, prefer `getHeadVisibleBlockedBySubjects` (falling back to `getBlockedBySubjects`) to decide `isBlocked` and control rendering of the row-level blocked pill.
- Add unit tests: `project-subjects-head-blocked-by.test.mjs` to cover head badge behavior for single/multiple/open/closed blockers and `project-subjects-table-blocked-pill.test.mjs` to verify the table pill is shown/hidden according to head visibility.

### Testing

- Added new unit tests `apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs` and `apps/web/js/views/project-subjects/project-subjects-table-blocked-pill.test.mjs` that exercise `renderSubjectBlockedByHeadHtml` and `renderFlatSujetRow` behaviors respectively. 
- No automated test suite was executed during this rollout. Please run the test suite (for example `node --test` or your CI) to validate these new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e613d0054083299b3b1db839560ffc)