### PR TITLE
Add actor override and debug instrumentation for update_subject_description RPC and frontend client

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -2,12 +2,13 @@ import { store } from "../store.js";
 import { buildSubjectHierarchyIndexes } from "./subject-hierarchy.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./project-situations-supabase.js";
-import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
 import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
+const SUBJECT_DESCRIPTION_DEBUG_FLAG = "__MDALL_DEBUG_SUBJECT_DESCRIPTION__";
 
 
 
@@ -43,6 +44,96 @@ function getMappedBackendProjectId() {
 
 async function getSupabaseAuthHeaders(extra = {}) {
   return buildSupabaseAuthHeaders(extra);
+}
+
+function isSubjectDescriptionDebugEnabled() {
+  return typeof window !== "undefined" && window?.[SUBJECT_DESCRIPTION_DEBUG_FLAG] === true;
+}
+
+function truncateDescriptionPreview(value = "", maxLength = 160) {
+  const raw = String(value || "");
+  if (raw.length <= maxLength) return raw;
+  return `${raw.slice(0, maxLength)}…`;
+}
+
+function safeJsonParse(text = "") {
+  const raw = String(text || "");
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function buildSubjectDescriptionDebugRequestId() {
+  return `subject-description-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function rpcCall(functionName, payload = {}) {
+  const rpcUrl = `${SUPABASE_URL}/rest/v1/rpc/${functionName}`;
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }),
+    body: JSON.stringify(payload || {})
+  });
+
+  if (!response.ok) {
+    const rawBody = await response.text().catch(() => "");
+    const parsedBody = safeJsonParse(rawBody);
+    const error = new Error(`${functionName} failed (${response.status}): ${rawBody || response.statusText || "Unknown error"}`);
+    error.status = response.status;
+    error.rawBody = rawBody;
+    error.parsedBody = parsedBody;
+    error.rpcUrl = rpcUrl;
+    error.payload = payload;
+    throw error;
+  }
+
+  const payloadText = await response.text().catch(() => "");
+  if (!payloadText) return null;
+  try {
+    return JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
+}
+
+async function gatherSubjectDescriptionFailureDiagnostics({
+  subjectId = "",
+  uploadSessionId = "",
+  actorPersonId = "",
+  description = ""
+} = {}) {
+  const payload = {
+    p_subject_id: normalizeUuid(subjectId) || null,
+    p_upload_session_id: normalizeUuid(uploadSessionId) || null,
+    p_actor_person_id: normalizeUuid(actorPersonId) || null,
+    p_description: String(description || "")
+  };
+
+  try {
+    const response = await rpcCall("debug_update_subject_description_context", payload);
+    return {
+      ok: true,
+      payload,
+      data: Array.isArray(response) ? (response[0] || null) : response
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      payload,
+      error: {
+        message: String(error?.message || error || ""),
+        status: Number(error?.status || 0) || null,
+        rawBody: String(error?.rawBody || ""),
+        parsedBody: error?.parsedBody ?? null
+      }
+    };
+  }
 }
 
 async function fetchProjectFlatSubjects(projectId) {
@@ -938,6 +1029,9 @@ export async function replaceSubjectLabels(subjectId, labelIds = []) {
 }
 
 export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {
+  const debugEnabled = isSubjectDescriptionDebugEnabled();
+  const debugRequestId = debugEnabled ? buildSubjectDescriptionDebugRequestId() : null;
+  const rpcUrl = `${SUPABASE_URL}/rest/v1/rpc/update_subject_description`;
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
   const rawDescription = typeof description === "string" ? description : String(description || "");
@@ -948,25 +1042,84 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
     throw new Error("description or uploadSessionId is required");
   }
 
-  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/update_subject_description`, {
-    method: "POST",
-    headers: await getSupabaseAuthHeaders({
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    }),
-    body: JSON.stringify({
-      p_subject_id: normalizedSubjectId,
-      p_description: nextDescription,
-      p_upload_session_id: normalizedUploadSessionId || null
-    })
-  });
-  if (!response.ok) {
-    const txt = await response.text().catch(() => "");
-    const rawError = txt || response.statusText || "Unknown error";
-    throw new Error(`update_subject_description failed (${response.status}): ${rawError}`);
+  let actorPersonId = "";
+  try {
+    actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  } catch (error) {
+    throw new Error(`update_subject_description identity resolution failed: ${String(error?.message || error || "unknown identity resolution error")}`);
+  }
+  if (!actorPersonId) {
+    throw new Error("update_subject_description identity resolution failed: no linked directory person found for current user");
   }
 
-  const payload = await response.json().catch(() => null);
+  const rpcPayload = {
+    p_subject_id: normalizedSubjectId,
+    p_description: nextDescription,
+    p_upload_session_id: normalizedUploadSessionId || null,
+    p_actor_person_id: actorPersonId
+  };
+  if (debugEnabled) rpcPayload.p_debug_request_id = debugRequestId;
+
+  if (debugEnabled) {
+    console.info("[subject-description] rpc request", {
+      timestamp: new Date().toISOString(),
+      subjectId: normalizedSubjectId,
+      uploadSessionId: normalizedUploadSessionId || null,
+      actorPersonId,
+      descriptionLength: rawDescription.length,
+      descriptionPreview: truncateDescriptionPreview(rawDescription),
+      rpcUrl,
+      payload: rpcPayload
+    });
+  }
+
+  let payload = null;
+  try {
+    payload = await rpcCall("update_subject_description", rpcPayload);
+  } catch (error) {
+    const statusCode = Number(error?.status || 0) || null;
+    const rawError = String(error?.rawBody || error?.message || error || "");
+    const parsedBody = error?.parsedBody ?? safeJsonParse(rawError);
+    let preflight = null;
+
+    if (debugEnabled) {
+      preflight = await gatherSubjectDescriptionFailureDiagnostics({
+        subjectId: normalizedSubjectId,
+        uploadSessionId: normalizedUploadSessionId,
+        actorPersonId,
+        description: nextDescription
+      });
+    }
+
+    if (debugEnabled) {
+      console.error("[subject-description] rpc failure", {
+        timestamp: new Date().toISOString(),
+        subjectId: normalizedSubjectId,
+        uploadSessionId: normalizedUploadSessionId || null,
+        actorPersonId,
+        descriptionLength: rawDescription.length,
+        descriptionPreview: truncateDescriptionPreview(rawDescription),
+        rpcUrl: String(error?.rpcUrl || rpcUrl),
+        payload: rpcPayload,
+        statusCode,
+        rawBody: rawError,
+        parsedBody,
+        preflight
+      });
+      if (preflight && !preflight.ok) {
+        console.error("[subject-description] debug preflight failure", {
+          timestamp: new Date().toISOString(),
+          rpc: "debug_update_subject_description_context",
+          payload: preflight.payload,
+          error: preflight.error
+        });
+      }
+    }
+
+    const preflightSummary = debugEnabled && preflight?.ok ? ` | preflight=${JSON.stringify(preflight.data)}` : "";
+    throw new Error(`update_subject_description failed (${statusCode || "unknown"}): ${rawError}${preflightSummary}`);
+  }
+
   const row = Array.isArray(payload) ? payload[0] : payload;
   const descriptionAttachments = Array.isArray(row?.description_attachments) ? row.description_attachments : [];
   return {

--- a/supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql
+++ b/supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql
@@ -1,0 +1,199 @@
+-- Align subject description RPC actor resolution with frontend identity bootstrap.
+-- Accept an explicit directory person id and only fallback to current_person_id().
+
+drop function if exists public.update_subject_description(uuid, text, uuid);
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown'
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format('update_subject_description failed at stage "%s": %s', v_stage, coalesce(v_sqlerrm, 'unknown error')),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, '')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid, uuid) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid, uuid) from public;

--- a/supabase/migrations/202606150019_update_subject_description_rpc_debug_instrumentation.sql
+++ b/supabase/migrations/202606150019_update_subject_description_rpc_debug_instrumentation.sql
@@ -1,0 +1,340 @@
+-- Add debug correlation id support and a read-only diagnostic preflight RPC
+-- for update_subject_description troubleshooting.
+
+drop function if exists public.update_subject_description(uuid, text, uuid, uuid);
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_debug_request_id text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+  v_debug_request_id text := nullif(trim(coalesce(p_debug_request_id, '')), '');
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown',
+      'debug_request_id', v_debug_request_id
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'debug_request_id', v_debug_request_id,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format(
+        'update_subject_description failed at stage "%s" [debug_request_id=%s]: %s',
+        v_stage,
+        coalesce(v_debug_request_id, 'n/a'),
+        coalesce(v_sqlerrm, 'unknown error')
+      ),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s; debug_request_id=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, ''),
+        coalesce(v_debug_request_id, 'n/a')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid, uuid, text) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid, uuid, text) from public;
+
+create or replace function public.debug_update_subject_description_context(
+  p_subject_id uuid,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_description text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_subject_found boolean := false;
+  v_subject_project_id uuid := null;
+  v_can_access boolean := null;
+  v_current_person_id uuid := null;
+  v_provided_actor_person_exists boolean := false;
+  v_effective_actor_person_id uuid := null;
+  v_upload_session_attachment_count integer := 0;
+  v_attachments_match_actor integer := 0;
+  v_attachments_match_subject integer := 0;
+  v_notes text[] := array[]::text[];
+  v_warnings text[] := array[]::text[];
+begin
+  if p_subject_id is null then
+    return jsonb_build_object(
+      'auth_uid', auth.uid(),
+      'subject_found', false,
+      'subject_project_id', null,
+      'can_access_project_subject_conversation', null,
+      'current_person_id', public.current_person_id(),
+      'provided_actor_person_id', p_actor_person_id,
+      'provided_actor_person_exists', false,
+      'effective_actor_person_id', coalesce(p_actor_person_id, public.current_person_id()),
+      'upload_session_attachment_count', 0,
+      'attachments_match_actor', 0,
+      'attachments_match_subject', 0,
+      'rpc_signature_expected', 'public.update_subject_description(uuid, text, uuid, uuid, text)',
+      'description_length', length(coalesce(p_description, '')),
+      'notes', jsonb_build_array('missing_subject_id'),
+      'warnings', jsonb_build_array('cannot evaluate subject/project access without subject id')
+    );
+  end if;
+
+  select * into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  v_subject_found := v_subject.id is not null;
+  v_subject_project_id := v_subject.project_id;
+  v_current_person_id := public.current_person_id();
+
+  if p_actor_person_id is not null then
+    select exists(
+      select 1 from public.directory_people dp where dp.id = p_actor_person_id
+    ) into v_provided_actor_person_exists;
+  end if;
+
+  v_effective_actor_person_id := coalesce(p_actor_person_id, v_current_person_id);
+
+  if v_subject_found then
+    v_can_access := public.can_access_project_subject_conversation(v_subject.project_id);
+  else
+    v_warnings := array_append(v_warnings, 'subject_not_found');
+  end if;
+
+  if p_upload_session_id is not null then
+    select count(*)
+      into v_upload_session_attachment_count
+    from public.subject_message_attachments sma
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id;
+
+    if v_effective_actor_person_id is not null then
+      select count(*)
+        into v_attachments_match_actor
+      from public.subject_message_attachments sma
+      where sma.deleted_at is null
+        and sma.upload_session_id = p_upload_session_id
+        and sma.uploaded_by_person_id = v_effective_actor_person_id;
+    end if;
+
+    if p_subject_id is not null then
+      select count(*)
+        into v_attachments_match_subject
+      from public.subject_message_attachments sma
+      where sma.deleted_at is null
+        and sma.upload_session_id = p_upload_session_id
+        and sma.subject_id = p_subject_id;
+    end if;
+  else
+    v_notes := array_append(v_notes, 'no_upload_session_id');
+  end if;
+
+  if not v_subject_found then
+    v_warnings := array_append(v_warnings, 'subject_not_visible_or_not_found');
+  end if;
+  if v_subject_found and v_can_access is false then
+    v_warnings := array_append(v_warnings, 'access_check_failed');
+  end if;
+  if v_effective_actor_person_id is null then
+    v_warnings := array_append(v_warnings, 'effective_actor_person_is_null');
+  end if;
+  if p_actor_person_id is not null and not v_provided_actor_person_exists then
+    v_warnings := array_append(v_warnings, 'provided_actor_person_missing');
+  end if;
+
+  return jsonb_build_object(
+    'auth_uid', auth.uid(),
+    'subject_found', v_subject_found,
+    'subject_project_id', v_subject_project_id,
+    'can_access_project_subject_conversation', v_can_access,
+    'current_person_id', v_current_person_id,
+    'provided_actor_person_id', p_actor_person_id,
+    'provided_actor_person_exists', v_provided_actor_person_exists,
+    'effective_actor_person_id', v_effective_actor_person_id,
+    'upload_session_attachment_count', v_upload_session_attachment_count,
+    'attachments_match_actor', v_attachments_match_actor,
+    'attachments_match_subject', v_attachments_match_subject,
+    'rpc_signature_expected', 'public.update_subject_description(uuid, text, uuid, uuid, text)',
+    'description_length', length(coalesce(p_description, '')),
+    'notes', to_jsonb(v_notes),
+    'warnings', to_jsonb(v_warnings)
+  );
+end;
+$$;
+
+grant execute on function public.debug_update_subject_description_context(uuid, uuid, uuid, text) to authenticated;
+revoke all on function public.debug_update_subject_description_context(uuid, uuid, uuid, text) from public;

--- a/supabase/migrations/202606150020_update_subject_description_rpc_actor_label_compat.sql
+++ b/supabase/migrations/202606150020_update_subject_description_rpc_actor_label_compat.sql
@@ -1,0 +1,207 @@
+-- Fix actor label resolution for directory_people schema without display_name/full_name columns.
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_debug_request_id text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+  v_debug_request_id text := nullif(trim(coalesce(p_debug_request_id, '')), '');
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown',
+      'debug_request_id', v_debug_request_id
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'debug_request_id', v_debug_request_id,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format(
+        'update_subject_description failed at stage "%s" [debug_request_id=%s]: %s',
+        v_stage,
+        coalesce(v_debug_request_id, 'n/a'),
+        coalesce(v_sqlerrm, 'unknown error')
+      ),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s; debug_request_id=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, ''),
+        coalesce(v_debug_request_id, 'n/a')
+      );
+end;
+$$;


### PR DESCRIPTION
### Motivation
- Ensure the frontend can explicitly assert the directory person identity when updating a subject description to align RPC behavior with frontend identity bootstrap.
- Provide debug correlation and a read-only preflight RPC to troubleshoot failed `update_subject_description` calls and attachment linking.
- Improve frontend-side RPC handling with safer JSON parsing, richer error reporting, and optional debug logging for description updates.

### Description
- Frontend: extended `apps/web/js/services/project-subjects-supabase.js` with helpers (`rpcCall`, `safeJsonParse`, `truncateDescriptionPreview`, debug flag, request id builder) and now resolve the current directory person id using `resolveCurrentUserDirectoryPersonId` before invoking the RPC; `updateSubjectDescription` now calls `update_subject_description` via `rpcCall` and optionally gathers preflight diagnostics via a new debug RPC on failure when debug is enabled. 
- Frontend: added structured debug logs and enriched error messages including optional preflight diagnostic payloads when `window.__MDALL_DEBUG_SUBJECT_DESCRIPTION__` is set.
- Backend: added three new Supabase migration SQL files that replace `public.update_subject_description` with variants that accept an explicit `p_actor_person_id` and optional `p_debug_request_id`, record `debug_request_id` in history, and add a new `debug_update_subject_description_context` read-only RPC to return diagnostic information about subject visibility, access, provided actor id, and attachment matching.
- Backend: included a compatibility variant to resolve actor label across different `directory_people` schemas, and adjusted grants so `authenticated` can execute the updated RPCs.

### Testing
- Ran the frontend test suite with `npm test`, and the tests passed. 
- Ran the linter with `npm run lint` with no new issues reported. 
- Applied the migrations to a local dev Supabase instance and exercised `update_subject_description` and `debug_update_subject_description_context`, and received the expected JSON diagnostics and RPC responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62e4f9b40832995756084f638b79e)