### PR TITLE
Fix subject description versions UI race and align dropdown/modal behavior

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProjectSubjectsDescription } from "./project-subjects-description.js";
+
+test("description versions: un rerender pendant le chargement ne bloque pas isLoading", async () => {
+  const store = {
+    user: { id: "user-1", avatar: "" },
+    projectForm: { collaborators: [] },
+    projectSubjectsView: {},
+    situationsView: {}
+  };
+
+  const runBucketState = { descriptions: { sujet: {}, situation: {} } };
+  let deferredResolve;
+  let loadCalls = 0;
+
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => {
+      store.projectSubjectsView ||= {};
+    },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: runBucketState }),
+    persistRunBucket: (updater) => updater(runBucketState),
+    getSelectionEntityType: (type) => type,
+    getEntityByType: (type, id) => ({ id, title: `${type}-${id}`, raw: { description: "Description" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-1", item: { id: "subject-1" } }),
+    rerenderScope: () => {
+      // Simule un rerender qui relit l'état au milieu du await.
+      api.closeDescriptionVersionsDropdown();
+    },
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async () => {
+      loadCalls += 1;
+      return await new Promise((resolve) => {
+        deferredResolve = resolve;
+      });
+    }
+  });
+
+  api.toggleDescriptionVersionsDropdown({});
+  deferredResolve?.([
+    {
+      id: "v1",
+      actor_user_id: "user-1",
+      actor_person_id: "person-1",
+      actor_first_name: "Ada",
+      actor_last_name: "Lovelace",
+      actor_name: "Ada Lovelace",
+      description_markdown: "Version 1",
+      created_at: new Date(Date.now() - 60_000).toISOString()
+    }
+  ]);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const versionsUi = store.projectSubjectsView.descriptionVersionsUi;
+  assert.equal(loadCalls, 1);
+  assert.equal(versionsUi.isLoading, false);
+  assert.equal(versionsUi.versions.length, 1);
+
+  api.toggleDescriptionVersionsDropdown({});
+  const html = api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-1", title: "Sujet", raw: { description: "Description" } }
+  });
+
+  assert.match(html, /Versions \(1\)/);
+  assert.doesNotMatch(html, /Chargement des versions/);
+  assert.match(html, /Ada Lovelace/);
+  assert.match(html, /il y a/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -3,6 +3,9 @@ import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 
 export function createProjectSubjectsDescription(config = {}) {
   const VERSIONS_LOG_PREFIX = "[subject-description-versions]";
+  const stateRefIds = new WeakMap();
+  let lastLoggedStateRefId = "";
+  let stateRefSeq = 0;
   const {
     store,
     ensureViewUiState,
@@ -41,36 +44,74 @@ export function createProjectSubjectsDescription(config = {}) {
     });
   }
 
-  function ensureDescriptionEditState() {
+  function getSubjectsViewStore() {
     ensureViewUiState();
-    const state = store.situationsView.descriptionEdit || {};
-    store.situationsView.descriptionEdit = {
-      entityType: state.entityType || null,
-      entityId: state.entityId || null,
-      draft: String(state.draft || ""),
-      previewMode: !!state.previewMode,
-      uploadSessionId: String(state.uploadSessionId || ""),
-      attachments: Array.isArray(state.attachments) ? state.attachments : [],
-      isSaving: !!state.isSaving,
-      error: String(state.error || "")
+    if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") {
+      store.projectSubjectsView = {};
+    }
+    return store.projectSubjectsView;
+  }
+
+  function getStateRefId(state) {
+    if (!state || typeof state !== "object") return "no-state";
+    if (!stateRefIds.has(state)) {
+      stateRefSeq += 1;
+      stateRefIds.set(state, `description-versions-ui-${stateRefSeq}`);
+    }
+    return stateRefIds.get(state);
+  }
+
+  function ensureDescriptionEditState() {
+    const view = getSubjectsViewStore();
+    view.descriptionEdit ??= {
+      entityType: null,
+      entityId: null,
+      draft: "",
+      previewMode: false,
+      uploadSessionId: "",
+      attachments: [],
+      isSaving: false,
+      error: ""
     };
-    return store.situationsView.descriptionEdit;
+    if (!Array.isArray(view.descriptionEdit.attachments)) view.descriptionEdit.attachments = [];
+    if (typeof view.descriptionEdit.previewMode !== "boolean") view.descriptionEdit.previewMode = false;
+    if (typeof view.descriptionEdit.isSaving !== "boolean") view.descriptionEdit.isSaving = false;
+    if (typeof view.descriptionEdit.error !== "string") view.descriptionEdit.error = "";
+    if (typeof view.descriptionEdit.uploadSessionId !== "string") view.descriptionEdit.uploadSessionId = "";
+    return view.descriptionEdit;
   }
 
   function ensureDescriptionVersionsUiState() {
-    ensureViewUiState();
-    const current = store.situationsView.descriptionVersionsUi || {};
-    store.situationsView.descriptionVersionsUi = {
-      entityType: current.entityType || null,
-      entityId: current.entityId || null,
-      isOpen: !!current.isOpen,
-      isLoading: !!current.isLoading,
-      error: String(current.error || ""),
-      versions: Array.isArray(current.versions) ? current.versions : [],
-      selectedVersionId: String(current.selectedVersionId || ""),
-      modalOpen: !!current.modalOpen
+    const view = getSubjectsViewStore();
+    const existing = view.descriptionVersionsUi;
+    view.descriptionVersionsUi ??= {
+      entityType: null,
+      entityId: null,
+      isOpen: false,
+      isLoading: false,
+      error: "",
+      versions: [],
+      selectedVersionId: "",
+      modalOpen: false,
+      loadToken: 0
     };
-    return store.situationsView.descriptionVersionsUi;
+    if (!Array.isArray(view.descriptionVersionsUi.versions)) view.descriptionVersionsUi.versions = [];
+    if (typeof view.descriptionVersionsUi.error !== "string") view.descriptionVersionsUi.error = "";
+    if (typeof view.descriptionVersionsUi.isOpen !== "boolean") view.descriptionVersionsUi.isOpen = false;
+    if (typeof view.descriptionVersionsUi.isLoading !== "boolean") view.descriptionVersionsUi.isLoading = false;
+    if (typeof view.descriptionVersionsUi.selectedVersionId !== "string") view.descriptionVersionsUi.selectedVersionId = "";
+    if (typeof view.descriptionVersionsUi.modalOpen !== "boolean") view.descriptionVersionsUi.modalOpen = false;
+    if (!Number.isFinite(Number(view.descriptionVersionsUi.loadToken))) view.descriptionVersionsUi.loadToken = 0;
+    const stateRefId = getStateRefId(view.descriptionVersionsUi);
+    if (!existing || lastLoggedStateRefId !== stateRefId) {
+      lastLoggedStateRefId = stateRefId;
+      logDescriptionVersions("state init", {
+        store: "store.projectSubjectsView.descriptionVersionsUi",
+        hasExistingState: !!existing,
+        stateRefId
+      });
+    }
+    return view.descriptionVersionsUi;
   }
 
   function formatRelativeTimeFromNow(ts = "") {
@@ -91,11 +132,7 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function formatVersionTimestamp(ts = "") {
-    const absolute = typeof fmtTs === "function" ? fmtTs(ts) : String(ts || "—");
-    const relative = formatRelativeTimeFromNow(ts);
-    return relative && relative !== "à l'instant"
-      ? `${absolute} (${relative})`
-      : absolute;
+    return typeof fmtTs === "function" ? fmtTs(ts) : String(ts || "—");
   }
 
   function buildVersionInitials(version = {}) {
@@ -269,19 +306,17 @@ export function createProjectSubjectsDescription(config = {}) {
     const forceReload = !!options.forceReload;
     const sameTarget = ui.entityType === entityType && ui.entityId === entityId;
     const versionsInMemory = Array.isArray(ui.versions) ? ui.versions.length : 0;
+    const previousLoading = !!ui.isLoading;
     logDescriptionVersions("ensure start", {
       entityType,
       entityId,
       forceReload,
       sameTarget,
-      isLoading: !!ui.isLoading,
-      versionsInMemory
+      previousIsLoading: previousLoading,
+      versionsInMemory,
+      stateRefId: getStateRefId(ui)
     });
-    if (ui.isLoading) {
-      logDescriptionVersions("ensure early return: already loading", { entityType, entityId });
-      return;
-    }
-    if (!forceReload && sameTarget && !ui.error && Array.isArray(ui.versions) && ui.versions.length) {
+    if (!forceReload && sameTarget && !ui.error && Array.isArray(ui.versions) && ui.versions.length && !previousLoading) {
       logDescriptionVersions("ensure early return: cache hit", {
         entityType,
         entityId,
@@ -289,26 +324,53 @@ export function createProjectSubjectsDescription(config = {}) {
       });
       return;
     }
-    logDescriptionVersions("ensure branch: loading triggered", {
+    const loadToken = Number(ui.loadToken || 0) + 1;
+    ui.loadToken = loadToken;
+    logDescriptionVersions("ensure loading begin", {
       entityType,
       entityId,
-      forceReload,
-      sameTarget
+      loadToken,
+      previousIsLoading: previousLoading,
+      versionsCount: versionsInMemory
     });
     ui.isLoading = true;
     ui.error = "";
     ui.entityType = entityType;
     ui.entityId = entityId;
+    logDescriptionVersions("rerender loading snapshot", {
+      loadToken,
+      snapshot: {
+        entityType: ui.entityType,
+        entityId: ui.entityId,
+        isLoading: ui.isLoading,
+        versionsCount: Array.isArray(ui.versions) ? ui.versions.length : 0,
+        error: ui.error,
+        stateRefId: getStateRefId(ui)
+      }
+    });
     rerenderScope(root);
     try {
       const versions = entityType === "sujet" && typeof loadSubjectDescriptionVersions === "function"
         ? await loadSubjectDescriptionVersions(entityId)
         : [];
-      ui.versions = Array.isArray(versions) ? versions : [];
-      if (!ui.selectedVersionId && ui.versions.length) {
-        ui.selectedVersionId = String(ui.versions[0]?.id || "");
+      const currentUi = ensureDescriptionVersionsUiState();
+      const isStaleResponse = Number(currentUi.loadToken || 0) !== loadToken;
+      const normalizedVersions = Array.isArray(versions) ? versions : [];
+      logDescriptionVersions("fetch resolved", {
+        entityType,
+        entityId,
+        loadToken,
+        rowsCount: normalizedVersions.length,
+        selectedVersionId: String(currentUi.selectedVersionId || ""),
+        ignoredAsStale: isStaleResponse,
+        stateRefId: getStateRefId(currentUi)
+      });
+      if (isStaleResponse) return;
+      currentUi.versions = normalizedVersions;
+      if (!currentUi.selectedVersionId && currentUi.versions.length) {
+        currentUi.selectedVersionId = String(currentUi.versions[0]?.id || "");
       }
-      if (!ui.versions.length) {
+      if (!currentUi.versions.length) {
         logDescriptionVersions("ensure loaded with empty result set", {
           entityType,
           entityId
@@ -327,23 +389,31 @@ export function createProjectSubjectsDescription(config = {}) {
         }
       }
     } catch (error) {
-      ui.error = buildDescriptionVersionsLoadError(error);
+      const currentUi = ensureDescriptionVersionsUiState();
+      const isStaleResponse = Number(currentUi.loadToken || 0) !== loadToken;
+      if (!isStaleResponse) currentUi.error = buildDescriptionVersionsLoadError(error);
       console.error(`${VERSIONS_LOG_PREFIX} ensure failed`, {
         timestamp: new Date().toISOString(),
         entityType,
         entityId,
         forceReload,
         sameTarget,
+        loadToken,
+        ignoredAsStale: isStaleResponse,
         error
       });
     } finally {
-      ui.isLoading = false;
-      logDescriptionVersions("ensure done", {
+      const currentUi = ensureDescriptionVersionsUiState();
+      if (Number(currentUi.loadToken || 0) === loadToken) currentUi.isLoading = false;
+      logDescriptionVersions("finally", {
         entityType,
         entityId,
-        versionsCount: Array.isArray(ui.versions) ? ui.versions.length : 0,
-        hasError: !!ui.error,
-        selectedVersionId: String(ui.selectedVersionId || "")
+        loadToken,
+        isLoadingFinal: !!currentUi.isLoading,
+        versionsCountFinal: Array.isArray(currentUi.versions) ? currentUi.versions.length : 0,
+        hasError: !!currentUi.error,
+        selectedVersionId: String(currentUi.selectedVersionId || ""),
+        stateRefId: getStateRefId(currentUi)
       });
       rerenderScope(root);
     }
@@ -393,6 +463,10 @@ export function createProjectSubjectsDescription(config = {}) {
     const version = Array.isArray(ui.versions)
       ? ui.versions.find((entry) => String(entry?.id || "") === ui.selectedVersionId)
       : null;
+    logDescriptionVersions("item click", {
+      versionId: ui.selectedVersionId,
+      foundVersion: !!version
+    });
     if (!version) {
       rerenderScope(root);
       return;
@@ -410,7 +484,9 @@ export function createProjectSubjectsDescription(config = {}) {
 
   function closeDescriptionVersionDetailsModalDom() {
     const modal = document.getElementById("detailsModal");
+    const body = document.getElementById("detailsBodyModal");
     if (!modal || modal.dataset.descriptionVersionModalOpen !== "true") return;
+    body?.classList.remove("details-body-modal--description-version");
     if (typeof setOverlayChromeOpenState === "function") {
       setOverlayChromeOpenState(modal, false);
     } else {
@@ -431,14 +507,21 @@ export function createProjectSubjectsDescription(config = {}) {
 
     const displayName = String(version?.actor_name || "Utilisateur");
     const dateLabel = formatVersionTimestamp(version?.created_at);
+    const dateRelativeLabel = formatRelativeTimeFromNow(version?.created_at);
     const initials = buildVersionInitials(version);
-    const avatarUrl = String(version?.actor_user_id || "") === String(store?.user?.id || "")
-      ? String(store?.user?.avatar || "")
-      : "";
+    const avatarUrl = resolveVersionAvatarUrl(version);
     const bodyMarkdown = String(version?.description_markdown || "");
+    const fullDateLabel = `${dateRelativeLabel} · ${dateLabel}`;
+    logDescriptionVersions("modal open", {
+      title: "Version de description",
+      author: displayName,
+      created_at: String(version?.created_at || ""),
+      markdownLength: bodyMarkdown.length
+    });
 
     title.textContent = "Version de description";
-    meta.textContent = dateLabel;
+    meta.textContent = fullDateLabel;
+    body.classList.add("details-body-modal--description-version");
     body.innerHTML = `
       <article class="description-version-details">
         <header class="description-version-details__header">
@@ -449,7 +532,7 @@ export function createProjectSubjectsDescription(config = {}) {
           </span>
           <div class="description-version-details__author">
             <div class="description-version-details__name">${escapeHtml(displayName)}</div>
-            <div class="description-version-details__date">${escapeHtml(dateLabel)}</div>
+            <div class="description-version-details__date" title="${escapeHtml(dateLabel)}">${escapeHtml(dateRelativeLabel)}</div>
           </div>
         </header>
         <div class="description-version-details__body gh-comment-body">
@@ -470,6 +553,33 @@ export function createProjectSubjectsDescription(config = {}) {
     return true;
   }
 
+  function resolveVersionAvatarUrl(version = {}) {
+    const directAvatar = firstNonEmpty(
+      version?.actor_avatar_url,
+      version?.actor_avatar,
+      version?.actor_user_avatar
+    );
+    if (directAvatar) return directAvatar;
+
+    if (String(version?.actor_user_id || "") === String(store?.user?.id || "")) {
+      return String(store?.user?.avatar || "");
+    }
+
+    const collaborators = Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators : [];
+    const actorUserId = String(version?.actor_user_id || "");
+    const actorPersonId = String(version?.actor_person_id || "");
+    const collaborator = collaborators.find((entry) => {
+      const linkedUserId = String(entry?.userId || entry?.linkedUserId || "");
+      const personId = String(entry?.personId || entry?.id || "");
+      return (actorUserId && linkedUserId === actorUserId) || (actorPersonId && personId === actorPersonId);
+    });
+    return String(firstNonEmpty(
+      collaborator?.avatar,
+      collaborator?.avatarUrl,
+      collaborator?.photo_url
+    ));
+  }
+
   function renderDescriptionVersionsTrigger(entityType, entityId) {
     const ui = ensureDescriptionVersionsUiState();
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
@@ -478,7 +588,7 @@ export function createProjectSubjectsDescription(config = {}) {
     return `
       <div class="issues-head-menu description-versions-dropdown ${isOpen ? "is-open" : ""}">
         <button
-          class="gh-btn description-versions-dropdown__trigger"
+          class="issues-head-menu__btn description-versions-dropdown__trigger"
           type="button"
           data-action="toggle-description-versions"
           aria-expanded="${isOpen ? "true" : "false"}"
@@ -498,6 +608,15 @@ export function createProjectSubjectsDescription(config = {}) {
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
     const versions = isTarget && Array.isArray(ui.versions) ? ui.versions : [];
     const count = versions.length;
+    logDescriptionVersions("dropdown render", {
+      entityType,
+      entityId,
+      isTarget,
+      isOpen: !!(isTarget && ui.isOpen),
+      isLoading: !!ui.isLoading,
+      versionsLength: count,
+      stateRefId: getStateRefId(ui)
+    });
     const loadingHtml = ui.isLoading ? `<div class="description-versions-dropdown__status">Chargement des versions…</div>` : "";
     const errorHtml = !ui.isLoading && ui.error
       ? `
@@ -511,13 +630,12 @@ export function createProjectSubjectsDescription(config = {}) {
       ? versions.map((version) => {
           const versionId = String(version?.id || "");
           const displayName = String(version?.actor_name || "Utilisateur");
-          const timestampLabel = formatVersionTimestamp(version?.created_at);
+          const timestampLabel = formatRelativeTimeFromNow(version?.created_at);
+          const absoluteTimestampLabel = formatVersionTimestamp(version?.created_at);
           const initials = buildVersionInitials(version);
-          const avatarUrl = String(version?.actor_user_id || "") === String(store?.user?.id || "")
-            ? String(store?.user?.avatar || "")
-            : "";
+          const avatarUrl = resolveVersionAvatarUrl(version);
           return `
-            <button type="button" class="gh-menu__item description-versions-dropdown__item" data-action="open-description-version-modal" data-version-id="${escapeHtml(versionId)}">
+            <button type="button" class="gh-menu__item description-versions-dropdown__item" data-action="open-description-version-modal" data-version-id="${escapeHtml(versionId)}" title="${escapeHtml(absoluteTimestampLabel)}">
               <span class="description-versions-dropdown__avatar">
                 ${avatarUrl
                   ? `<img src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(displayName)}">`
@@ -649,8 +767,8 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function clearDescriptionEditState() {
-    ensureViewUiState();
-    store.situationsView.descriptionEdit = {
+    const view = getSubjectsViewStore();
+    view.descriptionEdit = {
       entityType: null,
       entityId: null,
       draft: "",
@@ -749,7 +867,8 @@ export function createProjectSubjectsDescription(config = {}) {
     if (!target) return false;
     const entityType = getSelectionEntityType(target.type);
     const current = getEntityDescriptionState(entityType, target.id);
-    store.situationsView.descriptionEdit = {
+    const view = getSubjectsViewStore();
+    view.descriptionEdit = {
       entityType,
       entityId: target.id,
       draft: current.body || "",

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -8704,6 +8704,10 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   border-top:1px solid var(--line);
   padding-top:12px;
 }
+#detailsBodyModal.details-body-modal--description-version{
+  max-width:860px;
+  margin-inline:auto;
+}
 .gh-comment-body--editable{
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
### Motivation
- Corriger le bug où le dropdown “Versions” restait bloqué sur « Chargement des versions… » à cause de la recréation d’objet d’état à chaque lecture et d’écritures asynchrones sur une référence périmée.
- Réutiliser le pattern mutualisé de dropdowns du head et garder l’ouverture dans la modale existante tout en rendant le rendu compact et traçable.

### Description
- Stabilisation de l’état UI : l’état `descriptionVersionsUi` (et `descriptionEdit` pour cette feature) est initialisé de façon idempotente sur `store.projectSubjectsView` via `ensureDescriptionVersionsUiState()`/`ensureDescriptionEditState()` pour éviter la recréation d’objet à chaque lecture.
- Protection des réponses asynchrones : ajout d’un `loadToken` incrémental et vérification de validité des réponses pour ignorer les réponses obsolètes avant de mettre à jour l’état courant dans `ensureDescriptionVersionsLoaded()`.
- Alignement UI : le trigger utilise désormais les classes/structure partagées (`issues-head-menu__btn`, `gh-menu`) pour être cohérent avec les autres dropdowns head.
- Rendu et modal : item list conserve avatar + identité + date relative; résolution d’avatar plus robuste via `resolveVersionAvatarUrl()` (champs directs / utilisateur courant / collaborators / initials); la modale réutilise `#detailsModal` et reçoit une variante compacte via `details-body-modal--description-version` et `mdToHtml()` pour le contenu enrichi.
- Instrumentation : ajout de logs préfixés `[subject-description-versions]` aux étapes clés (initialisation d’état, début de chargement, snapshot avant rerender, résolution fetch avec indication stale/valid, rendu dropdown, clic item, ouverture modal) et d’un helper de `stateRefId` pour tracer les références d’état.
- Fichiers modifiés principaux : `apps/web/js/views/project-subjects/project-subjects-description.js`, `apps/web/style.css` (classe modale compacte), ajout du test `apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs`.

### Testing
- Test unitaire ajouté et exécuté : `node --test apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` — succès (le test reproduit un rerender pendant le `await` et vérifie que `isLoading` repasse à `false` et que la liste des versions s’affiche).
- Exécution locale du test a produit les logs d’instrumentation `[subject-description-versions]` et la sortie indique que le scénario race est résolu (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6532172c083299832884435e54cb7)