### PR TITLE
Add subject description version history UI and debug-capable update RPC

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -2,12 +2,13 @@ import { store } from "../store.js";
 import { buildSubjectHierarchyIndexes } from "./subject-hierarchy.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./project-situations-supabase.js";
-import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
 import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
+const SUBJECT_DESCRIPTION_DEBUG_FLAG = "__MDALL_DEBUG_SUBJECT_DESCRIPTION__";
 
 
 
@@ -43,6 +44,96 @@ function getMappedBackendProjectId() {
 
 async function getSupabaseAuthHeaders(extra = {}) {
   return buildSupabaseAuthHeaders(extra);
+}
+
+function isSubjectDescriptionDebugEnabled() {
+  return typeof window !== "undefined" && window?.[SUBJECT_DESCRIPTION_DEBUG_FLAG] === true;
+}
+
+function truncateDescriptionPreview(value = "", maxLength = 160) {
+  const raw = String(value || "");
+  if (raw.length <= maxLength) return raw;
+  return `${raw.slice(0, maxLength)}…`;
+}
+
+function safeJsonParse(text = "") {
+  const raw = String(text || "");
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function buildSubjectDescriptionDebugRequestId() {
+  return `subject-description-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function rpcCall(functionName, payload = {}) {
+  const rpcUrl = `${SUPABASE_URL}/rest/v1/rpc/${functionName}`;
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }),
+    body: JSON.stringify(payload || {})
+  });
+
+  if (!response.ok) {
+    const rawBody = await response.text().catch(() => "");
+    const parsedBody = safeJsonParse(rawBody);
+    const error = new Error(`${functionName} failed (${response.status}): ${rawBody || response.statusText || "Unknown error"}`);
+    error.status = response.status;
+    error.rawBody = rawBody;
+    error.parsedBody = parsedBody;
+    error.rpcUrl = rpcUrl;
+    error.payload = payload;
+    throw error;
+  }
+
+  const payloadText = await response.text().catch(() => "");
+  if (!payloadText) return null;
+  try {
+    return JSON.parse(payloadText);
+  } catch {
+    return null;
+  }
+}
+
+async function gatherSubjectDescriptionFailureDiagnostics({
+  subjectId = "",
+  uploadSessionId = "",
+  actorPersonId = "",
+  description = ""
+} = {}) {
+  const payload = {
+    p_subject_id: normalizeUuid(subjectId) || null,
+    p_upload_session_id: normalizeUuid(uploadSessionId) || null,
+    p_actor_person_id: normalizeUuid(actorPersonId) || null,
+    p_description: String(description || "")
+  };
+
+  try {
+    const response = await rpcCall("debug_update_subject_description_context", payload);
+    return {
+      ok: true,
+      payload,
+      data: Array.isArray(response) ? (response[0] || null) : response
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      payload,
+      error: {
+        message: String(error?.message || error || ""),
+        status: Number(error?.status || 0) || null,
+        rawBody: String(error?.rawBody || ""),
+        parsedBody: error?.parsedBody ?? null
+      }
+    };
+  }
 }
 
 async function fetchProjectFlatSubjects(projectId) {
@@ -938,6 +1029,9 @@ export async function replaceSubjectLabels(subjectId, labelIds = []) {
 }
 
 export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {
+  const debugEnabled = isSubjectDescriptionDebugEnabled();
+  const debugRequestId = debugEnabled ? buildSubjectDescriptionDebugRequestId() : null;
+  const rpcUrl = `${SUPABASE_URL}/rest/v1/rpc/update_subject_description`;
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
   const rawDescription = typeof description === "string" ? description : String(description || "");
@@ -948,25 +1042,84 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
     throw new Error("description or uploadSessionId is required");
   }
 
-  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/update_subject_description`, {
-    method: "POST",
-    headers: await getSupabaseAuthHeaders({
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    }),
-    body: JSON.stringify({
-      p_subject_id: normalizedSubjectId,
-      p_description: nextDescription,
-      p_upload_session_id: normalizedUploadSessionId || null
-    })
-  });
-  if (!response.ok) {
-    const txt = await response.text().catch(() => "");
-    const rawError = txt || response.statusText || "Unknown error";
-    throw new Error(`update_subject_description failed (${response.status}): ${rawError}`);
+  let actorPersonId = "";
+  try {
+    actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  } catch (error) {
+    throw new Error(`update_subject_description identity resolution failed: ${String(error?.message || error || "unknown identity resolution error")}`);
+  }
+  if (!actorPersonId) {
+    throw new Error("update_subject_description identity resolution failed: no linked directory person found for current user");
   }
 
-  const payload = await response.json().catch(() => null);
+  const rpcPayload = {
+    p_subject_id: normalizedSubjectId,
+    p_description: nextDescription,
+    p_upload_session_id: normalizedUploadSessionId || null,
+    p_actor_person_id: actorPersonId
+  };
+  if (debugEnabled) rpcPayload.p_debug_request_id = debugRequestId;
+
+  if (debugEnabled) {
+    console.info("[subject-description] rpc request", {
+      timestamp: new Date().toISOString(),
+      subjectId: normalizedSubjectId,
+      uploadSessionId: normalizedUploadSessionId || null,
+      actorPersonId,
+      descriptionLength: rawDescription.length,
+      descriptionPreview: truncateDescriptionPreview(rawDescription),
+      rpcUrl,
+      payload: rpcPayload
+    });
+  }
+
+  let payload = null;
+  try {
+    payload = await rpcCall("update_subject_description", rpcPayload);
+  } catch (error) {
+    const statusCode = Number(error?.status || 0) || null;
+    const rawError = String(error?.rawBody || error?.message || error || "");
+    const parsedBody = error?.parsedBody ?? safeJsonParse(rawError);
+    let preflight = null;
+
+    if (debugEnabled) {
+      preflight = await gatherSubjectDescriptionFailureDiagnostics({
+        subjectId: normalizedSubjectId,
+        uploadSessionId: normalizedUploadSessionId,
+        actorPersonId,
+        description: nextDescription
+      });
+    }
+
+    if (debugEnabled) {
+      console.error("[subject-description] rpc failure", {
+        timestamp: new Date().toISOString(),
+        subjectId: normalizedSubjectId,
+        uploadSessionId: normalizedUploadSessionId || null,
+        actorPersonId,
+        descriptionLength: rawDescription.length,
+        descriptionPreview: truncateDescriptionPreview(rawDescription),
+        rpcUrl: String(error?.rpcUrl || rpcUrl),
+        payload: rpcPayload,
+        statusCode,
+        rawBody: rawError,
+        parsedBody,
+        preflight
+      });
+      if (preflight && !preflight.ok) {
+        console.error("[subject-description] debug preflight failure", {
+          timestamp: new Date().toISOString(),
+          rpc: "debug_update_subject_description_context",
+          payload: preflight.payload,
+          error: preflight.error
+        });
+      }
+    }
+
+    const preflightSummary = debugEnabled && preflight?.ok ? ` | preflight=${JSON.stringify(preflight.data)}` : "";
+    throw new Error(`update_subject_description failed (${statusCode || "unknown"}): ${rawError}${preflightSummary}`);
+  }
+
   const row = Array.isArray(payload) ? payload[0] : payload;
   const descriptionAttachments = Array.isArray(row?.description_attachments) ? row.description_attachments : [];
   return {
@@ -977,6 +1130,72 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
     updated_at: String(row?.updated_at || ""),
     description_attachments: descriptionAttachments
   };
+}
+
+export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  const limit = Math.min(100, Math.max(1, Number(options?.limit || 50)));
+
+  const versionsUrl = new URL(`${SUPABASE_URL}/rest/v1/subject_description_versions`);
+  versionsUrl.searchParams.set("select", "id,subject_id,actor_user_id,actor_person_id,description_markdown,created_at");
+  versionsUrl.searchParams.set("subject_id", `eq.${normalizedSubjectId}`);
+  versionsUrl.searchParams.set("order", "created_at.desc");
+  versionsUrl.searchParams.set("limit", String(limit));
+
+  const versionsResponse = await fetch(versionsUrl.toString(), {
+    method: "GET",
+    headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
+    cache: "no-store"
+  });
+  if (!versionsResponse.ok) {
+    const txt = await versionsResponse.text().catch(() => "");
+    throw new Error(`subject_description_versions fetch failed (${versionsResponse.status}): ${txt}`);
+  }
+  const versionRows = await versionsResponse.json().catch(() => []);
+  const rows = Array.isArray(versionRows) ? versionRows : [];
+  const personIds = [...new Set(rows.map((row) => normalizeUuid(row?.actor_person_id)).filter(Boolean))];
+  const peopleById = {};
+  if (personIds.length) {
+    const peopleUrl = new URL(`${SUPABASE_URL}/rest/v1/directory_people`);
+    peopleUrl.searchParams.set("select", "id,first_name,last_name,email");
+    peopleUrl.searchParams.set("id", `in.(${personIds.join(",")})`);
+
+    const peopleResponse = await fetch(peopleUrl.toString(), {
+      method: "GET",
+      headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
+      cache: "no-store"
+    });
+    if (peopleResponse.ok) {
+      const peopleRows = await peopleResponse.json().catch(() => []);
+      (Array.isArray(peopleRows) ? peopleRows : []).forEach((person) => {
+        const personId = normalizeUuid(person?.id);
+        if (!personId) return;
+        peopleById[personId] = person;
+      });
+    }
+  }
+
+  return rows.map((row) => {
+    const actorPersonId = normalizeUuid(row?.actor_person_id);
+    const person = peopleById[actorPersonId] || {};
+    const firstName = String(person?.first_name || "").trim();
+    const lastName = String(person?.last_name || "").trim();
+    const fullName = [firstName, lastName].filter(Boolean).join(" ").trim();
+    const fallbackName = String(person?.email || "").trim();
+    return {
+      id: normalizeUuid(row?.id),
+      subject_id: normalizeUuid(row?.subject_id || normalizedSubjectId),
+      actor_user_id: normalizeUuid(row?.actor_user_id),
+      actor_person_id: actorPersonId,
+      actor_first_name: firstName,
+      actor_last_name: lastName,
+      actor_name: fullName || fallbackName || "Utilisateur",
+      actor_email: fallbackName,
+      description_markdown: String(row?.description_markdown || ""),
+      created_at: String(row?.created_at || "")
+    };
+  });
 }
 
 export async function loadLabelsForProject(projectId) {

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -14,7 +14,8 @@ import {
   addLabelToSubject as addLabelToSubjectInSupabase,
   removeLabelFromSubject as removeLabelFromSubjectInSupabase,
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase,
-  updateSubjectDescription as updateSubjectDescriptionInSupabase
+  updateSubjectDescription as updateSubjectDescriptionInSupabase,
+  loadSubjectDescriptionVersions as loadSubjectDescriptionVersionsInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
 import {
@@ -328,7 +329,8 @@ const projectSubjectsDescription = createProjectSubjectsDescription({
   currentDecisionTarget,
   rerenderScope: (...args) => projectSubjectsView.rerenderScope(...args),
   markEntityValidated: (entityType, entityId, options) => markEntityValidated(entityType, entityId, options),
-  updateSubjectDescription: (...args) => updateSubjectDescriptionInSupabase(...args)
+  updateSubjectDescription: (...args) => updateSubjectDescriptionInSupabase(...args),
+  loadSubjectDescriptionVersions: (...args) => loadSubjectDescriptionVersionsInSupabase(...args)
 });
 
 const {
@@ -339,6 +341,10 @@ const {
   syncDescriptionEditorDraft,
   getDescriptionEditState,
   ensureDescriptionUploadSessionId,
+  toggleDescriptionVersionsDropdown,
+  closeDescriptionVersionsDropdown,
+  openDescriptionVersionModal,
+  closeDescriptionVersionModal,
   applyDescriptionSave,
   startDescriptionEdit,
   renderDescriptionCard
@@ -371,6 +377,10 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   syncDescriptionEditorDraft,
   getDescriptionEditState,
   ensureDescriptionUploadSessionId,
+  toggleDescriptionVersionsDropdown,
+  closeDescriptionVersionsDropdown,
+  openDescriptionVersionModal,
+  closeDescriptionVersionModal,
   startDescriptionEdit,
   clearDescriptionEditState,
   applyDescriptionSave,

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -21,7 +21,8 @@ export function createProjectSubjectsDescription(config = {}) {
     currentDecisionTarget,
     rerenderScope,
     markEntityValidated,
-    updateSubjectDescription
+    updateSubjectDescription,
+    loadSubjectDescriptionVersions
   } = config;
 
   const createUploadSessionId = () => {
@@ -44,6 +45,49 @@ export function createProjectSubjectsDescription(config = {}) {
       error: String(state.error || "")
     };
     return store.situationsView.descriptionEdit;
+  }
+
+  function ensureDescriptionVersionsUiState() {
+    ensureViewUiState();
+    const current = store.situationsView.descriptionVersionsUi || {};
+    store.situationsView.descriptionVersionsUi = {
+      entityType: current.entityType || null,
+      entityId: current.entityId || null,
+      isOpen: !!current.isOpen,
+      isLoading: !!current.isLoading,
+      error: String(current.error || ""),
+      versions: Array.isArray(current.versions) ? current.versions : [],
+      selectedVersionId: String(current.selectedVersionId || ""),
+      modalOpen: !!current.modalOpen
+    };
+    return store.situationsView.descriptionVersionsUi;
+  }
+
+  function formatRelativeTimeFromNow(ts = "") {
+    const target = new Date(String(ts || ""));
+    if (Number.isNaN(target.getTime())) return "à l'instant";
+    const deltaMs = Date.now() - target.getTime();
+    const deltaMinutes = Math.round(deltaMs / 60000);
+    if (Math.abs(deltaMinutes) < 1) return "à l'instant";
+    if (Math.abs(deltaMinutes) < 60) return `il y a ${Math.abs(deltaMinutes)} min`;
+    const deltaHours = Math.round(deltaMinutes / 60);
+    if (Math.abs(deltaHours) < 24) return `il y a ${Math.abs(deltaHours)} h`;
+    const deltaDays = Math.round(deltaHours / 24);
+    if (Math.abs(deltaDays) < 30) return `il y a ${Math.abs(deltaDays)} j`;
+    const deltaMonths = Math.round(deltaDays / 30);
+    if (Math.abs(deltaMonths) < 12) return `il y a ${Math.abs(deltaMonths)} mois`;
+    const deltaYears = Math.round(deltaMonths / 12);
+    return `il y a ${Math.abs(deltaYears)} an${Math.abs(deltaYears) > 1 ? "s" : ""}`;
+  }
+
+  function buildVersionInitials(version = {}) {
+    const first = String(version?.actor_first_name || "").trim();
+    const last = String(version?.actor_last_name || "").trim();
+    const email = String(version?.actor_email || "").trim();
+    const fromNames = `${first.charAt(0)}${last.charAt(0)}`.trim();
+    if (fromNames) return fromNames.toUpperCase();
+    if (email) return email.charAt(0).toUpperCase();
+    return "U";
   }
 
   function getSujetSummary(sujet) {
@@ -194,6 +238,172 @@ export function createProjectSubjectsDescription(config = {}) {
     `;
   }
 
+  async function ensureDescriptionVersionsLoaded(root, entityType, entityId) {
+    const ui = ensureDescriptionVersionsUiState();
+    if (ui.isLoading) return;
+    ui.isLoading = true;
+    ui.error = "";
+    ui.entityType = entityType;
+    ui.entityId = entityId;
+    rerenderScope(root);
+    try {
+      const versions = entityType === "sujet" && typeof loadSubjectDescriptionVersions === "function"
+        ? await loadSubjectDescriptionVersions(entityId)
+        : [];
+      ui.versions = Array.isArray(versions) ? versions : [];
+      if (!ui.selectedVersionId && ui.versions.length) {
+        ui.selectedVersionId = String(ui.versions[0]?.id || "");
+      }
+    } catch (error) {
+      ui.error = String(error?.message || error || "Impossible de charger les versions.");
+    } finally {
+      ui.isLoading = false;
+      rerenderScope(root);
+    }
+  }
+
+  function closeDescriptionVersionsDropdown() {
+    const ui = ensureDescriptionVersionsUiState();
+    ui.isOpen = false;
+  }
+
+  function toggleDescriptionVersionsDropdown(root) {
+    const target = currentDecisionTarget(root);
+    if (!target) return;
+    const entityType = getSelectionEntityType(target.type);
+    const entityId = target.id;
+    const ui = ensureDescriptionVersionsUiState();
+    const isSameEntity = ui.entityType === entityType && ui.entityId === entityId;
+    ui.entityType = entityType;
+    ui.entityId = entityId;
+    ui.isOpen = !(isSameEntity && ui.isOpen);
+    if (ui.isOpen && entityType === "sujet") {
+      void ensureDescriptionVersionsLoaded(root, entityType, entityId);
+    }
+    rerenderScope(root);
+  }
+
+  function openDescriptionVersionModal(root, versionId = "") {
+    const ui = ensureDescriptionVersionsUiState();
+    ui.selectedVersionId = String(versionId || "");
+    ui.modalOpen = Boolean(ui.selectedVersionId);
+    ui.isOpen = false;
+    rerenderScope(root);
+  }
+
+  function closeDescriptionVersionModal(root) {
+    const ui = ensureDescriptionVersionsUiState();
+    ui.modalOpen = false;
+    rerenderScope(root);
+  }
+
+  function renderDescriptionVersionsTrigger(entityType, entityId) {
+    const ui = ensureDescriptionVersionsUiState();
+    const isTarget = ui.entityType === entityType && ui.entityId === entityId;
+    const isOpen = isTarget && ui.isOpen;
+    const count = isTarget && Array.isArray(ui.versions) ? ui.versions.length : 0;
+    return `
+      <div class="description-versions-menu">
+        <button
+          class="icon-btn icon-btn--sm description-versions-menu__trigger ${isOpen ? "is-open" : ""}"
+          type="button"
+          data-action="toggle-description-versions"
+          aria-expanded="${isOpen ? "true" : "false"}"
+          aria-haspopup="menu"
+          title="Versions"
+        >
+          <span>Versions${count ? ` (${count})` : ""}</span>
+          <span class="description-versions-menu__caret">${svgIcon("chevron-down")}</span>
+        </button>
+        ${isOpen ? renderDescriptionVersionsDropdown(entityType, entityId) : ""}
+      </div>
+    `;
+  }
+
+  function renderDescriptionVersionsDropdown(entityType, entityId) {
+    const ui = ensureDescriptionVersionsUiState();
+    const isTarget = ui.entityType === entityType && ui.entityId === entityId;
+    const versions = isTarget && Array.isArray(ui.versions) ? ui.versions : [];
+    const count = versions.length;
+    const loadingHtml = ui.isLoading ? `<div class="description-versions-menu__empty">Chargement des versions…</div>` : "";
+    const errorHtml = !ui.isLoading && ui.error ? `<div class="description-versions-menu__empty color-danger">${escapeHtml(ui.error)}</div>` : "";
+    const listHtml = !ui.isLoading && !ui.error && versions.length
+      ? versions.map((version) => {
+          const versionId = String(version?.id || "");
+          const displayName = String(version?.actor_name || "Utilisateur");
+          const relTime = formatRelativeTimeFromNow(version?.created_at);
+          const initials = buildVersionInitials(version);
+          const avatarUrl = String(version?.actor_user_id || "") === String(store?.user?.id || "")
+            ? String(store?.user?.avatar || "")
+            : "";
+          return `
+            <button type="button" class="description-versions-menu__item" data-action="open-description-version-modal" data-version-id="${escapeHtml(versionId)}">
+              <span class="description-versions-menu__avatar">
+                ${avatarUrl
+                  ? `<img src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(displayName)}">`
+                  : `<span class="description-versions-menu__avatar-fallback">${escapeHtml(initials)}</span>`}
+              </span>
+              <span class="description-versions-menu__item-content">
+                <span class="description-versions-menu__item-name">${escapeHtml(displayName)}</span>
+                <span class="description-versions-menu__item-meta">${escapeHtml(relTime)}</span>
+              </span>
+            </button>
+          `;
+        }).join("")
+      : (!ui.isLoading && !ui.error ? `<div class="description-versions-menu__empty">Aucune version disponible.</div>` : "");
+
+    return `
+      <div class="description-versions-menu__dropdown" data-role="description-versions-dropdown" role="menu">
+        <div class="description-versions-menu__title">Nombre de versions : ${count}</div>
+        ${loadingHtml}
+        ${errorHtml}
+        <div class="description-versions-menu__list">${listHtml}</div>
+      </div>
+    `;
+  }
+
+  function renderDescriptionVersionModal(selection) {
+    const entityType = getSelectionEntityType(selection.type);
+    const entityId = selection?.item?.id;
+    const ui = ensureDescriptionVersionsUiState();
+    if (!ui.modalOpen || ui.entityType !== entityType || ui.entityId !== entityId) return "";
+    const versions = Array.isArray(ui.versions) ? ui.versions : [];
+    const version = versions.find((entry) => String(entry?.id || "") === String(ui.selectedVersionId || "")) || null;
+    if (!version) return "";
+    const displayName = String(version?.actor_name || "Utilisateur");
+    const relTime = formatRelativeTimeFromNow(version?.created_at);
+    const bodyMarkdown = String(version?.description_markdown || "");
+    const avatarUrl = String(version?.actor_user_id || "") === String(store?.user?.id || "")
+      ? String(store?.user?.avatar || "")
+      : "";
+    return `
+      <div class="description-version-modal" data-role="description-version-modal">
+        <div class="description-version-modal__backdrop" data-action="close-description-version-modal"></div>
+        <div class="description-version-modal__dialog" role="dialog" aria-modal="true" aria-label="Version de description">
+          <div class="description-version-modal__head">
+            <div class="description-version-modal__title-wrap">
+              <span class="description-version-modal__avatar">
+                ${avatarUrl
+                  ? `<img src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(displayName)}">`
+                  : `<span class="description-version-modal__avatar-fallback">${escapeHtml(buildVersionInitials(version))}</span>`}
+              </span>
+              <div>
+                <div class="description-version-modal__title">${escapeHtml(displayName)}</div>
+                <div class="description-version-modal__subtitle">${escapeHtml(relTime)}</div>
+              </div>
+            </div>
+            <button type="button" class="icon-btn icon-btn--sm" data-action="close-description-version-modal" aria-label="Fermer">
+              ${svgIcon("x")}
+            </button>
+          </div>
+          <div class="description-version-modal__body">
+            ${mdToHtml(bodyMarkdown || "")}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   function renderDescriptionCard(selection) {
     const entityType = getSelectionEntityType(selection.type);
     const entityId = selection.item.id;
@@ -208,6 +418,7 @@ export function createProjectSubjectsDescription(config = {}) {
       fallbackName: "System"
     });
     const authorHtml = `<div class="gh-comment-author mono">${escapeHtml(identity.displayName)}</div>`;
+    const versionsTriggerHtml = entityType === "sujet" ? renderDescriptionVersionsTrigger(entityType, entityId) : "";
     const editButtonHtml = `
       <button class="icon-btn icon-btn--sm gh-comment-edit-btn" data-action="edit-description" type="button" aria-label="Modifier la description" title="Modifier la description">
         ${svgIcon("pencil")}
@@ -216,7 +427,7 @@ export function createProjectSubjectsDescription(config = {}) {
     const headerHtml = `
       <div class="gh-comment-header gh-comment-header--editable">
         <div class="gh-comment-header-main">${authorHtml}</div>
-        <div class="gh-comment-header-actions">${editButtonHtml}</div>
+        <div class="gh-comment-header-actions">${versionsTriggerHtml}${editButtonHtml}</div>
       </div>
     `;
 
@@ -295,6 +506,7 @@ export function createProjectSubjectsDescription(config = {}) {
           ${headerHtml}
           ${bodyHtml}
         </div>
+        ${renderDescriptionVersionModal(selection)}
       </div>
     `;
   }
@@ -425,6 +637,10 @@ export function createProjectSubjectsDescription(config = {}) {
     syncDescriptionEditorDraft,
     getDescriptionEditState,
     ensureDescriptionUploadSessionId,
+    toggleDescriptionVersionsDropdown,
+    closeDescriptionVersionsDropdown,
+    openDescriptionVersionModal,
+    closeDescriptionVersionModal,
     applyDescriptionSave,
     startDescriptionEdit,
     renderDescriptionCard

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -47,6 +47,10 @@ export function createProjectSubjectsEvents(config) {
     syncDescriptionEditorDraft,
     getDescriptionEditState,
     ensureDescriptionUploadSessionId,
+    toggleDescriptionVersionsDropdown,
+    closeDescriptionVersionsDropdown,
+    openDescriptionVersionModal,
+    closeDescriptionVersionModal,
     startDescriptionEdit,
     clearDescriptionEditState,
     applyDescriptionSave,
@@ -693,6 +697,31 @@ export function createProjectSubjectsEvents(config) {
     root.querySelectorAll("[data-action='save-description-edit']").forEach((btn) => {
       btn.onclick = async () => {
         await applyDescriptionSave(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='toggle-description-versions']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.stopPropagation();
+        toggleDescriptionVersionsDropdown?.(root);
+      };
+    });
+
+    root.querySelectorAll("[data-role='description-versions-dropdown']").forEach((dropdown) => {
+      dropdown.addEventListener("click", (event) => event.stopPropagation());
+    });
+
+    root.querySelectorAll("[data-action='open-description-version-modal'][data-version-id]").forEach((btn) => {
+      btn.onclick = () => {
+        const versionId = String(btn.dataset.versionId || "").trim();
+        if (!versionId) return;
+        openDescriptionVersionModal?.(root, versionId);
+      };
+    });
+
+    root.querySelectorAll("[data-action='close-description-version-modal']").forEach((btn) => {
+      btn.onclick = () => {
+        closeDescriptionVersionModal?.(root);
       };
     });
 
@@ -4139,9 +4168,12 @@ export function createProjectSubjectsEvents(config) {
 
     if (root.dataset.threadReplyDropdownDocumentBound !== "true") {
       document.addEventListener("click", () => {
+        const hadOpenDescriptionVersions = Boolean(root.querySelector("[data-role='description-versions-dropdown']"));
         root.querySelectorAll(".thread-comment-menu__dropdown.is-open").forEach((opened) => {
           opened.classList.remove("is-open");
         });
+        closeDescriptionVersionsDropdown?.();
+        if (hadOpenDescriptionVersions) rerenderScope(root);
       });
       root.dataset.threadReplyDropdownDocumentBound = "true";
     }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -8605,6 +8605,154 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 .gh-comment-edit-btn:hover{
   color:var(--text);
 }
+.description-versions-menu{
+  position:relative;
+}
+.description-versions-menu__trigger{
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+  color:var(--muted);
+}
+.description-versions-menu__trigger:hover{
+  color:var(--text);
+}
+.description-versions-menu__caret{
+  display:inline-flex;
+  width:14px;
+  height:14px;
+}
+.description-versions-menu__caret .octicon{
+  width:14px;
+  height:14px;
+}
+.description-versions-menu__dropdown{
+  position:absolute;
+  top:calc(100% + 6px);
+  right:0;
+  z-index:40;
+  width:320px;
+  max-height:340px;
+  overflow:auto;
+  background:var(--panel);
+  border:1px solid var(--line);
+  border-radius:12px;
+  box-shadow:0 14px 28px rgba(1,4,9,.45);
+  padding:8px;
+}
+.description-versions-menu__title{
+  font-size:12px;
+  color:var(--muted);
+  padding:6px 8px;
+}
+.description-versions-menu__list{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.description-versions-menu__item{
+  width:100%;
+  border:0;
+  background:transparent;
+  color:inherit;
+  border-radius:8px;
+  padding:6px 8px;
+  display:flex;
+  align-items:center;
+  gap:10px;
+  text-align:left;
+  cursor:pointer;
+}
+.description-versions-menu__item:hover{
+  background:rgba(110,118,129,.18);
+}
+.description-versions-menu__avatar,
+.description-version-modal__avatar{
+  width:24px;
+  height:24px;
+  border-radius:999px;
+  overflow:hidden;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border:1px solid var(--line);
+  background:rgba(110,118,129,.2);
+}
+.description-versions-menu__avatar img,
+.description-version-modal__avatar img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+.description-versions-menu__avatar-fallback,
+.description-version-modal__avatar-fallback{
+  font-size:11px;
+  font-weight:700;
+  color:var(--text);
+}
+.description-versions-menu__item-content{
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+}
+.description-versions-menu__item-name{
+  font-size:13px;
+  font-weight:600;
+}
+.description-versions-menu__item-meta{
+  font-size:12px;
+  color:var(--muted);
+}
+.description-versions-menu__empty{
+  padding:10px 8px;
+  color:var(--muted);
+  font-size:12px;
+}
+.description-version-modal{
+  position:fixed;
+  inset:0;
+  z-index:160;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.description-version-modal__backdrop{
+  position:absolute;
+  inset:0;
+  background:rgba(1,4,9,.55);
+}
+.description-version-modal__dialog{
+  position:relative;
+  width:min(840px, calc(100vw - 32px));
+  max-height:calc(100vh - 60px);
+  overflow:auto;
+  background:var(--panel);
+  border:1px solid var(--line);
+  border-radius:12px;
+  box-shadow:0 22px 46px rgba(1,4,9,.5);
+}
+.description-version-modal__head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:12px 14px;
+  border-bottom:1px solid var(--line);
+}
+.description-version-modal__title-wrap{
+  display:flex;
+  align-items:center;
+  gap:10px;
+}
+.description-version-modal__title{
+  font-weight:600;
+}
+.description-version-modal__subtitle{
+  font-size:12px;
+  color:var(--muted);
+}
+.description-version-modal__body{
+  padding:14px;
+}
 .gh-comment-body--editable{
   display:flex;
   flex-direction:column;

--- a/supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql
+++ b/supabase/migrations/202606150018_update_subject_description_rpc_actor_person_override.sql
@@ -1,0 +1,199 @@
+-- Align subject description RPC actor resolution with frontend identity bootstrap.
+-- Accept an explicit directory person id and only fallback to current_person_id().
+
+drop function if exists public.update_subject_description(uuid, text, uuid);
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown'
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format('update_subject_description failed at stage "%s": %s', v_stage, coalesce(v_sqlerrm, 'unknown error')),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, '')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid, uuid) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid, uuid) from public;

--- a/supabase/migrations/202606150019_update_subject_description_rpc_debug_instrumentation.sql
+++ b/supabase/migrations/202606150019_update_subject_description_rpc_debug_instrumentation.sql
@@ -1,0 +1,340 @@
+-- Add debug correlation id support and a read-only diagnostic preflight RPC
+-- for update_subject_description troubleshooting.
+
+drop function if exists public.update_subject_description(uuid, text, uuid, uuid);
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_debug_request_id text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+  v_debug_request_id text := nullif(trim(coalesce(p_debug_request_id, '')), '');
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(dp.display_name, dp.full_name, dp.email, 'Utilisateur')
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown',
+      'debug_request_id', v_debug_request_id
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'debug_request_id', v_debug_request_id,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format(
+        'update_subject_description failed at stage "%s" [debug_request_id=%s]: %s',
+        v_stage,
+        coalesce(v_debug_request_id, 'n/a'),
+        coalesce(v_sqlerrm, 'unknown error')
+      ),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s; debug_request_id=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, ''),
+        coalesce(v_debug_request_id, 'n/a')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid, uuid, text) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid, uuid, text) from public;
+
+create or replace function public.debug_update_subject_description_context(
+  p_subject_id uuid,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_description text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_subject_found boolean := false;
+  v_subject_project_id uuid := null;
+  v_can_access boolean := null;
+  v_current_person_id uuid := null;
+  v_provided_actor_person_exists boolean := false;
+  v_effective_actor_person_id uuid := null;
+  v_upload_session_attachment_count integer := 0;
+  v_attachments_match_actor integer := 0;
+  v_attachments_match_subject integer := 0;
+  v_notes text[] := array[]::text[];
+  v_warnings text[] := array[]::text[];
+begin
+  if p_subject_id is null then
+    return jsonb_build_object(
+      'auth_uid', auth.uid(),
+      'subject_found', false,
+      'subject_project_id', null,
+      'can_access_project_subject_conversation', null,
+      'current_person_id', public.current_person_id(),
+      'provided_actor_person_id', p_actor_person_id,
+      'provided_actor_person_exists', false,
+      'effective_actor_person_id', coalesce(p_actor_person_id, public.current_person_id()),
+      'upload_session_attachment_count', 0,
+      'attachments_match_actor', 0,
+      'attachments_match_subject', 0,
+      'rpc_signature_expected', 'public.update_subject_description(uuid, text, uuid, uuid, text)',
+      'description_length', length(coalesce(p_description, '')),
+      'notes', jsonb_build_array('missing_subject_id'),
+      'warnings', jsonb_build_array('cannot evaluate subject/project access without subject id')
+    );
+  end if;
+
+  select * into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  v_subject_found := v_subject.id is not null;
+  v_subject_project_id := v_subject.project_id;
+  v_current_person_id := public.current_person_id();
+
+  if p_actor_person_id is not null then
+    select exists(
+      select 1 from public.directory_people dp where dp.id = p_actor_person_id
+    ) into v_provided_actor_person_exists;
+  end if;
+
+  v_effective_actor_person_id := coalesce(p_actor_person_id, v_current_person_id);
+
+  if v_subject_found then
+    v_can_access := public.can_access_project_subject_conversation(v_subject.project_id);
+  else
+    v_warnings := array_append(v_warnings, 'subject_not_found');
+  end if;
+
+  if p_upload_session_id is not null then
+    select count(*)
+      into v_upload_session_attachment_count
+    from public.subject_message_attachments sma
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id;
+
+    if v_effective_actor_person_id is not null then
+      select count(*)
+        into v_attachments_match_actor
+      from public.subject_message_attachments sma
+      where sma.deleted_at is null
+        and sma.upload_session_id = p_upload_session_id
+        and sma.uploaded_by_person_id = v_effective_actor_person_id;
+    end if;
+
+    if p_subject_id is not null then
+      select count(*)
+        into v_attachments_match_subject
+      from public.subject_message_attachments sma
+      where sma.deleted_at is null
+        and sma.upload_session_id = p_upload_session_id
+        and sma.subject_id = p_subject_id;
+    end if;
+  else
+    v_notes := array_append(v_notes, 'no_upload_session_id');
+  end if;
+
+  if not v_subject_found then
+    v_warnings := array_append(v_warnings, 'subject_not_visible_or_not_found');
+  end if;
+  if v_subject_found and v_can_access is false then
+    v_warnings := array_append(v_warnings, 'access_check_failed');
+  end if;
+  if v_effective_actor_person_id is null then
+    v_warnings := array_append(v_warnings, 'effective_actor_person_is_null');
+  end if;
+  if p_actor_person_id is not null and not v_provided_actor_person_exists then
+    v_warnings := array_append(v_warnings, 'provided_actor_person_missing');
+  end if;
+
+  return jsonb_build_object(
+    'auth_uid', auth.uid(),
+    'subject_found', v_subject_found,
+    'subject_project_id', v_subject_project_id,
+    'can_access_project_subject_conversation', v_can_access,
+    'current_person_id', v_current_person_id,
+    'provided_actor_person_id', p_actor_person_id,
+    'provided_actor_person_exists', v_provided_actor_person_exists,
+    'effective_actor_person_id', v_effective_actor_person_id,
+    'upload_session_attachment_count', v_upload_session_attachment_count,
+    'attachments_match_actor', v_attachments_match_actor,
+    'attachments_match_subject', v_attachments_match_subject,
+    'rpc_signature_expected', 'public.update_subject_description(uuid, text, uuid, uuid, text)',
+    'description_length', length(coalesce(p_description, '')),
+    'notes', to_jsonb(v_notes),
+    'warnings', to_jsonb(v_warnings)
+  );
+end;
+$$;
+
+grant execute on function public.debug_update_subject_description_context(uuid, uuid, uuid, text) to authenticated;
+revoke all on function public.debug_update_subject_description_context(uuid, uuid, uuid, text) from public;

--- a/supabase/migrations/202606150020_update_subject_description_rpc_actor_label_compat.sql
+++ b/supabase/migrations/202606150020_update_subject_description_rpc_actor_label_compat.sql
@@ -1,0 +1,207 @@
+-- Fix actor label resolution for directory_people schema without display_name/full_name columns.
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_debug_request_id text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+  v_debug_request_id text := nullif(trim(coalesce(p_debug_request_id, '')), '');
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet mise à jour',
+    'La description du sujet a été mise à jour depuis l''éditeur riche.',
+    jsonb_build_object(
+      'previous_description', v_previous_description,
+      'next_description', coalesce(v_subject.description, ''),
+      'attachment_count', v_attachment_count,
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown',
+      'debug_request_id', v_debug_request_id
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'debug_request_id', v_debug_request_id,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format(
+        'update_subject_description failed at stage "%s" [debug_request_id=%s]: %s',
+        v_stage,
+        coalesce(v_debug_request_id, 'n/a'),
+        coalesce(v_sqlerrm, 'unknown error')
+      ),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s; debug_request_id=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, ''),
+        coalesce(v_debug_request_id, 'n/a')
+      );
+end;
+$$;


### PR DESCRIPTION
### Motivation

- Provide a version history for subject descriptions and a UI to inspect past description edits.  
- Align RPC actor resolution with frontend identity bootstrap so the server respects an explicit directory person id supplied by the client.  
- Add instrumentation and a diagnostic preflight RPC to help troubleshoot failing `update_subject_description` calls.

### Description

- Frontend: added RPC helper utilities (`rpcCall`, `gatherSubjectDescriptionFailureDiagnostics`, `isSubjectDescriptionDebugEnabled`, `truncateDescriptionPreview`, etc.), changed `updateSubjectDescription` to resolve the current directory person id via `resolveCurrentUserDirectoryPersonId` and pass `p_actor_person_id` (and optional debug id) to the RPC, and added `loadSubjectDescriptionVersions` to fetch version rows and related `directory_people` info.  
- UI: extended the description editor with a versions trigger, dropdown and modal (rendering and event handlers wired via `project-subjects-description.js` and `project-subjects-events.js`), exposed `loadSubjectDescriptionVersions` through the view layer, and updated `project-subjects.js` to wire the new functions.  
- Server/schema: added SQL migrations to update `public.update_subject_description` to accept `p_actor_person_id` and `p_debug_request_id`, to include debug instrumentation in RPC errors, and to add a read-only `debug_update_subject_description_context` preflight function; also added a compatibility variant to ensure actor label resolution works with different `directory_people` schemas.  
- Styling: added CSS rules for the versions menu and version modal in `style.css`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62e4f9b40832995756084f638b79e)