### PR TITLE
Fix subject description attachments source of truth and unify textarea autosize lifecycle

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -6,6 +6,10 @@ import { resolveCurrentBackendProjectId, resolveCurrentUserDirectoryPersonId } f
 import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 import { hydratePersistedSubjectAttachmentsObjectUrls } from "./subject-attachments-object-url.js";
+import {
+  normalizeAttachmentBucket,
+  normalizeSubjectAttachmentStoragePath
+} from "./subject-attachments-storage-path.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
@@ -157,7 +161,7 @@ async function fetchProjectFlatSubjects(projectId) {
     return [];
   }
 
-  const optionalColumns = ["document_ref_ids", "description_attachments"];
+  const optionalColumns = ["document_ref_ids"];
   const baseColumns = [
     "id", "subject_number", "project_id", "document_id", "analysis_run_id", "situation_id",
     "parent_subject_id", "parent_linked_at", "parent_child_order", "assignee_person_id",
@@ -205,6 +209,86 @@ async function fetchProjectFlatSubjects(projectId) {
 
   const json = await res.json().catch(() => []);
   return Array.isArray(json) ? json : [];
+}
+
+async function fetchDescriptionAttachmentsBySubjectIds(subjectIds = []) {
+  const ids = [...new Set((Array.isArray(subjectIds) ? subjectIds : []).map((value) => normalizeUuid(value)).filter(Boolean))];
+  if (!ids.length) return new Map();
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_message_attachments`);
+  url.searchParams.set("select", "id,project_id,subject_id,message_id,storage_bucket,storage_path,file_name,mime_type,size_bytes,width,height,sort_order,created_at,linked_at");
+  url.searchParams.set("subject_id", `in.(${ids.join(",")})`);
+  url.searchParams.set("message_id", "is.null");
+  url.searchParams.set("deleted_at", "is.null");
+  url.searchParams.set("linked_at", "not.is.null");
+  url.searchParams.set("order", "sort_order.asc");
+  url.searchParams.append("order", "created_at.asc");
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
+    cache: "no-store"
+  });
+  if (!response.ok) {
+    const txt = await response.text().catch(() => "");
+    throw new Error(`subject description attachments fetch failed (${response.status}): ${txt}`);
+  }
+
+  const rows = await response.json().catch(() => []);
+  const grouped = new Map();
+  const attachmentRows = Array.isArray(rows) ? rows : [];
+  const normalizedRows = attachmentRows.map((row) => {
+    const subjectId = normalizeUuid(row?.subject_id);
+    const storageBucket = normalizeAttachmentBucket(row?.storage_bucket, "subject-message-attachments");
+    return {
+      ...row,
+      id: normalizeUuid(row?.id),
+      subject_id: subjectId,
+      storage_bucket: storageBucket,
+      storage_path: normalizeSubjectAttachmentStoragePath(row?.storage_path, storageBucket),
+      file_name: String(row?.file_name || ""),
+      mime_type: String(row?.mime_type || "")
+    };
+  }).filter((row) => !!row.subject_id);
+
+  const hydratedRows = await hydratePersistedSubjectAttachmentsObjectUrls(normalizedRows, {
+    forceRefreshSignedUrls: true
+  });
+
+  hydratedRows.forEach((row) => {
+    const subjectId = normalizeUuid(row?.subject_id);
+    if (!subjectId) return;
+    const list = grouped.get(subjectId) || [];
+    list.push(row);
+    grouped.set(subjectId, list);
+  });
+
+  if (isSubjectDescriptionDebugEnabled()) {
+    let totalAttachments = 0;
+    let regeneratedUrls = 0;
+    let imageCount = 0;
+    let fileCardCount = 0;
+    grouped.forEach((entries, subjectId) => {
+      totalAttachments += entries.length;
+      regeneratedUrls += entries.filter((entry) => String(entry?.object_url || entry?.previewUrl || "").trim()).length;
+      imageCount += entries.filter((entry) => String(entry?.mime_type || "").toLowerCase().startsWith("image/")).length;
+      fileCardCount += entries.filter((entry) => !String(entry?.mime_type || "").toLowerCase().startsWith("image/")).length;
+      console.info("[subject-description-attachments] loaded", {
+        source: "subject_message_attachments",
+        subjectId,
+        attachments: entries.length
+      });
+    });
+    console.info("[subject-description-attachments] hydration summary", {
+      source: "subject_message_attachments",
+      subjects: grouped.size,
+      attachments: totalAttachments,
+      regeneratedUrls,
+      imageTiles: imageCount,
+      fileCards: fileCardCount
+    });
+  }
+  return grouped;
 }
 
 
@@ -1164,12 +1248,17 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
 
   const row = Array.isArray(payload) ? payload[0] : payload;
   const descriptionAttachmentsRaw = Array.isArray(row?.description_attachments) ? row.description_attachments : [];
-  const descriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(descriptionAttachmentsRaw);
-  console.info("[subject-description-attachments] rpc update hydration", {
-    subjectId: normalizedSubjectId,
-    rawAttachments: descriptionAttachmentsRaw.length,
-    hydratedWithObjectUrl: descriptionAttachments.filter((attachment) => String(attachment?.object_url || attachment?.previewUrl || attachment?.localPreviewUrl || "").trim()).length
+  const descriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(descriptionAttachmentsRaw, {
+    forceRefreshSignedUrls: true
   });
+  if (debugEnabled) {
+    console.info("[subject-description-attachments] rpc update hydration", {
+      source: "update_subject_description rpc",
+      subjectId: normalizedSubjectId,
+      rawAttachments: descriptionAttachmentsRaw.length,
+      hydratedWithObjectUrl: descriptionAttachments.filter((attachment) => String(attachment?.object_url || attachment?.previewUrl || "").trim()).length
+    });
+  }
   return {
     ...(row || {}),
     id: String(row?.id || normalizedSubjectId),
@@ -1500,20 +1589,25 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
     }
 
     const subjects = await fetchProjectFlatSubjects(backendProjectId);
-    const hydratedSubjects = await Promise.all((Array.isArray(subjects) ? subjects : []).map(async (subject) => {
-      const descriptionAttachments = Array.isArray(subject?.description_attachments) ? subject.description_attachments : [];
-      if (!descriptionAttachments.length) return subject;
-      const hydratedDescriptionAttachments = await hydratePersistedSubjectAttachmentsObjectUrls(descriptionAttachments);
-      console.info("[subject-description-attachments] hydrated subject description attachments", {
-        subjectId: String(subject?.id || ""),
-        attachments: descriptionAttachments.length,
-        hydratedWithObjectUrl: hydratedDescriptionAttachments.filter((attachment) => String(attachment?.object_url || attachment?.previewUrl || attachment?.localPreviewUrl || "").trim()).length
-      });
+    const subjectIds = (Array.isArray(subjects) ? subjects : []).map((subject) => normalizeUuid(subject?.id)).filter(Boolean);
+    const descriptionAttachmentsBySubjectId = await fetchDescriptionAttachmentsBySubjectIds(subjectIds).catch(() => new Map());
+    const hydratedSubjects = (Array.isArray(subjects) ? subjects : []).map((subject) => {
+      const subjectId = normalizeUuid(subject?.id);
+      const descriptionAttachments = Array.isArray(descriptionAttachmentsBySubjectId.get(subjectId))
+        ? descriptionAttachmentsBySubjectId.get(subjectId)
+        : [];
+      if (isSubjectDescriptionDebugEnabled()) {
+        console.info("[subject-description-attachments] merged subject attachments", {
+          source: "subject_message_attachments",
+          subjectId,
+          attachments: descriptionAttachments.length
+        });
+      }
       return {
         ...subject,
-        description_attachments: hydratedDescriptionAttachments
+        description_attachments: descriptionAttachments
       };
-    }));
+    });
     const subjectLinks = await fetchProjectSubjectLinks(backendProjectId).catch(() => []);
     const subjectAssignees = await fetchProjectSubjectAssignees(backendProjectId).catch(() => []);
     const subjectMessageCountsBySubjectId = await fetchProjectSubjectMessageCounts(backendProjectId).catch(() => ({}));

--- a/apps/web/js/services/subject-attachments-object-url.js
+++ b/apps/web/js/services/subject-attachments-object-url.js
@@ -27,9 +27,14 @@ export async function resolveSubjectAttachmentObjectUrl(bucket = SUBJECT_ATTACHM
   }
 }
 
-export async function hydratePersistedSubjectAttachmentsObjectUrls(attachments = []) {
+function isDescriptionAttachmentsDebugEnabled() {
+  return typeof window !== "undefined" && window?.__MDALL_DEBUG_SUBJECT_DESCRIPTION__ === true;
+}
+
+export async function hydratePersistedSubjectAttachmentsObjectUrls(attachments = [], options = {}) {
   const list = Array.isArray(attachments) ? attachments : [];
   if (!list.length) return [];
+  const forceRefreshSignedUrls = options?.forceRefreshSignedUrls === true;
   const hasUsableUrl = (attachment = {}) => String(
     attachment?.localPreviewUrl
     || attachment?.previewUrl
@@ -40,14 +45,26 @@ export async function hydratePersistedSubjectAttachmentsObjectUrls(attachments =
     || attachment?.object_url
     || ""
   ).trim().length > 0;
+  let refreshedUrls = 0;
   const urls = await Promise.all(list.map(async (attachment) => {
-    if (hasUsableUrl(attachment)) return "";
+    if (!forceRefreshSignedUrls && hasUsableUrl(attachment)) return "";
     if (!String(attachment?.storage_path || "").trim()) return "";
+    refreshedUrls += 1;
     return resolveSubjectAttachmentObjectUrl(attachment?.storage_bucket, attachment?.storage_path);
   }));
-  return list.map((attachment, index) => ({
+  const hydrated = list.map((attachment, index) => ({
     ...attachment,
-    object_url: String(attachment?.object_url || urls[index] || ""),
-    previewUrl: String(attachment?.previewUrl || attachment?.object_url || urls[index] || "")
+    object_url: String(forceRefreshSignedUrls ? (urls[index] || "") : (attachment?.object_url || urls[index] || "")),
+    previewUrl: String(forceRefreshSignedUrls
+      ? (urls[index] || "")
+      : (attachment?.previewUrl || attachment?.object_url || urls[index] || ""))
   }));
+  if (isDescriptionAttachmentsDebugEnabled()) {
+    console.info("[subject-description-attachments] object url hydration", {
+      attachments: list.length,
+      forceRefreshSignedUrls,
+      regeneratedUrls: refreshedUrls
+    });
+  }
+  return hydrated;
 }

--- a/apps/web/js/services/subject-attachments-object-url.test.mjs
+++ b/apps/web/js/services/subject-attachments-object-url.test.mjs
@@ -41,6 +41,18 @@ test("hydratePersistedSubjectAttachmentsObjectUrls enrichit les pièces jointes 
     assert.equal(hydrated.length, 1);
     assert.equal(hydrated[0].object_url, "https://signed.example/subject-message-attachments/project-1/subject-1/file.png");
     assert.equal(calls.length, 1);
+
+    calls.length = 0;
+    const forceHydrated = await hydratePersistedSubjectAttachmentsObjectUrls([
+      {
+        id: "a2",
+        storage_bucket: "subject-message-attachments",
+        storage_path: "project-1/subject-1/with-existing-url.pdf",
+        object_url: "https://expired.example/file.pdf"
+      }
+    ], { forceRefreshSignedUrls: true });
+    assert.equal(forceHydrated[0].object_url, "https://signed.example/subject-message-attachments/project-1/subject-1/with-existing-url.pdf");
+    assert.equal(calls.length, 1);
   } finally {
     supabase.storage = originalStorage;
   }

--- a/apps/web/js/utils/textarea-autosize.js
+++ b/apps/web/js/utils/textarea-autosize.js
@@ -6,7 +6,9 @@ export function autosizeTextarea(textarea, options = {}) {
     minHeightFallback = 110,
     comfortLines = 3,
     log = false,
-    logPrefix = "[textarea-autosize]"
+    logPrefix = "[textarea-autosize]",
+    cause = "manual",
+    textareaType = ""
   } = options || {};
 
   const computedStyle = typeof window !== "undefined" && typeof window.getComputedStyle === "function"
@@ -18,10 +20,36 @@ export function autosizeTextarea(textarea, options = {}) {
   const comfortHeight = lineHeight * Math.max(0, Number(comfortLines || 0));
   const previousHeight = Math.round(parseFloat(String(textarea.style.height || "0")) || textarea.offsetHeight || 0);
 
-  textarea.style.overflowY = "hidden";
-  textarea.style.height = "0px";
+  if (textarea.isConnected === false) {
+    return {
+      previousHeight,
+      nextHeight: previousHeight,
+      minHeight,
+      lineHeight,
+      comfortLines: Math.max(0, Number(comfortLines || 0)),
+      comfortHeight,
+      scrollHeight: 0,
+      skipped: "disconnected"
+    };
+  }
 
-  const targetHeight = Math.max(minHeight, Math.round(Number(textarea.scrollHeight || 0) + comfortHeight));
+  textarea.style.overflowY = "hidden";
+  textarea.style.height = "auto";
+
+  const measuredScrollHeight = Math.round(Number(textarea.scrollHeight || 0));
+  if (!measuredScrollHeight && textarea.offsetParent === null) {
+    return {
+      previousHeight,
+      nextHeight: previousHeight,
+      minHeight,
+      lineHeight,
+      comfortLines: Math.max(0, Number(comfortLines || 0)),
+      comfortHeight,
+      scrollHeight: measuredScrollHeight,
+      skipped: "not-measurable"
+    };
+  }
+  const targetHeight = Math.max(minHeight, Math.round(measuredScrollHeight + comfortHeight));
   textarea.style.height = `${targetHeight}px`;
 
   const shouldLog = !!log
@@ -29,8 +57,13 @@ export function autosizeTextarea(textarea, options = {}) {
     && window?.__MDALL_DEBUG_TEXTAREA_AUTOSIZE__ === true;
   if (shouldLog) {
     console.info(logPrefix, {
+      textareaType,
+      cause,
       previousHeight,
       nextHeight: targetHeight,
+      scrollHeight: measuredScrollHeight,
+      lineHeight,
+      comfortHeight,
       minHeight,
       comfortLines: Math.max(0, Number(comfortLines || 0))
     });
@@ -41,6 +74,27 @@ export function autosizeTextarea(textarea, options = {}) {
     nextHeight: targetHeight,
     minHeight,
     lineHeight,
-    comfortLines: Math.max(0, Number(comfortLines || 0))
+    comfortLines: Math.max(0, Number(comfortLines || 0)),
+    comfortHeight,
+    scrollHeight: measuredScrollHeight
   };
+}
+
+export function bindAutosizeTextarea(textarea, options = {}) {
+  if (!textarea || typeof textarea !== "object") {
+    return { resizeNow: () => null, resizeNextFrame: () => null };
+  }
+  const resizeNow = (cause = "manual") => autosizeTextarea(textarea, { ...options, cause });
+  const resizeNextFrame = (cause = "raf") => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => {
+        resizeNow(cause);
+      });
+      return null;
+    }
+    return resizeNow(cause);
+  };
+
+  resizeNow(options?.initialCause || "mount");
+  return { resizeNow, resizeNextFrame };
 }

--- a/apps/web/js/utils/textarea-autosize.test.mjs
+++ b/apps/web/js/utils/textarea-autosize.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { autosizeTextarea } from "./textarea-autosize.js";
+import { autosizeTextarea, bindAutosizeTextarea } from "./textarea-autosize.js";
 
 test("autosizeTextarea calcule la hauteur avec 3 lignes de confort", () => {
   global.window = {
@@ -29,4 +29,25 @@ test("autosizeTextarea retourne null si textarea invalide (sans style)", () => {
   const textarea = { isConnected: false };
   const result = autosizeTextarea(textarea);
   assert.equal(result, null);
+});
+
+test("bindAutosizeTextarea expose un resize manuel et RAF", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "100px" };
+    }
+  };
+  global.requestAnimationFrame = (fn) => fn();
+  const textarea = {
+    isConnected: true,
+    style: { height: "100px", overflowY: "auto" },
+    scrollHeight: 120,
+    offsetHeight: 100,
+    offsetParent: {}
+  };
+  const binder = bindAutosizeTextarea(textarea, { minHeightFallback: 90, comfortLines: 3, initialCause: "mount" });
+  const immediate = binder.resizeNow("input");
+  binder.resizeNextFrame("raf-open");
+  assert.equal(immediate?.nextHeight, 180);
+  assert.equal(textarea.style.height, "180px");
 });

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -15,7 +15,7 @@ import {
 } from "../../utils/subject-links.js";
 import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
-import { autosizeTextarea } from "../../utils/textarea-autosize.js";
+import { autosizeTextarea, bindAutosizeTextarea } from "../../utils/textarea-autosize.js";
 import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 
 export function createProjectSubjectsEvents(config) {
@@ -626,6 +626,56 @@ export function createProjectSubjectsEvents(config) {
 
   function wireDetailsInteractive(root) {
     if (!root) return;
+    const getTextareaAutosizeMeta = (textarea) => {
+      const type = textarea?.matches?.("#humanCommentBox")
+        ? "main-comment"
+        : textarea?.matches?.("[data-description-draft]")
+          ? "description"
+          : textarea?.matches?.("[data-thread-edit-draft]")
+            ? "inline-edit"
+            : textarea?.matches?.("[data-thread-reply-draft]")
+              ? "inline-reply"
+              : "unknown";
+      const minHeightFallback = type === "main-comment" ? 170 : 110;
+      return { type, minHeightFallback };
+    };
+    const runAutosize = (textarea, cause = "manual") => {
+      if (!textarea) return null;
+      const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
+      return autosizeTextarea(textarea, {
+        minHeightFallback,
+        comfortLines: 3,
+        log: true,
+        logPrefix: "[textarea-autosize]",
+        cause,
+        textareaType: type
+      });
+    };
+    const scheduleAutosize = (textarea, cause = "raf") => {
+      if (!textarea) return;
+      const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
+      const binder = bindAutosizeTextarea(textarea, {
+        minHeightFallback,
+        comfortLines: 3,
+        log: true,
+        logPrefix: "[textarea-autosize]",
+        textareaType: type,
+        initialCause: "noop"
+      });
+      binder.resizeNextFrame(cause);
+    };
+    const bindComposerAutosizeLifecycle = (textarea) => {
+      if (!textarea || textarea.dataset.autosizeBound === "true") return;
+      textarea.dataset.autosizeBound = "true";
+      runAutosize(textarea, "mount");
+      scheduleAutosize(textarea, "raf-open");
+      ["input", "paste", "cut", "drop"].forEach((eventName) => {
+        textarea.addEventListener(eventName, () => {
+          runAutosize(textarea, eventName);
+          scheduleAutosize(textarea, `raf-${eventName}`);
+        });
+      });
+    };
 
     bindSubjectMetaDropdownDocumentEvents();
     const dropdownHost = renderSubjectMetaDropdownHost(root);
@@ -682,7 +732,7 @@ export function createProjectSubjectsEvents(config) {
 
     const descriptionTextarea = root.querySelector("[data-description-draft]");
     if (descriptionTextarea) {
-      autosizeTextarea(descriptionTextarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+      bindComposerAutosizeLifecycle(descriptionTextarea);
     }
 
     root.querySelectorAll("[data-action='edit-description']").forEach((btn) => {
@@ -1255,7 +1305,7 @@ export function createProjectSubjectsEvents(config) {
       } else if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
-        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        runAutosize(textarea, "mention");
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1370,7 +1420,7 @@ export function createProjectSubjectsEvents(config) {
       } else if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
-        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        runAutosize(textarea, "subject-ref");
       } else {
         const replyUi = resolveInlineReplyUiState();
         if (mode === "reply") {
@@ -1624,18 +1674,14 @@ export function createProjectSubjectsEvents(config) {
         syncMainEmojiPopup({ composerKey: "main" });
       };
 
-      const syncMainComposerTextareaHeight = () => autosizeTextarea(commentTextarea, {
-        minHeightFallback: 170,
-        comfortLines: 3,
-        log: true,
-        logPrefix: "[textarea-autosize]"
-      });
+      const syncMainComposerTextareaHeight = (cause = "manual") => runAutosize(commentTextarea, cause);
 
-      syncMainComposerTextareaHeight();
+      bindComposerAutosizeLifecycle(commentTextarea);
+      syncMainComposerTextareaHeight("mount");
 
       commentTextarea.addEventListener("input", () => {
         store.situationsView.commentDraft = String(commentTextarea.value || "");
-        syncMainComposerTextareaHeight();
+        syncMainComposerTextareaHeight("input");
         void syncMainComposerAutocomplete();
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
       });
@@ -2829,12 +2875,7 @@ export function createProjectSubjectsEvents(config) {
       if (!submitButton) return;
       submitButton.disabled = !canSubmitInlineEdit(normalizedMessageId);
     };
-    const syncInlineReplyTextareaHeight = (textarea) => autosizeTextarea(textarea, {
-      minHeightFallback: 110,
-      comfortLines: 3,
-      log: true,
-      logPrefix: "[textarea-autosize]"
-    });
+    const syncInlineReplyTextareaHeight = (textarea, cause = "manual") => runAutosize(textarea, cause);
     const toggleInlineReplyEditorVisibility = (messageId = "", visible = false) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
@@ -3378,7 +3419,7 @@ export function createProjectSubjectsEvents(config) {
         });
         closeEmojiPopup({ rerender: false });
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
-        autosizeTextarea(textarea, { minHeightFallback: 170, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        runAutosize(textarea, "emoji");
         rerenderAutocompleteUi();
         return;
       }
@@ -3393,7 +3434,7 @@ export function createProjectSubjectsEvents(config) {
       if (mode === "description") {
         const descriptionState = resolveDescriptionEditorState();
         descriptionState.draft = String(result.nextText || "");
-        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        runAutosize(textarea, "emoji");
         rerenderAutocompleteUi();
         return;
       }
@@ -3410,6 +3451,7 @@ export function createProjectSubjectsEvents(config) {
     };
 
     root.querySelectorAll("[data-thread-reply-draft]").forEach((textarea) => {
+      bindComposerAutosizeLifecycle(textarea);
       syncInlineReplyTextareaHeight(textarea);
       textarea.addEventListener("input", () => {
         const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
@@ -3562,6 +3604,7 @@ export function createProjectSubjectsEvents(config) {
     });
 
     root.querySelectorAll("[data-thread-edit-draft]").forEach((textarea) => {
+      bindComposerAutosizeLifecycle(textarea);
       syncInlineReplyTextareaHeight(textarea);
       textarea.addEventListener("input", () => {
         const messageId = String(textarea.dataset.threadEditDraft || "").trim();
@@ -3888,7 +3931,10 @@ export function createProjectSubjectsEvents(config) {
         composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
         const textarea = composerRoot?.querySelector("[data-description-draft]");
-        if (textarea) autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        if (textarea) {
+          runAutosize(textarea, "preview-toggle");
+          scheduleAutosize(textarea, "raf-open");
+        }
       };
     });
     root.querySelectorAll("[data-action='description-tab-preview']").forEach((btn) => {
@@ -3919,7 +3965,7 @@ export function createProjectSubjectsEvents(config) {
         if (action === "subject-ref") {
           ensureSubjectRefTriggerInTextarea(textarea);
           syncDescriptionEditorDraft(root);
-          autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+          runAutosize(textarea, "subject-ref");
           closeMentionPopup({ rerender: false });
           closeEmojiPopup({ rerender: false });
           void syncSubjectRefPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`);
@@ -3929,7 +3975,7 @@ export function createProjectSubjectsEvents(config) {
         const didApply = applyMarkdownComposerAction(textarea, action);
         if (!didApply) return;
         syncDescriptionEditorDraft(root);
-        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        runAutosize(textarea, "toolbar");
         if (action === "mention") {
           void syncMentionPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`, { forceOpen: true });
         } else {
@@ -3962,10 +4008,10 @@ export function createProjectSubjectsEvents(config) {
     });
     root.querySelectorAll("[data-description-draft]").forEach((textarea) => {
       const composerKey = `description:${String(textarea.dataset.descriptionDraft || "").trim()}`;
-      autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+      bindComposerAutosizeLifecycle(textarea);
       textarea.addEventListener("input", () => {
         syncDescriptionEditorDraft(root);
-        autosizeTextarea(textarea, { minHeightFallback: 110, comfortLines: 3, log: true, logPrefix: "[textarea-autosize]" });
+        runAutosize(textarea, "input");
         void syncInlineAutocomplete(textarea, composerKey);
       });
       textarea.addEventListener("keydown", (event) => {


### PR DESCRIPTION
### Motivation

- Description attachments were intermittently missing because the frontend relied on a non-guaranteed `subjects.description_attachments` column instead of the attachment table as the source of truth. 
- Persisted attachment URLs could be stale because existing `object_url`/`previewUrl` values were trusted and not re-generated from `storage_path`. 
- The textarea auto-resize flow was fragile because it used `height = "0px"` and many ad‑hoc calls, causing incorrect sizing on mount, toggles and programmatic mutations. 

### Description

- Stop relying on `subjects.description_attachments` in `fetchProjectFlatSubjects()` and add `fetchDescriptionAttachmentsBySubjectIds(subjectIds)` which reads from `public.subject_message_attachments` (`message_id is null`, `deleted_at is null`, `linked_at not null`), normalizes storage metadata and hydrates signed URLs from `storage_path`. (modified: `apps/web/js/services/project-subjects-supabase.js`).
- Harden attachment URL hydration by adding `forceRefreshSignedUrls` to `hydratePersistedSubjectAttachmentsObjectUrls()` so signed URLs can be regenerated from `storage_path` even when an URL field already exists, and use it on description loads and RPC update hydration. (modified: `apps/web/js/services/subject-attachments-object-url.js` and usage sites in `project-subjects-supabase.js`).
- Preserve the immediate post-save UI patch of `target.item.description_attachments` while ensuring reloads rebuild the same state from `subject_message_attachments` so post-save and post-reload states converge. (modified: `apps/web/js/services/project-subjects-supabase.js`, small UX integration points remain in `apps/web/js/views/project-subjects/project-subjects-description.js`).
- Replace brittle autosize logic with a robust implementation using `height = "auto"`, measured `scrollHeight`, +3 comfort lines, non-measurable/disconnected guards and richer debug info, and expose a binder `bindAutosizeTextarea()` for immediate + RAF scheduling. (modified: `apps/web/js/utils/textarea-autosize.js`).
- Centralize and wire a single autosize lifecycle (`runAutosize`, `scheduleAutosize`, `bindComposerAutosizeLifecycle`) for all compose textareas (`#humanCommentBox`, `[data-description-draft]`, `[data-thread-reply-draft]`, `[data-thread-edit-draft]`) to cover mount, prefilled open (immediate + RAF), input, paste/cut/drop, toolbar/mention/emoji/subject-ref insertions and preview toggles. (modified: `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Add targeted debug instrumentation under the existing debug flags for `[subject-description-attachments]` and `[textarea-autosize]` (counts, regenerated URLs, previous/next heights). (modified: `apps/web/js/services/project-subjects-supabase.js`, `apps/web/js/services/subject-attachments-object-url.js`, `apps/web/js/utils/textarea-autosize.js`).
- Files changed: `apps/web/js/services/project-subjects-supabase.js`, `apps/web/js/services/subject-attachments-object-url.js`, `apps/web/js/services/subject-attachments-object-url.test.mjs`, `apps/web/js/utils/textarea-autosize.js`, `apps/web/js/utils/textarea-autosize.test.mjs`, `apps/web/js/views/project-subjects/project-subjects-events.js`.

### Testing

- Ran the unit suites with `node --test apps/web/js/services/subject-attachments-object-url.test.mjs apps/web/js/utils/textarea-autosize.test.mjs`, where the autosize tests passed and the attachment test was skipped in this environment due to ESM import limitations (`ERR_UNSUPPORTED_ESM_URL_SCHEME`).
- The new autosize binder behavior is covered by `apps/web/js/utils/textarea-autosize.test.mjs` and passed (including immediate and RAF resizes). 
- The hydrated-URL logic is covered by `apps/web/js/services/subject-attachments-object-url.test.mjs` and demonstrates the `forceRefreshSignedUrls` behavior, but that test is skipped here because the test runner cannot import the auth module in this environment; it ran locally in CI-like environments should pass when Supabase auth is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72f7017d88329926291dc32eec3a6)