### PR TITLE
Fix textarea autosize race, add subjects.document_ref_ids migration, and harden description attachments loading

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -14,6 +14,7 @@ import {
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
 const SUBJECT_DESCRIPTION_DEBUG_FLAG = "__MDALL_DEBUG_SUBJECT_DESCRIPTION__";
+const PROJECT_SUBJECTS_DEBUG_FLAG = "__MDALL_DEBUG_PROJECT_SUBJECTS__";
 
 
 
@@ -53,6 +54,10 @@ async function getSupabaseAuthHeaders(extra = {}) {
 
 function isSubjectDescriptionDebugEnabled() {
   return typeof window !== "undefined" && window?.[SUBJECT_DESCRIPTION_DEBUG_FLAG] === true;
+}
+
+function isProjectSubjectsDebugEnabled() {
+  return typeof window !== "undefined" && window?.[PROJECT_SUBJECTS_DEBUG_FLAG] === true;
 }
 
 function truncateDescriptionPreview(value = "", maxLength = 160) {
@@ -208,7 +213,17 @@ async function fetchProjectFlatSubjects(projectId) {
   }
 
   const json = await res.json().catch(() => []);
-  return Array.isArray(json) ? json : [];
+  const rows = Array.isArray(json) ? json : [];
+  if (isProjectSubjectsDebugEnabled()) {
+    const hasDocumentRefIdsInPayload = rows.some((row) => Object.prototype.hasOwnProperty.call(row || {}, "document_ref_ids"));
+    console.info("[project-subjects] fetch subjects", {
+      projectId: String(projectId || ""),
+      rows: rows.length,
+      missingOptionalColumns: [...missingOptionalColumns],
+      hasDocumentRefIdsInPayload
+    });
+  }
+  return rows;
 }
 
 async function fetchDescriptionAttachmentsBySubjectIds(subjectIds = []) {
@@ -1593,6 +1608,9 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
     const descriptionAttachmentsBySubjectId = await fetchDescriptionAttachmentsBySubjectIds(subjectIds).catch(() => new Map());
     const hydratedSubjects = (Array.isArray(subjects) ? subjects : []).map((subject) => {
       const subjectId = normalizeUuid(subject?.id);
+      const documentRefIds = Array.isArray(subject?.document_ref_ids)
+        ? subject.document_ref_ids.map((value) => normalizeUuid(value)).filter(Boolean)
+        : [];
       const descriptionAttachments = Array.isArray(descriptionAttachmentsBySubjectId.get(subjectId))
         ? descriptionAttachmentsBySubjectId.get(subjectId)
         : [];
@@ -1605,9 +1623,17 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
       }
       return {
         ...subject,
+        document_ref_ids: documentRefIds,
         description_attachments: descriptionAttachments
       };
     });
+    if (isProjectSubjectsDebugEnabled()) {
+      console.info("[project-subjects] hydrated subjects", {
+        projectId: backendProjectId,
+        count: hydratedSubjects.length,
+        subjectsWithDocumentRefs: hydratedSubjects.filter((subject) => Array.isArray(subject?.document_ref_ids) && subject.document_ref_ids.length > 0).length
+      });
+    }
     const subjectLinks = await fetchProjectSubjectLinks(backendProjectId).catch(() => []);
     const subjectAssignees = await fetchProjectSubjectAssignees(backendProjectId).catch(() => []);
     const subjectMessageCountsBySubjectId = await fetchProjectSubjectMessageCounts(backendProjectId).catch(() => ({}));

--- a/apps/web/js/utils/textarea-autosize.js
+++ b/apps/web/js/utils/textarea-autosize.js
@@ -19,6 +19,7 @@ export function autosizeTextarea(textarea, options = {}) {
   const minHeight = Math.max(Number(minHeightFallback || 0), minHeightCss);
   const comfortHeight = lineHeight * Math.max(0, Number(comfortLines || 0));
   const previousHeight = Math.round(parseFloat(String(textarea.style.height || "0")) || textarea.offsetHeight || 0);
+  const isVisible = textarea.offsetParent !== null || textarea.getClientRects?.().length > 0;
 
   if (textarea.isConnected === false) {
     return {
@@ -29,7 +30,8 @@ export function autosizeTextarea(textarea, options = {}) {
       comfortLines: Math.max(0, Number(comfortLines || 0)),
       comfortHeight,
       scrollHeight: 0,
-      skipped: "disconnected"
+      skipped: "disconnected",
+      visible: isVisible
     };
   }
 
@@ -46,7 +48,8 @@ export function autosizeTextarea(textarea, options = {}) {
       comfortLines: Math.max(0, Number(comfortLines || 0)),
       comfortHeight,
       scrollHeight: measuredScrollHeight,
-      skipped: "not-measurable"
+      skipped: "not-measurable",
+      visible: isVisible
     };
   }
   const targetHeight = Math.max(minHeight, Math.round(measuredScrollHeight + comfortHeight));
@@ -62,6 +65,7 @@ export function autosizeTextarea(textarea, options = {}) {
       previousHeight,
       nextHeight: targetHeight,
       scrollHeight: measuredScrollHeight,
+      visible: isVisible,
       lineHeight,
       comfortHeight,
       minHeight,
@@ -76,7 +80,8 @@ export function autosizeTextarea(textarea, options = {}) {
     lineHeight,
     comfortLines: Math.max(0, Number(comfortLines || 0)),
     comfortHeight,
-    scrollHeight: measuredScrollHeight
+    scrollHeight: measuredScrollHeight,
+    visible: isVisible
   };
 }
 

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -15,7 +15,7 @@ import {
 } from "../../utils/subject-links.js";
 import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
-import { autosizeTextarea, bindAutosizeTextarea } from "../../utils/textarea-autosize.js";
+import { autosizeTextarea } from "../../utils/textarea-autosize.js";
 import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 
 export function createProjectSubjectsEvents(config) {
@@ -651,28 +651,56 @@ export function createProjectSubjectsEvents(config) {
         textareaType: type
       });
     };
-    const scheduleAutosize = (textarea, cause = "raf") => {
+    const isAutosizeDebugEnabled = () => typeof window !== "undefined" && window?.__MDALL_DEBUG_TEXTAREA_AUTOSIZE__ === true;
+    const isElementMeasurable = (element) => {
+      if (!element || element.isConnected === false) return false;
+      if (element.closest?.("[hidden], .hidden")) return false;
+      return element.offsetParent !== null || element.getClientRects?.().length > 0;
+    };
+    const scheduleAutosizeAfterRender = (textarea, cause = "after-render", options = {}) => {
       if (!textarea) return;
-      const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
-      const binder = bindAutosizeTextarea(textarea, {
-        minHeightFallback,
-        comfortLines: 3,
-        log: true,
-        logPrefix: "[textarea-autosize]",
-        textareaType: type,
-        initialCause: "noop"
-      });
-      binder.resizeNextFrame(cause);
+      const { maxAttempts = 8 } = options || {};
+      let attempts = 0;
+      const schedulePass = () => {
+        if (typeof requestAnimationFrame !== "function") {
+          runAutosize(textarea, cause);
+          return;
+        }
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            attempts += 1;
+            const visible = isElementMeasurable(textarea);
+            if (!visible && attempts < maxAttempts) {
+              if (isAutosizeDebugEnabled()) {
+                console.info("[textarea-autosize]", {
+                  textareaType: getTextareaAutosizeMeta(textarea).type,
+                  cause,
+                  visible,
+                  deferredAfterRender: true,
+                  attempts
+                });
+              }
+              schedulePass();
+              return;
+            }
+            runAutosize(textarea, `${cause}${attempts > 1 ? `:attempt-${attempts}` : ""}`);
+          });
+        });
+      };
+      schedulePass();
+    };
+    const scheduleAutosizeAfterVisibility = (textarea, cause = "after-visibility", options = {}) => {
+      scheduleAutosizeAfterRender(textarea, cause, options);
     };
     const bindComposerAutosizeLifecycle = (textarea) => {
       if (!textarea || textarea.dataset.autosizeBound === "true") return;
       textarea.dataset.autosizeBound = "true";
       runAutosize(textarea, "mount");
-      scheduleAutosize(textarea, "raf-open");
+      scheduleAutosizeAfterVisibility(textarea, "mount-after-visible");
       ["input", "paste", "cut", "drop"].forEach((eventName) => {
         textarea.addEventListener(eventName, () => {
           runAutosize(textarea, eventName);
-          scheduleAutosize(textarea, `raf-${eventName}`);
+          scheduleAutosizeAfterRender(textarea, `after-render-${eventName}`);
         });
       });
     };
@@ -737,7 +765,9 @@ export function createProjectSubjectsEvents(config) {
 
     root.querySelectorAll("[data-action='edit-description']").forEach((btn) => {
       btn.onclick = () => {
-        startDescriptionEdit(root);
+        const didStart = startDescriptionEdit(root);
+        if (!didStart) return;
+        scheduleAutosizeAfterVisibility(root.querySelector("[data-description-draft]"), "description-edit-open");
       };
     });
 
@@ -1315,7 +1345,7 @@ export function createProjectSubjectsEvents(config) {
           replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
           syncInlineEditSubmitButton(messageId);
         }
-        syncInlineReplyTextareaHeight(textarea);
+        scheduleAutosizeAfterRender(textarea, "inline-mention");
       }
       textarea.focus();
       textarea.selectionStart = result.nextCursorIndex;
@@ -1430,7 +1460,7 @@ export function createProjectSubjectsEvents(config) {
           replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
           syncInlineEditSubmitButton(messageId);
         }
-        syncInlineReplyTextareaHeight(textarea);
+        scheduleAutosizeAfterRender(textarea, "inline-subject-ref");
       }
       textarea.focus();
       textarea.selectionStart = result.nextCursorIndex;
@@ -1646,7 +1676,7 @@ export function createProjectSubjectsEvents(config) {
         commentTextarea.selectionEnd = result.nextCursorIndex;
         closeEmojiPopup({ rerender: false });
         if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
-        syncMainComposerTextareaHeight();
+        syncMainComposerTextareaHeight("emoji", { afterRender: true });
         rerenderAutocompleteUi({
           selector: "#humanCommentBox",
           shouldFocus: true,
@@ -1674,7 +1704,12 @@ export function createProjectSubjectsEvents(config) {
         syncMainEmojiPopup({ composerKey: "main" });
       };
 
-      const syncMainComposerTextareaHeight = (cause = "manual") => runAutosize(commentTextarea, cause);
+      const syncMainComposerTextareaHeight = (cause = "manual", options = {}) => {
+        runAutosize(commentTextarea, cause);
+        if (options?.afterRender === true) {
+          scheduleAutosizeAfterRender(commentTextarea, `main-${cause}`);
+        }
+      };
 
       bindComposerAutosizeLifecycle(commentTextarea);
       syncMainComposerTextareaHeight("mount");
@@ -1841,7 +1876,7 @@ export function createProjectSubjectsEvents(config) {
             closeMentionPopup({ rerender: false });
             closeEmojiPopup({ rerender: false });
             store.situationsView.commentDraft = String(commentTextarea.value || "");
-            syncMainComposerTextareaHeight();
+            syncMainComposerTextareaHeight("subject-ref", { afterRender: true });
             if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
             void syncSubjectRefPopupForTextarea(commentTextarea, "main");
             commentTextarea.focus();
@@ -1855,7 +1890,7 @@ export function createProjectSubjectsEvents(config) {
             closeEmojiPopup({ rerender: false });
           }
           store.situationsView.commentDraft = String(commentTextarea.value || "");
-          syncMainComposerTextareaHeight();
+          syncMainComposerTextareaHeight("toolbar", { afterRender: true });
           if (store.situationsView.commentPreviewMode) syncCommentPreview(root);
         };
       });
@@ -2496,6 +2531,7 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = () => {
         store.situationsView.commentPreviewMode = false;
         rerenderDiscussionComposerScope(btn);
+        scheduleAutosizeAfterVisibility(root.querySelector("#humanCommentBox"), "main-preview-write");
       };
     });
 
@@ -2875,10 +2911,10 @@ export function createProjectSubjectsEvents(config) {
       if (!submitButton) return;
       submitButton.disabled = !canSubmitInlineEdit(normalizedMessageId);
     };
-    const syncInlineReplyTextareaHeight = (textarea, cause = "manual") => runAutosize(textarea, cause);
-    const toggleInlineReplyEditorVisibility = (messageId = "", visible = false) => {
+    const toggleInlineReplyEditorVisibility = (messageId = "", visible = false, options = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
+      const onRendered = typeof options?.onRendered === "function" ? options.onRendered : null;
       scheduleScopedDomRender(`inline-reply-editor:${normalizedMessageId}`, () => {
         const editor = root.querySelector(`[data-inline-reply-editor="${selectorValue(normalizedMessageId)}"]`);
         if (!editor) return;
@@ -2890,11 +2926,13 @@ export function createProjectSubjectsEvents(config) {
         editor.classList.toggle("hidden", !visible);
         if (visible) editor.removeAttribute("aria-hidden");
         else editor.setAttribute("aria-hidden", "true");
+        if (onRendered) onRendered(editor);
       });
     };
-    const toggleInlineEditEditorVisibility = (messageId = "", visible = false) => {
+    const toggleInlineEditEditorVisibility = (messageId = "", visible = false, options = {}) => {
       const normalizedMessageId = String(messageId || "").trim();
       if (!normalizedMessageId) return;
+      const onRendered = typeof options?.onRendered === "function" ? options.onRendered : null;
       scheduleScopedDomRender(`inline-edit-editor:${normalizedMessageId}`, () => {
         const editor = root.querySelector(`[data-inline-edit-editor="${selectorValue(normalizedMessageId)}"]`);
         const content = root.querySelector(`[data-thread-comment-content="${selectorValue(normalizedMessageId)}"]`);
@@ -2909,6 +2947,7 @@ export function createProjectSubjectsEvents(config) {
           else editor.setAttribute("aria-hidden", "true");
         }
         if (content) content.classList.toggle("hidden", !!visible);
+        if (onRendered) onRendered(editor);
       });
     };
     const closeInlineReplyEditor = (messageId = "") => {
@@ -3231,19 +3270,23 @@ export function createProjectSubjectsEvents(config) {
         if (previouslyExpandedMessageId && previouslyExpandedMessageId !== messageId) {
           toggleInlineReplyEditorVisibility(previouslyExpandedMessageId, false);
         }
-        toggleInlineReplyEditorVisibility(messageId, true);
-        const textarea = root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
-        if (textarea) {
-          textarea.value = String(replyUi.draftsByMessageId?.[messageId] || "");
-          syncInlineReplyTextareaHeight(textarea);
-          syncInlineReplySubmitButton(messageId);
-          requestAnimationFrame(() => {
-            debugThreadReply("reply_editor_presence", { messageId, found: true });
-            textarea.focus();
-          });
-        } else {
-          console.warn("[subject-thread-reply] inline reply textarea missing", { messageId });
-        }
+        toggleInlineReplyEditorVisibility(messageId, true, {
+          onRendered: () => {
+            const textarea = root.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
+            if (!textarea) {
+              console.warn("[subject-thread-reply] inline reply textarea missing", { messageId });
+              return;
+            }
+            textarea.value = String(replyUi.draftsByMessageId?.[messageId] || "");
+            scheduleAutosizeAfterVisibility(textarea, "inline-reply-open");
+            syncInlineReplySubmitButton(messageId);
+            scheduleAutosizeAfterVisibility(textarea, "inline-reply-visible-focus");
+            requestAnimationFrame(() => {
+              debugThreadReply("reply_editor_presence", { messageId, found: true });
+              textarea.focus();
+            });
+          }
+        });
       };
     });
 
@@ -3264,16 +3307,19 @@ export function createProjectSubjectsEvents(config) {
           clearInlineEditAttachmentsState(previousEditMessageId);
           toggleInlineEditEditorVisibility(previousEditMessageId, false);
         }
-        toggleInlineEditEditorVisibility(messageId, true);
-        const textarea = root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
-        if (textarea) {
-          textarea.value = String(replyUi.editDraftsByMessageId?.[messageId] || "");
-          syncInlineReplyTextareaHeight(textarea);
-          syncInlineEditSubmitButton(messageId);
-          requestAnimationFrame(() => textarea.focus());
-        } else {
-          console.warn("[subject-thread-reply] inline edit textarea missing", { messageId });
-        }
+        toggleInlineEditEditorVisibility(messageId, true, {
+          onRendered: () => {
+            const textarea = root.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
+            if (!textarea) {
+              console.warn("[subject-thread-reply] inline edit textarea missing", { messageId });
+              return;
+            }
+            textarea.value = String(replyUi.editDraftsByMessageId?.[messageId] || "");
+            scheduleAutosizeAfterVisibility(textarea, "inline-edit-open");
+            syncInlineEditSubmitButton(messageId);
+            requestAnimationFrame(() => textarea.focus());
+          }
+        });
       };
     });
 
@@ -3446,19 +3492,19 @@ export function createProjectSubjectsEvents(config) {
         replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
         syncInlineEditSubmitButton(messageId);
       }
-      syncInlineReplyTextareaHeight(textarea);
+      scheduleAutosizeAfterVisibility(textarea, "inline-reply-bind");
       rerenderAutocompleteUi();
     };
 
     root.querySelectorAll("[data-thread-reply-draft]").forEach((textarea) => {
       bindComposerAutosizeLifecycle(textarea);
-      syncInlineReplyTextareaHeight(textarea);
+      scheduleAutosizeAfterVisibility(textarea, "inline-reply-bind-initial");
       textarea.addEventListener("input", () => {
         const messageId = String(textarea.dataset.threadReplyDraft || "").trim();
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
-        syncInlineReplyTextareaHeight(textarea);
+        runAutosize(textarea, "inline-reply-input");
         syncInlineReplySubmitButton(messageId);
         void syncInlineAutocomplete(textarea, `reply:${messageId}`);
       });
@@ -3564,7 +3610,7 @@ export function createProjectSubjectsEvents(config) {
             const result = applyInlineEmojiSuggestion(textarea, emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
             const replyUi = resolveInlineReplyUiState();
             if (messageId) replyUi.draftsByMessageId[messageId] = String(result.nextText || "");
-            syncInlineReplyTextareaHeight(textarea);
+            scheduleAutosizeAfterRender(textarea, "inline-reply-emoji");
             syncInlineReplySubmitButton(messageId);
             return;
           }
@@ -3605,13 +3651,13 @@ export function createProjectSubjectsEvents(config) {
 
     root.querySelectorAll("[data-thread-edit-draft]").forEach((textarea) => {
       bindComposerAutosizeLifecycle(textarea);
-      syncInlineReplyTextareaHeight(textarea);
+      scheduleAutosizeAfterVisibility(textarea, "inline-edit-bind");
       textarea.addEventListener("input", () => {
         const messageId = String(textarea.dataset.threadEditDraft || "").trim();
         if (!messageId) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
-        syncInlineReplyTextareaHeight(textarea);
+        runAutosize(textarea, "inline-edit-input");
         syncInlineEditSubmitButton(messageId);
         void syncInlineAutocomplete(textarea, `edit:${messageId}`);
       });
@@ -3717,7 +3763,7 @@ export function createProjectSubjectsEvents(config) {
             const result = applyInlineEmojiSuggestion(textarea, emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
             const replyUi = resolveInlineReplyUiState();
             if (messageId) replyUi.editDraftsByMessageId[messageId] = String(result.nextText || "");
-            syncInlineReplyTextareaHeight(textarea);
+            scheduleAutosizeAfterRender(textarea, "inline-edit-emoji");
             syncInlineEditSubmitButton(messageId);
             return;
           }
@@ -3774,7 +3820,7 @@ export function createProjectSubjectsEvents(config) {
         textareaWrap?.classList.remove("hidden");
         previewWrap?.classList.add("hidden");
         const textarea = composerRoot?.querySelector(`[data-thread-reply-draft="${selectorValue(messageId)}"]`);
-        if (textarea) syncInlineReplyTextareaHeight(textarea);
+        if (textarea) scheduleAutosizeAfterVisibility(textarea, "inline-reply-preview-write");
       };
     });
 
@@ -3821,7 +3867,7 @@ export function createProjectSubjectsEvents(config) {
         composerRoot?.querySelector(".comment-composer__editor")?.classList.remove("hidden");
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
         const textarea = composerRoot?.querySelector(`[data-thread-edit-draft="${selectorValue(messageId)}"]`);
-        if (textarea) syncInlineReplyTextareaHeight(textarea);
+        if (textarea) scheduleAutosizeAfterVisibility(textarea, "inline-edit-preview-write");
       };
     });
 
@@ -3863,7 +3909,7 @@ export function createProjectSubjectsEvents(config) {
           ensureSubjectRefTriggerInTextarea(textarea);
           const replyUi = resolveInlineReplyUiState();
           replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
-          syncInlineReplyTextareaHeight(textarea);
+          scheduleAutosizeAfterRender(textarea, "inline-reply-toolbar-subject-ref");
           syncInlineReplySubmitButton(messageId);
           closeMentionPopup({ rerender: false });
           closeEmojiPopup({ rerender: false });
@@ -3875,7 +3921,7 @@ export function createProjectSubjectsEvents(config) {
         if (!didApply) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.draftsByMessageId[messageId] = String(textarea.value || "");
-        syncInlineReplyTextareaHeight(textarea);
+        scheduleAutosizeAfterRender(textarea, "inline-reply-toolbar");
         syncInlineReplySubmitButton(messageId);
         if (action === "mention") void syncMentionPopupForTextarea(textarea, `reply:${messageId}`, { forceOpen: true });
         else {
@@ -3897,7 +3943,7 @@ export function createProjectSubjectsEvents(config) {
           ensureSubjectRefTriggerInTextarea(textarea);
           const replyUi = resolveInlineReplyUiState();
           replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
-          syncInlineReplyTextareaHeight(textarea);
+          scheduleAutosizeAfterRender(textarea, "inline-edit-toolbar-subject-ref");
           syncInlineEditSubmitButton(messageId);
           closeMentionPopup({ rerender: false });
           closeEmojiPopup({ rerender: false });
@@ -3909,7 +3955,7 @@ export function createProjectSubjectsEvents(config) {
         if (!didApply) return;
         const replyUi = resolveInlineReplyUiState();
         replyUi.editDraftsByMessageId[messageId] = String(textarea.value || "");
-        syncInlineReplyTextareaHeight(textarea);
+        scheduleAutosizeAfterRender(textarea, "inline-edit-toolbar");
         syncInlineEditSubmitButton(messageId);
         if (action === "mention") void syncMentionPopupForTextarea(textarea, `edit:${messageId}`, { forceOpen: true });
         else {
@@ -3932,8 +3978,7 @@ export function createProjectSubjectsEvents(config) {
         composerRoot?.querySelector(".comment-composer__preview-wrap")?.classList.add("hidden");
         const textarea = composerRoot?.querySelector("[data-description-draft]");
         if (textarea) {
-          runAutosize(textarea, "preview-toggle");
-          scheduleAutosize(textarea, "raf-open");
+          scheduleAutosizeAfterVisibility(textarea, "description-preview-write");
         }
       };
     });
@@ -3965,7 +4010,7 @@ export function createProjectSubjectsEvents(config) {
         if (action === "subject-ref") {
           ensureSubjectRefTriggerInTextarea(textarea);
           syncDescriptionEditorDraft(root);
-          runAutosize(textarea, "subject-ref");
+          scheduleAutosizeAfterRender(textarea, "description-toolbar-subject-ref");
           closeMentionPopup({ rerender: false });
           closeEmojiPopup({ rerender: false });
           void syncSubjectRefPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`);
@@ -3975,7 +4020,7 @@ export function createProjectSubjectsEvents(config) {
         const didApply = applyMarkdownComposerAction(textarea, action);
         if (!didApply) return;
         syncDescriptionEditorDraft(root);
-        runAutosize(textarea, "toolbar");
+        scheduleAutosizeAfterRender(textarea, "description-toolbar");
         if (action === "mention") {
           void syncMentionPopupForTextarea(textarea, `description:${String(textarea.dataset.descriptionDraft || "")}`, { forceOpen: true });
         } else {
@@ -4011,7 +4056,7 @@ export function createProjectSubjectsEvents(config) {
       bindComposerAutosizeLifecycle(textarea);
       textarea.addEventListener("input", () => {
         syncDescriptionEditorDraft(root);
-        runAutosize(textarea, "input");
+        runAutosize(textarea, "description-input");
         void syncInlineAutocomplete(textarea, composerKey);
       });
       textarea.addEventListener("keydown", (event) => {

--- a/supabase/migrations/202606150023_subjects_document_ref_ids.sql
+++ b/supabase/migrations/202606150023_subjects_document_ref_ids.sql
@@ -1,0 +1,9 @@
+alter table public.subjects
+  add column if not exists document_ref_ids uuid[] not null default '{}'::uuid[];
+
+comment on column public.subjects.document_ref_ids is
+  'Consolidated document reference ids linked to the subject for front-end document reference workflows.';
+
+update public.subjects
+set document_ref_ids = '{}'::uuid[]
+where document_ref_ids is null;


### PR DESCRIPTION
### Motivation
- Fix a persistent textarea auto-resize bug caused by measuring textareas before the editor DOM was actually rendered/unhidden and therefore not measurable.
- Align the database schema with front-end expectations by adding the missing `document_ref_ids` column to `public.subjects` to avoid PostgREST 400 fallbacks.
- Keep the reliable attachments loading model (from `subject_message_attachments`) and ensure the hydrated subject rows consistently expose `description_attachments` without creating a hidden dependency on `subjects.description_attachments`.

### Description
- Added a Supabase migration `supabase/migrations/202606150023_subjects_document_ref_ids.sql` that runs: `alter table public.subjects add column if not exists document_ref_ids uuid[] not null default '{}'::uuid[];` with a column comment and a null-to-`{}` backfill.
- Reworked autosize scheduling in `apps/web/js/views/project-subjects/project-subjects-events.js`: introduced `scheduleAutosizeAfterRender` / `scheduleAutosizeAfterVisibility` helpers that perform a double `requestAnimationFrame` pass, check measurability (`isConnected`, not hidden, `offsetParent` / `getClientRects`) and retry up to a bounded number of attempts before measuring; moved many resize calls to use this scheduler and added `onRendered` callbacks to `toggleInlineReplyEditorVisibility` / `toggleInlineEditEditorVisibility` so resizes run after `scheduleScopedDomRender` completes.
- Kept `autosizeTextarea` semantics but added visibility telemetry (returned `visible` and logs when debug flag enabled) in `apps/web/js/utils/textarea-autosize.js` to help diagnose deferred attempts and previous/next heights.
- Hardened subject loading in `apps/web/js/services/project-subjects-supabase.js`: normalized `document_ref_ids` on hydrated subject rows (ensuring `[]` when absent), added an activatable debug flag `__MDALL_DEBUG_PROJECT_SUBJECTS__` that logs whether `document_ref_ids` was present in the payload and reporting when subjects are hydrated, and left the description attachments flow unchanged (still fetching from `subject_message_attachments` and hydrating signed URLs with `forceRefreshSignedUrls: true`).
- Files modified: `supabase/migrations/202606150023_subjects_document_ref_ids.sql`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/services/project-subjects-supabase.js`, `apps/web/js/utils/textarea-autosize.js`.

### Testing
- Performed static checks: `node --check apps/web/js/views/project-subjects/project-subjects-events.js` (OK), `node --check apps/web/js/services/project-subjects-supabase.js` (OK), and `node --check apps/web/js/utils/textarea-autosize.js` (OK).
- No runtime UI/E2E or DB migration execution was performed in this environment; the migration file is present and idempotent (`if not exists`) so it can be applied safely in CI / deployment to remove the PostgREST 400 fallback once run.
- Added debug instrumentation to observe in an integrated environment: enable `window.__MDALL_DEBUG_TEXTAREA_AUTOSIZE__` and `window.__MDALL_DEBUG_PROJECT_SUBJECTS__` to get detailed logs about autosize attempts and the presence of `document_ref_ids` in responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73466dfbc8329856007b96cf4c4ba)