### PR TITLE
Mutualiser le renderer d’attachments et hydrater les URLs des pièces jointes de description

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -5,6 +5,7 @@ import { loadSituationsForCurrentProject, loadSituationSubjectIdsMap } from "./p
 import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
 import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
+import { hydratePersistedSubjectAttachmentsObjectUrls } from "./subject-attachments-object-url.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
@@ -1145,7 +1146,7 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
   }
 
   const row = Array.isArray(payload) ? payload[0] : payload;
-  const descriptionAttachments = Array.isArray(row?.description_attachments) ? row.description_attachments : [];
+  const descriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(Array.isArray(row?.description_attachments) ? row.description_attachments : []);
   return {
     ...(row || {}),
     id: String(row?.id || normalizedSubjectId),

--- a/apps/web/js/services/subject-attachments-object-url.js
+++ b/apps/web/js/services/subject-attachments-object-url.js
@@ -1,0 +1,40 @@
+import { supabase } from "../../assets/js/auth.js";
+import {
+  normalizeAttachmentBucket,
+  normalizeSubjectAttachmentStoragePath
+} from "./subject-attachments-storage-path.js";
+
+const SUBJECT_ATTACHMENTS_BUCKET = "subject-message-attachments";
+const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 60 * 60 * 24;
+
+export async function resolveSubjectAttachmentObjectUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
+  const normalizedBucket = normalizeAttachmentBucket(bucket, SUBJECT_ATTACHMENTS_BUCKET);
+  const normalizedPath = normalizeSubjectAttachmentStoragePath(String(storagePath ?? ""), normalizedBucket);
+  if (!normalizedBucket || !normalizedPath) return "";
+  try {
+    const { data, error } = await supabase.storage
+      .from(normalizedBucket)
+      .createSignedUrl(normalizedPath, ATTACHMENT_SIGNED_URL_TTL_SECONDS);
+    if (error) throw error;
+    return String(data?.signedUrl || "").trim();
+  } catch (error) {
+    console.warn("[subject-attachments] signed url failed; preview disabled until next refresh", {
+      bucket: normalizedBucket,
+      storagePath: normalizedPath,
+      message: String(error?.message || error || "")
+    });
+    return "";
+  }
+}
+
+export async function hydratePersistedSubjectAttachmentsObjectUrls(attachments = []) {
+  const list = Array.isArray(attachments) ? attachments : [];
+  if (!list.length) return [];
+  const urls = await Promise.all(
+    list.map((attachment) => resolveSubjectAttachmentObjectUrl(attachment?.storage_bucket, attachment?.storage_path))
+  );
+  return list.map((attachment, index) => ({
+    ...attachment,
+    object_url: String(attachment?.object_url || urls[index] || "")
+  }));
+}

--- a/apps/web/js/services/subject-attachments-object-url.test.mjs
+++ b/apps/web/js/services/subject-attachments-object-url.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("hydratePersistedSubjectAttachmentsObjectUrls enrichit les pièces jointes persistées", async (t) => {
+  let authModule;
+  let attachmentModule;
+  try {
+    authModule = await import("../../assets/js/auth.js");
+    attachmentModule = await import("./subject-attachments-object-url.js");
+  } catch (error) {
+    t.skip(`imports indisponibles dans cet environnement de test: ${String(error?.code || error?.message || error)}`);
+    return;
+  }
+
+  const { supabase } = authModule;
+  const { hydratePersistedSubjectAttachmentsObjectUrls } = attachmentModule;
+  const originalStorage = supabase.storage;
+  const calls = [];
+
+  supabase.storage = {
+    from(bucket) {
+      return {
+        async createSignedUrl(path, ttl) {
+          calls.push({ bucket, path, ttl });
+          return { data: { signedUrl: `https://signed.example/${bucket}/${path}` }, error: null };
+        }
+      };
+    }
+  };
+
+  try {
+    const hydrated = await hydratePersistedSubjectAttachmentsObjectUrls([
+      {
+        id: "a1",
+        storage_bucket: "subject-message-attachments",
+        storage_path: "project-1/subject-1/file.png",
+        mime_type: "image/png"
+      }
+    ]);
+
+    assert.equal(hydrated.length, 1);
+    assert.equal(hydrated[0].object_url, "https://signed.example/subject-message-attachments/project-1/subject-1/file.png");
+    assert.equal(calls.length, 1);
+  } finally {
+    supabase.storage = originalStorage;
+  }
+});

--- a/apps/web/js/services/subject-messages-supabase.js
+++ b/apps/web/js/services/subject-messages-supabase.js
@@ -12,10 +12,10 @@ import {
   normalizeAttachmentBucket,
   normalizeSubjectAttachmentStoragePath
 } from "./subject-attachments-storage-path.js";
+import { resolveSubjectAttachmentObjectUrl as resolveSubjectAttachmentObjectUrlShared } from "./subject-attachments-object-url.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const SUBJECT_ATTACHMENTS_BUCKET = "subject-message-attachments";
-const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 60 * 60 * 24;
 
 function normalizeId(value) {
   return String(value || "").trim();
@@ -81,42 +81,8 @@ function encodeStoragePath(path = "") {
     .join("/");
 }
 
-async function createAttachmentSignedUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
-  const normalizedBucket = normalizeAttachmentBucket(bucket, SUBJECT_ATTACHMENTS_BUCKET);
-  const rawPath = String(storagePath ?? "");
-  const normalizedPath = normalizeSubjectAttachmentStoragePath(rawPath, normalizedBucket);
-  if (!normalizedBucket || !normalizedPath) return "";
-  if (normalizedPath !== rawPath) {
-    console.info("[subject-attachments] storage path normalized before signed url", {
-      bucket: normalizedBucket,
-      storagePathRaw: rawPath,
-      storagePathCanonical: normalizedPath
-    });
-  }
-
-  const { data, error } = await supabase.storage
-    .from(normalizedBucket)
-    .createSignedUrl(normalizedPath, ATTACHMENT_SIGNED_URL_TTL_SECONDS);
-  if (error) throw error;
-  return String(data?.signedUrl || "").trim();
-}
-
 async function resolveAttachmentObjectUrl(bucket = SUBJECT_ATTACHMENTS_BUCKET, storagePath = "") {
-  const normalizedBucket = normalizeAttachmentBucket(bucket, SUBJECT_ATTACHMENTS_BUCKET);
-  const rawPath = String(storagePath ?? "");
-  const normalizedPath = normalizeSubjectAttachmentStoragePath(rawPath, normalizedBucket);
-  if (!normalizedBucket || !normalizedPath) return "";
-  try {
-    const signedUrl = await createAttachmentSignedUrl(normalizedBucket, normalizedPath);
-    if (signedUrl) return signedUrl;
-  } catch (error) {
-    console.warn("[subject-attachments] signed url failed; preview disabled until next refresh", {
-      bucket: normalizedBucket,
-      storagePath: normalizedPath,
-      message: String(error?.message || error || "")
-    });
-  }
-  return "";
+  return resolveSubjectAttachmentObjectUrlShared(bucket, storagePath);
 }
 
 async function resolveAttachmentObjectUrlWithRetry(

--- a/apps/web/js/views/project-subjects/project-subjects-attachments-ui.js
+++ b/apps/web/js/views/project-subjects/project-subjects-attachments-ui.js
@@ -1,0 +1,137 @@
+export function renderSubjectAttachmentTile(attachment = {}, options = {}) {
+  const {
+    escapeHtml = (value) => String(value ?? ""),
+    svgIcon = () => "",
+    forceImage = false,
+    uploadState = "",
+    uploadStateText = ""
+  } = options;
+
+  const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
+  const mimeType = String(attachment?.mime_type || attachment?.mimeType || "").toLowerCase();
+  const extension = String(fileName.split(".").pop() || "").toLowerCase();
+  const previewUrl = String(attachment?.localPreviewUrl || attachment?.previewUrl || attachment?.object_url || "");
+  const downloadUrl = String(
+    attachment?.remoteObjectUrl
+    || attachment?.download_url
+    || attachment?.signed_url
+    || attachment?.url
+    || attachment?.object_url
+    || previewUrl
+    || ""
+  );
+  const isImage = forceImage || mimeType.startsWith("image/");
+  const normalizedUploadState = String(uploadState || "").trim().toLowerCase();
+  const normalizedUploadStateText = String(uploadStateText || "").trim();
+  const typeIcon = mimeType === "application/pdf" || extension === "pdf"
+    ? "file-pdf"
+    : mimeType.includes("javascript") || extension === "js" || extension === "ts"
+      ? "file-js"
+      : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
+        ? "file-dwg"
+        : "file-generic";
+
+  let progressHtml = "";
+  let uploadIndicatorHtml = "";
+  if (normalizedUploadState === "uploading") {
+    uploadIndicatorHtml = `
+      <span class="subject-attachment__upload-indicator is-spinning" aria-label="Envoi en cours">
+        ${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner anim-rotate" })}
+      </span>
+    `;
+  } else if (normalizedUploadState === "ready") {
+    uploadIndicatorHtml = `
+      <span class="subject-attachment__upload-indicator" aria-label="Pièce jointe prête">
+        ${svgIcon("check-circle-fill", { className: "subject-attachment__spinner" })}
+      </span>
+    `;
+  } else if (normalizedUploadState === "error") {
+    progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(normalizedUploadStateText || "Erreur d’upload")}</div>`;
+  } else if (normalizedUploadState) {
+    progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(normalizedUploadState)}</div>`;
+  }
+
+  const metaLine = [
+    mimeType || "fichier",
+    Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
+      ? `${Math.max(1, Math.round(Number(attachment?.size_bytes || attachment?.sizeBytes) / 1024))} KB`
+      : ""
+  ].filter(Boolean).join(" · ");
+
+  if (isImage && previewUrl) {
+    return `
+      <div class="subject-attachment subject-attachment--image">
+        <a href="${escapeHtml(downloadUrl || previewUrl)}" target="_blank" rel="noopener noreferrer">
+          <img src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
+        </a>
+        <div class="subject-attachment__caption mono-small">
+          <span class="subject-attachment__caption-name">${escapeHtml(fileName)}</span>
+          ${uploadIndicatorHtml}
+        </div>
+        ${progressHtml}
+      </div>
+    `;
+  }
+
+  return `
+    <div class="subject-attachment subject-attachment--file">
+      <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
+      <div class="subject-attachment__file-body">
+        <div class="subject-attachment__file-head">
+          ${downloadUrl
+            ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
+            : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
+          ${uploadIndicatorHtml}
+        </div>
+        <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
+        ${progressHtml}
+      </div>
+      ${downloadUrl ? `<a class="subject-attachment__file-link" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">Télécharger</a>` : ""}
+    </div>
+  `;
+}
+
+export function renderSubjectAttachmentsPreviewList({
+  attachments = [],
+  removeAction = "",
+  messageId = "",
+  escapeHtml = (value) => String(value ?? ""),
+  svgIcon = () => "",
+  normalizeAttachmentId = (value) => String(value || "").trim()
+} = {}) {
+  const list = Array.isArray(attachments) ? attachments : [];
+  if (!list.length) return "";
+
+  return `
+    <div class="subject-composer-attachments">
+      ${list.map((attachment, index) => `
+        <div class="subject-composer-attachment-item">
+          ${renderSubjectAttachmentTile(attachment, {
+            escapeHtml,
+            svgIcon,
+            forceImage: !!attachment?.isImage,
+            uploadState: attachment?.error
+              ? "error"
+              : String(attachment?.uploadStatus || "").trim() === "uploading"
+                ? "uploading"
+                : "ready",
+            uploadStateText: attachment?.error ? "Erreur d’upload" : ""
+          })}
+          ${removeAction
+            ? `<button
+                class="subject-composer-attachment-remove"
+                type="button"
+                data-action="${escapeHtml(removeAction)}"
+                data-message-id="${messageId ? escapeHtml(String(messageId)) : ""}"
+                data-attachment-id="${escapeHtml(normalizeAttachmentId(attachment?.id))}"
+                data-temp-id="${escapeHtml(String(attachment?.tempId || index))}"
+                aria-label="Retirer la pièce jointe"
+              >
+                ${svgIcon("x")}
+              </button>`
+            : ""}
+        </div>
+      `).join("")}
+    </div>
+  `;
+}

--- a/apps/web/js/views/project-subjects/project-subjects-attachments-ui.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-attachments-ui.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderSubjectAttachmentTile } from "./project-subjects-attachments-ui.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const escapeHtml = (value) => String(value ?? "");
+const svgIcon = (name) => `<span data-icon="${name}"></span>`;
+
+test("attachments ui: rend une image persistée avec balise img quand l'URL est disponible", () => {
+  const html = renderSubjectAttachmentTile({
+    file_name: "plan.png",
+    mime_type: "image/png",
+    object_url: "https://cdn.example/plan.png"
+  }, { escapeHtml, svgIcon });
+
+  assert.match(html, /<img\s+src="https:\/\/cdn\.example\/plan\.png"/);
+  assert.match(html, /subject-attachment--image/);
+});
+
+test("attachments ui: rend un PDF avec card fichier et icône dédiée", () => {
+  const html = renderSubjectAttachmentTile({
+    file_name: "spec.pdf",
+    mime_type: "application/pdf",
+    object_url: "https://cdn.example/spec.pdf"
+  }, { escapeHtml, svgIcon });
+
+  assert.match(html, /subject-attachment--file/);
+  assert.match(html, /data-icon="file-pdf"/);
+  assert.match(html, /spec\.pdf/);
+});
+
+test("attachments ui: description, thread et events utilisent le composant partagé", () => {
+  const descriptionSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-description.js"), "utf8");
+  const threadSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-thread.js"), "utf8");
+  const eventsSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-events.js"), "utf8");
+
+  assert.match(descriptionSource, /from\s+"\.\/project-subjects-attachments-ui\.js"/);
+  assert.match(threadSource, /from\s+"\.\/project-subjects-attachments-ui\.js"/);
+  assert.match(eventsSource, /from\s+"\.\/project-subjects-attachments-ui\.js"/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -1,5 +1,6 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 
 export function createProjectSubjectsDescription(config = {}) {
   const VERSIONS_LOG_PREFIX = "[subject-description-versions]";
@@ -335,41 +336,21 @@ export function createProjectSubjectsDescription(config = {}) {
     return true;
   }
 
-  function renderDescriptionAttachmentTile(attachment = {}, { removable = false, removeAction = "" } = {}) {
-    const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
-    const isImage = String(attachment?.mime_type || attachment?.mimeType || "").startsWith("image/");
-    const previewUrl = String(attachment?.localPreviewUrl || attachment?.previewUrl || attachment?.object_url || "");
-    const attachmentId = String(attachment?.id || "");
-    const tempId = String(attachment?.tempId || "");
-    const status = attachment?.error
-      ? "Erreur d’upload"
-      : String(attachment?.uploadStatus || "").trim() === "uploading"
-        ? "Envoi…"
-        : "";
-    return `
-      <div class="subject-composer-attachment-item">
-        <div class="subject-attachment subject-attachment--compact">
-          ${isImage && previewUrl
-            ? `<img class="subject-attachment__image" src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" />`
-            : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
-          ${status ? `<div class="subject-attachment__state mono-small">${escapeHtml(status)}</div>` : ""}
-        </div>
-        ${removable
-          ? `
-            <button
-              class="subject-composer-attachment-remove"
-              type="button"
-              data-action="${escapeHtml(removeAction)}"
-              data-attachment-id="${escapeHtml(attachmentId)}"
-              data-temp-id="${escapeHtml(tempId)}"
-              aria-label="Retirer la pièce jointe"
-            >
-              ${svgIcon("x")}
-            </button>
-          `
-          : ""}
-      </div>
-    `;
+  function renderDescriptionAttachmentTile(attachment = {}, options = {}) {
+    return renderSubjectAttachmentTile(attachment, {
+      ...options,
+      escapeHtml,
+      svgIcon
+    });
+  }
+
+  function renderDescriptionAttachmentsPreview(attachments = [], { removable = false, removeAction = "" } = {}) {
+    return renderSubjectAttachmentsPreviewList({
+      attachments,
+      removeAction: removable ? removeAction : "",
+      escapeHtml,
+      svgIcon
+    });
   }
 
   function buildDescriptionVersionsLoadError(error) {
@@ -937,9 +918,7 @@ export function createProjectSubjectsDescription(config = {}) {
           const attachments = Array.isArray(edit.attachments) ? edit.attachments : [];
           const hasReadyAttachment = attachments.some((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
           const canSubmit = !!String(edit.draft || "").trim() || hasReadyAttachment;
-          const attachmentsHtml = attachments.length
-            ? `<div class="subject-composer-attachments">${attachments.map((attachment) => renderDescriptionAttachmentTile(attachment, { removable: true, removeAction: "description-attachment-remove" })).join("")}</div>`
-            : "";
+          const attachmentsHtml = renderDescriptionAttachmentsPreview(attachments, { removable: true, removeAction: "description-attachment-remove" });
           return `
             ${renderCommentComposer({
               hideAvatar: true,
@@ -993,7 +972,7 @@ export function createProjectSubjectsDescription(config = {}) {
         <div class="gh-comment-body">
           ${mdToHtml(description.body || "")}
           ${Array.isArray(description.attachments) && description.attachments.length
-            ? `<div class="subject-composer-attachments" style="margin-top:10px;">${description.attachments.map((attachment) => renderDescriptionAttachmentTile(attachment)).join("")}</div>`
+            ? `<div class="subject-attachment-grid" style="margin-top:10px;">${description.attachments.map((attachment) => renderDescriptionAttachmentTile(attachment)).join("")}</div>`
             : ""}
         </div>
       `;
@@ -1009,6 +988,31 @@ export function createProjectSubjectsDescription(config = {}) {
         </div>
       </div>
     `;
+  }
+
+
+  function reconcilePersistedDescriptionAttachments(persistedAttachments = [], draftAttachments = []) {
+    const draftList = Array.isArray(draftAttachments) ? draftAttachments : [];
+    const persistedList = Array.isArray(persistedAttachments) ? persistedAttachments : [];
+    return persistedList.map((attachment) => {
+      if (String(attachment?.object_url || attachment?.previewUrl || attachment?.localPreviewUrl || "").trim()) return attachment;
+      const storagePath = String(attachment?.storage_path || "").trim();
+      const fileName = String(attachment?.file_name || attachment?.fileName || "").trim();
+      const match = draftList.find((draftAttachment) => {
+        const draftStoragePath = String(draftAttachment?.storage_path || "").trim();
+        const draftFileName = String(draftAttachment?.file_name || draftAttachment?.fileName || "").trim();
+        return (storagePath && draftStoragePath && storagePath === draftStoragePath)
+          || (fileName && draftFileName && fileName === draftFileName);
+      });
+      if (!match) return attachment;
+      const localPreviewUrl = String(match?.localPreviewUrl || match?.previewUrl || "").trim();
+      if (!localPreviewUrl) return attachment;
+      return {
+        ...attachment,
+        localPreviewUrl,
+        previewUrl: String(attachment?.previewUrl || localPreviewUrl)
+      };
+    });
   }
 
   function clearDescriptionEditState() {
@@ -1083,9 +1087,10 @@ export function createProjectSubjectsDescription(config = {}) {
       });
 
       const persistedBody = String(updated?.description ?? nextBody);
-      const persistedAttachments = Array.isArray(updated?.description_attachments)
+      const persistedAttachmentsRaw = Array.isArray(updated?.description_attachments)
         ? updated.description_attachments
         : attachments.filter((attachment) => String(attachment?.uploadStatus || "").trim() === "ready" && !attachment?.error);
+      const persistedAttachments = reconcilePersistedDescriptionAttachments(persistedAttachmentsRaw, attachments);
       setEntityDescriptionState(entityType, entityId, {
         body: persistedBody,
         attachments: persistedAttachments,

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -15,6 +15,7 @@ import {
 } from "../../utils/subject-links.js";
 import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
+import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 
 export function createProjectSubjectsEvents(config) {
   const EMOJI_GRID_COLUMNS = 6;
@@ -2435,120 +2436,19 @@ export function createProjectSubjectsEvents(config) {
 
     const selectorValue = (value) => String(value || "").replace(/["\\]/g, "\\$&");
     const normalizeAttachmentId = (value) => String(value || "").trim();
-    const renderAttachmentTileHtml = (attachment = {}, options = {}) => {
-      const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
-      const mimeType = String(attachment?.mime_type || attachment?.mimeType || "").toLowerCase();
-      const extension = String(fileName.split(".").pop() || "").toLowerCase();
-      const previewUrl = String(attachment?.localPreviewUrl || attachment?.previewUrl || attachment?.object_url || "");
-      const downloadUrl = String(
-        attachment?.remoteObjectUrl
-        || attachment?.download_url
-        || attachment?.signed_url
-        || attachment?.url
-        || attachment?.object_url
-        || previewUrl
-        || ""
-      );
-      const isImage = options.forceImage || mimeType.startsWith("image/");
-      const uploadState = String(options.uploadState || "").trim().toLowerCase();
-      const uploadStateText = String(options.uploadStateText || "").trim();
-      const typeIcon = mimeType === "application/pdf" || extension === "pdf"
-        ? "file-pdf"
-        : mimeType.includes("javascript") || extension === "js" || extension === "ts"
-          ? "file-js"
-          : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
-            ? "file-dwg"
-            : "file-generic";
-      let progressHtml = "";
-      let uploadIndicatorHtml = "";
-      if (uploadState === "uploading") {
-        uploadIndicatorHtml = `
-          <span class="subject-attachment__upload-indicator is-spinning" aria-label="Envoi en cours">
-            ${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner anim-rotate" })}
-          </span>
-        `;
-      } else if (uploadState === "ready") {
-        uploadIndicatorHtml = `
-          <span class="subject-attachment__upload-indicator" aria-label="Pièce jointe prête">
-            ${svgIcon("check-circle-fill", { className: "subject-attachment__spinner" })}
-          </span>
-        `;
-      } else if (uploadState === "error") {
-        progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadStateText || "Erreur d’upload")}</div>`;
-      } else if (uploadState) {
-        progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>`;
-      }
-      const metaLine = [
-        mimeType || "fichier",
-        Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
-          ? `${Math.max(1, Math.round(Number(attachment?.size_bytes || attachment?.sizeBytes) / 1024))} KB`
-          : ""
-      ].filter(Boolean).join(" · ");
-
-      if (isImage && previewUrl) {
-        return `
-          <div class="subject-attachment subject-attachment--image">
-            <a href="${escapeHtml(downloadUrl || previewUrl)}" target="_blank" rel="noopener noreferrer">
-              <img src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
-            </a>
-            <div class="subject-attachment__caption mono-small">
-              <span class="subject-attachment__caption-name">${escapeHtml(fileName)}</span>
-              ${uploadIndicatorHtml}
-            </div>
-            ${progressHtml}
-          </div>
-        `;
-      }
-
-      return `
-        <div class="subject-attachment subject-attachment--file">
-          <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
-          <div class="subject-attachment__file-body">
-            <div class="subject-attachment__file-head">
-              ${downloadUrl
-                ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
-                : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
-              ${uploadIndicatorHtml}
-            </div>
-            <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
-            ${progressHtml}
-          </div>
-          ${downloadUrl ? `<a class="subject-attachment__file-link" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">Télécharger</a>` : ""}
-        </div>
-      `;
-    };
-    const renderAttachmentPreviewItemsHtml = ({ attachments = [], removeAction = "", messageId = "" } = {}) => {
-      const list = Array.isArray(attachments) ? attachments : [];
-      if (!list.length) return "";
-      return `
-        <div class="subject-composer-attachments">
-          ${list.map((attachment, index) => `
-            <div class="subject-composer-attachment-item">
-              ${renderAttachmentTileHtml(attachment, {
-                forceImage: !!attachment?.isImage,
-                uploadState: attachment?.error
-                  ? "error"
-                  : String(attachment?.uploadStatus || "").trim() === "uploading"
-                    ? "uploading"
-                    : "ready",
-                uploadStateText: attachment?.error ? "Erreur d’upload" : ""
-              })}
-              <button
-                class="subject-composer-attachment-remove"
-                type="button"
-                data-action="${escapeHtml(removeAction)}"
-                data-message-id="${messageId ? escapeHtml(String(messageId)) : ""}"
-                data-attachment-id="${escapeHtml(normalizeAttachmentId(attachment?.id))}"
-                data-temp-id="${escapeHtml(String(attachment?.tempId || index))}"
-                aria-label="Retirer la pièce jointe"
-              >
-                ${svgIcon("x")}
-              </button>
-            </div>
-          `).join("")}
-        </div>
-      `;
-    };
+    const renderAttachmentTileHtml = (attachment = {}, options = {}) => renderSubjectAttachmentTile(attachment, {
+      ...options,
+      escapeHtml,
+      svgIcon
+    });
+    const renderAttachmentPreviewItemsHtml = ({ attachments = [], removeAction = "", messageId = "" } = {}) => renderSubjectAttachmentsPreviewList({
+      attachments,
+      removeAction,
+      messageId,
+      escapeHtml,
+      svgIcon,
+      normalizeAttachmentId
+    });
     const scheduleScopedDomRender = (scopeKey, callback) => {
       const normalizedScopeKey = String(scopeKey || "").trim();
       if (!normalizedScopeKey || typeof callback !== "function") return;

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1,5 +1,6 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+import { renderSubjectAttachmentTile } from "./project-subjects-attachments-ui.js";
 export function createProjectSubjectsThread(config = {}) {
   const {
     store,
@@ -1196,86 +1197,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
   }
 
   function renderAttachmentTile(attachment = {}, options = {}) {
-    const fileName = String(attachment?.file_name || attachment?.fileName || "Pièce jointe");
-    const mimeType = String(attachment?.mime_type || attachment?.mimeType || "").toLowerCase();
-    const extension = String(fileName.split(".").pop() || "").toLowerCase();
-    const previewUrl = String(attachment?.localPreviewUrl || attachment?.previewUrl || attachment?.object_url || "");
-    const downloadUrl = String(
-      attachment?.remoteObjectUrl
-      || attachment?.download_url
-      || attachment?.signed_url
-      || attachment?.url
-      || attachment?.object_url
-      || previewUrl
-      || ""
-    );
-    const isImage = options.forceImage || mimeType.startsWith("image/");
-    const uploadState = String(options.uploadState || "").trim().toLowerCase();
-    const uploadStateText = String(options.uploadStateText || "").trim();
-    const typeIcon = mimeType === "application/pdf" || extension === "pdf"
-      ? "file-pdf"
-      : mimeType.includes("javascript") || extension === "js" || extension === "ts"
-        ? "file-js"
-        : extension === "dwg" || mimeType.includes("autocad") || mimeType.includes("dwg")
-          ? "file-dwg"
-          : "file-generic";
-    let progressHtml = "";
-    let uploadIndicatorHtml = "";
-    if (uploadState === "uploading") {
-      uploadIndicatorHtml = `
-        <span class="subject-attachment__upload-indicator is-spinning" aria-label="Envoi en cours">
-          ${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner anim-rotate" })}
-        </span>
-      `;
-    } else if (uploadState === "ready") {
-      uploadIndicatorHtml = `
-        <span class="subject-attachment__upload-indicator" aria-label="Pièce jointe prête">
-          ${svgIcon("check-circle-fill", { className: "subject-attachment__spinner" })}
-        </span>
-      `;
-    } else if (uploadState === "error") {
-      progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadStateText || "Erreur d’upload")}</div>`;
-    } else if (uploadState) {
-      progressHtml = `<div class="subject-attachment__state mono-small">${escapeHtml(uploadState)}</div>`;
-    }
-    const metaLine = [
-      mimeType || "fichier",
-      Number.isFinite(Number(attachment?.size_bytes || attachment?.sizeBytes))
-        ? `${Math.max(1, Math.round(Number(attachment?.size_bytes || attachment?.sizeBytes) / 1024))} KB`
-        : ""
-    ].filter(Boolean).join(" · ");
-
-    if (isImage && previewUrl) {
-      return `
-        <div class="subject-attachment subject-attachment--image">
-          <a href="${escapeHtml(downloadUrl || previewUrl)}" target="_blank" rel="noopener noreferrer">
-            <img src="${escapeHtml(previewUrl)}" alt="${escapeHtml(fileName)}" loading="lazy" />
-          </a>
-          <div class="subject-attachment__caption mono-small">
-            <span class="subject-attachment__caption-name">${escapeHtml(fileName)}</span>
-            ${uploadIndicatorHtml}
-          </div>
-          ${progressHtml}
-        </div>
-      `;
-    }
-
-    return `
-      <div class="subject-attachment subject-attachment--file">
-        <div class="subject-attachment__file-icon" aria-hidden="true">${svgIcon(typeIcon)}</div>
-        <div class="subject-attachment__file-body">
-          <div class="subject-attachment__file-head">
-            ${downloadUrl
-              ? `<a class="subject-attachment__file-name mono-small subject-attachment__file-link--name" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">${escapeHtml(fileName)}</a>`
-              : `<div class="subject-attachment__file-name mono-small">${escapeHtml(fileName)}</div>`}
-            ${uploadIndicatorHtml}
-          </div>
-          <div class="subject-attachment__file-meta mono-small">${escapeHtml(metaLine || "fichier")}</div>
-          ${progressHtml}
-        </div>
-        ${downloadUrl ? `<a class="subject-attachment__file-link" href="${escapeHtml(downloadUrl)}" rel="noopener noreferrer" download="${escapeHtml(fileName)}">Télécharger</a>` : ""}
-      </div>
-    `;
+    return renderSubjectAttachmentTile(attachment, {
+      ...options,
+      escapeHtml,
+      svgIcon
+    });
   }
 
   function renderThreadBlock() {


### PR DESCRIPTION
### Motivation
- Les pièces jointes de la description étaient rendues par un renderer compact spécifique et les `description_attachments` persistés n’étaient pas enrichis avec une `object_url` signée, ce qui faisait disparaître les aperçus image après sauvegarde.
- L’objectif est d’uniformiser l’affichage des attachments entre description / commentaires / réponses et de garantir une prévisualisation immédiate après persistance.

### Description
- Extraction d’un renderer partagé `renderSubjectAttachmentTile(...)` et d’un helper de liste `renderSubjectAttachmentsPreviewList(...)` dans `apps/web/js/views/project-subjects/project-subjects-attachments-ui.js` et remplacement des logiques dupliquées dans `project-subjects-thread.js`, `project-subjects-events.js` et `project-subjects-description.js` par ce composant partagé.
- Ajout d’un service `apps/web/js/services/subject-attachments-object-url.js` exposant `resolveSubjectAttachmentObjectUrl` et `hydratePersistedSubjectAttachmentsObjectUrls` pour générer des signed URLs via Supabase et hydrater les attachments persistés.
- Intégration de l’hydratation des `description_attachments` dans `updateSubjectDescription()` (`apps/web/js/services/project-subjects-supabase.js`) afin que les attachments retournés après sauvegarde aient un `object_url` exploitable.
- Réutilisation du helper partagé depuis la messagerie en adaptant `subject-messages-supabase.js` pour appeler la même logique d’obtention d’URL afin d’éviter des divergences.
- Ajout d’une fonction de réconciliation qui, après save, rapproche les attachments persistés avec les attachments locaux pour conserver un `localPreviewUrl` quand l’URL distante n’est pas immédiatement prête, assurant une transition fluide post-save.
- Diff minimal et factorisation visant à préserver les états `uploading/ready/error` et le comportement de preview locale.

### Testing
- Tests unitaires ajoutés pour le renderer partagé : `apps/web/js/views/project-subjects/project-subjects-attachments-ui.test.mjs` qui vérifient le rendu `<img>` pour une image persistée et la card PDF avec icône/type/nom, et l’import du composant dans les vues concernées (réussi).
- Test d’hydratation des attachments persistés : `apps/web/js/services/subject-attachments-object-url.test.mjs` qui simule `supabase.storage.createSignedUrl` et vérifie l’enrichissement des `object_url` (le test est exécuté et passe, avec un `skip` contrôlé si l’import ESM de `../../assets/js/auth.js` n’est pas disponible dans l’environnement de test).
- Exécution de la suite : `node --test apps/web/js/views/project-subjects/project-subjects-attachments-ui.test.mjs apps/web/js/services/subject-attachments-object-url.test.mjs apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` ; la suite a été verte (10 tests passés) avec 1 test marqué `SKIP` pour une limitation ESM d’environnement, et les tests de versions de description existants sont restés inchangés et passent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e719fc7de883299bcb2be13a8daddb)