### PR TITLE
Fix Mdall avatar rendering, sync description author to latest version, and make document refs resilient

### DIFF
--- a/apps/web/js/services/project-document-selectors.js
+++ b/apps/web/js/services/project-document-selectors.js
@@ -21,6 +21,19 @@ function normalizeEntityDocumentRefs(entity = {}) {
   return [...new Set([...directRefs, ...rawRefs, ...singleDocumentIds].map((value) => String(value || "")).filter(Boolean))];
 }
 
+function buildDocumentRefFallback(documentId = "") {
+  const id = String(documentId || "").trim();
+  if (!id) return null;
+  return {
+    id,
+    name: id,
+    title: id,
+    phaseCode: "",
+    phaseLabel: "",
+    __unresolved: true
+  };
+}
+
 function isEntityCounted(entity = {}) {
   const reviewState = normalizeReviewState(entity.review_state || entity?.raw?.review_state || "pending");
   return reviewState !== "rejected" && reviewState !== "dismissed";
@@ -110,7 +123,32 @@ function getBlockedByCount(subjectId) {
 export function getSelectionDocumentRefs(selection) {
   const item = selection?.item || null;
   if (!item) return [];
-  return resolveDocumentRefs(normalizeEntityDocumentRefs(item)).map(decorateDocumentWithPhase).filter(Boolean);
+  const subjectId = String(item?.id || item?.subject_id || "");
+  const normalizedRefIds = normalizeEntityDocumentRefs(item);
+  console.info("[subject-document-refs] resolve start", {
+    subjectId,
+    document_id: String(item?.document_id || ""),
+    document_ref_ids: Array.isArray(item?.document_ref_ids) ? item.document_ref_ids : [],
+    raw_document_id: String(item?.raw?.document_id || ""),
+    raw_document_ref_ids: Array.isArray(item?.raw?.document_ref_ids) ? item.raw.document_ref_ids : []
+  });
+
+  const resolvedDocs = resolveDocumentRefs(normalizedRefIds);
+  const resolvedById = new Map(resolvedDocs.map((doc) => [String(doc?.id || ""), doc]));
+  const renderable = normalizedRefIds
+    .map((documentId) => resolvedById.get(String(documentId || "")) || buildDocumentRefFallback(documentId))
+    .filter(Boolean)
+    .map(decorateDocumentWithPhase)
+    .filter(Boolean);
+  const unresolvedRefIds = normalizedRefIds.filter((documentId) => !resolvedById.has(String(documentId || "")));
+  console.info("[subject-document-refs] resolve result", {
+    subjectId,
+    normalizedRefIds,
+    resolvedDocsCount: resolvedDocs.length,
+    unresolvedRefIds,
+    renderableCount: renderable.length
+  });
+  return renderable;
 }
 
 export function getDocumentStatsMap({

--- a/apps/web/js/services/project-document-selectors.test.mjs
+++ b/apps/web/js/services/project-document-selectors.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getSelectionDocumentRefs } from "./project-document-selectors.js";
+import { store } from "../store.js";
+
+test("document refs: conserve les refs multiples et garde un fallback quand docs non hydratés", () => {
+  store.projectDocuments = {
+    items: [
+      { id: "doc-1", name: "Document 1", phaseCode: "APS", phaseLabel: "Avant Projet Sommaire" }
+    ],
+    activeDocumentId: null,
+    lastAnalysisDocumentIds: []
+  };
+
+  const refs = getSelectionDocumentRefs({
+    item: {
+      id: "subject-1",
+      document_id: "doc-1",
+      document_ref_ids: ["doc-2", "doc-1"],
+      raw: {
+        document_ref_ids: ["doc-3"],
+        document_id: "doc-1"
+      }
+    }
+  });
+
+  assert.equal(refs.length, 3);
+  assert.deepEqual(refs.map((ref) => ref.id), ["doc-2", "doc-1", "doc-3"]);
+  assert.equal(refs.find((ref) => ref.id === "doc-1")?.name, "Document 1");
+  assert.equal(refs.find((ref) => ref.id === "doc-2")?.name, "doc-2");
+  assert.equal(refs.find((ref) => ref.id === "doc-3")?.name, "doc-3");
+});

--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -144,7 +144,7 @@ async function fetchProjectFlatSubjects(projectId) {
   const url = new URL(`${SUPABASE_URL}/rest/v1/subjects`);
   url.searchParams.set(
     "select",
-    "id,subject_number,project_id,document_id,analysis_run_id,situation_id,parent_subject_id,parent_linked_at,parent_child_order,assignee_person_id,title,description,priority,status,closure_reason,subject_type,created_at,updated_at,closed_at"
+    "id,subject_number,project_id,document_id,document_ref_ids,analysis_run_id,situation_id,parent_subject_id,parent_linked_at,parent_child_order,assignee_person_id,title,description,priority,status,closure_reason,subject_type,created_at,updated_at,closed_at"
   );
   url.searchParams.set("project_id", `eq.${projectId}`);
   url.searchParams.set("order", "created_at.asc");

--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -341,3 +341,114 @@ test("description versions: une réponse tardive de A est ignorée après passag
 
   cleanupFakeDom();
 });
+
+test("description versions: la version système affiche Heimdall sans fallback bitmap", async () => {
+  installFakeDom({
+    "sujet::subject-1": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) }
+  });
+  const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: (name) => `<svg data-icon="${name}"></svg>`,
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: { descriptions: { sujet: {}, situation: {} } } }),
+    persistRunBucket: () => {},
+    getSelectionEntityType: (type) => type,
+    getEntityByType: (type, id) => ({ id, title: `${type}-${id}`, raw: { description: "Description" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-1", item: { id: "subject-1" } }),
+    rerenderScope: () => {},
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async () => [{
+      id: "v1",
+      actor_name: "Mdall",
+      actor_is_system: true,
+      actor_user_id: "",
+      actor_person_id: "",
+      description_markdown: "system",
+      created_at: new Date().toISOString()
+    }]
+  });
+
+  api.toggleDescriptionVersionsDropdown({});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  api.renderDescriptionVersionsDropdownHost({ querySelector: () => ({ getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) }) });
+  const hostHtml = globalThis.document.getElementById("descriptionVersionsDropdownHost")?.innerHTML || "";
+  assert.match(hostHtml, /icons\.svg#heimdall/);
+  assert.doesNotMatch(hostHtml, /avatar-entreprise\.jfif/);
+
+  cleanupFakeDom();
+});
+
+test("description versions: l'auteur de la carte est réaligné sur la dernière version chargée", async () => {
+  installFakeDom({
+    "sujet::subject-1": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) }
+  });
+  const runBucketState = {
+    descriptions: {
+      sujet: {
+        "subject-1": {
+          body: "Description initiale",
+          author: "Ancien auteur",
+          agent: "human",
+          avatar_type: "human",
+          avatar_initial: "A"
+        }
+      },
+      situation: {}
+    }
+  };
+  const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: (name) => `<svg data-icon="${name}"></svg>`,
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: runBucketState }),
+    persistRunBucket: (updater) => updater(runBucketState),
+    getSelectionEntityType: (type) => type,
+    getEntityByType: (type, id) => ({ id, title: `${type}-${id}`, raw: { description: "Description" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-1", item: { id: "subject-1" } }),
+    rerenderScope: () => {},
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async () => [{
+      id: "v-last",
+      actor_name: "Nouveau Auteur",
+      actor_user_id: "u2",
+      actor_person_id: "p2",
+      description_markdown: "new",
+      created_at: new Date().toISOString()
+    }]
+  });
+
+  api.toggleDescriptionVersionsDropdown({});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const html = api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-1", title: "Sujet", raw: { description: "Description initiale" } }
+  });
+  assert.match(html, /Nouveau Auteur/);
+  assert.doesNotMatch(html, /Ancien auteur/);
+
+  cleanupFakeDom();
+});

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -141,6 +141,79 @@ export function createProjectSubjectsDescription(config = {}) {
     return typeof fmtTs === "function" ? fmtTs(ts) : String(ts || "—");
   }
 
+  function isSystemDescriptionVersionActor(version = {}) {
+    return version?.actor_is_system === true || (!version?.actor_user_id && !version?.actor_person_id);
+  }
+
+  function buildDescriptionIdentityPatchFromVersion(version = {}) {
+    const isSystemActor = isSystemDescriptionVersionActor(version);
+    const displayName = String(version?.actor_name || "").trim();
+    const avatarUrl = resolveVersionAvatarUrl(version);
+    const identity = getAuthorIdentity({
+      author: isSystemActor ? "system" : (displayName || "Utilisateur"),
+      agent: isSystemActor ? "system" : "human",
+      avatarUrl,
+      currentUserAvatar: store?.user?.avatar,
+      humanAvatarHtml: SVG_AVATAR_HUMAN,
+      fallbackName: isSystemActor ? "Mdall" : "Utilisateur"
+    });
+    return {
+      author: identity.displayName,
+      agent: isSystemActor ? "system" : "human",
+      avatar_type: identity.avatarType,
+      avatar_initial: identity.avatarInitial || "S",
+      avatarSource: isSystemActor ? "heimdall" : (avatarUrl ? "avatar-url" : "fallback-initial")
+    };
+  }
+
+  function syncDescriptionCurrentAuthorFromVersions(entityType, entityId, versions = []) {
+    if (entityType !== "sujet" || !entityId || !Array.isArray(versions) || !versions.length) return;
+    const latestVersion = versions[0] || {};
+    const previousState = getEntityDescriptionState(entityType, entityId);
+    const patch = buildDescriptionIdentityPatchFromVersion(latestVersion);
+    console.info("[subject-description-current-author] versions loaded", {
+      subjectId: entityId,
+      versionsCount: versions.length,
+      latestVersionId: String(latestVersion?.id || ""),
+      latestActorName: String(latestVersion?.actor_name || ""),
+      latestActorUserId: String(latestVersion?.actor_user_id || ""),
+      latestActorPersonId: String(latestVersion?.actor_person_id || ""),
+      latestActorIsSystem: isSystemDescriptionVersionActor(latestVersion)
+    });
+    console.info("[subject-description-current-author] display sync", {
+      subjectId: entityId,
+      previousAuthor: String(previousState?.author || ""),
+      nextAuthor: String(patch.author || ""),
+      previousAgent: String(previousState?.agent || ""),
+      nextAgent: String(patch.agent || ""),
+      avatarSource: patch.avatarSource
+    });
+    if (
+      String(previousState?.author || "") === String(patch.author || "")
+      && String(previousState?.agent || "") === String(patch.agent || "")
+      && String(previousState?.avatar_type || "") === String(patch.avatar_type || "")
+      && String(previousState?.avatar_initial || "") === String(patch.avatar_initial || "")
+    ) return;
+    setEntityDescriptionState(entityType, entityId, {
+      author: patch.author,
+      agent: patch.agent,
+      avatar_type: patch.avatar_type,
+      avatar_initial: patch.avatar_initial
+    });
+  }
+
+  function getVersionAuthorIdentity(version = {}) {
+    const patch = buildDescriptionIdentityPatchFromVersion(version);
+    return getAuthorIdentity({
+      author: patch.author,
+      agent: patch.agent,
+      avatarUrl: resolveVersionAvatarUrl(version),
+      currentUserAvatar: store?.user?.avatar,
+      humanAvatarHtml: SVG_AVATAR_HUMAN,
+      fallbackName: "Utilisateur"
+    });
+  }
+
   function buildVersionInitials(version = {}) {
     const first = String(version?.actor_first_name || "").trim();
     const last = String(version?.actor_last_name || "").trim();
@@ -427,6 +500,7 @@ export function createProjectSubjectsDescription(config = {}) {
       if (!currentUi.selectedVersionId && currentUi.versions.length) {
         currentUi.selectedVersionId = String(currentUi.versions[0]?.id || "");
       }
+      syncDescriptionCurrentAuthorFromVersions(entityType, entityId, currentUi.versions);
       if (!currentUi.versions.length) {
         logDescriptionVersions("ensure loaded with empty result set", {
           entityType,
@@ -574,11 +648,11 @@ export function createProjectSubjectsDescription(config = {}) {
     const body = document.getElementById("detailsBodyModal");
     if (!modal || !title || !meta || !body) return false;
 
-    const displayName = String(version?.actor_name || "Utilisateur");
+    const identity = getVersionAuthorIdentity(version);
+    const displayName = String(identity.displayName || "Utilisateur");
     const dateLabel = formatVersionTimestamp(version?.created_at);
     const dateRelativeLabel = formatRelativeTimeFromNow(version?.created_at);
     const initials = buildVersionInitials(version);
-    const avatarUrl = resolveVersionAvatarUrl(version);
     const bodyMarkdown = String(version?.description_markdown || "");
     const fullDateLabel = `${dateRelativeLabel} · ${dateLabel}`;
     logDescriptionVersions("modal open", {
@@ -595,9 +669,7 @@ export function createProjectSubjectsDescription(config = {}) {
       <article class="description-version-details">
         <header class="description-version-details__header">
           <span class="description-version-details__avatar">
-            ${avatarUrl
-              ? `<img src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(displayName)}">`
-              : `<span class="description-version-details__avatar-fallback">${escapeHtml(initials)}</span>`}
+            ${identity.avatarHtml || `<span class="description-version-details__avatar-fallback">${escapeHtml(initials)}</span>`}
           </span>
           <div class="description-version-details__author">
             <div class="description-version-details__name">${escapeHtml(displayName)}</div>
@@ -623,9 +695,7 @@ export function createProjectSubjectsDescription(config = {}) {
   }
 
   function resolveVersionAvatarUrl(version = {}) {
-    if (version?.actor_is_system === true || (!version?.actor_user_id && !version?.actor_person_id)) {
-      return "/assets/images/avatar-entreprise.jfif";
-    }
+    if (isSystemDescriptionVersionActor(version)) return "";
     const directAvatar = firstNonEmpty(
       version?.actor_avatar_url,
       version?.actor_avatar,
@@ -703,17 +773,15 @@ export function createProjectSubjectsDescription(config = {}) {
     const listHtml = !ui.isLoading && !ui.error && versions.length
       ? versions.map((version) => {
           const versionId = String(version?.id || "");
-          const displayName = String(version?.actor_name || "Utilisateur");
+          const identity = getVersionAuthorIdentity(version);
+          const displayName = String(identity.displayName || "Utilisateur");
           const timestampLabel = formatRelativeTimeFromNow(version?.created_at);
           const absoluteTimestampLabel = formatVersionTimestamp(version?.created_at);
           const initials = buildVersionInitials(version);
-          const avatarUrl = resolveVersionAvatarUrl(version);
           return `
             <button type="button" class="gh-menu__item description-versions-dropdown__item" data-action="open-description-version-modal" data-version-id="${escapeHtml(versionId)}" title="${escapeHtml(absoluteTimestampLabel)}">
               <span class="description-versions-dropdown__avatar">
-                ${avatarUrl
-                  ? `<img src="${escapeHtml(avatarUrl)}" alt="${escapeHtml(displayName)}">`
-                  : `<span class="description-versions-dropdown__avatar-fallback">${escapeHtml(initials)}</span>`}
+                ${identity.avatarHtml || `<span class="description-versions-dropdown__avatar-fallback">${escapeHtml(initials)}</span>`}
               </span>
               <span class="description-versions-dropdown__item-inline">
                 <span class="description-versions-dropdown__item-name">${escapeHtml(displayName)}</span>
@@ -973,6 +1041,7 @@ export function createProjectSubjectsDescription(config = {}) {
       }, { actor: "Human", agent: "human" });
       markEntityValidated(entityType, entityId, { actor: "Human", agent: "human" });
       clearDescriptionEditState();
+      void ensureDescriptionVersionsLoaded(root, entityType, entityId, { forceReload: true });
       rerenderScope(root);
       return;
     }


### PR DESCRIPTION
### Motivation
- Corriger le rendu de l’avatar système (Mdall) qui utilisait un fallback bitmap inadapté et rendre l’apparence homogène dans le dropdown et la modale de détail de version.
- Fiabiliser l’auteur affiché dans la carte de description pour qu’il reflète toujours la version la plus récente chargée depuis `subject_description_versions` plutôt qu’un état local obsolète.
- Éviter la disparition intermittente des « Références documentaires » quand les documents ne sont pas entièrement hydratés ou quand `document_ref_ids` n’étaient pas récupérés depuis la source.

### Description
- Remplacement du fallback bitmap par une identité auteur mutualisée : construction de l’identité via `getAuthorIdentity` et rendu de l’avatar système Heimdall (uniforme dans dropdown et modale) ; suppression de `/assets/images/avatar-entreprise.jfif` pour les versions système. (modifié : `project-subjects-description.js`).
- Ajout d’un sync explicite de l’auteur courant à partir de la dernière version chargée (`versions[0]`), avec protections contre réponses tardives et logs structurés `[subject-description-current-author]` ; mise à jour de l’état de description via `setEntityDescriptionState` si nécessaire. (modifié : `project-subjects-description.js`).
- Après sauvegarde de description, déclenchement d’un reload des versions pour réaligner proprement les métadonnées auteur quand le backend les fournit de façon asynchrone. (modifié : `project-subjects-description.js`).
- Renforcement de la résolution des références documentaires : récupération de `document_ref_ids` depuis l’API sujets, normalisation des refs, résolution des docs connus et fallback renderable par ID pour les refs non hydratées, plus logs structurés `[subject-document-refs]`. (modifié : `project-document-selectors.js`, `project-subjects-supabase.js`).
- Ajout et adaptation de tests unitaires pour couvrir : rendu Heimdall pour versions système, réalignement de l’auteur de la carte sur la dernière version et comportement resilient des références documentaires lorsqu’une partie des documents n’est pas hydratée. (ajouté/modifié les fichiers de test). 
- Fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-description.js`, `apps/web/js/services/project-document-selectors.js`, `apps/web/js/services/project-subjects-supabase.js`, `apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs`, `apps/web/js/services/project-document-selectors.test.mjs`.

### Testing
- Tests unitaires exécutés : `project-subjects-description-versions.test.mjs` et `project-document-selectors.test.mjs` via `node --test`, couvrant dropdown/modale/version-system avatar, auteur courant realign et refs documentaires with partial hydration. 
- Résultat : tous les tests lancés ont réussi (tests verts dans les deux fichiers exécutés). 
- Note : logs de diagnostic structurés ont été ajoutés pour validation temporaire en environnement d’intégration et peuvent être réduits/supprimés ultérieurement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70df3f5d08329aadeb715be54c3f4)