### PR TITLE
Improve subject autocomplete textarea resolution, autosize refactor and add debug logging

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -824,6 +824,25 @@ export function createProjectSubjectsEvents(config) {
       else syncAutocompletePopups();
     };
 
+    const AUTOCOMPLETE_LOG_PREFIX = "[subject-autocomplete]";
+
+    const logAutocompleteEvent = (eventName, payload = {}) => {
+      console.log(`${AUTOCOMPLETE_LOG_PREFIX} ${eventName}`, payload);
+    };
+
+    const syncComposerTextareaHeight = (textarea, { minHeightFallback = 110 } = {}) => {
+      if (!textarea) return;
+      const computedStyle = window.getComputedStyle(textarea);
+      const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
+      const minHeight = Math.max(minHeightFallback, Math.round(parseFloat(computedStyle.minHeight) || minHeightFallback));
+      const comfortExtraLines = 3;
+      const extraPadding = lineHeight * comfortExtraLines;
+      textarea.style.overflowY = "hidden";
+      textarea.style.height = "auto";
+      const nextHeight = Math.max(minHeight, textarea.scrollHeight + extraPadding);
+      textarea.style.height = `${nextHeight}px`;
+    };
+
     const getTextareaSelector = ({ composerKey = "main", messageId = "" } = {}) => {
       if (composerKey === "main") return "#humanCommentBox";
       if (composerKey === "reply" && messageId) return `[data-thread-reply-draft="${selectorValue(messageId)}"]`;
@@ -839,10 +858,33 @@ export function createProjectSubjectsEvents(config) {
       return { mode, messageId };
     };
 
-    const getTextareaForComposerKey = (composerKey = "") => {
+    const findComposerTextareaByKey = (composerKey = "", scopeRoot = null) => {
       const { mode, messageId } = splitComposerKey(composerKey);
       const selector = getTextareaSelector({ composerKey: mode, messageId });
-      return selector ? root.querySelector(selector) : null;
+      if (!selector) {
+        logAutocompleteEvent("resolve textarea", {
+          composerKey,
+          selector,
+          found: false
+        });
+        return null;
+      }
+      const scopedRoot = scopeRoot && scopeRoot.isConnected ? scopeRoot : null;
+      const scopedTextarea = scopedRoot?.querySelector?.(selector) || null;
+      const textarea = scopedTextarea || document.querySelector(selector);
+      logAutocompleteEvent("resolve textarea", {
+        composerKey,
+        selector,
+        scopeProvided: !!scopeRoot,
+        scopeConnected: !!scopedRoot,
+        found: !!textarea
+      });
+      return textarea;
+    };
+
+    const getTextareaForComposerKey = (composerKey = "") => {
+      const currentRoot = typeof config.getSubjectsCurrentRoot === "function" ? config.getSubjectsCurrentRoot() : root;
+      return findComposerTextareaByKey(composerKey, currentRoot);
     };
 
     const focusComposerTextarea = (composerKey = "") => {
@@ -1208,20 +1250,27 @@ export function createProjectSubjectsEvents(config) {
 
     const pickMentionSuggestion = (suggestion, composerKey = "main") => {
       const textarea = getTextareaForComposerKey(composerKey);
-      if (!textarea) return;
+      if (!textarea) {
+        logAutocompleteEvent("missing textarea", { composerKey, action: "mention-pick" });
+        return;
+      }
       const mentionState = getMentionState();
       const context = {
         triggerStart: mentionState.triggerStart,
         triggerEnd: Number(textarea.selectionStart || mentionState.triggerEnd || 0)
       };
+      const cursorBefore = Number(textarea.selectionStart || 0);
+      const lengthBefore = String(textarea.value || "").length;
       const result = applyMentionSuggestion(textarea.value || "", context, suggestion);
       textarea.value = result.nextText;
       const { mode, messageId = "" } = splitComposerKey(composerKey);
       if (mode === "main") {
         store.situationsView.commentDraft = String(result.nextText || "");
+        syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
       } else if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
+        syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1236,6 +1285,13 @@ export function createProjectSubjectsEvents(config) {
       textarea.focus();
       textarea.selectionStart = result.nextCursorIndex;
       textarea.selectionEnd = result.nextCursorIndex;
+      logAutocompleteEvent("apply mention", {
+        composerKey,
+        lengthBefore,
+        lengthAfter: String(result.nextText || "").length,
+        cursorBefore,
+        cursorAfter: result.nextCursorIndex
+      });
       closeMentionPopup({ rerender: false });
       closeEmojiPopup({ rerender: false });
       if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
@@ -1310,20 +1366,27 @@ export function createProjectSubjectsEvents(config) {
 
     const pickSubjectRefSuggestion = (suggestion = {}, composerKey = "main") => {
       const textarea = getTextareaForComposerKey(composerKey);
-      if (!textarea) return;
+      if (!textarea) {
+        logAutocompleteEvent("missing textarea", { composerKey, action: "subject-ref-pick" });
+        return;
+      }
       const subjectRefState = getSubjectRefState();
       const context = {
         triggerStart: subjectRefState.triggerStart,
         triggerEnd: Number(textarea.selectionStart || subjectRefState.triggerEnd || 0)
       };
+      const cursorBefore = Number(textarea.selectionStart || 0);
+      const lengthBefore = String(textarea.value || "").length;
       const result = applySubjectRefSuggestion(textarea.value || "", context, suggestion);
       textarea.value = String(result.nextText || "");
       const { mode, messageId = "" } = splitComposerKey(composerKey);
       if (mode === "main") {
         store.situationsView.commentDraft = String(result.nextText || "");
+        syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
       } else if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
+        syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1338,6 +1401,13 @@ export function createProjectSubjectsEvents(config) {
       textarea.focus();
       textarea.selectionStart = result.nextCursorIndex;
       textarea.selectionEnd = result.nextCursorIndex;
+      logAutocompleteEvent("apply subject-ref", {
+        composerKey,
+        lengthBefore,
+        lengthAfter: String(result.nextText || "").length,
+        cursorBefore,
+        cursorAfter: result.nextCursorIndex
+      });
       closeSubjectRefPopup({ rerender: false });
       closeMentionPopup({ rerender: false });
       closeEmojiPopup({ rerender: false });
@@ -1571,15 +1641,7 @@ export function createProjectSubjectsEvents(config) {
       };
 
       const syncMainComposerTextareaHeight = () => {
-        const computedStyle = window.getComputedStyle(commentTextarea);
-        const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
-        const minHeight = Math.max(170, Math.round(parseFloat(computedStyle.minHeight) || 170));
-        const comfortExtraLines = 3;
-        const extraPadding = lineHeight * comfortExtraLines;
-        commentTextarea.style.overflowY = "hidden";
-        commentTextarea.style.height = "auto";
-        const nextHeight = Math.max(minHeight, commentTextarea.scrollHeight + extraPadding);
-        commentTextarea.style.height = `${nextHeight}px`;
+        syncComposerTextareaHeight(commentTextarea, { minHeightFallback: 170 });
       };
 
       syncMainComposerTextareaHeight();
@@ -2781,16 +2843,7 @@ export function createProjectSubjectsEvents(config) {
       submitButton.disabled = !canSubmitInlineEdit(normalizedMessageId);
     };
     const syncInlineReplyTextareaHeight = (textarea) => {
-      if (!textarea) return;
-      const computedStyle = window.getComputedStyle(textarea);
-      const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
-      const minHeight = Math.max(110, Math.round(parseFloat(computedStyle.minHeight) || 110));
-      const comfortExtraLines = 3;
-      const extraPadding = lineHeight * comfortExtraLines;
-      textarea.style.overflowY = "hidden";
-      textarea.style.height = "auto";
-      const nextHeight = Math.max(minHeight, textarea.scrollHeight + extraPadding);
-      textarea.style.height = `${nextHeight}px`;
+      syncComposerTextareaHeight(textarea, { minHeightFallback: 110 });
     };
     const toggleInlineReplyEditorVisibility = (messageId = "", visible = false) => {
       const normalizedMessageId = String(messageId || "").trim();
@@ -3306,7 +3359,12 @@ export function createProjectSubjectsEvents(config) {
       const normalizedKey = String(composerKey || "").trim();
       if (!normalizedKey) return;
       const textarea = getTextareaForComposerKey(normalizedKey);
-      if (!textarea) return;
+      if (!textarea) {
+        logAutocompleteEvent("missing textarea", { composerKey: normalizedKey, action: "emoji-pick" });
+        return;
+      }
+      const cursorBefore = Number(textarea.selectionStart || 0);
+      const lengthBefore = String(textarea.value || "").length;
       const [mode = "main", messageId = ""] = normalizedKey.split(":");
       if (normalizedKey === "main") {
         const emojiState = getEmojiState();
@@ -3321,6 +3379,13 @@ export function createProjectSubjectsEvents(config) {
         textarea.focus();
         textarea.selectionStart = result.nextCursorIndex;
         textarea.selectionEnd = result.nextCursorIndex;
+        logAutocompleteEvent("apply emoji", {
+          composerKey: normalizedKey,
+          lengthBefore,
+          lengthAfter: String(result.nextText || "").length,
+          cursorBefore,
+          cursorAfter: result.nextCursorIndex
+        });
         closeEmojiPopup({ rerender: false });
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
         const computedStyle = window.getComputedStyle(textarea);
@@ -3335,6 +3400,13 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
       const result = applyInlineEmojiSuggestion(textarea, suggestion);
+      logAutocompleteEvent("apply emoji", {
+        composerKey: normalizedKey,
+        lengthBefore,
+        lengthAfter: String(result.nextText || "").length,
+        cursorBefore,
+        cursorAfter: result.nextCursorIndex
+      });
       if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
@@ -3674,6 +3746,8 @@ export function createProjectSubjectsEvents(config) {
         previewTab?.setAttribute("aria-selected", "false");
         textareaWrap?.classList.remove("hidden");
         previewWrap?.classList.add("hidden");
+        const textarea = composerRoot?.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+        if (textarea) requestAnimationFrame(() => syncInlineReplyTextareaHeight(textarea));
       };
     });
 
@@ -3719,6 +3793,8 @@ export function createProjectSubjectsEvents(config) {
         previewTab?.setAttribute("aria-selected", "false");
         composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
+        const textarea = composerRoot?.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+        if (textarea) requestAnimationFrame(() => syncInlineReplyTextareaHeight(textarea));
       };
     });
 
@@ -3827,6 +3903,10 @@ export function createProjectSubjectsEvents(config) {
         composerRoot?.querySelector("[data-action='description-tab-preview']")?.classList.remove("is-active");
         composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
+        const textarea = composerRoot?.querySelector("[data-description-draft]");
+        if (textarea instanceof HTMLTextAreaElement) {
+          requestAnimationFrame(() => syncComposerTextareaHeight(textarea, { minHeightFallback: 170 }));
+        }
       };
     });
     root.querySelectorAll("[data-action='description-tab-preview']").forEach((btn) => {
@@ -3856,6 +3936,7 @@ export function createProjectSubjectsEvents(config) {
         if (action === "subject-ref") {
           ensureSubjectRefTriggerInTextarea(textarea);
           syncDescriptionEditorDraft(root);
+          syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
           closeMentionPopup({ rerender: false });
           closeEmojiPopup({ rerender: false });
           void syncSubjectRefPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`);
@@ -3865,6 +3946,7 @@ export function createProjectSubjectsEvents(config) {
         const didApply = applyMarkdownComposerAction(textarea, action);
         if (!didApply) return;
         syncDescriptionEditorDraft(root);
+        syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
         if (action === "mention") {
           void syncMentionPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`, { forceOpen: true });
         } else {
@@ -3897,8 +3979,10 @@ export function createProjectSubjectsEvents(config) {
     });
     root.querySelectorAll("[data-description-draft]").forEach((textarea) => {
       const composerKey = `description:${String(textarea.dataset.descriptionDraft || "").trim()}`;
+      syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
       textarea.addEventListener("input", () => {
         syncDescriptionEditorDraft(root);
+        syncComposerTextareaHeight(textarea, { minHeightFallback: 170 });
         void syncInlineAutocomplete(textarea, composerKey);
       });
       textarea.addEventListener("keydown", (event) => {
@@ -4126,6 +4210,10 @@ export function createProjectSubjectsEvents(config) {
         if (!(target instanceof Element)) return;
         const mentionBtn = target.closest("[data-action='mention-pick'][data-person-id]");
         if (mentionBtn instanceof HTMLElement) {
+          logAutocompleteEvent("click pick", {
+            action: "mention-pick",
+            composerKey: String(mentionBtn.dataset.composerKey || "main")
+          });
           pickMentionSuggestion({
             personId: String(mentionBtn.dataset.personId || "").trim(),
             label: String(mentionBtn.dataset.label || "").trim()
@@ -4136,6 +4224,10 @@ export function createProjectSubjectsEvents(config) {
         if (emojiBtn instanceof HTMLElement) {
           const composerKey = String(emojiBtn.dataset.composerKey || "").trim();
           if (!composerKey) return;
+          logAutocompleteEvent("click pick", {
+            action: "emoji-pick",
+            composerKey
+          });
           applyEmojiSuggestionByComposerKey(composerKey, {
             emoji: String(emojiBtn.dataset.emoji || "").trim(),
             shortcode: String(emojiBtn.dataset.shortcode || "").trim()
@@ -4144,6 +4236,10 @@ export function createProjectSubjectsEvents(config) {
         }
         const subjectRefBtn = target.closest("[data-action='subject-ref-pick'][data-subject-id][data-subject-number]");
         if (!(subjectRefBtn instanceof HTMLElement)) return;
+        logAutocompleteEvent("click pick", {
+          action: "subject-ref-pick",
+          composerKey: String(subjectRefBtn.dataset.composerKey || "main")
+        });
         pickSubjectRefSuggestion({
           subjectId: String(subjectRefBtn.dataset.subjectId || "").trim(),
           subjectNumber: Number(subjectRefBtn.dataset.subjectNumber || 0)


### PR DESCRIPTION
### Motivation
- Make textarea resolution for autocomplete more robust in cases where the composer DOM may be scoped or re-rendered and enable easier debugging of autocomplete interactions.
- Reduce duplicated textarea autosize logic by consolidating into a single helper to ensure consistent behavior across main, reply, edit and description composers.

### Description
- Add `AUTOCOMPLETE_LOG_PREFIX` and `logAutocompleteEvent` to emit debug logs for key autocomplete actions and failures.
- Introduce `syncComposerTextareaHeight(textarea, { minHeightFallback })` to centralize textarea autosizing and replace inline duplication across main, inline reply, edit and description code paths.
- Add `findComposerTextareaByKey(composerKey, scopeRoot)` which resolves textarea selectors with optional scoping and detailed logging, and make `getTextareaForComposerKey` use the configured current root via `config.getSubjectsCurrentRoot`.
- Add safety logging when expected textareas are missing and emit logs on apply/pick actions (`mention`, `emoji`, `subject-ref`) including cursor and length metadata, and add UI height sync calls on tab toggles and formatting actions.
- Wire click handlers to log picks and maintain previous behavior for applying suggestions, focusing, updating drafts and rerendering autocomplete UI.

### Testing
- Ran the frontend unit test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully.
- Verified that autocomplete-related unit tests covering mention/emoji/subject-ref behavior remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e720c2d0488329adbeeb500b489ca1)