### PR TITLE
Fix immediate textarea update after emoji pick

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -3294,6 +3294,7 @@ export function createProjectSubjectsEvents(config) {
       };
       const result = applyEmojiSuggestion(textarea.value || "", context, suggestion);
       textarea.value = String(result.nextText || "");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
       textarea.focus();
       textarea.selectionStart = result.nextCursorIndex;
       textarea.selectionEnd = result.nextCursorIndex;
@@ -3315,6 +3316,7 @@ export function createProjectSubjectsEvents(config) {
         };
         const result = applyEmojiSuggestion(textarea.value || "", context, suggestion);
         textarea.value = result.nextText;
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
         store.situationsView.commentDraft = String(result.nextText || "");
         textarea.focus();
         textarea.selectionStart = result.nextCursorIndex;


### PR DESCRIPTION
### Motivation
- Picking an emoji from the autocomplete popup updated the textarea value but the textarea-bound UI (preview/height/drafts) did not reflect the change until the next keystroke, causing a visible delay.

### Description
- Dispatch an `input` event immediately after inserting an emoji in `applyInlineEmojiSuggestion` and in the `main` branch of `applyEmojiSuggestionByComposerKey` inside `apps/web/js/views/project-subjects/project-subjects-events.js` so UI bindings update right away.

### Testing
- Ran `node --check apps/web/js/views/project-subjects/project-subjects-events.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71dd36b38832994e863a6662e94c1)