### PR TITLE
Remove noisy debug logging and UI state instrumentation from subject/document modules

### DIFF
--- a/apps/web/js/services/project-document-selectors.js
+++ b/apps/web/js/services/project-document-selectors.js
@@ -123,15 +123,7 @@ function getBlockedByCount(subjectId) {
 export function getSelectionDocumentRefs(selection) {
   const item = selection?.item || null;
   if (!item) return [];
-  const subjectId = String(item?.id || item?.subject_id || "");
   const normalizedRefIds = normalizeEntityDocumentRefs(item);
-  console.info("[subject-document-refs] resolve start", {
-    subjectId,
-    document_id: String(item?.document_id || ""),
-    document_ref_ids: Array.isArray(item?.document_ref_ids) ? item.document_ref_ids : [],
-    raw_document_id: String(item?.raw?.document_id || ""),
-    raw_document_ref_ids: Array.isArray(item?.raw?.document_ref_ids) ? item.raw.document_ref_ids : []
-  });
 
   const resolvedDocs = resolveDocumentRefs(normalizedRefIds);
   const resolvedById = new Map(resolvedDocs.map((doc) => [String(doc?.id || ""), doc]));
@@ -140,14 +132,6 @@ export function getSelectionDocumentRefs(selection) {
     .filter(Boolean)
     .map(decorateDocumentWithPhase)
     .filter(Boolean);
-  const unresolvedRefIds = normalizedRefIds.filter((documentId) => !resolvedById.has(String(documentId || "")));
-  console.info("[subject-document-refs] resolve result", {
-    subjectId,
-    normalizedRefIds,
-    resolvedDocsCount: resolvedDocs.length,
-    unresolvedRefIds,
-    renderableCount: renderable.length
-  });
   return renderable;
 }
 

--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1320,23 +1320,11 @@ export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
   versionsUrl.searchParams.set("subject_id", `eq.${normalizedSubjectId}`);
   versionsUrl.searchParams.set("order", "created_at.desc");
   versionsUrl.searchParams.set("limit", String(limit));
-  console.info(`${logPrefix} fetch start`, {
-    timestamp: new Date().toISOString(),
-    subjectId: normalizedSubjectId,
-    limit,
-    url: versionsUrl.toString()
-  });
 
   const versionsResponse = await fetch(versionsUrl.toString(), {
     method: "GET",
     headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
     cache: "no-store"
-  });
-  console.info(`${logPrefix} fetch response`, {
-    timestamp: new Date().toISOString(),
-    subjectId: normalizedSubjectId,
-    status: Number(versionsResponse.status || 0),
-    statusText: String(versionsResponse.statusText || "")
   });
   if (!versionsResponse.ok) {
     const txt = await versionsResponse.text().catch(() => "");
@@ -1366,18 +1354,6 @@ export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
   }
   const versionRows = await versionsResponse.json().catch(() => []);
   const rows = Array.isArray(versionRows) ? versionRows : [];
-  console.info(`${logPrefix} fetch success`, {
-    timestamp: new Date().toISOString(),
-    subjectId: normalizedSubjectId,
-    rowsCount: rows.length,
-    sample: rows.slice(0, 3).map((row) => ({
-      id: normalizeUuid(row?.id),
-      subject_id: normalizeUuid(row?.subject_id),
-      actor_user_id: normalizeUuid(row?.actor_user_id),
-      actor_person_id: normalizeUuid(row?.actor_person_id),
-      created_at: String(row?.created_at || "")
-    }))
-  });
   if (!rows.length) {
     console.warn(`${logPrefix} fetch succeeded but returned no version rows`, {
       timestamp: new Date().toISOString(),
@@ -1385,11 +1361,6 @@ export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
     });
   }
   const personIds = [...new Set(rows.map((row) => normalizeUuid(row?.actor_person_id)).filter(Boolean))];
-  console.info(`${logPrefix} directory_people fetch candidates`, {
-    timestamp: new Date().toISOString(),
-    subjectId: normalizedSubjectId,
-    personIds
-  });
   const peopleById = {};
   if (personIds.length) {
     const peopleUrl = new URL(`${SUPABASE_URL}/rest/v1/directory_people`);
@@ -1414,12 +1385,6 @@ export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
     }
     if (peopleResponse?.ok) {
       const peopleRows = await peopleResponse.json().catch(() => []);
-      console.info(`${logPrefix} directory_people fetch success`, {
-        timestamp: new Date().toISOString(),
-        subjectId: normalizedSubjectId,
-        status: Number(peopleResponse.status || 0),
-        rowsCount: Array.isArray(peopleRows) ? peopleRows.length : 0
-      });
       (Array.isArray(peopleRows) ? peopleRows : []).forEach((person) => {
         const personId = normalizeUuid(person?.id);
         if (!personId) return;

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -4,9 +4,6 @@ import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from
 
 export function createProjectSubjectsDescription(config = {}) {
   const VERSIONS_LOG_PREFIX = "[subject-description-versions]";
-  const stateRefIds = new WeakMap();
-  let lastLoggedStateRefId = "";
-  let stateRefSeq = 0;
   const {
     store,
     ensureViewUiState,
@@ -38,11 +35,8 @@ export function createProjectSubjectsDescription(config = {}) {
     return `${chunk()}${chunk()}-${chunk()}-${chunk()}-${chunk()}-${chunk()}${chunk()}${chunk()}`;
   };
 
-  function logDescriptionVersions(message, payload = {}) {
-    console.info(`${VERSIONS_LOG_PREFIX} ${message}`, {
-      timestamp: new Date().toISOString(),
-      ...payload
-    });
+  function logDescriptionVersions() {
+    // Debug logs intentionally disabled.
   }
 
   function getSubjectsViewStore() {
@@ -51,15 +45,6 @@ export function createProjectSubjectsDescription(config = {}) {
       store.projectSubjectsView = {};
     }
     return store.projectSubjectsView;
-  }
-
-  function getStateRefId(state) {
-    if (!state || typeof state !== "object") return "no-state";
-    if (!stateRefIds.has(state)) {
-      stateRefSeq += 1;
-      stateRefIds.set(state, `description-versions-ui-${stateRefSeq}`);
-    }
-    return stateRefIds.get(state);
   }
 
   function isHtmlElement(value) {
@@ -90,7 +75,6 @@ export function createProjectSubjectsDescription(config = {}) {
 
   function ensureDescriptionVersionsUiState() {
     const view = getSubjectsViewStore();
-    const existing = view.descriptionVersionsUi;
     view.descriptionVersionsUi ??= {
       entityType: null,
       entityId: null,
@@ -109,15 +93,6 @@ export function createProjectSubjectsDescription(config = {}) {
     if (typeof view.descriptionVersionsUi.selectedVersionId !== "string") view.descriptionVersionsUi.selectedVersionId = "";
     if (typeof view.descriptionVersionsUi.modalOpen !== "boolean") view.descriptionVersionsUi.modalOpen = false;
     if (!Number.isFinite(Number(view.descriptionVersionsUi.loadToken))) view.descriptionVersionsUi.loadToken = 0;
-    const stateRefId = getStateRefId(view.descriptionVersionsUi);
-    if (!existing || lastLoggedStateRefId !== stateRefId) {
-      lastLoggedStateRefId = stateRefId;
-      logDescriptionVersions("state init", {
-        store: "store.projectSubjectsView.descriptionVersionsUi",
-        hasExistingState: !!existing,
-        stateRefId
-      });
-    }
     return view.descriptionVersionsUi;
   }
 
@@ -172,23 +147,6 @@ export function createProjectSubjectsDescription(config = {}) {
     const latestVersion = versions[0] || {};
     const previousState = getEntityDescriptionState(entityType, entityId);
     const patch = buildDescriptionIdentityPatchFromVersion(latestVersion);
-    console.info("[subject-description-current-author] versions loaded", {
-      subjectId: entityId,
-      versionsCount: versions.length,
-      latestVersionId: String(latestVersion?.id || ""),
-      latestActorName: String(latestVersion?.actor_name || ""),
-      latestActorUserId: String(latestVersion?.actor_user_id || ""),
-      latestActorPersonId: String(latestVersion?.actor_person_id || ""),
-      latestActorIsSystem: isSystemDescriptionVersionActor(latestVersion)
-    });
-    console.info("[subject-description-current-author] display sync", {
-      subjectId: entityId,
-      previousAuthor: String(previousState?.author || ""),
-      nextAuthor: String(patch.author || ""),
-      previousAgent: String(previousState?.agent || ""),
-      nextAgent: String(patch.agent || ""),
-      avatarSource: patch.avatarSource
-    });
     if (
       String(previousState?.author || "") === String(patch.author || "")
       && String(previousState?.agent || "") === String(patch.agent || "")
@@ -416,8 +374,7 @@ export function createProjectSubjectsDescription(config = {}) {
       forceReload,
       sameTarget,
       previousIsLoading: previousLoading,
-      versionsInMemory,
-      stateRefId: getStateRefId(ui)
+      versionsInMemory
     });
     if (!forceReload && sameTarget && !ui.error && Array.isArray(ui.versions) && ui.versions.length && !previousLoading) {
       logDescriptionVersions("ensure early return: cache hit", {
@@ -447,8 +404,7 @@ export function createProjectSubjectsDescription(config = {}) {
         entityId: ui.entityId,
         isLoading: ui.isLoading,
         versionsCount: Array.isArray(ui.versions) ? ui.versions.length : 0,
-        error: ui.error,
-        stateRefId: getStateRefId(ui)
+        error: ui.error
       }
     });
     rerenderScope(root);
@@ -465,8 +421,7 @@ export function createProjectSubjectsDescription(config = {}) {
         loadToken,
         rowsCount: normalizedVersions.length,
         selectedVersionId: String(currentUi.selectedVersionId || ""),
-        ignoredAsStale: isStaleResponse,
-        stateRefId: getStateRefId(currentUi)
+        ignoredAsStale: isStaleResponse
       });
       if (isStaleResponse) {
         logDescriptionVersions("stale response ignored", {
@@ -533,8 +488,7 @@ export function createProjectSubjectsDescription(config = {}) {
         isLoadingFinal: !!currentUi.isLoading,
         versionsCountFinal: Array.isArray(currentUi.versions) ? currentUi.versions.length : 0,
         hasError: !!currentUi.error,
-        selectedVersionId: String(currentUi.selectedVersionId || ""),
-        stateRefId: getStateRefId(currentUi)
+        selectedVersionId: String(currentUi.selectedVersionId || "")
       });
       rerenderScope(root);
     }
@@ -739,8 +693,7 @@ export function createProjectSubjectsDescription(config = {}) {
       isTarget,
       isOpen: !!(isTarget && ui.isOpen),
       isLoading: !!ui.isLoading,
-      versionsLength: count,
-      stateRefId: getStateRefId(ui)
+      versionsLength: count
     });
     const loadingHtml = ui.isLoading ? `<div class="description-versions-dropdown__status">Chargement des versions…</div>` : "";
     const errorHtml = !ui.isLoading && ui.error


### PR DESCRIPTION
### Motivation

- Reduce noisy console output and remove dev-only instrumentation that was used for tracing description-version UI state and document resolution flows.
- Clean up unused variables and minor dead code introduced for debug tracing.

### Description

- Removed verbose `console.info` debug logs from `getSelectionDocumentRefs` in `project-document-selectors.js` and eliminated an unused `subjectId` local variable.  
- Disabled/removed many debug `console.info` calls in `loadSubjectDescriptionVersions` in `project-subjects-supabase.js` (fetch start/response/success and people fetch candidate/success logs).  
- Reworked description-versions UI instrumentation in `project-subjects-description.js` by removing the `stateRefIds` tracking (`WeakMap`, sequence, and `getStateRefId`) and replacing `logDescriptionVersions` with a no-op to silence debug traces while keeping existing high-level control flow intact.  
- Kept error/warning logging and functional logic unchanged to preserve behavior while reducing development log noise.

### Testing

- Ran the frontend test suite with `yarn test` and all tests passed.  
- Ran linting (`yarn lint`) and a production build (`yarn build`) to validate no syntax/packaging regressions, both completed successfully.  
- Manual smoke verification of subject description versions and document refs UI flows showed no functional regressions after removing the debug logging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73fc06ea483299ffa531f54827b4c)