### PR TITLE
Align subject description identity resolution with messaging flow

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -2,7 +2,7 @@ import { store } from "../store.js";
 import { buildSubjectHierarchyIndexes } from "./subject-hierarchy.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./project-situations-supabase.js";
-import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
 import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 
@@ -43,6 +43,33 @@ function getMappedBackendProjectId() {
 
 async function getSupabaseAuthHeaders(extra = {}) {
   return buildSupabaseAuthHeaders(extra);
+}
+
+async function rpcCall(functionName, payload = {}) {
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${functionName}`, {
+    method: "POST",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }),
+    body: JSON.stringify(payload || {})
+  });
+
+  if (!response.ok) {
+    const rawBody = await response.text().catch(() => "");
+    const error = new Error(`${functionName} failed (${response.status}): ${rawBody || response.statusText || "Unknown error"}`);
+    error.status = response.status;
+    error.rawBody = rawBody;
+    throw error;
+  }
+
+  const payloadText = await response.text().catch(() => "");
+  if (!payloadText) return null;
+  try {
+    return JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
 }
 
 async function fetchProjectFlatSubjects(projectId) {
@@ -948,25 +975,29 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
     throw new Error("description or uploadSessionId is required");
   }
 
-  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/update_subject_description`, {
-    method: "POST",
-    headers: await getSupabaseAuthHeaders({
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    }),
-    body: JSON.stringify({
-      p_subject_id: normalizedSubjectId,
-      p_description: nextDescription,
-      p_upload_session_id: normalizedUploadSessionId || null
-    })
-  });
-  if (!response.ok) {
-    const txt = await response.text().catch(() => "");
-    const rawError = txt || response.statusText || "Unknown error";
-    throw new Error(`update_subject_description failed (${response.status}): ${rawError}`);
+  let actorPersonId = "";
+  try {
+    actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  } catch (error) {
+    throw new Error(`update_subject_description identity resolution failed: ${String(error?.message || error || "unknown identity resolution error")}`);
+  }
+  if (!actorPersonId) {
+    throw new Error("update_subject_description identity resolution failed: no linked directory person found for current user");
   }
 
-  const payload = await response.json().catch(() => null);
+  let payload = null;
+  try {
+    payload = await rpcCall("update_subject_description", {
+      p_subject_id: normalizedSubjectId,
+      p_description: nextDescription,
+      p_upload_session_id: normalizedUploadSessionId || null,
+      p_actor_person_id: actorPersonId
+    });
+  } catch (error) {
+    const rawError = String(error?.rawBody || error?.message || error || "");
+    throw new Error(`update_subject_description failed: ${rawError}`);
+  }
+
   const row = Array.isArray(payload) ? payload[0] : payload;
   const descriptionAttachments = Array.isArray(row?.description_attachments) ? row.description_attachments : [];
   return {

--- a/supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql
+++ b/supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql
@@ -1,0 +1,199 @@
+-- Align subject description RPC actor resolution with frontend identity bootstrap.
+-- Accept an explicit directory person id and only fallback to current_person_id().
+
+drop function if exists public.update_subject_description(uuid, text, uuid);
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown'
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format('update_subject_description failed at stage "%s": %s', v_stage, coalesce(v_sqlerrm, 'unknown error')),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, '')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid, uuid) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid, uuid) from public;


### PR DESCRIPTION
### Motivation
- Fix failing description saves (400 from `rpc/update_subject_description`) by aligning the description flow with the already-working messaging identity bootstrap so the RPC always receives a resolved `directory_people.id`.
- Avoid a parallel identity resolution path on the server that sometimes returns `null` by making the frontend resolve the actor and the RPC accept an explicit actor override while keeping a safe server fallback.

### Description
- Frontend: import and call `resolveCurrentUserDirectoryPersonId()` from `project-supabase-sync.js` and fail early if no `directory_people` id is resolved before attempting to save a description. (modified `apps/web/js/services/project-subjects-supabase.js`)
- Frontend: introduce a shared `rpcCall(...)` helper in `project-subjects-supabase.js` and replace the ad-hoc `fetch` call for `update_subject_description` with this helper, passing `p_actor_person_id` in the payload. (modified `apps/web/js/services/project-subjects-supabase.js`)
- Backend: add migration `202606150018_update_subject_description_rpc_actor_person_override.sql` to change `public.update_subject_description(...)` signature to accept `p_actor_person_id uuid default null`, use `coalesce(p_actor_person_id, public.current_person_id())`, strictly validate the actor exists in `directory_people`, and reuse that actor id for attachment linkage, `subject_description_versions`, and `subject_history` insertions.
- Kept requested constraints: no Edge Function changes, no modifications to `deploy-supabase.yml`, and maintained stage-aware SQL error context for better diagnostics.

### Testing
- Automated JS syntax check `node --check apps/web/js/services/project-subjects-supabase.js` was executed and passed.
- Repo checks (`git status`, `git diff`) were run to confirm changed files are as expected; they succeeded.
- No full integration or DB migrations were executed in this environment; end-to-end verification (apply migration and run UI scenarios) is required against a Supabase instance and is described below as recommended manual tests.

Recommended end-to-end checks to run after applying the migration:
- Save description text only and verify a row is inserted in `subject_description_versions` and `subject_history` without duplication.
- Save description text + attachments and verify attachments with `upload_session_id` are linked to the subject with `uploaded_by_person_id` matching the actor and counts reflected in history payload.
- Verify attachments-only case if UI supports it.
- Confirm no changes were made to `deploy-supabase.yml`.

Modified files:
- `apps/web/js/services/project-subjects-supabase.js`
- `supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62e4f9b40832995756084f638b79e)