### PR TITLE
Corrige la synchronisation du dropdown « Versions » au changement de sujet

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -3,6 +3,42 @@ import assert from "node:assert/strict";
 
 import { createProjectSubjectsDescription } from "./project-subjects-description.js";
 
+function installFakeDom(anchorByKey = {}) {
+  const fakeNodesById = new Map();
+  globalThis.window = { innerWidth: 1200, innerHeight: 900 };
+  globalThis.CSS = { escape: (value) => String(value || "") };
+  globalThis.document = {
+    body: {
+      appendChild: (node) => {
+        if (node?.id) fakeNodesById.set(node.id, node);
+        return node;
+      }
+    },
+    documentElement: { clientWidth: 1200, clientHeight: 900 },
+    createElement: () => ({
+      id: "",
+      className: "",
+      style: {},
+      innerHTML: "",
+      attributes: {},
+      setAttribute(name, value) { this.attributes[name] = value; },
+      getAttribute(name) { return this.attributes[name]; },
+      querySelector: () => null
+    }),
+    getElementById: (id) => fakeNodesById.get(id) || null,
+    querySelector: (selector) => {
+      const match = String(selector || "").match(/data-description-versions-anchor=\"([^\"]+)\"/);
+      return match ? anchorByKey[match[1]] || null : null;
+    }
+  };
+}
+
+function cleanupFakeDom() {
+  delete globalThis.document;
+  delete globalThis.window;
+  delete globalThis.CSS;
+}
+
 test("description versions: un rerender pendant le chargement ne bloque pas isLoading", async () => {
   const fakeNodesById = new Map();
   const fakeAnchor = {
@@ -128,37 +164,11 @@ test("description versions: un rerender pendant le chargement ne bloque pas isLo
 });
 
 test("description versions: en dropdown ouvert, un changement de ticket recharge la bonne cible", async () => {
-  const fakeNodesById = new Map();
   const fakeAnchors = {
     "sujet::subject-1": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) },
     "sujet::subject-2": { getBoundingClientRect: () => ({ top: 120, right: 340, bottom: 160, left: 280, width: 60, height: 40 }) }
   };
-  globalThis.window = { innerWidth: 1200, innerHeight: 900 };
-  globalThis.CSS = { escape: (value) => String(value || "") };
-  globalThis.document = {
-    body: {
-      appendChild: (node) => {
-        if (node?.id) fakeNodesById.set(node.id, node);
-        return node;
-      }
-    },
-    documentElement: { clientWidth: 1200, clientHeight: 900 },
-    createElement: () => ({
-      id: "",
-      className: "",
-      style: {},
-      innerHTML: "",
-      attributes: {},
-      setAttribute(name, value) { this.attributes[name] = value; },
-      getAttribute(name) { return this.attributes[name]; },
-      querySelector: () => null
-    }),
-    getElementById: (id) => fakeNodesById.get(id) || null,
-    querySelector: (selector) => {
-      const match = String(selector || "").match(/data-description-versions-anchor=\"([^\"]+)\"/);
-      return match ? fakeAnchors[match[1]] || null : null;
-    }
-  };
+  installFakeDom(fakeAnchors);
 
   const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
   const runBucketState = { descriptions: { sujet: {}, situation: {} } };
@@ -212,9 +222,122 @@ test("description versions: en dropdown ouvert, un changement de ticket recharge
 
   assert.deepEqual(loads, ["subject-1", "subject-2"]);
   assert.equal(store.projectSubjectsView.descriptionVersionsUi.entityId, "subject-2");
-  assert.match(globalThis.document.getElementById("descriptionVersionsDropdownHost")?.innerHTML || "", /subject-2-markdown|Mdall/);
+  const hostHtml = globalThis.document.getElementById("descriptionVersionsDropdownHost")?.innerHTML || "";
+  assert.match(hostHtml, /subject-2-markdown|Mdall/);
+  assert.doesNotMatch(hostHtml, /subject-1-markdown/);
+  assert.equal(store.projectSubjectsView.descriptionVersionsUi.selectedVersionId, "v-subject-2");
 
-  delete globalThis.document;
-  delete globalThis.window;
-  delete globalThis.CSS;
+  cleanupFakeDom();
+});
+
+test("description versions: dropdown fermé puis changement de sujet charge directement la nouvelle cible à l'ouverture", async () => {
+  const fakeAnchors = {
+    "sujet::subject-a": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) },
+    "sujet::subject-b": { getBoundingClientRect: () => ({ top: 100, right: 340, bottom: 140, left: 280, width: 60, height: 40 }) }
+  };
+  installFakeDom(fakeAnchors);
+
+  const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
+  let selectedSubjectId = "subject-a";
+  const loads = [];
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: { descriptions: { sujet: {}, situation: {} } } }),
+    persistRunBucket: () => {},
+    getSelectionEntityType: (type) => type,
+    getEntityByType: (type, id) => ({ id, title: `${type}-${id}`, raw: { description: "Description" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: selectedSubjectId, item: { id: selectedSubjectId } }),
+    rerenderScope: () => {},
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async (subjectId) => {
+      loads.push(subjectId);
+      return [{ id: `v-${subjectId}`, actor_name: subjectId, description_markdown: subjectId, created_at: new Date().toISOString() }];
+    }
+  });
+
+  api.toggleDescriptionVersionsDropdown({});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  api.toggleDescriptionVersionsDropdown({});
+
+  selectedSubjectId = "subject-b";
+  api.toggleDescriptionVersionsDropdown({});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  api.renderDescriptionVersionsDropdownHost({ querySelector: () => fakeAnchors[`sujet::${selectedSubjectId}`] });
+
+  assert.deepEqual(loads, ["subject-a", "subject-b"]);
+  assert.equal(store.projectSubjectsView.descriptionVersionsUi.entityId, "subject-b");
+  assert.match(globalThis.document.getElementById("descriptionVersionsDropdownHost")?.innerHTML || "", /subject-b/);
+  assert.doesNotMatch(globalThis.document.getElementById("descriptionVersionsDropdownHost")?.innerHTML || "", /subject-a/);
+
+  cleanupFakeDom();
+});
+
+test("description versions: une réponse tardive de A est ignorée après passage à B", async () => {
+  const fakeAnchors = {
+    "sujet::A": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) },
+    "sujet::B": { getBoundingClientRect: () => ({ top: 120, right: 340, bottom: 160, left: 280, width: 60, height: 40 }) }
+  };
+  installFakeDom(fakeAnchors);
+
+  const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
+  let selectedSubjectId = "A";
+  const deferred = new Map();
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: { descriptions: { sujet: {}, situation: {} } } }),
+    persistRunBucket: () => {},
+    getSelectionEntityType: (type) => type,
+    getEntityByType: (type, id) => ({ id, title: `${type}-${id}`, raw: { description: "Description" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: selectedSubjectId, item: { id: selectedSubjectId } }),
+    rerenderScope: () => {},
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async (subjectId) => {
+      return await new Promise((resolve) => {
+        deferred.set(subjectId, resolve);
+      });
+    }
+  });
+
+  api.toggleDescriptionVersionsDropdown({});
+  selectedSubjectId = "B";
+  api.renderDescriptionVersionsDropdownHost({ querySelector: () => fakeAnchors["sujet::B"] });
+  deferred.get("B")?.([{ id: "v-B", actor_name: "B", description_markdown: "B", created_at: new Date().toISOString() }]);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  deferred.get("A")?.([{ id: "v-A", actor_name: "A", description_markdown: "A", created_at: new Date().toISOString() }]);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  api.renderDescriptionVersionsDropdownHost({ querySelector: () => fakeAnchors["sujet::B"] });
+
+  const hostHtml = globalThis.document.getElementById("descriptionVersionsDropdownHost")?.innerHTML || "";
+  assert.match(hostHtml, /v-B|>B</);
+  assert.doesNotMatch(hostHtml, /v-A|>A</);
+  assert.equal(store.projectSubjectsView.descriptionVersionsUi.entityId, "B");
+  assert.equal(store.projectSubjectsView.descriptionVersionsUi.selectedVersionId, "v-B");
+
+  cleanupFakeDom();
 });

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -307,6 +307,49 @@ export function createProjectSubjectsDescription(config = {}) {
     return `Échec du chargement des versions${statusChunk}. ${normalizedDetail}`;
   }
 
+  function resetDescriptionVersionsUiForTargetChange(ui, options = {}) {
+    ui.selectedVersionId = "";
+    ui.versions = [];
+    ui.error = "";
+    if (options.resetLoading !== false) ui.isLoading = false;
+  }
+
+  function syncDescriptionVersionsTarget(root) {
+    const ui = ensureDescriptionVersionsUiState();
+    const target = currentDecisionTarget(root);
+    const nextEntityTypeRaw = target?.type ? getSelectionEntityType(target.type) : "";
+    const nextEntityType = nextEntityTypeRaw === "sujet" ? "sujet" : "";
+    const nextEntityId = nextEntityType ? String(target?.id || "") : "";
+    const previousEntityType = String(ui.entityType || "");
+    const previousEntityId = String(ui.entityId || "");
+    const wasOpen = !!ui.isOpen;
+    const changed = previousEntityType !== nextEntityType || previousEntityId !== nextEntityId;
+
+    if (changed) {
+      resetDescriptionVersionsUiForTargetChange(ui);
+      ui.entityType = nextEntityType;
+      ui.entityId = nextEntityId;
+      logDescriptionVersions("target changed", {
+        previousEntityType,
+        previousEntityId,
+        nextEntityType,
+        nextEntityId,
+        wasOpen
+      });
+    }
+    if (!nextEntityType && ui.isOpen) ui.isOpen = false;
+
+    return {
+      changed,
+      wasOpen,
+      isOpen: !!ui.isOpen,
+      entityType: String(ui.entityType || ""),
+      entityId: String(ui.entityId || ""),
+      previousEntityType,
+      previousEntityId
+    };
+  }
+
   async function ensureDescriptionVersionsLoaded(root, entityType, entityId, options = {}) {
     const ui = ensureDescriptionVersionsUiState();
     const forceReload = !!options.forceReload;
@@ -371,7 +414,15 @@ export function createProjectSubjectsDescription(config = {}) {
         ignoredAsStale: isStaleResponse,
         stateRefId: getStateRefId(currentUi)
       });
-      if (isStaleResponse) return;
+      if (isStaleResponse) {
+        logDescriptionVersions("stale response ignored", {
+          entityType,
+          entityId,
+          loadToken,
+          versionsCount: normalizedVersions.length
+        });
+        return;
+      }
       currentUi.versions = normalizedVersions;
       if (!currentUi.selectedVersionId && currentUi.versions.length) {
         currentUi.selectedVersionId = String(currentUi.versions[0]?.id || "");
@@ -397,7 +448,16 @@ export function createProjectSubjectsDescription(config = {}) {
     } catch (error) {
       const currentUi = ensureDescriptionVersionsUiState();
       const isStaleResponse = Number(currentUi.loadToken || 0) !== loadToken;
-      if (!isStaleResponse) currentUi.error = buildDescriptionVersionsLoadError(error);
+      if (isStaleResponse) {
+        logDescriptionVersions("stale response ignored", {
+          entityType,
+          entityId,
+          loadToken,
+          stage: "catch"
+        });
+      } else {
+        currentUi.error = buildDescriptionVersionsLoadError(error);
+      }
       console.error(`${VERSIONS_LOG_PREFIX} ensure failed`, {
         timestamp: new Date().toISOString(),
         entityType,
@@ -432,32 +492,31 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function retryDescriptionVersionsLoad(root) {
+    syncDescriptionVersionsTarget(root);
     const ui = ensureDescriptionVersionsUiState();
     if (!ui.entityType || !ui.entityId) return;
     void ensureDescriptionVersionsLoaded(root, ui.entityType, ui.entityId, { forceReload: true });
   }
 
   function toggleDescriptionVersionsDropdown(root) {
-    const target = currentDecisionTarget(root);
-    if (!target) return;
-    const entityType = getSelectionEntityType(target.type);
-    const entityId = target.id;
+    const sync = syncDescriptionVersionsTarget(root);
+    if (!sync.entityType || !sync.entityId) return;
+    const entityType = sync.entityType;
+    const entityId = sync.entityId;
     const ui = ensureDescriptionVersionsUiState();
-    const isSameEntity = ui.entityType === entityType && ui.entityId === entityId;
     const prevOpen = !!ui.isOpen;
-    ui.entityType = entityType;
-    ui.entityId = entityId;
-    ui.isOpen = !(isSameEntity && ui.isOpen);
+    ui.isOpen = !ui.isOpen;
     const willLoad = ui.isOpen && entityType === "sujet";
     logDescriptionVersions("toggle dropdown", {
       entityType,
       entityId,
+      targetChanged: sync.changed,
       previousIsOpen: prevOpen,
       nextIsOpen: !!ui.isOpen,
       triggeredLoad: willLoad
     });
     if (ui.isOpen && entityType === "sujet") {
-      void ensureDescriptionVersionsLoaded(root, entityType, entityId);
+      void ensureDescriptionVersionsLoaded(root, entityType, entityId, { forceReload: sync.changed && sync.wasOpen });
     } else {
       hideDescriptionVersionsDropdownHost();
     }
@@ -593,7 +652,8 @@ export function createProjectSubjectsDescription(config = {}) {
     ));
   }
 
-  function renderDescriptionVersionsTrigger(entityType, entityId) {
+  function renderDescriptionVersionsTrigger(root, entityType, entityId) {
+    syncDescriptionVersionsTarget(root);
     const ui = ensureDescriptionVersionsUiState();
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
     const isOpen = isTarget && ui.isOpen;
@@ -732,30 +792,10 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function renderDescriptionVersionsDropdownHost(root) {
+    const sync = syncDescriptionVersionsTarget(root);
     const ui = ensureDescriptionVersionsUiState();
-    const activeTarget = currentDecisionTarget(root);
-    if (ui.isOpen && activeTarget?.id) {
-      const activeEntityType = getSelectionEntityType(activeTarget.type);
-      const activeEntityId = String(activeTarget.id || "");
-      if (activeEntityType !== "sujet") {
-        ui.isOpen = false;
-        hideDescriptionVersionsDropdownHost();
-      }
-      if (activeEntityType !== ui.entityType || activeEntityId !== String(ui.entityId || "")) {
-        ui.entityType = activeEntityType;
-        ui.entityId = activeEntityId;
-        ui.selectedVersionId = "";
-        ui.versions = [];
-        ui.error = "";
-        logDescriptionVersions("host target switched", {
-          entityType: activeEntityType,
-          entityId: activeEntityId,
-          stateRefId: getStateRefId(ui)
-        });
-        if (activeEntityType === "sujet") {
-          void ensureDescriptionVersionsLoaded(root, activeEntityType, activeEntityId, { forceReload: true });
-        }
-      }
+    if (ui.isOpen && sync.changed && sync.entityType === "sujet" && sync.entityId) {
+      void ensureDescriptionVersionsLoaded(root, sync.entityType, sync.entityId, { forceReload: true });
     }
     const host = ensureDescriptionVersionsDropdownHost();
     const entityType = String(ui.entityType || "");
@@ -766,6 +806,9 @@ export function createProjectSubjectsDescription(config = {}) {
     }
     host.innerHTML = renderDescriptionVersionsDropdownContent(entityType, entityId);
     host.setAttribute("aria-hidden", "false");
+    if (!ui.isLoading && !ui.error && (!Array.isArray(ui.versions) || ui.versions.length === 0) && entityType === "sujet") {
+      void ensureDescriptionVersionsLoaded(root, entityType, entityId);
+    }
     syncDescriptionVersionsDropdownPosition(root);
     return host;
   }
@@ -784,7 +827,7 @@ export function createProjectSubjectsDescription(config = {}) {
       fallbackName: "System"
     });
     const authorHtml = `<div class="gh-comment-author mono">${escapeHtml(identity.displayName)}</div>`;
-    const versionsTriggerHtml = entityType === "sujet" ? renderDescriptionVersionsTrigger(entityType, entityId) : "";
+    const versionsTriggerHtml = entityType === "sujet" ? renderDescriptionVersionsTrigger(null, entityType, entityId) : "";
     const editButtonHtml = `
       <button class="icon-btn icon-btn--sm gh-comment-edit-btn" data-action="edit-description" type="button" aria-label="Modifier la description" title="Modifier la description">
         ${svgIcon("pencil")}


### PR DESCRIPTION
### Motivation
- Le store singleton `store.projectSubjectsView.descriptionVersionsUi` était mal synchronisé avec la sélection courante, ce qui laissait des états périmés (`versions`, `selectedVersionId`, `error`, `entityId`) affichés après un changement de sujet.
- Il faut centraliser la détection du changement de cible et réinitialiser proprement l’état lié à l’ancienne cible avant tout rendu ou action d’ouverture/fermeture du dropdown.

### Description
- Ajout d’un helper `syncDescriptionVersionsTarget(root)` qui lit la sélection via `currentDecisionTarget(root)`, détecte un changement de cible, réinitialise l’état lié à l’ancienne cible via `resetDescriptionVersionsUiForTargetChange(...)` et loggue un message `target changed` avec ancien/nouveau couple cible et état d’ouverture; il renvoie un objet synthétique utile (`changed`, `entityType`, `entityId`, etc.).
- Adaptation de `toggleDescriptionVersionsDropdown(root)` pour appeler `syncDescriptionVersionsTarget(root)` avant toute décision d’ouverture/fermeture et forcer le reload approprié si la cible a changé alors que le dropdown était ouvert.
- Simplification de `renderDescriptionVersionsDropdownHost(root)` pour s’appuyer sur la cible déjà synchronisée et ne déclencher le rechargement que si nécessaire; suppression de la logique locale de basculement de cible dans le host.
- Renforcement de `ensureDescriptionVersionsLoaded(...)` en conservant le mécanisme `loadToken` et en ajoutant des logs explicites `stale response ignored` (try/catch + fetch) pour éviter qu’une réponse tardive repeuple l’UI d’une ancienne cible.
- Ajout d’instrumentation console homogène (au moins `state init`, `target changed`, `toggle dropdown`, `ensure loading begin`, `fetch resolved`, `stale response ignored`, `finally`) incluant timestamp, `entityType`, `entityId`, `loadToken` et comptages pertinents.
- Mise à jour du déclenchement du rendu du trigger `renderDescriptionVersionsTrigger` pour synchroniser la cible en amont.
- Tests unitaires étendus/modifiés dans `apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` pour couvrir ouverture + switch A→B, fermé + switch + ouverture, réponse asynchrone tardive ignorée et reset de `selectedVersionId`.

### Testing
- Exécution des tests unitaires modifiés via `node --test apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` et succès de l’ensemble des cas (4 tests passés).
- Les logs console ajoutés ont été visibles pendant l’exécution des tests et montrent les étapes `target changed`, `toggle dropdown`, `ensure loading begin`, `fetch resolved`, `stale response ignored` et `finally` comme attendu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682b1e37c83299b0f31807f11dbb7)