### PR TITLE
Activer l'édition riche de la description de sujet (RPC + UI mutualisée)

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -937,6 +937,46 @@ export async function replaceSubjectLabels(subjectId, labelIds = []) {
   return true;
 }
 
+export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  const nextDescription = String(description || "").trim();
+  const normalizedUploadSessionId = normalizeUuid(uploadSessionId);
+  if (!nextDescription && !normalizedUploadSessionId) {
+    throw new Error("description or uploadSessionId is required");
+  }
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/rpc/update_subject_description`);
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }),
+    body: JSON.stringify({
+      p_subject_id: normalizedSubjectId,
+      p_description: nextDescription,
+      p_upload_session_id: normalizedUploadSessionId || null
+    })
+  });
+
+  if (!response.ok) {
+    const txt = await response.text().catch(() => "");
+    throw new Error(`update_subject_description failed (${response.status}): ${txt}`);
+  }
+
+  const payload = await response.json().catch(() => null);
+  const row = Array.isArray(payload) ? payload[0] : payload;
+  const normalizedAttachments = Array.isArray(row?.description_attachments)
+    ? row.description_attachments
+    : [];
+  return {
+    ...(row || {}),
+    description: String(row?.description || nextDescription),
+    description_attachments: normalizedAttachments
+  };
+}
+
 export async function loadLabelsForProject(projectId) {
   const resolvedProjectId = await getResolvedProjectId(projectId);
   if (!resolvedProjectId) {

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -13,7 +13,8 @@ import {
   deleteLabel as deleteLabelInSupabase,
   addLabelToSubject as addLabelToSubjectInSupabase,
   removeLabelFromSubject as removeLabelFromSubjectInSupabase,
-  replaceSubjectAssignees as replaceSubjectAssigneesInSupabase
+  replaceSubjectAssignees as replaceSubjectAssigneesInSupabase,
+  updateSubjectDescription as updateSubjectDescriptionInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
 import {
@@ -317,6 +318,7 @@ const projectSubjectsDescription = createProjectSubjectsDescription({
   mdToHtml,
   nowIso,
   SVG_AVATAR_HUMAN,
+  renderCommentComposer,
   getRunBucket,
   persistRunBucket,
   getSelectionEntityType,
@@ -325,8 +327,8 @@ const projectSubjectsDescription = createProjectSubjectsDescription({
   setEntityReviewMeta,
   currentDecisionTarget,
   rerenderScope: (...args) => projectSubjectsView.rerenderScope(...args),
-  addActivity: (entityType, entityId, kind, message, meta, options) => addActivity(entityType, entityId, kind, message, meta, options),
-  markEntityValidated: (entityType, entityId, options) => markEntityValidated(entityType, entityId, options)
+  markEntityValidated: (entityType, entityId, options) => markEntityValidated(entityType, entityId, options),
+  updateSubjectDescription: (...args) => updateSubjectDescriptionInSupabase(...args)
 });
 
 const {
@@ -335,6 +337,8 @@ const {
   claimDescriptionAsHuman,
   clearDescriptionEditState,
   syncDescriptionEditorDraft,
+  getDescriptionEditState,
+  ensureDescriptionUploadSessionId,
   applyDescriptionSave,
   startDescriptionEdit,
   renderDescriptionCard
@@ -365,6 +369,8 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getToggleSubjectBlockingForRelation: () => toggleSubjectBlockingForRelation,
   getReorderSubjectChildren: () => reorderSubjectChildren,
   syncDescriptionEditorDraft,
+  getDescriptionEditState,
+  ensureDescriptionUploadSessionId,
   startDescriptionEdit,
   clearDescriptionEditState,
   applyDescriptionSave,

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -1,4 +1,6 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
+import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+
 export function createProjectSubjectsDescription(config = {}) {
   const {
     store,
@@ -9,6 +11,7 @@ export function createProjectSubjectsDescription(config = {}) {
     mdToHtml,
     nowIso,
     SVG_AVATAR_HUMAN,
+    renderCommentComposer,
     getRunBucket,
     persistRunBucket,
     getSelectionEntityType,
@@ -17,9 +20,30 @@ export function createProjectSubjectsDescription(config = {}) {
     setEntityReviewMeta,
     currentDecisionTarget,
     rerenderScope,
-    addActivity,
-    markEntityValidated
+    markEntityValidated,
+    updateSubjectDescription
   } = config;
+
+  const createUploadSessionId = () => {
+    if (window?.crypto?.randomUUID) return window.crypto.randomUUID();
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  };
+
+  function ensureDescriptionEditState() {
+    ensureViewUiState();
+    const state = store.situationsView.descriptionEdit || {};
+    store.situationsView.descriptionEdit = {
+      entityType: state.entityType || null,
+      entityId: state.entityId || null,
+      draft: String(state.draft || ""),
+      previewMode: !!state.previewMode,
+      uploadSessionId: String(state.uploadSessionId || ""),
+      attachments: Array.isArray(state.attachments) ? state.attachments : [],
+      isSaving: !!state.isSaving,
+      error: String(state.error || "")
+    };
+    return store.situationsView.descriptionEdit;
+  }
 
   function getSujetSummary(sujet) {
     const raw = sujet?.raw || {};
@@ -49,6 +73,7 @@ export function createProjectSubjectsDescription(config = {}) {
 
     return {
       body: String(body || ""),
+      attachments: Array.isArray(entity?.description_attachments) ? entity.description_attachments : [],
       author: firstNonEmpty(entity?.agent, entity?.raw?.agent, "system"),
       agent: String(firstNonEmpty(entity?.agent, entity?.raw?.agent, "system")).toLowerCase(),
       avatar_type: "agent",
@@ -74,6 +99,7 @@ export function createProjectSubjectsDescription(config = {}) {
       ...defaults,
       ...stored,
       body: firstNonEmpty(stored.body, defaults.body, ""),
+      attachments: Array.isArray(stored.attachments) ? stored.attachments : defaults.attachments,
       author: firstNonEmpty(stored.author, defaults.author, "system"),
       agent: String(firstNonEmpty(stored.agent, defaults.agent, "system")).toLowerCase(),
       avatar_type: firstNonEmpty(stored.avatar_type, defaults.avatar_type, "agent"),
@@ -104,37 +130,74 @@ export function createProjectSubjectsDescription(config = {}) {
 
     const meta = getEntityReviewMeta(entityType, entityId);
     setEntityReviewMeta(entityType, entityId, {
+      ...meta,
       has_human_edit: Boolean(getRunBucket().bucket?.descriptions?.[entityType]?.[entityId]?.is_human_edited)
     }, options);
+  }
+
+  function isEditingDescription(selection) {
+    const edit = ensureDescriptionEditState();
+    if (!selection?.item?.id) return false;
+    const entityType = getSelectionEntityType(selection.type);
+    return edit.entityType === entityType && edit.entityId === selection.item.id;
   }
 
   function claimDescriptionAsHuman(entityType, entityId, options = {}) {
     const current = getEntityDescriptionState(entityType, entityId);
     if (String(current.agent || "").toLowerCase() === "human" && current.avatar_type === "human") return false;
-
     setEntityDescriptionState(entityType, entityId, {
       body: current.body,
+      attachments: Array.isArray(current.attachments) ? current.attachments : [],
       author: "human",
       agent: "human",
       avatar_type: "human",
       avatar_initial: "H"
     }, options);
-
     return true;
   }
 
-  function isEditingDescription(selection) {
-    ensureViewUiState();
-    if (!selection?.item?.id) return false;
-    const entityType = getSelectionEntityType(selection.type);
-    return store.situationsView.descriptionEdit?.entityType === entityType
-      && store.situationsView.descriptionEdit?.entityId === selection.item.id;
+  function renderDescriptionAttachmentTile(attachment = {}, { removable = false, removeAction = "" } = {}) {
+    const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
+    const isImage = String(attachment?.mime_type || attachment?.mimeType || "").startsWith("image/");
+    const previewUrl = String(attachment?.localPreviewUrl || attachment?.previewUrl || attachment?.object_url || "");
+    const attachmentId = String(attachment?.id || "");
+    const tempId = String(attachment?.tempId || "");
+    const status = attachment?.error
+      ? "Erreur d’upload"
+      : String(attachment?.uploadStatus || "").trim() === "uploading"
+        ? "Envoi…"
+        : "";
+    return `
+      <div class="subject-composer-attachment-item">
+        <div class="subject-attachment subject-attachment--compact">
+          ${isImage && previewUrl
+            ? `<img class="subject-attachment__image" src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" />`
+            : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+          ${status ? `<div class="subject-attachment__state mono-small">${escapeHtml(status)}</div>` : ""}
+        </div>
+        ${removable
+          ? `
+            <button
+              class="subject-composer-attachment-remove"
+              type="button"
+              data-action="${escapeHtml(removeAction)}"
+              data-attachment-id="${escapeHtml(attachmentId)}"
+              data-temp-id="${escapeHtml(tempId)}"
+              aria-label="Retirer la pièce jointe"
+            >
+              ${svgIcon("x")}
+            </button>
+          `
+          : ""}
+      </div>
+    `;
   }
 
   function renderDescriptionCard(selection) {
     const entityType = getSelectionEntityType(selection.type);
     const entityId = selection.item.id;
     const description = getEntityDescriptionState(selection);
+    const edit = ensureDescriptionEditState();
     const editing = isEditingDescription(selection);
     const identity = getAuthorIdentity({
       author: description.author || "system",
@@ -143,14 +206,12 @@ export function createProjectSubjectsDescription(config = {}) {
       humanAvatarHtml: SVG_AVATAR_HUMAN,
       fallbackName: "System"
     });
-    const isHuman = identity.isHuman;
     const authorHtml = `<div class="gh-comment-author mono">${escapeHtml(identity.displayName)}</div>`;
     const editButtonHtml = `
       <button class="icon-btn icon-btn--sm gh-comment-edit-btn" data-action="edit-description" type="button" aria-label="Modifier la description" title="Modifier la description">
         ${svgIcon("pencil")}
       </button>
     `;
-
     const headerHtml = `
       <div class="gh-comment-header gh-comment-header--editable">
         <div class="gh-comment-header-main">${authorHtml}</div>
@@ -159,16 +220,70 @@ export function createProjectSubjectsDescription(config = {}) {
     `;
 
     const bodyHtml = editing
-      ? `
-        <div class="gh-comment-body gh-comment-body--editable">
-          <textarea class="comment-editor__textarea description-editor__textarea" data-description-editor rows="7">${escapeHtml(store.situationsView.descriptionEdit?.draft || description.body || "")}</textarea>
-          <div class="description-editor__actions">
-            <button class="gh-btn" data-action="cancel-description-edit" type="button">Annuler</button>
-            <button class="gh-btn gh-btn--comment" data-action="save-description-edit" data-entity-type="${escapeHtml(entityType)}" data-entity-id="${escapeHtml(entityId)}" type="button">Sauvegarder</button>
-          </div>
+      ? (() => {
+          const attachments = Array.isArray(edit.attachments) ? edit.attachments : [];
+          const hasReadyAttachment = attachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+          const canSubmit = !!String(edit.draft || "").trim() || hasReadyAttachment;
+          const attachmentsHtml = attachments.length
+            ? `<div class="subject-composer-attachments">${attachments.map((attachment) => renderDescriptionAttachmentTile(attachment, { removable: true, removeAction: "description-attachment-remove" })).join("")}</div>`
+            : "";
+          return `
+            ${renderCommentComposer({
+              hideAvatar: true,
+              hideTitle: true,
+              previewMode: !!edit.previewMode,
+              textareaId: `descriptionEditBox-${entityId}`,
+              previewId: `descriptionEditPreview-${entityId}`,
+              textareaValue: String(edit.draft || ""),
+              textareaAttributes: {
+                "data-description-draft": entityId
+              },
+              placeholder: "Modifier la description, glisser-déposer une pièce jointe...",
+              tabWriteAction: "description-tab-write",
+              tabPreviewAction: "description-tab-preview",
+              tabsClassName: "comment-composer__tabs--thread-reply",
+              composerClassName: "comment-composer--thread-reply-editor comment-composer--thread-edit-root",
+              toolbarHtml: renderSubjectMarkdownToolbar({ buttonAction: "description-format", svgIcon, extraData: { entityId } }),
+              previewHtml: String(edit.draft || "").trim()
+                ? mdToHtml(String(edit.draft || ""), { preserveMessageLineBreaks: true })
+                : "",
+              previewEmptyHint: "Use Markdown to format your comment",
+              actionsHtml: `
+                <div class="thread-inline-reply-editor__actions">
+                  <button class="gh-btn" data-action="cancel-description-edit" type="button">Annuler</button>
+                  <button class="gh-btn gh-btn--comment gh-btn--primary" data-action="save-description-edit" data-entity-type="${escapeHtml(entityType)}" data-entity-id="${escapeHtml(entityId)}" type="button" ${canSubmit && !edit.isSaving ? "" : "disabled"}>${edit.isSaving ? "Mise à jour…" : "Mettre à jour la description"}</button>
+                </div>
+              `,
+              footerHtml: `
+                <input
+                  id="descriptionAttachmentInput-${escapeHtml(entityId)}"
+                  type="file"
+                  class="subject-composer-file-input"
+                  data-role="description-file-input"
+                  data-entity-id="${escapeHtml(entityId)}"
+                  multiple
+                />
+                <div
+                  class="subject-composer-attachments-preview ${attachments.length ? "" : "hidden"}"
+                  data-role="description-attachments-preview"
+                  data-entity-id="${escapeHtml(entityId)}"
+                  aria-live="polite"
+                >
+                  ${attachmentsHtml}
+                </div>
+                ${edit.error ? `<div class="mono-small color-danger" style="margin-top:8px;">${escapeHtml(edit.error)}</div>` : ""}
+              `
+            })}
+          `;
+        })()
+      : `
+        <div class="gh-comment-body">
+          ${mdToHtml(description.body || "")}
+          ${Array.isArray(description.attachments) && description.attachments.length
+            ? `<div class="subject-composer-attachments" style="margin-top:10px;">${description.attachments.map((attachment) => renderDescriptionAttachmentTile(attachment)).join("")}</div>`
+            : ""}
         </div>
-      `
-      : `<div class="gh-comment-body">${mdToHtml(description.body || "")}</div>`;
+      `;
 
     return `
       <div class="gh-comment gh-comment--description">
@@ -188,14 +303,30 @@ export function createProjectSubjectsDescription(config = {}) {
     store.situationsView.descriptionEdit = {
       entityType: null,
       entityId: null,
-      draft: ""
+      draft: "",
+      previewMode: false,
+      uploadSessionId: "",
+      attachments: [],
+      isSaving: false,
+      error: ""
     };
   }
 
   function syncDescriptionEditorDraft(root) {
-    const ta = root.querySelector("[data-description-editor]");
+    const ta = root.querySelector("[data-description-draft]");
     if (!ta) return;
-    store.situationsView.descriptionEdit.draft = ta.value;
+    const edit = ensureDescriptionEditState();
+    edit.draft = String(ta.value || "");
+  }
+
+  function getDescriptionEditState() {
+    return ensureDescriptionEditState();
+  }
+
+  function ensureDescriptionUploadSessionId() {
+    const edit = ensureDescriptionEditState();
+    if (!String(edit.uploadSessionId || "")) edit.uploadSessionId = createUploadSessionId();
+    return edit.uploadSessionId;
   }
 
   async function applyDescriptionSave(root) {
@@ -204,43 +335,63 @@ export function createProjectSubjectsDescription(config = {}) {
 
     const entityType = getSelectionEntityType(target.type);
     const entityId = target.id;
-    const ta = root.querySelector("[data-description-editor]");
-    if (!ta) return;
+    const edit = ensureDescriptionEditState();
+    const nextBody = String(edit.draft || "").trim();
+    const attachments = Array.isArray(edit.attachments) ? edit.attachments : [];
+    const hasReadyAttachment = attachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+    if (!nextBody && !hasReadyAttachment) return;
 
-    const nextBody = String(ta.value || "").trim();
-    if (!nextBody) return;
-
-    const current = getEntityDescriptionState(entityType, entityId);
-    const previousBody = String(current.body || "").trim();
-    const initialAuthor = firstNonEmpty(current.author, target.item?.agent, "system");
-    const initialAgent = String(firstNonEmpty(current.agent, target.item?.agent, "system")).toLowerCase();
-
-    if (nextBody === previousBody && initialAgent === "human") {
+    if (entityType !== "sujet" || typeof updateSubjectDescription !== "function") {
+      setEntityDescriptionState(entityType, entityId, {
+        body: nextBody,
+        attachments,
+        author: "human",
+        agent: "human",
+        avatar_type: "human",
+        avatar_initial: "H"
+      }, { actor: "Human", agent: "human" });
+      markEntityValidated(entityType, entityId, { actor: "Human", agent: "human" });
       clearDescriptionEditState();
       rerenderScope(root);
       return;
     }
 
-    addActivity(entityType, entityId, "description_version_initial", previousBody, {
-      previous_author: initialAuthor
-    }, { actor: initialAuthor, agent: initialAgent || "system" });
-
-    setEntityDescriptionState(entityType, entityId, {
-      body: nextBody,
-      author: "human",
-      agent: "human",
-      avatar_type: "human",
-      avatar_initial: "H"
-    }, { actor: "Human", agent: "human" });
-
-    markEntityValidated(entityType, entityId, { actor: "Human", agent: "human" });
-
-    addActivity(entityType, entityId, "description_version_saved", nextBody, {
-      previous_author: initialAuthor
-    }, { actor: "Human", agent: "human" });
-
-    clearDescriptionEditState();
+    edit.isSaving = true;
+    edit.error = "";
     rerenderScope(root);
+
+    try {
+      const uploadSessionId = hasReadyAttachment ? String(edit.uploadSessionId || "").trim() : "";
+      const updated = await updateSubjectDescription({
+        subjectId: entityId,
+        description: nextBody,
+        uploadSessionId
+      });
+
+      const persistedBody = String(updated?.description ?? nextBody);
+      const persistedAttachments = Array.isArray(updated?.description_attachments)
+        ? updated.description_attachments
+        : attachments.filter((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+      setEntityDescriptionState(entityType, entityId, {
+        body: persistedBody,
+        attachments: persistedAttachments,
+        author: "human",
+        agent: "human",
+        avatar_type: "human",
+        avatar_initial: "H"
+      }, { actor: "Human", agent: "human" });
+      if (target?.item && typeof target.item === "object") {
+        target.item.description = persistedBody;
+        target.item.description_attachments = persistedAttachments;
+      }
+      markEntityValidated(entityType, entityId, { actor: "Human", agent: "human" });
+      clearDescriptionEditState();
+      rerenderScope(root);
+    } catch (error) {
+      edit.isSaving = false;
+      edit.error = String(error?.message || error || "Impossible de mettre à jour la description.");
+      rerenderScope(root);
+    }
   }
 
   function startDescriptionEdit(root) {
@@ -251,7 +402,12 @@ export function createProjectSubjectsDescription(config = {}) {
     store.situationsView.descriptionEdit = {
       entityType,
       entityId: target.id,
-      draft: current.body || ""
+      draft: current.body || "",
+      previewMode: false,
+      uploadSessionId: "",
+      attachments: Array.isArray(current.attachments) ? [...current.attachments] : [],
+      isSaving: false,
+      error: ""
     };
     rerenderScope(root);
     return true;
@@ -266,6 +422,8 @@ export function createProjectSubjectsDescription(config = {}) {
     claimDescriptionAsHuman,
     clearDescriptionEditState,
     syncDescriptionEditorDraft,
+    getDescriptionEditState,
+    ensureDescriptionUploadSessionId,
     applyDescriptionSave,
     startDescriptionEdit,
     renderDescriptionCard

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -45,6 +45,8 @@ export function createProjectSubjectsEvents(config) {
     getToggleSubjectBlockingForRelation,
     getReorderSubjectChildren,
     syncDescriptionEditorDraft,
+    getDescriptionEditState,
+    ensureDescriptionUploadSessionId,
     startDescriptionEdit,
     clearDescriptionEditState,
     applyDescriptionSave,
@@ -668,7 +670,7 @@ export function createProjectSubjectsEvents(config) {
 
     syncSubjectMetaDropdownPosition(getSubjectMetaScopeRoot());
 
-    const descriptionTextarea = root.querySelector("[data-description-editor]");
+    const descriptionTextarea = root.querySelector("[data-description-draft]");
     if (descriptionTextarea) {
       descriptionTextarea.addEventListener("input", () => {
         syncDescriptionEditorDraft(root);
@@ -768,6 +770,7 @@ export function createProjectSubjectsEvents(config) {
       if (composerKey === "main") return "#humanCommentBox";
       if (composerKey === "reply" && messageId) return `[data-thread-reply-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "edit" && messageId) return `[data-thread-edit-draft="${selectorValue(messageId)}"]`;
+      if (composerKey === "description" && messageId) return `[data-description-draft="${selectorValue(messageId)}"]`;
       return "";
     };
 
@@ -1158,6 +1161,9 @@ export function createProjectSubjectsEvents(config) {
       const { mode, messageId = "" } = splitComposerKey(composerKey);
       if (mode === "main") {
         store.situationsView.commentDraft = String(result.nextText || "");
+      } else if (mode === "description") {
+        const descriptionState = getDescriptionEditorState();
+        descriptionState.draft = String(result.nextText || "");
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1257,6 +1263,9 @@ export function createProjectSubjectsEvents(config) {
       const { mode, messageId = "" } = splitComposerKey(composerKey);
       if (mode === "main") {
         store.situationsView.commentDraft = String(result.nextText || "");
+      } else if (mode === "description") {
+        const descriptionState = getDescriptionEditorState();
+        descriptionState.draft = String(result.nextText || "");
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -2647,6 +2656,13 @@ export function createProjectSubjectsEvents(config) {
       } catch {}
       return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     };
+    const getDescriptionEditorState = () => {
+      if (typeof getDescriptionEditState === "function") {
+        const state = getDescriptionEditState();
+        if (state && typeof state === "object") return state;
+      }
+      return store.situationsView?.descriptionEdit || {};
+    };
     const isImageFile = (file) => String(file?.type || "").toLowerCase().startsWith("image/");
     const toObjectUrl = (file) => {
       try {
@@ -2662,6 +2678,94 @@ export function createProjectSubjectsEvents(config) {
     };
     const releaseAttachmentPreviewUrls = (attachment = {}) => {
       revokeObjectUrl(String(attachment?.localPreviewUrl || ""));
+    };
+    const renderDescriptionAttachmentsPreview = () => {
+      const state = getDescriptionEditorState();
+      const entityId = String(state?.entityId || "").trim();
+      if (!entityId) return;
+      const container = root.querySelector(
+        `[data-role='description-attachments-preview'][data-entity-id="${selectorValue(entityId)}"]`
+      );
+      if (!container) return;
+      const items = Array.isArray(state?.attachments) ? state.attachments : [];
+      container.innerHTML = renderAttachmentPreviewItemsHtml({
+        attachments: items,
+        removeAction: "description-attachment-remove"
+      });
+      container.classList.toggle("hidden", !items.length);
+    };
+    const addDescriptionFiles = async (files = []) => {
+      const list = Array.from(files || []).filter(Boolean);
+      if (!list.length) return;
+      const selection = getScopedSelection(root);
+      if (selection?.type !== "sujet") return;
+      const state = getDescriptionEditorState();
+      const entityId = String(state?.entityId || "").trim();
+      if (!entityId) return;
+      const projectId = String(selection?.item?.project_id || "").trim();
+      if (!projectId || typeof uploadAttachmentFile !== "function") return;
+      const uploadSessionId = typeof ensureDescriptionUploadSessionId === "function"
+        ? String(ensureDescriptionUploadSessionId() || "").trim()
+        : (String(state.uploadSessionId || "").trim() || createUploadSessionId());
+      if (!state.uploadSessionId) state.uploadSessionId = uploadSessionId;
+
+      const attachments = Array.isArray(state.attachments) ? state.attachments : [];
+      state.attachments = attachments;
+      for (const file of list) {
+        const tempId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        const localPreviewUrl = toObjectUrl(file);
+        const pending = {
+          id: "",
+          tempId,
+          file_name: String(file?.name || "fichier"),
+          mime_type: String(file?.type || ""),
+          size_bytes: Number(file?.size || 0),
+          localPreviewUrl,
+          previewUrl: localPreviewUrl,
+          isImage: isImageFile(file),
+          uploadStatus: "uploading",
+          error: ""
+        };
+        attachments.push(pending);
+        renderDescriptionAttachmentsPreview();
+        try {
+          const uploaded = await uploadAttachmentFile({
+            subjectId: entityId,
+            projectId,
+            uploadSessionId,
+            file,
+            sortOrder: attachments.length - 1
+          });
+          pending.id = String(uploaded?.id || "");
+          pending.storage_path = String(uploaded?.storage_path || "");
+          pending.object_url = String(uploaded?.object_url || "");
+          pending.previewUrl = pending.previewUrl || pending.object_url || "";
+          pending.uploadStatus = "ready";
+          pending.error = "";
+        } catch (error) {
+          pending.uploadStatus = "error";
+          pending.error = String(error?.message || error || "Erreur d'upload");
+        }
+        renderDescriptionAttachmentsPreview();
+      }
+    };
+    const removeDescriptionAttachment = async ({ attachmentId = "", tempId = "" } = {}) => {
+      const state = getDescriptionEditorState();
+      const attachments = Array.isArray(state.attachments) ? state.attachments : [];
+      const normalizedAttachmentId = String(attachmentId || "").trim();
+      const targetIndex = attachments.findIndex((entry) => String(entry?.tempId || "") === String(tempId || "") || String(entry?.id || "") === normalizedAttachmentId);
+      if (targetIndex < 0) return;
+      const current = attachments[targetIndex];
+      attachments.splice(targetIndex, 1);
+      renderDescriptionAttachmentsPreview();
+      releaseAttachmentPreviewUrls(current);
+      if (normalizedAttachmentId && typeof removeTemporaryAttachment === "function") {
+        try {
+          await removeTemporaryAttachment({ attachmentId: normalizedAttachmentId });
+        } catch (error) {
+          console.warn("[subject-attachments] remove temporary attachment failed", error);
+        }
+      }
     };
     const getInlineReplyAttachmentsState = (messageId = "", { createIfMissing = false } = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
@@ -3271,6 +3375,12 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
       const result = applyInlineEmojiSuggestion(textarea, suggestion);
+      if (mode === "description") {
+        const descriptionState = getDescriptionEditorState();
+        descriptionState.draft = String(result.nextText || "");
+        rerenderAutocompleteUi();
+        return;
+      }
       const replyUi = resolveInlineReplyUiState();
       if (mode === "reply") {
         replyUi.draftsByMessageId[messageId] = String(result.nextText || "");
@@ -3745,6 +3855,120 @@ export function createProjectSubjectsEvents(config) {
         }
         textarea.focus();
       };
+    });
+    root.querySelectorAll("[data-action='description-tab-write']").forEach((btn) => {
+      btn.onclick = () => {
+        const entityId = String(btn.closest(".gh-comment")?.querySelector("[data-description-draft]")?.dataset.descriptionDraft || "").trim();
+        const descriptionState = getDescriptionEditorState();
+        if (entityId) descriptionState.entityId = entityId;
+        descriptionState.previewMode = false;
+        const composerRoot = btn.closest(".comment-composer");
+        composerRoot?.querySelector("[data-action='description-tab-write']")?.classList.add("is-active");
+        composerRoot?.querySelector("[data-action='description-tab-preview']")?.classList.remove("is-active");
+        composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
+        composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
+      };
+    });
+    root.querySelectorAll("[data-action='description-tab-preview']").forEach((btn) => {
+      btn.onclick = () => {
+        const descriptionState = getDescriptionEditorState();
+        descriptionState.previewMode = true;
+        const composerRoot = btn.closest(".comment-composer");
+        const textarea = composerRoot?.querySelector("[data-description-draft]");
+        const previewWrap = composerRoot?.querySelector(".comment-composer__preview");
+        composerRoot?.querySelector("[data-action='description-tab-write']")?.classList.remove("is-active");
+        composerRoot?.querySelector("[data-action='description-tab-preview']")?.classList.add("is-active");
+        composerRoot?.querySelector(".comment-composer__editor")?.classList.add("hidden");
+        composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.remove("hidden");
+        if (previewWrap) {
+          const markdown = String(textarea?.value || descriptionState.draft || "");
+          previewWrap.innerHTML = markdown.trim()
+            ? mdToHtml(markdown, { preserveMessageLineBreaks: true })
+            : `<div class="comment-composer__preview-empty">Use Markdown to format your comment</div>`;
+        }
+      };
+    });
+    root.querySelectorAll("[data-action='description-format'][data-format]").forEach((btn) => {
+      btn.onclick = () => {
+        const action = String(btn.dataset.format || "").trim();
+        const textarea = root.querySelector("[data-description-draft]");
+        if (!action || !textarea) return;
+        if (action === "subject-ref") {
+          ensureSubjectRefTriggerInTextarea(textarea);
+          syncDescriptionEditorDraft(root);
+          closeMentionPopup({ rerender: false });
+          closeEmojiPopup({ rerender: false });
+          void syncSubjectRefPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`);
+          textarea.focus();
+          return;
+        }
+        const didApply = applyMarkdownComposerAction(textarea, action);
+        if (!didApply) return;
+        syncDescriptionEditorDraft(root);
+        if (action === "mention") {
+          void syncMentionPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`, { forceOpen: true });
+        } else {
+          closeMentionPopup({ rerender: false });
+          closeEmojiPopup({ rerender: false });
+        }
+        textarea.focus();
+      };
+    });
+    root.querySelectorAll("[data-action='description-attachments-pick']").forEach((btn) => {
+      btn.onclick = () => {
+        const input = root.querySelector("[data-role='description-file-input']");
+        input?.click();
+      };
+    });
+    root.querySelectorAll("[data-role='description-file-input']").forEach((input) => {
+      input.addEventListener("change", async (event) => {
+        const files = Array.from(event?.target?.files || []);
+        if (files.length) await addDescriptionFiles(files);
+        input.value = "";
+      });
+    });
+    root.querySelectorAll("[data-action='description-attachment-remove']").forEach((btn) => {
+      btn.onclick = async () => {
+        await removeDescriptionAttachment({
+          attachmentId: String(btn.dataset.attachmentId || ""),
+          tempId: String(btn.dataset.tempId || "")
+        });
+      };
+    });
+    root.querySelectorAll("[data-description-draft]").forEach((textarea) => {
+      const composerKey = `description:${String(textarea.dataset.descriptionDraft || "").trim()}`;
+      textarea.addEventListener("input", () => {
+        syncDescriptionEditorDraft(root);
+        void syncInlineAutocomplete(textarea, composerKey);
+      });
+      textarea.addEventListener("keydown", (event) => {
+        if (CARET_NAVIGATION_KEYS.has(event.key)) {
+          requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
+        }
+      });
+      textarea.addEventListener("click", () => { void syncInlineAutocomplete(textarea, composerKey); });
+      textarea.addEventListener("keyup", () => { void syncInlineAutocomplete(textarea, composerKey); });
+      const editor = textarea.closest(".comment-composer");
+      const dropzone = editor?.querySelector(".comment-composer__editor");
+      if (!dropzone) return;
+      ["dragenter", "dragover"].forEach((eventName) => {
+        dropzone.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dropzone.classList.add("is-dragover");
+        });
+      });
+      ["dragleave", "dragend", "drop"].forEach((eventName) => {
+        dropzone.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dropzone.classList.remove("is-dragover");
+        });
+      });
+      dropzone.addEventListener("drop", async (event) => {
+        const files = Array.from(event?.dataTransfer?.files || []);
+        if (files.length) await addDescriptionFiles(files);
+      });
     });
     root.querySelectorAll("[data-action='thread-reply-attachments-pick'][data-message-id]").forEach((btn) => {
       btn.onclick = () => {

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -87,9 +87,19 @@ export function createProjectSubjectsState({ store }) {
       v.descriptionEdit = {
         entityType: null,
         entityId: null,
-        draft: ""
+        draft: "",
+        previewMode: false,
+        uploadSessionId: "",
+        attachments: [],
+        isSaving: false,
+        error: ""
       };
     }
+    if (typeof v.descriptionEdit.previewMode !== "boolean") v.descriptionEdit.previewMode = false;
+    if (typeof v.descriptionEdit.uploadSessionId !== "string") v.descriptionEdit.uploadSessionId = "";
+    if (!Array.isArray(v.descriptionEdit.attachments)) v.descriptionEdit.attachments = [];
+    if (typeof v.descriptionEdit.isSaving !== "boolean") v.descriptionEdit.isSaving = false;
+    if (typeof v.descriptionEdit.error !== "string") v.descriptionEdit.error = "";
     if (!v.drilldown || typeof v.drilldown !== "object") {
       v.drilldown = {
         isOpen: false,
@@ -212,7 +222,12 @@ export function createProjectSubjectsState({ store }) {
     v.descriptionEdit = {
       entityType: null,
       entityId: null,
-      draft: ""
+      draft: "",
+      previewMode: false,
+      uploadSessionId: "",
+      attachments: [],
+      isSaving: false,
+      error: ""
     };
     v.subjectMetaDropdown = {
       field: null,

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1,4 +1,5 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
+import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 export function createProjectSubjectsThread(config = {}) {
   const {
     store,
@@ -826,86 +827,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     return { commentsById, childrenByParentId };
   }
 
-  function renderMarkdownToolbar(buttonAction, extraData = {}) {
-    const toolbarButtons = [
-      { action: "heading", icon: "markdown-heading", label: "Titre (H3)" },
-      { action: "bold", icon: "markdown-bold", label: "Gras" },
-      { action: "italic", icon: "markdown-italic", label: "Italique" },
-      { action: "underline", icon: "markdown-underline", label: "Souligné" },
-      { action: "quote", icon: "markdown-quote", label: "Citation" },
-      { action: "code", icon: "markdown-code", label: "Code" },
-      { action: "link", icon: "markdown-link", label: "Lien" },
-      { action: "ordered-list", icon: "markdown-list-ordered", label: "Liste numérotée" },
-      { action: "bullet-list", icon: "markdown-list-unordered", label: "Liste à puces" },
-      { action: "checklist", icon: "markdown-tasklist", label: "Checklist" },
-      { action: "mention", icon: "markdown-mention", label: "Mention" },
-      { action: "subject-ref", icon: "cross-reference", label: "Référence sujet" }
-    ];
-    const toDataAttributeName = (key) => String(key || "")
-      .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-      .replace(/[\s_]+/g, "-")
-      .toLowerCase();
-    const extraAttributes = Object.entries(extraData)
-      .map(([key, value]) => `data-${escapeHtml(toDataAttributeName(key))}="${escapeHtml(String(value || ""))}"`)
-      .join(" ");
-    const renderToolbarButton = (button = {}) => `
-      <button
-        class="comment-toolbar-btn"
-        type="button"
-        data-action="${escapeHtml(buttonAction)}"
-        data-format="${escapeHtml(button.action)}"
-        ${extraAttributes}
-        title="${escapeHtml(button.label)}"
-        aria-label="${escapeHtml(button.label)}"
-      >
-        ${svgIcon(button.icon)}
-      </button>
-    `;
-
-    const shouldUseComposerLayout = buttonAction === "composer-format"
-      || buttonAction === "thread-reply-format"
-      || buttonAction === "thread-edit-format";
-    if (!shouldUseComposerLayout) {
-      return toolbarButtons.map((button) => renderToolbarButton(button)).join("");
-    }
-
-    const attachmentAction = buttonAction === "thread-edit-format"
-      ? "thread-edit-attachments-pick"
-      : buttonAction === "thread-reply-format"
-        ? "thread-reply-attachments-pick"
-        : "composer-attachments-pick";
-    const attachmentButton = `
-      <button
-        class="comment-toolbar-btn"
-        type="button"
-        data-action="${escapeHtml(attachmentAction)}"
-        ${extraAttributes}
-        title="Pièce jointe"
-        aria-label="Pièce jointe"
-      >
-        ${svgIcon("paperclip")}
-      </button>
-    `;
-
-    const groupOne = ["heading", "bold", "italic", "underline", "quote", "code", "link"];
-    const groupTwo = ["ordered-list", "bullet-list", "checklist"];
-    const mentionButton = toolbarButtons.find((button) => button.action === "mention");
-    const subjectRefButton = toolbarButtons.find((button) => button.action === "subject-ref");
-    const renderGroup = (actions = []) => actions
-      .map((action) => toolbarButtons.find((button) => button.action === action))
-      .filter(Boolean)
-      .map((button) => renderToolbarButton(button))
-      .join("");
-
-    return `
-      <div class="comment-toolbar-layout">
-        <div class="comment-toolbar-layout__group">${renderGroup(groupOne)}</div>
-        <div class="comment-toolbar-layout__group">${renderGroup(groupTwo)}</div>
-        <div class="comment-toolbar-layout__group">${attachmentButton}${mentionButton ? renderToolbarButton(mentionButton) : ""}${subjectRefButton ? renderToolbarButton(subjectRefButton) : ""}</div>
-      </div>
-    `;
-  }
-
   function renderInlineReplyComposer({ commentId, isExpanded, draft, previewMode, attachments = [], depth = 0 }) {
     if (!commentId) return "";
     const pendingAttachments = Array.isArray(attachments) ? attachments : [];
@@ -963,7 +884,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           tabPreviewAction: "thread-reply-tab-preview",
           tabsClassName: "comment-composer__tabs--thread-reply",
           composerClassName: "comment-composer--thread-reply-editor",
-          toolbarHtml: renderMarkdownToolbar("thread-reply-format", { messageId: commentId }),
+          toolbarHtml: renderSubjectMarkdownToolbar({ buttonAction: "thread-reply-format", svgIcon, extraData: { messageId: commentId } }),
           previewHtml: normalizedDraft.trim()
             ? mdToHtml(normalizedDraft, { preserveMessageLineBreaks: true })
             : "",
@@ -1058,7 +979,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           tabPreviewAction: "thread-edit-tab-preview",
           tabsClassName: "comment-composer__tabs--thread-reply",
           composerClassName: `comment-composer--thread-reply-editor ${composerEditClass}`,
-          toolbarHtml: renderMarkdownToolbar("thread-edit-format", { messageId: commentId }),
+          toolbarHtml: renderSubjectMarkdownToolbar({ buttonAction: "thread-edit-format", svgIcon, extraData: { messageId: commentId } }),
           previewHtml: normalizedDraft.trim()
             ? mdToHtml(normalizedDraft, { preserveMessageLineBreaks: true })
             : "",
@@ -1435,9 +1356,13 @@ priority=${firstNonEmpty(subject.priority, "")}`
           targetHtml = entityId
             ? `${entityType} ${entityTitle}${entityDisplayLinkHtml(entityType, entityId)}${descendants > 0 ? ` · ${descendants} descendant(s)` : ""}`
             : "this";
-        } else if (kind === "description_version_initial" || kind === "description_version_saved") {
+        } else if (kind === "description_version_initial" || kind === "description_version_saved" || kind === "subject_description_updated") {
           iconHtml = `<span class="tl-ico-wrap tl-ico-reopened" aria-hidden="true">${svgIcon("pencil")}</span>`;
-          verb = kind === "description_version_initial" ? "archived description" : "saved description";
+          verb = kind === "description_version_initial"
+            ? "archived description"
+            : kind === "subject_description_updated"
+              ? "updated description on"
+              : "saved description";
           const entityType = String(e?.entity_type || "").toLowerCase();
           const entityId = String(e?.entity_id || "");
           const entity = getEntityByType(entityType, entityId);
@@ -1602,7 +1527,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       `
       : "";
 
-    const toolbarHtml = renderMarkdownToolbar("composer-format");
+    const toolbarHtml = renderSubjectMarkdownToolbar({ buttonAction: "composer-format", svgIcon });
 
     const attachmentState = getComposerAttachmentsState();
     const normalizedSubjectId = type === "sujet" ? normalizeId(item.id) : "";

--- a/apps/web/js/views/ui/subject-rich-editor.js
+++ b/apps/web/js/views/ui/subject-rich-editor.js
@@ -1,0 +1,89 @@
+import { escapeHtml } from "../../utils/escape-html.js";
+
+export function renderSubjectMarkdownToolbar({
+  buttonAction = "composer-format",
+  svgIcon,
+  extraData = {}
+} = {}) {
+  const toolbarButtons = [
+    { action: "heading", icon: "markdown-heading", label: "Titre (H3)" },
+    { action: "bold", icon: "markdown-bold", label: "Gras" },
+    { action: "italic", icon: "markdown-italic", label: "Italique" },
+    { action: "underline", icon: "markdown-underline", label: "Souligné" },
+    { action: "quote", icon: "markdown-quote", label: "Citation" },
+    { action: "code", icon: "markdown-code", label: "Code" },
+    { action: "link", icon: "markdown-link", label: "Lien" },
+    { action: "ordered-list", icon: "markdown-list-ordered", label: "Liste numérotée" },
+    { action: "bullet-list", icon: "markdown-list-unordered", label: "Liste à puces" },
+    { action: "checklist", icon: "markdown-tasklist", label: "Checklist" },
+    { action: "mention", icon: "markdown-mention", label: "Mention" },
+    { action: "subject-ref", icon: "cross-reference", label: "Référence sujet" }
+  ];
+
+  const toDataAttributeName = (key) => String(key || "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[\s_]+/g, "-")
+    .toLowerCase();
+  const extraAttributes = Object.entries(extraData)
+    .map(([key, value]) => `data-${escapeHtml(toDataAttributeName(key))}="${escapeHtml(String(value || ""))}"`)
+    .join(" ");
+  const renderToolbarButton = (button = {}) => `
+    <button
+      class="comment-toolbar-btn"
+      type="button"
+      data-action="${escapeHtml(buttonAction)}"
+      data-format="${escapeHtml(button.action)}"
+      ${extraAttributes}
+      title="${escapeHtml(button.label)}"
+      aria-label="${escapeHtml(button.label)}"
+    >
+      ${svgIcon(button.icon)}
+    </button>
+  `;
+
+  const shouldUseComposerLayout = buttonAction === "composer-format"
+    || buttonAction === "thread-reply-format"
+    || buttonAction === "thread-edit-format"
+    || buttonAction === "description-format";
+  if (!shouldUseComposerLayout) {
+    return toolbarButtons.map((button) => renderToolbarButton(button)).join("");
+  }
+
+  const attachmentAction = buttonAction === "thread-edit-format"
+    ? "thread-edit-attachments-pick"
+    : buttonAction === "thread-reply-format"
+      ? "thread-reply-attachments-pick"
+      : buttonAction === "description-format"
+        ? "description-attachments-pick"
+        : "composer-attachments-pick";
+  const attachmentButton = `
+    <button
+      class="comment-toolbar-btn"
+      type="button"
+      data-action="${escapeHtml(attachmentAction)}"
+      ${extraAttributes}
+      title="Pièce jointe"
+      aria-label="Pièce jointe"
+    >
+      ${svgIcon("paperclip")}
+    </button>
+  `;
+
+  const groupOne = ["heading", "bold", "italic", "underline", "quote", "code", "link"];
+  const groupTwo = ["ordered-list", "bullet-list", "checklist"];
+  const mentionButton = toolbarButtons.find((button) => button.action === "mention");
+  const subjectRefButton = toolbarButtons.find((button) => button.action === "subject-ref");
+  const renderGroup = (actions = []) => actions
+    .map((action) => toolbarButtons.find((button) => button.action === action))
+    .filter(Boolean)
+    .map((button) => renderToolbarButton(button))
+    .join("");
+
+  return `
+    <div class="comment-toolbar-layout">
+      <div class="comment-toolbar-layout__group">${renderGroup(groupOne)}</div>
+      <div class="comment-toolbar-layout__group">${renderGroup(groupTwo)}</div>
+      <div class="comment-toolbar-layout__group">${attachmentButton}${mentionButton ? renderToolbarButton(mentionButton) : ""}${subjectRefButton ? renderToolbarButton(subjectRefButton) : ""}</div>
+    </div>
+  `;
+}

--- a/supabase/migrations/202606150014_subject_description_edit_rpc.sql
+++ b/supabase/migrations/202606150014_subject_description_edit_rpc.sql
@@ -1,0 +1,133 @@
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_result jsonb;
+begin
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_person_id := public.current_person_id();
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  v_previous_description := coalesce(v_subject.description, '');
+
+  update public.subjects s
+  set
+    description = coalesce(p_description, ''),
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l\'éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id
+    )
+  );
+
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid) from public;


### PR DESCRIPTION
### Motivation
- La description d’un sujet était éditable en UI mais non persistée en backend, et l’éditeur utilisé n’était pas le même que celui des commentaires.
- Objectif : réutiliser l’éditeur riche existant (tabs Write/Preview, toolbar, popups, upload) et brancher une persistance backend atomique sans dupliquer la logique des éditeurs de message.

### Description
- Backend : ajout d’une migration `supabase/migrations/202606150014_subject_description_edit_rpc.sql` qui crée la RPC `public.update_subject_description(p_subject_id, p_description, p_upload_session_id)` ; la RPC vérifie l’existence du sujet et les droits (`can_access_project_subject_conversation`), met à jour `public.subjects.description` + `updated_at`, rattache les pièces jointes de la session d’upload (attachments with `message_id IS NULL`), écrit un enregistrement dans `public.subject_history` avec `event_type = 'subject_description_updated'` et retourne un JSON du sujet mis à jour (incluant `description_attachments`).
- API client : ajout de `updateSubjectDescription(...)` dans `apps/web/js/services/project-subjects-supabase.js` pour appeler la RPC et normaliser la réponse.
- UI mutualisé : nouveau helper `apps/web/js/views/ui/subject-rich-editor.js` qui fournit la toolbar markdown mutualisable pour composers et description.
- UI description : remplacement de l’éditeur simpliste par un composer riche basé sur `renderCommentComposer()` dans `apps/web/js/views/project-subjects/project-subjects-description.js` (tabs Écrire/Aperçu, toolbar, popups `:,@,#`, drag&drop, input fichier, preview d’attachements, bouton vert exact `Mettre à jour la description`, gestion d’état saving/erreur, conservation du draft en cas d’erreur).
- Etat & events : enrichissement de `store.situationsView.descriptionEdit` (`draft`, `previewMode`, `uploadSessionId`, `attachments`, `isSaving`, `error`) dans `apps/web/js/views/project-subjects/project-subjects-state.js`, et branchement des handlers (tabs, format actions, upload/drop, suppression d’attachement, autocompletion) dans `apps/web/js/views/project-subjects/project-subjects-events.js` en introduisant un mode composer `description:<id>` réutilisant l’infrastructure autocomplete existante.
- Rendu / timeline : réutilisation du helper toolbar dans `project-subjects-thread.js` et prise en charge côté UI du `subject_description_updated` dans le rendu d’activités pour que l’historique backend apparaisse correctement.
- Wiring : injection de `updateSubjectDescriptionInSupabase` dans `apps/web/js/views/project-subjects.js` et usage par le module description.

### Testing
- Vérifications statiques JS : `node --check` sur les fichiers modifiés (passé).
- Tests automatisés existants lancés : `node apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` (suite existante exécutée et OK).
- Résultat global : compilation / checks et test ciblé réussis (aucune erreur signalée).

Migration ajoutée : `supabase/migrations/202606150014_subject_description_edit_rpc.sql`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61a3ccee4832981c30676c9c723a3)