### PR TITLE
Description versions: dropdown host, positioning, stale-load protection and tests

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -348,6 +348,8 @@ const {
   openDescriptionVersionModal,
   closeDescriptionVersionModal,
   retryDescriptionVersionsLoad,
+  renderDescriptionVersionsDropdownHost,
+  syncDescriptionVersionsDropdownPosition,
   applyDescriptionSave,
   startDescriptionEdit,
   renderDescriptionCard
@@ -385,6 +387,8 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   openDescriptionVersionModal,
   closeDescriptionVersionModal,
   retryDescriptionVersionsLoad,
+  renderDescriptionVersionsDropdownHost,
+  syncDescriptionVersionsDropdownPosition,
   startDescriptionEdit,
   clearDescriptionEditState,
   applyDescriptionSave,

--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProjectSubjectsDescription } from "./project-subjects-description.js";
+
+test("description versions: un rerender pendant le chargement ne bloque pas isLoading", async () => {
+  const fakeNodesById = new Map();
+  const fakeAnchor = {
+    getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 })
+  };
+  const fakeBody = {
+    appendChild: (node) => {
+      if (node?.id) fakeNodesById.set(node.id, node);
+      return node;
+    }
+  };
+  globalThis.window = {
+    innerWidth: 1200,
+    innerHeight: 900
+  };
+  globalThis.CSS = { escape: (value) => String(value || "") };
+  globalThis.document = {
+    body: fakeBody,
+    documentElement: { clientWidth: 1200, clientHeight: 900 },
+    createElement: () => ({
+      id: "",
+      className: "",
+      style: {},
+      innerHTML: "",
+      attributes: {},
+      setAttribute(name, value) { this.attributes[name] = value; },
+      getAttribute(name) { return this.attributes[name]; },
+      querySelector: () => null
+    }),
+    getElementById: (id) => fakeNodesById.get(id) || null,
+    querySelector: (selector) => String(selector || "").includes("data-description-versions-anchor") ? fakeAnchor : null
+  };
+
+  const store = {
+    user: { id: "user-1", avatar: "" },
+    projectForm: { collaborators: [] },
+    projectSubjectsView: {},
+    situationsView: {}
+  };
+
+  const runBucketState = { descriptions: { sujet: {}, situation: {} } };
+  let deferredResolve;
+  let loadCalls = 0;
+  let simulatedInterruptionDone = false;
+
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => {
+      store.projectSubjectsView ||= {};
+    },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: runBucketState }),
+    persistRunBucket: (updater) => updater(runBucketState),
+    getSelectionEntityType: (type) => type,
+    getEntityByType: (type, id) => ({ id, title: `${type}-${id}`, raw: { description: "Description" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-1", item: { id: "subject-1" } }),
+    rerenderScope: () => {
+      // Simule un rerender qui relit l'état au milieu du await.
+      if (simulatedInterruptionDone) return;
+      simulatedInterruptionDone = true;
+      api.closeDescriptionVersionsDropdown();
+    },
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async () => {
+      loadCalls += 1;
+      return await new Promise((resolve) => {
+        deferredResolve = resolve;
+      });
+    }
+  });
+
+  api.toggleDescriptionVersionsDropdown({});
+  deferredResolve?.([
+    {
+      id: "v1",
+      actor_user_id: "user-1",
+      actor_person_id: "person-1",
+      actor_first_name: "Ada",
+      actor_last_name: "Lovelace",
+      actor_name: "Ada Lovelace",
+      description_markdown: "Version 1",
+      created_at: new Date(Date.now() - 60_000).toISOString()
+    }
+  ]);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const versionsUi = store.projectSubjectsView.descriptionVersionsUi;
+  assert.equal(loadCalls, 1);
+  assert.equal(versionsUi.isLoading, false);
+  assert.equal(versionsUi.versions.length, 1);
+
+  api.toggleDescriptionVersionsDropdown({});
+  const root = {
+    querySelector: () => fakeAnchor
+  };
+  const html = api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-1", title: "Sujet", raw: { description: "Description" } }
+  });
+  api.renderDescriptionVersionsDropdownHost(root);
+  const hostHtml = (globalThis.document?.getElementById?.("descriptionVersionsDropdownHost")?.innerHTML || "");
+
+  assert.match(html, /Versions \(1\)/);
+  assert.doesNotMatch(hostHtml, /Chargement des versions/);
+  assert.match(hostHtml, /Ada Lovelace/);
+  assert.match(hostHtml, /il y a/);
+
+  delete globalThis.document;
+  delete globalThis.window;
+  delete globalThis.CSS;
+});

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -3,6 +3,9 @@ import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 
 export function createProjectSubjectsDescription(config = {}) {
   const VERSIONS_LOG_PREFIX = "[subject-description-versions]";
+  const stateRefIds = new WeakMap();
+  let lastLoggedStateRefId = "";
+  let stateRefSeq = 0;
   const {
     store,
     ensureViewUiState,
@@ -41,36 +44,80 @@ export function createProjectSubjectsDescription(config = {}) {
     });
   }
 
-  function ensureDescriptionEditState() {
+  function getSubjectsViewStore() {
     ensureViewUiState();
-    const state = store.situationsView.descriptionEdit || {};
-    store.situationsView.descriptionEdit = {
-      entityType: state.entityType || null,
-      entityId: state.entityId || null,
-      draft: String(state.draft || ""),
-      previewMode: !!state.previewMode,
-      uploadSessionId: String(state.uploadSessionId || ""),
-      attachments: Array.isArray(state.attachments) ? state.attachments : [],
-      isSaving: !!state.isSaving,
-      error: String(state.error || "")
+    if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") {
+      store.projectSubjectsView = {};
+    }
+    return store.projectSubjectsView;
+  }
+
+  function getStateRefId(state) {
+    if (!state || typeof state !== "object") return "no-state";
+    if (!stateRefIds.has(state)) {
+      stateRefSeq += 1;
+      stateRefIds.set(state, `description-versions-ui-${stateRefSeq}`);
+    }
+    return stateRefIds.get(state);
+  }
+
+  function isHtmlElement(value) {
+    if (!value || typeof value !== "object") return false;
+    if (typeof HTMLElement !== "undefined" && value instanceof HTMLElement) return true;
+    return typeof value.querySelector === "function" || typeof value.getBoundingClientRect === "function";
+  }
+
+  function ensureDescriptionEditState() {
+    const view = getSubjectsViewStore();
+    view.descriptionEdit ??= {
+      entityType: null,
+      entityId: null,
+      draft: "",
+      previewMode: false,
+      uploadSessionId: "",
+      attachments: [],
+      isSaving: false,
+      error: ""
     };
-    return store.situationsView.descriptionEdit;
+    if (!Array.isArray(view.descriptionEdit.attachments)) view.descriptionEdit.attachments = [];
+    if (typeof view.descriptionEdit.previewMode !== "boolean") view.descriptionEdit.previewMode = false;
+    if (typeof view.descriptionEdit.isSaving !== "boolean") view.descriptionEdit.isSaving = false;
+    if (typeof view.descriptionEdit.error !== "string") view.descriptionEdit.error = "";
+    if (typeof view.descriptionEdit.uploadSessionId !== "string") view.descriptionEdit.uploadSessionId = "";
+    return view.descriptionEdit;
   }
 
   function ensureDescriptionVersionsUiState() {
-    ensureViewUiState();
-    const current = store.situationsView.descriptionVersionsUi || {};
-    store.situationsView.descriptionVersionsUi = {
-      entityType: current.entityType || null,
-      entityId: current.entityId || null,
-      isOpen: !!current.isOpen,
-      isLoading: !!current.isLoading,
-      error: String(current.error || ""),
-      versions: Array.isArray(current.versions) ? current.versions : [],
-      selectedVersionId: String(current.selectedVersionId || ""),
-      modalOpen: !!current.modalOpen
+    const view = getSubjectsViewStore();
+    const existing = view.descriptionVersionsUi;
+    view.descriptionVersionsUi ??= {
+      entityType: null,
+      entityId: null,
+      isOpen: false,
+      isLoading: false,
+      error: "",
+      versions: [],
+      selectedVersionId: "",
+      modalOpen: false,
+      loadToken: 0
     };
-    return store.situationsView.descriptionVersionsUi;
+    if (!Array.isArray(view.descriptionVersionsUi.versions)) view.descriptionVersionsUi.versions = [];
+    if (typeof view.descriptionVersionsUi.error !== "string") view.descriptionVersionsUi.error = "";
+    if (typeof view.descriptionVersionsUi.isOpen !== "boolean") view.descriptionVersionsUi.isOpen = false;
+    if (typeof view.descriptionVersionsUi.isLoading !== "boolean") view.descriptionVersionsUi.isLoading = false;
+    if (typeof view.descriptionVersionsUi.selectedVersionId !== "string") view.descriptionVersionsUi.selectedVersionId = "";
+    if (typeof view.descriptionVersionsUi.modalOpen !== "boolean") view.descriptionVersionsUi.modalOpen = false;
+    if (!Number.isFinite(Number(view.descriptionVersionsUi.loadToken))) view.descriptionVersionsUi.loadToken = 0;
+    const stateRefId = getStateRefId(view.descriptionVersionsUi);
+    if (!existing || lastLoggedStateRefId !== stateRefId) {
+      lastLoggedStateRefId = stateRefId;
+      logDescriptionVersions("state init", {
+        store: "store.projectSubjectsView.descriptionVersionsUi",
+        hasExistingState: !!existing,
+        stateRefId
+      });
+    }
+    return view.descriptionVersionsUi;
   }
 
   function formatRelativeTimeFromNow(ts = "") {
@@ -91,11 +138,7 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function formatVersionTimestamp(ts = "") {
-    const absolute = typeof fmtTs === "function" ? fmtTs(ts) : String(ts || "—");
-    const relative = formatRelativeTimeFromNow(ts);
-    return relative && relative !== "à l'instant"
-      ? `${absolute} (${relative})`
-      : absolute;
+    return typeof fmtTs === "function" ? fmtTs(ts) : String(ts || "—");
   }
 
   function buildVersionInitials(version = {}) {
@@ -269,19 +312,17 @@ export function createProjectSubjectsDescription(config = {}) {
     const forceReload = !!options.forceReload;
     const sameTarget = ui.entityType === entityType && ui.entityId === entityId;
     const versionsInMemory = Array.isArray(ui.versions) ? ui.versions.length : 0;
+    const previousLoading = !!ui.isLoading;
     logDescriptionVersions("ensure start", {
       entityType,
       entityId,
       forceReload,
       sameTarget,
-      isLoading: !!ui.isLoading,
-      versionsInMemory
+      previousIsLoading: previousLoading,
+      versionsInMemory,
+      stateRefId: getStateRefId(ui)
     });
-    if (ui.isLoading) {
-      logDescriptionVersions("ensure early return: already loading", { entityType, entityId });
-      return;
-    }
-    if (!forceReload && sameTarget && !ui.error && Array.isArray(ui.versions) && ui.versions.length) {
+    if (!forceReload && sameTarget && !ui.error && Array.isArray(ui.versions) && ui.versions.length && !previousLoading) {
       logDescriptionVersions("ensure early return: cache hit", {
         entityType,
         entityId,
@@ -289,26 +330,53 @@ export function createProjectSubjectsDescription(config = {}) {
       });
       return;
     }
-    logDescriptionVersions("ensure branch: loading triggered", {
+    const loadToken = Number(ui.loadToken || 0) + 1;
+    ui.loadToken = loadToken;
+    logDescriptionVersions("ensure loading begin", {
       entityType,
       entityId,
-      forceReload,
-      sameTarget
+      loadToken,
+      previousIsLoading: previousLoading,
+      versionsCount: versionsInMemory
     });
     ui.isLoading = true;
     ui.error = "";
     ui.entityType = entityType;
     ui.entityId = entityId;
+    logDescriptionVersions("rerender loading snapshot", {
+      loadToken,
+      snapshot: {
+        entityType: ui.entityType,
+        entityId: ui.entityId,
+        isLoading: ui.isLoading,
+        versionsCount: Array.isArray(ui.versions) ? ui.versions.length : 0,
+        error: ui.error,
+        stateRefId: getStateRefId(ui)
+      }
+    });
     rerenderScope(root);
     try {
       const versions = entityType === "sujet" && typeof loadSubjectDescriptionVersions === "function"
         ? await loadSubjectDescriptionVersions(entityId)
         : [];
-      ui.versions = Array.isArray(versions) ? versions : [];
-      if (!ui.selectedVersionId && ui.versions.length) {
-        ui.selectedVersionId = String(ui.versions[0]?.id || "");
+      const currentUi = ensureDescriptionVersionsUiState();
+      const isStaleResponse = Number(currentUi.loadToken || 0) !== loadToken;
+      const normalizedVersions = Array.isArray(versions) ? versions : [];
+      logDescriptionVersions("fetch resolved", {
+        entityType,
+        entityId,
+        loadToken,
+        rowsCount: normalizedVersions.length,
+        selectedVersionId: String(currentUi.selectedVersionId || ""),
+        ignoredAsStale: isStaleResponse,
+        stateRefId: getStateRefId(currentUi)
+      });
+      if (isStaleResponse) return;
+      currentUi.versions = normalizedVersions;
+      if (!currentUi.selectedVersionId && currentUi.versions.length) {
+        currentUi.selectedVersionId = String(currentUi.versions[0]?.id || "");
       }
-      if (!ui.versions.length) {
+      if (!currentUi.versions.length) {
         logDescriptionVersions("ensure loaded with empty result set", {
           entityType,
           entityId
@@ -327,23 +395,31 @@ export function createProjectSubjectsDescription(config = {}) {
         }
       }
     } catch (error) {
-      ui.error = buildDescriptionVersionsLoadError(error);
+      const currentUi = ensureDescriptionVersionsUiState();
+      const isStaleResponse = Number(currentUi.loadToken || 0) !== loadToken;
+      if (!isStaleResponse) currentUi.error = buildDescriptionVersionsLoadError(error);
       console.error(`${VERSIONS_LOG_PREFIX} ensure failed`, {
         timestamp: new Date().toISOString(),
         entityType,
         entityId,
         forceReload,
         sameTarget,
+        loadToken,
+        ignoredAsStale: isStaleResponse,
         error
       });
     } finally {
-      ui.isLoading = false;
-      logDescriptionVersions("ensure done", {
+      const currentUi = ensureDescriptionVersionsUiState();
+      if (Number(currentUi.loadToken || 0) === loadToken) currentUi.isLoading = false;
+      logDescriptionVersions("finally", {
         entityType,
         entityId,
-        versionsCount: Array.isArray(ui.versions) ? ui.versions.length : 0,
-        hasError: !!ui.error,
-        selectedVersionId: String(ui.selectedVersionId || "")
+        loadToken,
+        isLoadingFinal: !!currentUi.isLoading,
+        versionsCountFinal: Array.isArray(currentUi.versions) ? currentUi.versions.length : 0,
+        hasError: !!currentUi.error,
+        selectedVersionId: String(currentUi.selectedVersionId || ""),
+        stateRefId: getStateRefId(currentUi)
       });
       rerenderScope(root);
     }
@@ -352,6 +428,7 @@ export function createProjectSubjectsDescription(config = {}) {
   function closeDescriptionVersionsDropdown() {
     const ui = ensureDescriptionVersionsUiState();
     ui.isOpen = false;
+    hideDescriptionVersionsDropdownHost();
   }
 
   function retryDescriptionVersionsLoad(root) {
@@ -381,6 +458,8 @@ export function createProjectSubjectsDescription(config = {}) {
     });
     if (ui.isOpen && entityType === "sujet") {
       void ensureDescriptionVersionsLoaded(root, entityType, entityId);
+    } else {
+      hideDescriptionVersionsDropdownHost();
     }
     rerenderScope(root);
   }
@@ -390,9 +469,14 @@ export function createProjectSubjectsDescription(config = {}) {
     ui.selectedVersionId = String(versionId || "");
     ui.modalOpen = false;
     ui.isOpen = false;
+    hideDescriptionVersionsDropdownHost();
     const version = Array.isArray(ui.versions)
       ? ui.versions.find((entry) => String(entry?.id || "") === ui.selectedVersionId)
       : null;
+    logDescriptionVersions("item click", {
+      versionId: ui.selectedVersionId,
+      foundVersion: !!version
+    });
     if (!version) {
       rerenderScope(root);
       return;
@@ -410,7 +494,9 @@ export function createProjectSubjectsDescription(config = {}) {
 
   function closeDescriptionVersionDetailsModalDom() {
     const modal = document.getElementById("detailsModal");
+    const body = document.getElementById("detailsBodyModal");
     if (!modal || modal.dataset.descriptionVersionModalOpen !== "true") return;
+    body?.classList.remove("details-body-modal--description-version");
     if (typeof setOverlayChromeOpenState === "function") {
       setOverlayChromeOpenState(modal, false);
     } else {
@@ -431,14 +517,21 @@ export function createProjectSubjectsDescription(config = {}) {
 
     const displayName = String(version?.actor_name || "Utilisateur");
     const dateLabel = formatVersionTimestamp(version?.created_at);
+    const dateRelativeLabel = formatRelativeTimeFromNow(version?.created_at);
     const initials = buildVersionInitials(version);
-    const avatarUrl = String(version?.actor_user_id || "") === String(store?.user?.id || "")
-      ? String(store?.user?.avatar || "")
-      : "";
+    const avatarUrl = resolveVersionAvatarUrl(version);
     const bodyMarkdown = String(version?.description_markdown || "");
+    const fullDateLabel = `${dateRelativeLabel} · ${dateLabel}`;
+    logDescriptionVersions("modal open", {
+      title: "Version de description",
+      author: displayName,
+      created_at: String(version?.created_at || ""),
+      markdownLength: bodyMarkdown.length
+    });
 
     title.textContent = "Version de description";
-    meta.textContent = dateLabel;
+    meta.textContent = fullDateLabel;
+    body.classList.add("details-body-modal--description-version");
     body.innerHTML = `
       <article class="description-version-details">
         <header class="description-version-details__header">
@@ -449,7 +542,7 @@ export function createProjectSubjectsDescription(config = {}) {
           </span>
           <div class="description-version-details__author">
             <div class="description-version-details__name">${escapeHtml(displayName)}</div>
-            <div class="description-version-details__date">${escapeHtml(dateLabel)}</div>
+            <div class="description-version-details__date" title="${escapeHtml(dateLabel)}">${escapeHtml(dateRelativeLabel)}</div>
           </div>
         </header>
         <div class="description-version-details__body gh-comment-body">
@@ -470,17 +563,46 @@ export function createProjectSubjectsDescription(config = {}) {
     return true;
   }
 
+  function resolveVersionAvatarUrl(version = {}) {
+    const directAvatar = firstNonEmpty(
+      version?.actor_avatar_url,
+      version?.actor_avatar,
+      version?.actor_user_avatar
+    );
+    if (directAvatar) return directAvatar;
+
+    if (String(version?.actor_user_id || "") === String(store?.user?.id || "")) {
+      return String(store?.user?.avatar || "");
+    }
+
+    const collaborators = Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators : [];
+    const actorUserId = String(version?.actor_user_id || "");
+    const actorPersonId = String(version?.actor_person_id || "");
+    const collaborator = collaborators.find((entry) => {
+      const linkedUserId = String(entry?.userId || entry?.linkedUserId || "");
+      const personId = String(entry?.personId || entry?.id || "");
+      return (actorUserId && linkedUserId === actorUserId) || (actorPersonId && personId === actorPersonId);
+    });
+    return String(firstNonEmpty(
+      collaborator?.avatar,
+      collaborator?.avatarUrl,
+      collaborator?.photo_url
+    ));
+  }
+
   function renderDescriptionVersionsTrigger(entityType, entityId) {
     const ui = ensureDescriptionVersionsUiState();
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
     const isOpen = isTarget && ui.isOpen;
     const count = isTarget && Array.isArray(ui.versions) ? ui.versions.length : 0;
+    const anchorKey = `${entityType}::${entityId}`;
     return `
       <div class="issues-head-menu description-versions-dropdown ${isOpen ? "is-open" : ""}">
         <button
-          class="gh-btn description-versions-dropdown__trigger"
+          class="issues-head-menu__btn description-versions-dropdown__trigger"
           type="button"
           data-action="toggle-description-versions"
+          data-description-versions-anchor="${escapeHtml(anchorKey)}"
           aria-expanded="${isOpen ? "true" : "false"}"
           aria-haspopup="menu"
           title="Versions"
@@ -488,16 +610,24 @@ export function createProjectSubjectsDescription(config = {}) {
           <span>Versions${count ? ` (${count})` : ""}</span>
           <span class="description-versions-dropdown__caret">${svgIcon("chevron-down")}</span>
         </button>
-        ${renderDescriptionVersionsDropdown(entityType, entityId)}
       </div>
     `;
   }
 
-  function renderDescriptionVersionsDropdown(entityType, entityId) {
+  function renderDescriptionVersionsDropdownContent(entityType, entityId) {
     const ui = ensureDescriptionVersionsUiState();
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
     const versions = isTarget && Array.isArray(ui.versions) ? ui.versions : [];
     const count = versions.length;
+    logDescriptionVersions("dropdown render", {
+      entityType,
+      entityId,
+      isTarget,
+      isOpen: !!(isTarget && ui.isOpen),
+      isLoading: !!ui.isLoading,
+      versionsLength: count,
+      stateRefId: getStateRefId(ui)
+    });
     const loadingHtml = ui.isLoading ? `<div class="description-versions-dropdown__status">Chargement des versions…</div>` : "";
     const errorHtml = !ui.isLoading && ui.error
       ? `
@@ -511,19 +641,18 @@ export function createProjectSubjectsDescription(config = {}) {
       ? versions.map((version) => {
           const versionId = String(version?.id || "");
           const displayName = String(version?.actor_name || "Utilisateur");
-          const timestampLabel = formatVersionTimestamp(version?.created_at);
+          const timestampLabel = formatRelativeTimeFromNow(version?.created_at);
+          const absoluteTimestampLabel = formatVersionTimestamp(version?.created_at);
           const initials = buildVersionInitials(version);
-          const avatarUrl = String(version?.actor_user_id || "") === String(store?.user?.id || "")
-            ? String(store?.user?.avatar || "")
-            : "";
+          const avatarUrl = resolveVersionAvatarUrl(version);
           return `
-            <button type="button" class="gh-menu__item description-versions-dropdown__item" data-action="open-description-version-modal" data-version-id="${escapeHtml(versionId)}">
+            <button type="button" class="gh-menu__item description-versions-dropdown__item" data-action="open-description-version-modal" data-version-id="${escapeHtml(versionId)}" title="${escapeHtml(absoluteTimestampLabel)}">
               <span class="description-versions-dropdown__avatar">
                 ${avatarUrl
                   ? `<img src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(displayName)}">`
                   : `<span class="description-versions-dropdown__avatar-fallback">${escapeHtml(initials)}</span>`}
               </span>
-              <span class="description-versions-dropdown__item-content">
+              <span class="description-versions-dropdown__item-inline">
                 <span class="description-versions-dropdown__item-name">${escapeHtml(displayName)}</span>
                 <span class="description-versions-dropdown__item-meta">${escapeHtml(timestampLabel)}</span>
               </span>
@@ -534,12 +663,84 @@ export function createProjectSubjectsDescription(config = {}) {
 
     return `
       <div class="gh-menu issues-head-menu__dropdown description-versions-dropdown__menu ${isTarget && ui.isOpen ? "gh-menu--open" : ""}" data-role="description-versions-dropdown" role="menu">
-        <div class="gh-menu__title">Versions (${count})</div>
+        <div class="gh-menu__title description-versions-dropdown__title">versions (${count})</div>
         ${loadingHtml}
         ${errorHtml}
         <div class="description-versions-dropdown__list">${listHtml}</div>
       </div>
     `;
+  }
+
+  function ensureDescriptionVersionsDropdownHost() {
+    let host = document.getElementById("descriptionVersionsDropdownHost");
+    if (!host) {
+      host = document.createElement("div");
+      host.id = "descriptionVersionsDropdownHost";
+      host.className = "description-versions-dropdown-host";
+      host.setAttribute("aria-hidden", "true");
+      document.body.appendChild(host);
+    }
+    return host;
+  }
+
+  function hideDescriptionVersionsDropdownHost() {
+    const host = ensureDescriptionVersionsDropdownHost();
+    host.innerHTML = "";
+    host.setAttribute("aria-hidden", "true");
+  }
+
+  function resolveDescriptionVersionsAnchor(root, entityType, entityId) {
+    const anchorKey = `${entityType}::${entityId}`;
+    const selector = `[data-description-versions-anchor="${CSS.escape(anchorKey)}"]`;
+    const inRoot = root?.querySelector?.(selector);
+    if (isHtmlElement(inRoot)) return inRoot;
+    const fallback = document.querySelector(selector);
+    return isHtmlElement(fallback) ? fallback : null;
+  }
+
+  function syncDescriptionVersionsDropdownPosition(root) {
+    const ui = ensureDescriptionVersionsUiState();
+    const host = ensureDescriptionVersionsDropdownHost();
+    if (host.getAttribute("aria-hidden") === "true") return;
+    const anchor = resolveDescriptionVersionsAnchor(root, ui.entityType, ui.entityId);
+    if (!anchor) {
+      hideDescriptionVersionsDropdownHost();
+      return;
+    }
+    const menu = host.querySelector("[data-role='description-versions-dropdown']");
+    if (!isHtmlElement(menu)) return;
+    const anchorRect = anchor.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const margin = 12;
+    let left = anchorRect.right - menuRect.width;
+    let top = anchorRect.bottom + 6;
+    if (left < margin) left = margin;
+    if (left + menuRect.width > viewportWidth - margin) {
+      left = Math.max(margin, viewportWidth - menuRect.width - margin);
+    }
+    if (top + menuRect.height > viewportHeight - margin) {
+      top = Math.max(margin, anchorRect.top - menuRect.height - 6);
+    }
+    host.style.position = "fixed";
+    host.style.left = `${Math.round(left)}px`;
+    host.style.top = `${Math.round(top)}px`;
+  }
+
+  function renderDescriptionVersionsDropdownHost(root) {
+    const ui = ensureDescriptionVersionsUiState();
+    const host = ensureDescriptionVersionsDropdownHost();
+    const entityType = String(ui.entityType || "");
+    const entityId = String(ui.entityId || "");
+    if (!ui.isOpen || !entityType || !entityId) {
+      hideDescriptionVersionsDropdownHost();
+      return host;
+    }
+    host.innerHTML = renderDescriptionVersionsDropdownContent(entityType, entityId);
+    host.setAttribute("aria-hidden", "false");
+    syncDescriptionVersionsDropdownPosition(root);
+    return host;
   }
 
   function renderDescriptionCard(selection) {
@@ -649,8 +850,8 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function clearDescriptionEditState() {
-    ensureViewUiState();
-    store.situationsView.descriptionEdit = {
+    const view = getSubjectsViewStore();
+    view.descriptionEdit = {
       entityType: null,
       entityId: null,
       draft: "",
@@ -749,7 +950,8 @@ export function createProjectSubjectsDescription(config = {}) {
     if (!target) return false;
     const entityType = getSelectionEntityType(target.type);
     const current = getEntityDescriptionState(entityType, target.id);
-    store.situationsView.descriptionEdit = {
+    const view = getSubjectsViewStore();
+    view.descriptionEdit = {
       entityType,
       entityId: target.id,
       draft: current.body || "",
@@ -779,6 +981,8 @@ export function createProjectSubjectsDescription(config = {}) {
     openDescriptionVersionModal,
     closeDescriptionVersionModal,
     retryDescriptionVersionsLoad,
+    renderDescriptionVersionsDropdownHost,
+    syncDescriptionVersionsDropdownPosition,
     applyDescriptionSave,
     startDescriptionEdit,
     renderDescriptionCard

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -52,6 +52,8 @@ export function createProjectSubjectsEvents(config) {
     openDescriptionVersionModal,
     closeDescriptionVersionModal,
     retryDescriptionVersionsLoad,
+    renderDescriptionVersionsDropdownHost,
+    syncDescriptionVersionsDropdownPosition,
     startDescriptionEdit,
     clearDescriptionEditState,
     applyDescriptionSave,
@@ -101,6 +103,7 @@ export function createProjectSubjectsEvents(config) {
   let detachDropdownDocumentEvents = null;
   let modalEventsBound = false;
   let subjectsTabResetBound = false;
+  let descriptionVersionsPositionBound = false;
 
   function isSubissuesDndDebugEnabled() {
     try {
@@ -708,11 +711,12 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
-    root.querySelectorAll("[data-role='description-versions-dropdown']").forEach((dropdown) => {
-      dropdown.addEventListener("click", (event) => event.stopPropagation());
-    });
+    const descriptionVersionsHost = renderDescriptionVersionsDropdownHost?.(root) || null;
+    if (descriptionVersionsHost instanceof HTMLElement) {
+      descriptionVersionsHost.onclick = (event) => event.stopPropagation();
+    }
 
-    root.querySelectorAll("[data-action='open-description-version-modal'][data-version-id]").forEach((btn) => {
+    (descriptionVersionsHost || root).querySelectorAll("[data-action='open-description-version-modal'][data-version-id]").forEach((btn) => {
       btn.onclick = () => {
         const versionId = String(btn.dataset.versionId || "").trim();
         if (!versionId) return;
@@ -720,11 +724,13 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
-    root.querySelectorAll("[data-action='reload-description-versions']").forEach((btn) => {
+    (descriptionVersionsHost || root).querySelectorAll("[data-action='reload-description-versions']").forEach((btn) => {
       btn.onclick = () => {
         retryDescriptionVersionsLoad?.(root);
       };
     });
+
+    syncDescriptionVersionsDropdownPosition?.(root);
 
     const detailsModal = document.getElementById("detailsModal");
     if (detailsModal && detailsModal.dataset.descriptionVersionBound !== "true") {
@@ -4190,7 +4196,7 @@ export function createProjectSubjectsEvents(config) {
 
     if (root.dataset.threadReplyDropdownDocumentBound !== "true") {
       document.addEventListener("click", () => {
-        const hadOpenDescriptionVersions = Boolean(root.querySelector("[data-role='description-versions-dropdown'].gh-menu--open"));
+        const hadOpenDescriptionVersions = Boolean(document.querySelector("#descriptionVersionsDropdownHost [data-role='description-versions-dropdown'].gh-menu--open"));
         root.querySelectorAll(".thread-comment-menu__dropdown.is-open").forEach((opened) => {
           opened.classList.remove("is-open");
         });
@@ -4198,6 +4204,11 @@ export function createProjectSubjectsEvents(config) {
         if (hadOpenDescriptionVersions) rerenderScope(root);
       });
       root.dataset.threadReplyDropdownDocumentBound = "true";
+    }
+    if (!descriptionVersionsPositionBound) {
+      descriptionVersionsPositionBound = true;
+      window.addEventListener("resize", () => syncDescriptionVersionsDropdownPosition?.(getSubjectMetaScopeRoot?.() || document));
+      document.addEventListener("scroll", () => syncDescriptionVersionsDropdownPosition?.(getSubjectMetaScopeRoot?.() || document), true);
     }
     const autocompleteLayer = getAutocompleteLayer();
     if (autocompleteLayer && autocompleteLayer.layer.dataset.subjectAutocompleteBound !== "true") {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -8608,12 +8608,29 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 .description-versions-dropdown{
   position:relative;
 }
+.description-versions-dropdown-host{
+  position:fixed;
+  left:0;
+  top:0;
+  z-index:calc(var(--z-assist) + 20);
+  pointer-events:none;
+}
+.description-versions-dropdown-host .description-versions-dropdown__menu{
+  position:static;
+  margin:0;
+  pointer-events:auto;
+}
 .description-versions-dropdown__trigger{
   display:inline-flex;
   align-items:center;
   gap:6px;
   min-height:30px;
   padding-inline:10px;
+  font-size:12px;
+  color:var(--muted);
+}
+.description-versions-dropdown__trigger:hover{
+  color:var(--text);
 }
 .description-versions-dropdown__caret{
   display:inline-flex;
@@ -8629,6 +8646,12 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   right:0;
   width:320px;
   max-height:340px;
+}
+.description-versions-dropdown__title{
+  font-size:12px;
+  color:var(--muted);
+  padding:8px 10px;
+  text-transform:none;
 }
 .description-versions-dropdown__list{
   display:flex;
@@ -8663,18 +8686,23 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   font-weight:700;
   color:var(--text);
 }
-.description-versions-dropdown__item-content{
+.description-versions-dropdown__item-inline{
   min-width:0;
   display:flex;
-  flex-direction:column;
+  align-items:baseline;
+  gap:8px;
 }
 .description-versions-dropdown__item-name{
   font-size:13px;
   font-weight:600;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 .description-versions-dropdown__item-meta{
   font-size:12px;
   color:var(--muted);
+  white-space:nowrap;
 }
 .description-versions-dropdown__status{
   padding:8px 10px;
@@ -8703,6 +8731,10 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 .description-version-details__body{
   border-top:1px solid var(--line);
   padding-top:12px;
+}
+#detailsBodyModal.details-body-modal--description-version{
+  max-width:860px;
+  margin-inline:auto;
 }
 .gh-comment-body--editable{
   display:flex;


### PR DESCRIPTION
### Motivation
- Improve the UX and reliability of the description-versions UI by rendering the dropdown into a dedicated host element, keeping it positioned relative to an anchor, and preventing race conditions when loading versions.
- Centralize description-related view state under `projectSubjectsView` and add safer DOM handling and logging to aid debugging.

### Description
- Move description edit/versions UI storage from `situationsView` to `projectSubjectsView` and add robust normalization helpers (`getSubjectsViewStore`, `ensureDescriptionEditState`, `ensureDescriptionVersionsUiState`).
- Introduce a dedicated floating host for the versions dropdown (`descriptionVersionsDropdownHost`) with CSS (`.description-versions-dropdown-host`) and functions to create, render, hide and position it (`ensureDescriptionVersionsDropdownHost`, `renderDescriptionVersionsDropdownHost`, `hideDescriptionVersionsDropdownHost`, `syncDescriptionVersionsDropdownPosition`, `resolveDescriptionVersionsAnchor`).
- Protect against stale async responses using a `loadToken` and skip updating UI when a stale response arrives, and ensure `isLoading` is not permanently blocked by rerenders during loading.
- Add avatar resolution logic for version rows (`resolveVersionAvatarUrl`) and improve timestamp/label formatting in the dropdown and modal (relative + absolute labels); add DOM class management for details modal body.
- Wire host usage into events so host clicks do not bubble, hook open/reload/version click handlers against the host, and add global listeners for `resize` and `scroll` to re-sync dropdown position.
- Add structured debug logging and lightweight state ref ids to help trace UI lifecycle and loading flows.
- Add CSS rules to style the new host, trigger, list and detail modal adjustments.
- Export new methods from the description factory: `renderDescriptionVersionsDropdownHost` and `syncDescriptionVersionsDropdownPosition` and update event wiring to use them.

### Testing
- Added a unit test `apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` that simulates toggling the versions dropdown, stubbing DOM/window, forcing a rerender during an in-flight load and ensuring `isLoading` becomes `false` after the response; this test passed when run with `node --test`.
- Ran the repository test suite with `pnpm test` to validate integration with event bindings and CSS changes; the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6532172c083299832884435e54cb7)