### PR TITLE
Consolidate subject description persistence into RPC and remove trigger

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -940,9 +940,11 @@ export async function replaceSubjectLabels(subjectId, labelIds = []) {
 export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
-  const nextDescription = String(description || "").trim();
+  const rawDescription = typeof description === "string" ? description : String(description || "");
+  const normalizedDescription = rawDescription.trim();
+  const nextDescription = normalizedDescription ? rawDescription : "";
   const normalizedUploadSessionId = normalizeUuid(uploadSessionId);
-  if (!nextDescription && !normalizedUploadSessionId) {
+  if (!normalizedDescription && !normalizedUploadSessionId) {
     throw new Error("description or uploadSessionId is required");
   }
 
@@ -960,7 +962,8 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
   });
   if (!response.ok) {
     const txt = await response.text().catch(() => "");
-    throw new Error(`update_subject_description failed (${response.status}): ${txt}`);
+    const rawError = txt || response.statusText || "Unknown error";
+    throw new Error(`update_subject_description failed (${response.status}): ${rawError}`);
   }
 
   const payload = await response.json().catch(() => null);

--- a/supabase/migrations/202606150017_update_subject_description_rpc_hardened_no_trigger.sql
+++ b/supabase/migrations/202606150017_update_subject_description_rpc_hardened_no_trigger.sql
@@ -1,0 +1,191 @@
+-- Consolidate subject description persistence/history/versioning into RPC.
+-- Remove trigger side-effects to keep a single deterministic write path.
+
+drop trigger if exists trg_log_subject_description_update on public.subjects;
+drop function if exists public.trg_log_subject_description_update();
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve current person';
+  v_person_id := public.current_person_id();
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown'
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format('update_subject_description failed at stage "%s": %s', v_stage, coalesce(v_sqlerrm, 'unknown error')),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, '')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid) from public;


### PR DESCRIPTION
### Motivation
- A persisted 400 error was caused by a hybrid backend: the RPC performed an `UPDATE subjects` while an `AFTER UPDATE` trigger (`trg_log_subject_description_update`) also ran side-effects (inserting into `subject_description_versions` and `subject_history`), making failures opaque and fragile.
- The goal is a single deterministic write path for description save + attachments + versioning + history to improve robustness and diagnostics.

### Description
- Add migration `supabase/migrations/202606150017_update_subject_description_rpc_hardened_no_trigger.sql` that drops the trigger and its function and replaces `public.update_subject_description(...)` with a hardened RPC that: loads the subject, enforces access via `can_access_project_subject_conversation`, resolves `current_person_id()`, captures previous description, updates `subjects.description`, links attachments when `p_upload_session_id` is provided, inserts into `subject_description_versions`, inserts into `subject_history`, and returns a complete JSON payload including `description_attachments`.
- The new RPC includes stage-based exception diagnostics (`v_stage` + stacked diagnostics) so PostgREST errors surface the failing stage and SQL details (sqlstate/detail/hint) without fully masking the original error.
- Update frontend `apps/web/js/services/project-subjects-supabase.js` in `updateSubjectDescription` to preserve submitted markdown (avoid destructive trimming), keep emptiness checks based on trimmed value, and surface raw Supabase error text more explicitly.
- Files modified: `supabase/migrations/202606150017_update_subject_description_rpc_hardened_no_trigger.sql` (new) and `apps/web/js/services/project-subjects-supabase.js` (updated).

### Testing
- Ran `node --check apps/web/js/services/project-subjects-supabase.js`, which succeeded.
- Ran `node --test apps/web/js/views/project-subjects/project-subjects-imports.test.mjs`, which passed (all tests OK).
- Verified no changes were made to deployment config (`deploy-supabase.yml`) in the diff inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62a60c55c8329a4a3c709dbccf9f9)