### PR TITLE
Fiabilise la sélection de sujet : priorise le clic utilisateur et ignore les loads async périmés

### DIFF
--- a/apps/web/js/services/project-subjects-selection-concurrency.js
+++ b/apps/web/js/services/project-subjects-selection-concurrency.js
@@ -1,0 +1,74 @@
+function normalizeUuid(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  const match = raw.match(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i);
+  return (match ? match[0] : raw).toLowerCase();
+}
+
+function computeSituationIdForSubject(result = {}, subjectId = null) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  if (!normalizedSubjectId) return null;
+  const subject = result?.subjectsById?.[normalizedSubjectId];
+  const subjectSituationId = normalizeUuid(subject?.situation_id);
+  if (subjectSituationId) return subjectSituationId;
+  const subjectIdsBySituationId = result?.subjectIdsBySituationId && typeof result.subjectIdsBySituationId === "object"
+    ? result.subjectIdsBySituationId
+    : {};
+  for (const [situationId, subjectIds] of Object.entries(subjectIdsBySituationId)) {
+    if (!Array.isArray(subjectIds)) continue;
+    if (subjectIds.map((value) => normalizeUuid(value)).includes(normalizedSubjectId)) {
+      return normalizeUuid(situationId);
+    }
+  }
+  return null;
+}
+
+export function resolveSelectionAfterSubjectsLoad({
+  result = {},
+  currentSelectedSubjectId = null,
+  currentSelectionRevision = 0,
+  loadStartSelectionRevision = 0,
+  snapshotSelectedSubjectId = null
+} = {}) {
+  const subjectsById = result?.subjectsById && typeof result.subjectsById === "object" ? result.subjectsById : {};
+  const subjects = Array.isArray(result?.subjects) ? result.subjects : [];
+  const normalizedCurrentSelectedSubjectId = normalizeUuid(currentSelectedSubjectId);
+  const normalizedSnapshotSelectedSubjectId = normalizeUuid(snapshotSelectedSubjectId);
+  const hasNewerUserSelection = Number(currentSelectionRevision) !== Number(loadStartSelectionRevision);
+
+  let selectedSubjectId = null;
+  let selectionReason = "none";
+
+  if (normalizedCurrentSelectedSubjectId && subjectsById[normalizedCurrentSelectedSubjectId]) {
+    selectedSubjectId = normalizedCurrentSelectedSubjectId;
+    selectionReason = "keep-current-selection";
+  } else if (!hasNewerUserSelection && normalizedSnapshotSelectedSubjectId && subjectsById[normalizedSnapshotSelectedSubjectId]) {
+    selectedSubjectId = normalizedSnapshotSelectedSubjectId;
+    selectionReason = "restore-load-snapshot-selection";
+  } else if (subjects[0]?.id) {
+    selectedSubjectId = normalizeUuid(subjects[0].id);
+    selectionReason = "fallback-first-subject";
+  }
+
+  return {
+    selectedSubjectId: selectedSubjectId || null,
+    selectedSituationId: computeSituationIdForSubject(result, selectedSubjectId),
+    hasNewerUserSelection,
+    selectionReason
+  };
+}
+
+export function shouldIgnoreSubjectsLoadApply({
+  loadRequestId = 0,
+  latestLoadRequestId = 0,
+  loadProjectScopeId = null,
+  currentProjectScopeId = null
+} = {}) {
+  if (Number(loadRequestId || 0) !== Number(latestLoadRequestId || 0)) {
+    return { ignore: true, reason: "newer-request-exists" };
+  }
+  if ((loadProjectScopeId || null) !== (currentProjectScopeId || null)) {
+    return { ignore: true, reason: "project-changed-before-apply" };
+  }
+  return { ignore: false, reason: "apply" };
+}

--- a/apps/web/js/services/project-subjects-selection-concurrency.test.mjs
+++ b/apps/web/js/services/project-subjects-selection-concurrency.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveSelectionAfterSubjectsLoad,
+  shouldIgnoreSubjectsLoadApply
+} from "./project-subjects-selection-concurrency.js";
+
+const SUBJECT_A = "11111111-1111-4111-8111-111111111111";
+const SUBJECT_B = "22222222-2222-4222-8222-222222222222";
+const SUBJECT_C = "33333333-3333-4333-8333-333333333333";
+const SITUATION_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const SITUATION_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const SITUATION_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+function buildResult(subjectIds = []) {
+  const subjectsById = Object.fromEntries(subjectIds.map((id) => [id, { id, situation_id: id === SUBJECT_A ? SITUATION_A : id === SUBJECT_B ? SITUATION_B : SITUATION_C }]));
+  return {
+    subjects: subjectIds.map((id) => ({ id })),
+    subjectsById,
+    situationsById: {
+      [SITUATION_A]: { id: SITUATION_A },
+      [SITUATION_B]: { id: SITUATION_B },
+      [SITUATION_C]: { id: SITUATION_C }
+    }
+  };
+}
+
+test("TEST 1: conserve la sélection utilisateur plus récente après la fin du load", () => {
+  const resolved = resolveSelectionAfterSubjectsLoad({
+    result: buildResult([SUBJECT_A, SUBJECT_B]),
+    currentSelectedSubjectId: SUBJECT_B,
+    currentSelectionRevision: 8,
+    loadStartSelectionRevision: 7,
+    snapshotSelectedSubjectId: SUBJECT_A
+  });
+  assert.equal(resolved.selectedSubjectId, SUBJECT_B);
+  assert.equal(resolved.selectedSituationId, SITUATION_B);
+  assert.equal(resolved.hasNewerUserSelection, true);
+});
+
+test("TEST 2: ignore un load périmé quand une requête plus récente existe", () => {
+  const decision = shouldIgnoreSubjectsLoadApply({
+    loadRequestId: 1,
+    latestLoadRequestId: 2,
+    loadProjectScopeId: "project-a",
+    currentProjectScopeId: "project-a"
+  });
+  assert.equal(decision.ignore, true);
+  assert.equal(decision.reason, "newer-request-exists");
+});
+
+test("TEST 3: ignore le résultat si le projet a changé pendant le load", () => {
+  const decision = shouldIgnoreSubjectsLoadApply({
+    loadRequestId: 2,
+    latestLoadRequestId: 2,
+    loadProjectScopeId: "project-a",
+    currentProjectScopeId: "project-b"
+  });
+  assert.equal(decision.ignore, true);
+  assert.equal(decision.reason, "project-changed-before-apply");
+});
+
+test("TEST 4: fallback sur un sujet valide et situation cohérente si la sélection n'existe plus", () => {
+  const resolved = resolveSelectionAfterSubjectsLoad({
+    result: buildResult([SUBJECT_C]),
+    currentSelectedSubjectId: SUBJECT_A,
+    currentSelectionRevision: 5,
+    loadStartSelectionRevision: 5,
+    snapshotSelectedSubjectId: SUBJECT_A
+  });
+  assert.equal(resolved.selectedSubjectId, SUBJECT_C);
+  assert.equal(resolved.selectedSituationId, SITUATION_C);
+  assert.equal(resolved.selectionReason, "fallback-first-subject");
+});

--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -7,6 +7,10 @@ import { invalidateSubjectRefIndex } from "../utils/subject-ref-index.js";
 import { normalizeAssigneeIds } from "./subject-assignees-service.js";
 import { hydratePersistedSubjectAttachmentsObjectUrls } from "./subject-attachments-object-url.js";
 import {
+  resolveSelectionAfterSubjectsLoad,
+  shouldIgnoreSubjectsLoadApply
+} from "./project-subjects-selection-concurrency.js";
+import {
   normalizeAttachmentBucket,
   normalizeSubjectAttachmentStoragePath
 } from "./subject-attachments-storage-path.js";
@@ -15,6 +19,7 @@ const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
 const SUBJECT_DESCRIPTION_DEBUG_FLAG = "__MDALL_DEBUG_SUBJECT_DESCRIPTION__";
 const PROJECT_SUBJECTS_DEBUG_FLAG = "__MDALL_DEBUG_PROJECT_SUBJECTS__";
+const SUBJECTS_SELECTION_DEBUG_FLAG = "__MDALL_DEBUG_SUBJECTS_SELECTION__";
 
 
 
@@ -59,6 +64,26 @@ function isSubjectDescriptionDebugEnabled() {
 function isProjectSubjectsDebugEnabled() {
   return typeof window !== "undefined" && window?.[PROJECT_SUBJECTS_DEBUG_FLAG] === true;
 }
+
+function isSubjectsSelectionDebugEnabled() {
+  return typeof window !== "undefined" && window?.[SUBJECTS_SELECTION_DEBUG_FLAG] === true;
+}
+
+function debugSubjectsSelection(eventName, payload = {}) {
+  if (!isSubjectsSelectionDebugEnabled()) return;
+  console.info(`[subjects-selection] ${eventName}`, payload);
+}
+
+function ensureProjectSubjectsSelectionConcurrencyState() {
+  if (!(store.projectSubjectsView && typeof store.projectSubjectsView === "object")) return;
+  if (!Number.isFinite(Number(store.projectSubjectsView.selectionRevision))) {
+    store.projectSubjectsView.selectionRevision = 0;
+  }
+  if (!Number.isFinite(Number(store.projectSubjectsView.lastLoadRequestId))) {
+    store.projectSubjectsView.lastLoadRequestId = 0;
+  }
+}
+
 
 function truncateDescriptionPreview(value = "", maxLength = 160) {
   const raw = String(value || "");
@@ -1527,12 +1552,16 @@ function buildProjectFlatSubjectsResult(subjectRows = [], subjectLinks = [], opt
 }
 
 export async function loadFlatSubjectsForCurrentProject(options = {}) {
+  ensureProjectSubjectsSelectionConcurrencyState();
   const force = !!options.force;
   const currentProjectScopeId = String(store.currentProjectId || "").trim() || null;
   const existing = Array.isArray(store.projectSubjectsView?.subjectsData) ? store.projectSubjectsView.subjectsData : [];
   if (!force && existing.length && store.projectSubjectsView?.projectScopeId === currentProjectScopeId) {
     return existing;
   }
+
+  const loadRequestId = Number(store.projectSubjectsView.lastLoadRequestId || 0) + 1;
+  store.projectSubjectsView.lastLoadRequestId = loadRequestId;
 
   if (store.projectSubjectsView && typeof store.projectSubjectsView === "object") {
     store.projectSubjectsView.loading = true;
@@ -1550,15 +1579,36 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
   try {
     const mappedBackendProjectId = normalizeUuid(getMappedBackendProjectId());
     const backendProjectId = await getResolvedProjectId();
+    const loadStartSelectionRevision = Number(store.projectSubjectsView?.selectionRevision || 0);
     const previousSelectedSubjectId = normalizeUuid(
       store.projectSubjectsView?.selectedSubjectId
       || store.projectSubjectsView?.selectedSujetId
     );
-    const previousSelectedSituationId = normalizeUuid(
-      store.projectSubjectsView?.selectedSituationId
-    );
+    debugSubjectsSelection("load start", {
+      projectId: backendProjectId || currentProjectScopeId || null,
+      requestId: loadRequestId,
+      selectionRevision: loadStartSelectionRevision,
+      selectedSubjectIdBefore: previousSelectedSubjectId || null
+    });
 
     if (!backendProjectId) {
+      const staleDecision = shouldIgnoreSubjectsLoadApply({
+        loadRequestId,
+        latestLoadRequestId: Number(store.projectSubjectsView?.lastLoadRequestId || 0),
+        loadProjectScopeId: currentProjectScopeId,
+        currentProjectScopeId: String(store.currentProjectId || "").trim() || null
+      });
+      if (staleDecision.ignore) {
+        debugSubjectsSelection("stale load ignored", {
+          projectId: currentProjectScopeId,
+          requestId: loadRequestId,
+          selectionRevision: Number(store.projectSubjectsView?.selectionRevision || 0),
+          selectedSubjectIdBefore: previousSelectedSubjectId || null,
+          selectedSubjectIdAfter: normalizeUuid(store.projectSubjectsView?.selectedSubjectId || store.projectSubjectsView?.selectedSujetId) || null,
+          reason: staleDecision.reason
+        });
+        return store.projectSubjectsView.subjectsData || [];
+      }
       store.projectSubjectsView.subjectsData = [];
       store.projectSubjectsView.projectScopeId = currentProjectScopeId;
       store.projectSubjectsView.rawSubjectsResult = {
@@ -1706,6 +1756,34 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
       ...result.situationsById
     };
 
+    const currentProjectScopeIdAtApplyTime = String(store.currentProjectId || "").trim() || null;
+    const staleDecision = shouldIgnoreSubjectsLoadApply({
+      loadRequestId,
+      latestLoadRequestId: Number(store.projectSubjectsView?.lastLoadRequestId || 0),
+      loadProjectScopeId: currentProjectScopeId,
+      currentProjectScopeId: currentProjectScopeIdAtApplyTime
+    });
+    if (staleDecision.ignore) {
+      debugSubjectsSelection("stale load ignored", {
+        projectId: backendProjectId || currentProjectScopeId || null,
+        requestId: loadRequestId,
+        selectionRevision: Number(store.projectSubjectsView?.selectionRevision || 0),
+        selectedSubjectIdBefore: previousSelectedSubjectId || null,
+        selectedSubjectIdAfter: normalizeUuid(store.projectSubjectsView?.selectedSubjectId || store.projectSubjectsView?.selectedSujetId) || null,
+        reason: staleDecision.reason
+      });
+      return store.projectSubjectsView.subjectsData || [];
+    }
+
+    debugSubjectsSelection("load resolved", {
+      projectId: backendProjectId || currentProjectScopeId || null,
+      requestId: loadRequestId,
+      selectionRevision: Number(store.projectSubjectsView?.selectionRevision || 0),
+      selectedSubjectIdBefore: normalizeUuid(store.projectSubjectsView?.selectedSubjectId || store.projectSubjectsView?.selectedSujetId) || null,
+      selectedSubjectIdAfter: normalizeUuid(store.projectSubjectsView?.selectedSubjectId || store.projectSubjectsView?.selectedSujetId) || null,
+      reason: "apply-load-result"
+    });
+
     store.projectSubjectsView.subjectsData = result.subjects;
     store.projectSubjectsView.rawSubjectsResult = result;
     store.projectSubjectsView.rawResult = result;
@@ -1726,19 +1804,63 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
       previousExpandedSubjectIds.filter((subjectId) => !!result.subjectsById?.[subjectId])
     );
     store.projectSubjectsView.expandedSujets = store.projectSubjectsView.expandedSubjectIds;
-    const nextSelectedSubjectId = previousSelectedSubjectId && result.subjectsById?.[previousSelectedSubjectId]
-      ? previousSelectedSubjectId
-      : (result.subjects[0]?.id || null);
-    const nextSelectedSituationId = previousSelectedSituationId && result.situationsById?.[previousSelectedSituationId]
-      ? previousSelectedSituationId
-      : (store.projectSubjectsView.selectedSituationId || null);
+    const currentSelectedSubjectIdAtApplyTime = normalizeUuid(
+      store.projectSubjectsView?.selectedSubjectId
+      || store.projectSubjectsView?.selectedSujetId
+    );
+    const currentSelectionRevision = Number(store.projectSubjectsView?.selectionRevision || 0);
+    const {
+      selectedSubjectId: nextSelectedSubjectId,
+      selectedSituationId: nextSelectedSituationId,
+      hasNewerUserSelection,
+      selectionReason
+    } = resolveSelectionAfterSubjectsLoad({
+      result,
+      currentSelectedSubjectId: currentSelectedSubjectIdAtApplyTime,
+      currentSelectionRevision,
+      loadStartSelectionRevision,
+      snapshotSelectedSubjectId: previousSelectedSubjectId
+    });
+    if (hasNewerUserSelection) {
+      debugSubjectsSelection("preserve newer user selection", {
+        projectId: backendProjectId || currentProjectScopeId || null,
+        requestId: loadRequestId,
+        selectionRevision: currentSelectionRevision,
+        selectedSubjectIdBefore: previousSelectedSubjectId || null,
+        selectedSubjectIdAfter: nextSelectedSubjectId || null,
+        reason: selectionReason
+      });
+    }
+    if (selectionReason === "fallback-first-subject") {
+      debugSubjectsSelection("fallback to first subject", {
+        projectId: backendProjectId || currentProjectScopeId || null,
+        requestId: loadRequestId,
+        selectionRevision: currentSelectionRevision,
+        selectedSubjectIdBefore: currentSelectedSubjectIdAtApplyTime || null,
+        selectedSubjectIdAfter: nextSelectedSubjectId || null,
+        reason: selectionReason
+      });
+    }
 
     store.projectSubjectsView.selectedSubjectId = nextSelectedSubjectId;
     store.projectSubjectsView.selectedSujetId = nextSelectedSubjectId;
     store.projectSubjectsView.selectedSituationId = nextSelectedSituationId;
     store.projectSubjectsView.subjectsSelectedNodeId = nextSelectedSubjectId || "";
+    if (store.situationsView && typeof store.situationsView === "object") {
+      store.situationsView.selectedSubjectId = nextSelectedSubjectId;
+      store.situationsView.selectedSujetId = nextSelectedSubjectId;
+      store.situationsView.selectedSituationId = nextSelectedSituationId;
+    }
     store.projectSubjectsView.loading = false;
     store.projectSubjectsView.loaded = true;
+    debugSubjectsSelection("apply result", {
+      projectId: backendProjectId || currentProjectScopeId || null,
+      requestId: loadRequestId,
+      selectionRevision: currentSelectionRevision,
+      selectedSubjectIdBefore: currentSelectedSubjectIdAtApplyTime || null,
+      selectedSubjectIdAfter: nextSelectedSubjectId || null,
+      reason: selectionReason
+    });
 
 
     return result.subjects;
@@ -1751,6 +1873,7 @@ export async function loadFlatSubjectsForCurrentProject(options = {}) {
 }
 
 export function resetFlatSubjectsForCurrentProject() {
+  ensureProjectSubjectsSelectionConcurrencyState();
   store.projectSubjectsView.subjectsData = [];
   store.projectSubjectsView.rawSubjectsResult = null;
   store.projectSubjectsView.rawResult = null;
@@ -1765,4 +1888,5 @@ export function resetFlatSubjectsForCurrentProject() {
   store.projectSubjectsView.subjectsSelectedNodeId = "";
   store.projectSubjectsView.search = "";
   store.projectSubjectsView.page = 1;
+  store.projectSubjectsView.lastLoadRequestId = Number(store.projectSubjectsView.lastLoadRequestId || 0);
 }

--- a/apps/web/js/store.js
+++ b/apps/web/js/store.js
@@ -29,6 +29,8 @@ function createProjectSubjectsViewState() {
   selectedSituationId: null,
   selectedSujetId: null,
   selectedSubjectId: null,
+  selectionRevision: 0,
+  lastLoadRequestId: 0,
   selectedRelationContext: null,
 
   filters: {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -2479,7 +2479,7 @@ export function createProjectSubjectsEvents(config) {
     root.querySelectorAll(".js-sub-right-select-sujet").forEach((btn) => {
       btn.onclick = () => {
         const sujetId = String(btn.dataset.sujetId || "");
-        if (sujetId) selectSujet(sujetId);
+        if (sujetId) selectSubject(sujetId);
       };
     });
 
@@ -4876,7 +4876,7 @@ export function createProjectSubjectsEvents(config) {
         const entityType = String(titleTrigger.dataset.rowEntityType || "");
         const entityId = String(titleTrigger.dataset.rowEntityId || "");
         if (entityType === "sujet") {
-          (selectSubject || selectSujet)(entityId);
+          selectSubject(entityId);
           return;
         }
         if (entityType === "situation") {

--- a/apps/web/js/views/project-subjects/project-subjects-selection.js
+++ b/apps/web/js/views/project-subjects/project-subjects-selection.js
@@ -8,6 +8,41 @@ export function createProjectSubjectsSelection({
   rerenderPanels,
   markEntitySeen
 }) {
+  const SUBJECTS_SELECTION_DEBUG_FLAG = "__MDALL_DEBUG_SUBJECTS_SELECTION__";
+
+  function isSelectionDebugEnabled() {
+    return typeof window !== "undefined" && window?.[SUBJECTS_SELECTION_DEBUG_FLAG] === true;
+  }
+
+  function debugSelection(eventName, payload = {}) {
+    if (!isSelectionDebugEnabled()) return;
+    console.info(`[subjects-selection] ${eventName}`, payload);
+  }
+
+  function markUserSelectionRevision(reason, selection = {}) {
+    ensureViewUiState();
+    const viewState = store.projectSubjectsView || {};
+    const beforeRevision = Number(viewState.selectionRevision || 0);
+    const nextRevision = beforeRevision + 1;
+    viewState.selectionRevision = nextRevision;
+    debugSelection("user select", {
+      projectId: String(store.currentProjectId || "").trim() || null,
+      requestId: Number(viewState.lastLoadRequestId || 0),
+      selectionRevision: nextRevision,
+      selectedSubjectIdBefore: normalizeSelectionSubjectId({
+        selectedSubjectId: viewState.selectedSubjectId,
+        selectedSujetId: viewState.selectedSujetId
+      }),
+      selectedSubjectIdAfter: normalizeSelectionSubjectId(selection),
+      reason
+    });
+    return nextRevision;
+  }
+
+  function normalizeSelectionSubjectId(selection = {}) {
+    return selection?.selectedSubjectId || selection?.selectedSujetId || null;
+  }
+
   function syncLegacySituationsView(selection = {}) {
     if (!(store.situationsView && typeof store.situationsView === "object")) return;
     if (Object.prototype.hasOwnProperty.call(selection, "selectedSituationId")) {
@@ -81,6 +116,7 @@ export function createProjectSubjectsSelection({
     const situation = getNestedSituation(situationId);
     if (!situation) return null;
     setActiveSelection({ selectedSituationId: situation.id, selectedSubjectId: null });
+    markUserSelectionRevision("select-situation", { selectedSubjectId: null });
     getViewState().showTableOnly = true;
     viewState.detailsModalOpen = false;
     syncLegacySituationsView({
@@ -107,6 +143,7 @@ export function createProjectSubjectsSelection({
       viewState.tableScrollRestoreY = getDocumentScrollTop();
     }
     setActiveSelection({ selectedSituationId: situation?.id || null, selectedSubjectId: sujet.id });
+    markUserSelectionRevision("select-subject", { selectedSubjectId: sujet.id });
     if (situation?.id) viewState.expandedSituations.add(situation.id);
     viewState.rightSubissuesOpen = true;
     viewState.showTableOnly = false;

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -17,6 +17,12 @@ export function createProjectSubjectsState({ store }) {
     if (typeof view.loaded !== "boolean") {
       view.loaded = false;
     }
+    if (!Number.isFinite(Number(view.selectionRevision))) {
+      view.selectionRevision = 0;
+    }
+    if (!Number.isFinite(Number(view.lastLoadRequestId))) {
+      view.lastLoadRequestId = 0;
+    }
     return view;
   }
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -538,7 +538,11 @@ function createSubjectFromDraft() {
 
   setSubjectObjectiveIds(subjectId, nextMeta.objectiveIds);
   store.situationsView.selectedSujetId = subjectId;
+  store.situationsView.selectedSubjectId = subjectId;
   store.situationsView.selectedSituationId = nextMeta.situationIds[0] || store.situationsView.selectedSituationId || null;
+  store.projectSubjectsView.selectedSujetId = subjectId;
+  store.projectSubjectsView.selectedSubjectId = subjectId;
+  store.projectSubjectsView.selectedSituationId = nextMeta.situationIds[0] || store.projectSubjectsView.selectedSituationId || null;
   store.situationsView.createSubjectForm.validationError = "";
   return { ok: true, subjectId };
 }


### PR DESCRIPTION
### Motivation
- Corriger une course où `loadFlatSubjectsForCurrentProject()` pouvait réécrire une sélection snapshotée et afficher le mauvais sujet si l'utilisateur cliquait pendant un reload async.
- Faire du clic utilisateur la source de vérité pour la sélection et éviter toute pollution croisée lors de changements de projet ou de réponses hors-ordre.

### Description
- Ajout de l'outillage de concurrence pour la sélection : `selectionRevision` et `lastLoadRequestId` déclarés dans le `store` et initialisés via `ensureProjectSubjectsSelectionConcurrencyState()` (fichiers modifiés : `apps/web/js/store.js`, `apps/web/js/views/project-subjects/project-subjects-state.js`, `apps/web/js/services/project-subjects-supabase.js`).
- Nouvelle logique extraite dans `apps/web/js/services/project-subjects-selection-concurrency.js` : `resolveSelectionAfterSubjectsLoad()` calcule de façon déterministe `{selectedSubjectId, selectedSituationId}` selon l'ordre de priorité demandé, et `shouldIgnoreSubjectsLoadApply()` décide d'ignorer les loads périmés ou cross-project.
- Hardening de `loadFlatSubjectsForCurrentProject()` pour : assigner un monotone `loadRequestId`, snapshotter `selectionRevision` au démarrage, ignorer les réponses périmées ou si le projet a changé, et n'appliquer les résultats que si cohérents (fichier modifié : `apps/web/js/services/project-subjects-supabase.js`).
- Priorisation explicite du clic utilisateur : incrémentation de `selectionRevision` à chaque `selectSubject` / `selectSituation` via `markUserSelectionRevision()` (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-selection.js`) et écriture contrôlée des deux champs legacy `selectedSujetId` / `selectedSubjectId` plus sync vers `store.situationsView` au besoin (fichiers : `project-subjects-selection.js`, `project-subjects-view.js`).
- Instrumentation console activable avec `window.__MDALL_DEBUG_SUBJECTS_SELECTION__` produisant des logs ciblés (`user select`, `load start`, `load resolved`, `stale load ignored`, `preserve newer user selection`, `fallback to first subject`, `apply result`) pour faciliter le diagnostic (fichier : `project-subjects-supabase.js` et selection module).
- Unification du chemin de clic sur les lignes sujet pour toujours appeler `selectSubject(...)` (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Ajout de tests unitaires d'anti-régression dans `apps/web/js/services/project-subjects-selection-concurrency.test.mjs` couvrant les scénarios demandés (sélection utilisateur plus récente, loads chevauchants périmés, changement de projet pendant un load, fallback cohérent).

### Testing
- Exécution des tests ajoutés avec `node --test apps/web/js/services/project-subjects-selection-concurrency.test.mjs` et tous les tests unitaires (4) sont passés avec succès.
- Les modifications ont été restreintes aux fichiers listés et conservent la compatibilité avec les champs legacy `selectedSujetId` / `selectedSubjectId`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73d56cacc8329a1e23c516857825e)