### PR TITLE
Fix description attachment hydration and centralize textarea autosize

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -71,6 +71,21 @@ function buildSubjectDescriptionDebugRequestId() {
   return `subject-description-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+function extractMissingColumnFromSupabaseError(rawBody = "") {
+  const parsedBody = safeJsonParse(String(rawBody || ""));
+  const details = String(
+    parsedBody?.message
+    || parsedBody?.details
+    || parsedBody?.hint
+    || rawBody
+    || ""
+  );
+  const match = details.match(/column\s+subjects\.([a-zA-Z0-9_]+)/i)
+    || details.match(/subjects\s+"([a-zA-Z0-9_]+)"/i)
+    || details.match(/\b([a-zA-Z0-9_]+)\b\s+does not exist/i);
+  return String(match?.[1] || "").trim();
+}
+
 async function rpcCall(functionName, payload = {}) {
   const rpcUrl = `${SUPABASE_URL}/rest/v1/rpc/${functionName}`;
   const response = await fetch(rpcUrl, {
@@ -142,13 +157,23 @@ async function fetchProjectFlatSubjects(projectId) {
     return [];
   }
 
-  const selectWithRefs = "id,subject_number,project_id,document_id,document_ref_ids,analysis_run_id,situation_id,parent_subject_id,parent_linked_at,parent_child_order,assignee_person_id,title,description,priority,status,closure_reason,subject_type,created_at,updated_at,closed_at";
-  const selectWithoutRefs = "id,subject_number,project_id,document_id,analysis_run_id,situation_id,parent_subject_id,parent_linked_at,parent_child_order,assignee_person_id,title,description,priority,status,closure_reason,subject_type,created_at,updated_at,closed_at";
+  const optionalColumns = ["document_ref_ids", "description_attachments"];
+  const baseColumns = [
+    "id", "subject_number", "project_id", "document_id", "analysis_run_id", "situation_id",
+    "parent_subject_id", "parent_linked_at", "parent_child_order", "assignee_person_id",
+    "title", "description", "priority", "status", "closure_reason", "subject_type",
+    "created_at", "updated_at", "closed_at"
+  ];
   const headers = await getSupabaseAuthHeaders({ Accept: "application/json" });
+  const missingOptionalColumns = new Set();
 
-  const fetchSubjects = async (selectQuery) => {
+  const fetchSubjects = async () => {
+    const selectColumns = [
+      ...baseColumns,
+      ...optionalColumns.filter((column) => !missingOptionalColumns.has(column))
+    ];
     const url = new URL(`${SUPABASE_URL}/rest/v1/subjects`);
-    url.searchParams.set("select", selectQuery);
+    url.searchParams.set("select", selectColumns.join(","));
     url.searchParams.set("project_id", `eq.${projectId}`);
     url.searchParams.set("order", "created_at.asc");
     return fetch(url.toString(), {
@@ -158,28 +183,19 @@ async function fetchProjectFlatSubjects(projectId) {
     });
   };
 
-  let res = await fetchSubjects(selectWithRefs);
-  if (!res.ok && Number(res.status || 0) === 400) {
+  let res = await fetchSubjects();
+  while (!res.ok && Number(res.status || 0) === 400) {
     const rawBody = await res.text().catch(() => "");
-    const parsedBody = safeJsonParse(rawBody);
-    const details = String(
-      parsedBody?.message
-      || parsedBody?.details
-      || parsedBody?.hint
-      || rawBody
-      || ""
-    ).toLowerCase();
-    const missingDocumentRefsColumn = details.includes("document_ref_ids");
-    if (missingDocumentRefsColumn) {
-      console.warn("[project-subjects] subjects table has no document_ref_ids column; falling back to legacy select", {
-        projectId: String(projectId || ""),
-        status: Number(res.status || 0),
-        details: String(parsedBody?.message || parsedBody?.details || rawBody || "")
-      });
-      res = await fetchSubjects(selectWithoutRefs);
-    } else {
+    const missingColumn = extractMissingColumnFromSupabaseError(rawBody);
+    if (!optionalColumns.includes(missingColumn) || missingOptionalColumns.has(missingColumn)) {
       throw new Error(`subjects fetch failed (${res.status}): ${rawBody}`);
     }
+    missingOptionalColumns.add(missingColumn);
+    console.warn("[project-subjects] subjects table missing optional column; falling back", {
+      projectId: String(projectId || ""),
+      missingColumn
+    });
+    res = await fetchSubjects();
   }
 
   if (!res.ok) {
@@ -190,6 +206,7 @@ async function fetchProjectFlatSubjects(projectId) {
   const json = await res.json().catch(() => []);
   return Array.isArray(json) ? json : [];
 }
+
 
 
 async function fetchProjectSubjectMessageCounts(projectId) {
@@ -1146,7 +1163,13 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
   }
 
   const row = Array.isArray(payload) ? payload[0] : payload;
-  const descriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(Array.isArray(row?.description_attachments) ? row.description_attachments : []);
+  const descriptionAttachmentsRaw = Array.isArray(row?.description_attachments) ? row.description_attachments : [];
+  const descriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(descriptionAttachmentsRaw);
+  console.info("[subject-description-attachments] rpc update hydration", {
+    subjectId: normalizedSubjectId,
+    rawAttachments: descriptionAttachmentsRaw.length,
+    hydratedWithObjectUrl: descriptionAttachments.filter((attachment) => String(attachment?.object_url || attachment?.previewUrl || attachment?.localPreviewUrl || "").trim()).length
+  });
   return {
     ...(row || {}),
     id: String(row?.id || normalizedSubjectId),
@@ -1477,6 +1500,20 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
     }
 
     const subjects = await fetchProjectFlatSubjects(backendProjectId);
+    const hydratedSubjects = await Promise.all((Array.isArray(subjects) ? subjects : []).map(async (subject) => {
+      const descriptionAttachments = Array.isArray(subject?.description_attachments) ? subject.description_attachments : [];
+      if (!descriptionAttachments.length) return subject;
+      const hydratedDescriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(descriptionAttachments);
+      console.info("[subject-description-attachments] hydrated subject description attachments", {
+        subjectId: String(subject?.id || ""),
+        attachments: descriptionAttachments.length,
+        hydratedWithObjectUrl: hydratedDescriptionAttachments.filter((attachment) => String(attachment?.object_url || attachment?.previewUrl || attachment?.localPreviewUrl || "").trim()).length
+      });
+      return {
+        ...subject,
+        description_attachments: hydratedDescriptionAttachments
+      };
+    }));
     const subjectLinks = await fetchProjectSubjectLinks(backendProjectId).catch(() => []);
     const subjectAssignees = await fetchProjectSubjectAssignees(backendProjectId).catch(() => []);
     const subjectMessageCountsBySubjectId = await fetchProjectSubjectMessageCounts(backendProjectId).catch(() => ({}));
@@ -1486,7 +1523,7 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
       .map((situation) => String(situation?.id || "").trim())
       .filter(Boolean);
     const subjectIdsBySituationId = await loadSituationSubjectIdsMap(manualSituationIds).catch(() => ({}));
-    const result = buildProjectFlatSubjectsResult(subjects, subjectLinks, { runId: store.ui.runId || "" });
+    const result = buildProjectFlatSubjectsResult(hydratedSubjects, subjectLinks, { runId: store.ui.runId || "" });
     result.assigneePersonIdsBySubjectId = {};
     result.subjectMessageCountsBySubjectId = subjectMessageCountsBySubjectId && typeof subjectMessageCountsBySubjectId === "object"
       ? subjectMessageCountsBySubjectId

--- a/apps/web/js/services/subject-attachments-object-url.js
+++ b/apps/web/js/services/subject-attachments-object-url.js
@@ -30,11 +30,24 @@ export async function resolveSubjectAttachmentObjectUrl(bucket = SUBJECT_ATTACHM
 export async function hydratePersistedSubjectAttachmentsObjectUrls(attachments = []) {
   const list = Array.isArray(attachments) ? attachments : [];
   if (!list.length) return [];
-  const urls = await Promise.all(
-    list.map((attachment) => resolveSubjectAttachmentObjectUrl(attachment?.storage_bucket, attachment?.storage_path))
-  );
+  const hasUsableUrl = (attachment = {}) => String(
+    attachment?.localPreviewUrl
+    || attachment?.previewUrl
+    || attachment?.remoteObjectUrl
+    || attachment?.download_url
+    || attachment?.signed_url
+    || attachment?.url
+    || attachment?.object_url
+    || ""
+  ).trim().length > 0;
+  const urls = await Promise.all(list.map(async (attachment) => {
+    if (hasUsableUrl(attachment)) return "";
+    if (!String(attachment?.storage_path || "").trim()) return "";
+    return resolveSubjectAttachmentObjectUrl(attachment?.storage_bucket, attachment?.storage_path);
+  }));
   return list.map((attachment, index) => ({
     ...attachment,
-    object_url: String(attachment?.object_url || urls[index] || "")
+    object_url: String(attachment?.object_url || urls[index] || ""),
+    previewUrl: String(attachment?.previewUrl || attachment?.object_url || urls[index] || "")
   }));
 }

--- a/apps/web/js/utils/textarea-autosize.js
+++ b/apps/web/js/utils/textarea-autosize.js
@@ -1,0 +1,44 @@
+export function autosizeTextarea(textarea, options = {}) {
+  if (!textarea || typeof textarea !== "object") return null;
+  if (typeof textarea.isConnected === "boolean" && !textarea.isConnected) return null;
+  if (typeof textarea.style !== "object") return null;
+
+  const {
+    minHeightFallback = 110,
+    comfortLines = 3,
+    log = false,
+    logPrefix = "[textarea-autosize]"
+  } = options || {};
+
+  const computedStyle = typeof window !== "undefined" && typeof window.getComputedStyle === "function"
+    ? window.getComputedStyle(textarea)
+    : null;
+  const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle?.lineHeight || "") || 20));
+  const minHeightCss = Math.round(parseFloat(computedStyle?.minHeight || "") || 0);
+  const minHeight = Math.max(Number(minHeightFallback || 0), minHeightCss);
+  const comfortHeight = lineHeight * Math.max(0, Number(comfortLines || 0));
+  const previousHeight = Math.round(parseFloat(String(textarea.style.height || "0")) || textarea.offsetHeight || 0);
+
+  textarea.style.overflowY = "hidden";
+  textarea.style.height = "auto";
+
+  const targetHeight = Math.max(minHeight, Math.round(Number(textarea.scrollHeight || 0) + comfortHeight));
+  textarea.style.height = `${targetHeight}px`;
+
+  if (log) {
+    console.info(logPrefix, {
+      previousHeight,
+      nextHeight: targetHeight,
+      minHeight,
+      comfortLines: Math.max(0, Number(comfortLines || 0))
+    });
+  }
+
+  return {
+    previousHeight,
+    nextHeight: targetHeight,
+    minHeight,
+    lineHeight,
+    comfortLines: Math.max(0, Number(comfortLines || 0))
+  };
+}

--- a/apps/web/js/utils/textarea-autosize.test.mjs
+++ b/apps/web/js/utils/textarea-autosize.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { autosizeTextarea } from "./textarea-autosize.js";
+
+test("autosizeTextarea calcule la hauteur avec 3 lignes de confort", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "120px" };
+    }
+  };
+
+  const textarea = {
+    isConnected: true,
+    style: { height: "120px", overflowY: "auto" },
+    scrollHeight: 210,
+    offsetHeight: 120
+  };
+
+  const result = autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3 });
+
+  assert.equal(textarea.style.overflowY, "hidden");
+  assert.equal(textarea.style.height, "270px");
+  assert.equal(result?.nextHeight, 270);
+  assert.equal(result?.minHeight, 120);
+});
+
+test("autosizeTextarea ignore les textarea détachées", () => {
+  const textarea = { isConnected: false, style: {} };
+  const result = autosizeTextarea(textarea);
+  assert.equal(result, null);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -15,6 +15,7 @@ import {
 } from "../../utils/subject-links.js";
 import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
+import { autosizeTextarea } from "../../utils/textarea-autosize.js";
 import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 
 export function createProjectSubjectsEvents(config) {
@@ -681,9 +682,7 @@ export function createProjectSubjectsEvents(config) {
 
     const descriptionTextarea = root.querySelector("[data-description-draft]");
     if (descriptionTextarea) {
-      descriptionTextarea.addEventListener("input", () => {
-        syncDescriptionEditorDraft(root);
-      });
+      autosizeTextarea(descriptionTextarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
     }
 
     root.querySelectorAll("[data-action='edit-description']").forEach((btn) => {
@@ -1256,6 +1255,7 @@ export function createProjectSubjectsEvents(config) {
       } else if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
+        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1370,6 +1370,7 @@ export function createProjectSubjectsEvents(config) {
       } else if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
+        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1623,17 +1624,12 @@ export function createProjectSubjectsEvents(config) {
         syncMainEmojiPopup({ composerKey: "main" });
       };
 
-      const syncMainComposerTextareaHeight = () => {
-        const computedStyle = window.getComputedStyle(commentTextarea);
-        const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
-        const minHeight = Math.max(170, Math.round(parseFloat(computedStyle.minHeight) || 170));
-        const comfortExtraLines = 3;
-        const extraPadding = lineHeight * comfortExtraLines;
-        commentTextarea.style.overflowY = "hidden";
-        commentTextarea.style.height = "auto";
-        const nextHeight = Math.max(minHeight, commentTextarea.scrollHeight + extraPadding);
-        commentTextarea.style.height = `${nextHeight}px`;
-      };
+      const syncMainComposerTextareaHeight = () => autosizeTextarea(commentTextarea, {
+        minHeightFallback: 170,
+        comfortLines: 3,
+        log: true,
+        logPrefix: "[textarea-autosize]"
+      });
 
       syncMainComposerTextareaHeight();
 
@@ -2833,18 +2829,12 @@ export function createProjectSubjectsEvents(config) {
       if (!submitButton) return;
       submitButton.disabled = !canSubmitInlineEdit(normalizedMessageId);
     };
-    const syncInlineReplyTextareaHeight = (textarea) => {
-      if (!textarea) return;
-      const computedStyle = window.getComputedStyle(textarea);
-      const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
-      const minHeight = Math.max(110, Math.round(parseFloat(computedStyle.minHeight) || 110));
-      const comfortExtraLines = 3;
-      const extraPadding = lineHeight * comfortExtraLines;
-      textarea.style.overflowY = "hidden";
-      textarea.style.height = "auto";
-      const nextHeight = Math.max(minHeight, textarea.scrollHeight + extraPadding);
-      textarea.style.height = `${nextHeight}px`;
-    };
+    const syncInlineReplyTextareaHeight = (textarea) => autosizeTextarea(textarea, {
+      minHeightFallback: 110,
+      comfortLines: 3,
+      log: true,
+      logPrefix: "[textarea-autosize]"
+    });
     const toggleInlineReplyEditorVisibility = (messageId = "", visible = false) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -3388,14 +3378,7 @@ export function createProjectSubjectsEvents(config) {
         });
         closeEmojiPopup({ rerender: false });
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
-        const computedStyle = window.getComputedStyle(textarea);
-        const lineHeight = Math.max(16, Math.round(parseFloat(computedStyle.lineHeight) || 20));
-        const minHeight = Math.max(170, Math.round(parseFloat(computedStyle.minHeight) || 170));
-        const comfortExtraLines = 3;
-        const extraPadding = lineHeight * comfortExtraLines;
-        textarea.style.overflowY = "hidden";
-        textarea.style.height = "auto";
-        textarea.style.height = `${Math.max(minHeight, textarea.scrollHeight + extraPadding)}px`;
+        autosizeTextarea(textarea, { minHeightFallback: 170, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
         rerenderAutocompleteUi();
         return;
       }
@@ -3410,6 +3393,7 @@ export function createProjectSubjectsEvents(config) {
       if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
+        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
         rerenderAutocompleteUi();
         return;
       }
@@ -3746,6 +3730,8 @@ export function createProjectSubjectsEvents(config) {
         previewTab?.setAttribute("aria-selected", "false");
         textareaWrap?.classList.remove("hidden");
         previewWrap?.classList.add("hidden");
+        const textarea = composerRoot?.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+        if (textarea) syncInlineReplyTextareaHeight(textarea);
       };
     });
 
@@ -3791,6 +3777,8 @@ export function createProjectSubjectsEvents(config) {
         previewTab?.setAttribute("aria-selected", "false");
         composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
+        const textarea = composerRoot?.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+        if (textarea) syncInlineReplyTextareaHeight(textarea);
       };
     });
 
@@ -3899,6 +3887,8 @@ export function createProjectSubjectsEvents(config) {
         composerRoot?.querySelector("[data-action='description-tab-preview']")?.classList.remove("is-active");
         composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
+        const textarea = composerRoot?.querySelector("[data-description-draft]");
+        if (textarea) autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
       };
     });
     root.querySelectorAll("[data-action='description-tab-preview']").forEach((btn) => {
@@ -3923,11 +3913,13 @@ export function createProjectSubjectsEvents(config) {
     root.querySelectorAll("[data-action='description-format'][data-format]").forEach((btn) => {
       btn.onclick = () => {
         const action = String(btn.dataset.format || "").trim();
-        const textarea = root.querySelector("[data-description-draft]");
+        const composerRoot = btn.closest(".comment-composer");
+        const textarea = composerRoot?.querySelector("[data-description-draft]");
         if (!action || !textarea) return;
         if (action === "subject-ref") {
           ensureSubjectRefTriggerInTextarea(textarea);
           syncDescriptionEditorDraft(root);
+          autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
           closeMentionPopup({ rerender: false });
           closeEmojiPopup({ rerender: false });
           void syncSubjectRefPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`);
@@ -3937,6 +3929,7 @@ export function createProjectSubjectsEvents(config) {
         const didApply = applyMarkdownComposerAction(textarea, action);
         if (!didApply) return;
         syncDescriptionEditorDraft(root);
+        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
         if (action === "mention") {
           void syncMentionPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`, { forceOpen: true });
         } else {
@@ -3969,8 +3962,10 @@ export function createProjectSubjectsEvents(config) {
     });
     root.querySelectorAll("[data-description-draft]").forEach((textarea) => {
       const composerKey = `description:${String(textarea.dataset.descriptionDraft || "").trim()}`;
+      autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
       textarea.addEventListener("input", () => {
         syncDescriptionEditorDraft(root);
+        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
         void syncInlineAutocomplete(textarea, composerKey);
       });
       textarea.addEventListener("keydown", (event) => {


### PR DESCRIPTION
### Motivation
- Reliable rendering of subject description attachments was intermittent because `description_attachments` was not always selected/hydrated when loading subjects and persisted attachments could lack a usable URL lifecycle; this produced missing images/cards after open/change/reload/save. 
- Textarea auto-resize regressed because the logic was duplicated and inconsistently applied across description editors and comment composers, so programmatic changes (toolbar, autocomplete, preview toggles, rerender) did not always recalc height. 
- The intent is to robustly hydrate description attachments URLs when subjects are loaded/updated and to centralize autosize behavior so all editors behave consistently without changing existing render components. 

### Description
- Treat `description_attachments` as an optional column when fetching subjects and implement a safe fallback if the DB schema lacks it, by progressively removing missing optional columns on 400 errors. (modified `apps/web/js/services/project-subjects-supabase.js`).
- Hydrate description attachments object URLs after list load and after the `update_subject_description` RPC call using the existing signer helper, and log hydration events with the prefix `[subject-description-attachments]`. (modified `apps/web/js/services/project-subjects-supabase.js`).
- Strengthened `hydratePersistedSubjectAttachmentsObjectUrls` so it regenerates a signed URL only when no usable preview/download URL exists and also fills `previewUrl` fallback; keeps existing local preview behavior. (modified `apps/web/js/services/subject-attachments-object-url.js`).
- Added a shared helper `autosizeTextarea(textarea, options)` to centralize auto-resize logic (3 comfort lines, respect CSS `min-height`, overflow hidden, guards for detached elements). (new file `apps/web/js/utils/textarea-autosize.js`).
- Replaced duplicated resize code in `project-subjects-events.js` with the helper and ensured autosize is invoked at mount, on `input`, after markdown toolbar actions, after autocomplete/mention/emoji/subject-ref insertions, and on write/preview toggles for: main composer, inline reply, inline edit, and description editor; added targeted `[textarea-autosize]` logs. (modified `apps/web/js/views/project-subjects/project-subjects-events.js`).
- No new rendering components introduced; existing `renderSubjectAttachmentTile` / `renderSubjectAttachmentsPreviewList` remain in use and keep image vs file-card behavior intact.

### Testing
- Ran unit tests: `node --test apps/web/js/services/subject-attachments-object-url.test.mjs apps/web/js/views/project-subjects/project-subjects-attachments-ui.test.mjs apps/web/js/utils/textarea-autosize.test.mjs`, which completed with 6 tests total (5 passed, 1 skipped due to environment import limitations). 
- Performed static checks: `node --check` on `apps/web/js/services/project-subjects-supabase.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, and `apps/web/js/utils/textarea-autosize.js`, all succeeded with no syntax errors. 
- The changes were designed to preserve existing signed URL generation and attachment rendering paths while applying autosize uniformly; manual UI validation scenarios described in the task should be exercised in a browser to confirm runtime behavior (attachments visible after open/change/reload/save and textarea auto-resize across editors and after toolbar/autocomplete actions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7275cec5c8329b5a6169232ade802)