### PR TITLE
Ajouter édition inline du titre d’un sujet via RPC dédié

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1309,6 +1309,46 @@ export async function updateSubjectDescription({ subjectId, description, uploadS
   };
 }
 
+export async function updateSubjectTitle({ subjectId, title } = {}) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  const nextTitle = String(title || "").trim();
+  if (!nextTitle) throw new Error("Le titre du sujet ne peut pas être vide.");
+
+  let actorPersonId = "";
+  try {
+    actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  } catch (error) {
+    throw new Error(`update_subject_title identity resolution failed: ${String(error?.message || error || "unknown identity resolution error")}`);
+  }
+  if (!actorPersonId) {
+    throw new Error("update_subject_title identity resolution failed: no linked directory person found for current user");
+  }
+
+  let payload = null;
+  try {
+    payload = await rpcCall("update_subject_title", {
+      p_subject_id: normalizedSubjectId,
+      p_title: nextTitle,
+      p_actor_person_id: actorPersonId
+    });
+  } catch (error) {
+    const statusCode = Number(error?.status || 0) || null;
+    throw new Error(
+      `Impossible de mettre à jour le titre du sujet (${statusCode || "unknown"}): ${String(error?.message || error || "unknown error")}`
+    );
+  }
+
+  const row = Array.isArray(payload) ? (payload[0] || {}) : (payload || {});
+  return {
+    id: normalizeUuid(row?.id || normalizedSubjectId),
+    project_id: normalizeUuid(row?.project_id),
+    title: String(row?.title || nextTitle),
+    normalized_title: String(row?.normalized_title || ""),
+    updated_at: String(row?.updated_at || "")
+  };
+}
+
 export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
   const logPrefix = "[subject-description-versions]";
   const normalizedSubjectId = normalizeUuid(subjectId);

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -15,6 +15,7 @@ import {
   removeLabelFromSubject as removeLabelFromSubjectInSupabase,
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase,
   updateSubjectDescription as updateSubjectDescriptionInSupabase,
+  updateSubjectTitle as updateSubjectTitleInSupabase,
   loadSubjectDescriptionVersions as loadSubjectDescriptionVersionsInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
@@ -114,6 +115,7 @@ import { createProjectSubjectsPersistence } from "./project-subjects/project-sub
 import { createProjectSubjectsSelection } from "./project-subjects/project-subjects-selection.js";
 import { createProjectSubjectsReviewState } from "./project-subjects/project-subjects-review-state.js";
 import { createProjectSubjectsDescription } from "./project-subjects/project-subjects-description.js";
+import { createProjectSubjectsTitle } from "./project-subjects/project-subjects-title.js";
 import { createProjectSubjectsThread } from "./project-subjects/project-subjects-thread.js";
 import { createProjectSubjectsActions } from "./project-subjects/project-subjects-actions.js";
 import { createProjectSubjectsEvents } from "./project-subjects/project-subjects-events.js";
@@ -355,6 +357,25 @@ const {
   renderDescriptionCard
 } = projectSubjectsDescription;
 
+const projectSubjectsTitle = createProjectSubjectsTitle({
+  store,
+  ensureViewUiState,
+  currentDecisionTarget,
+  getSelectionEntityType,
+  getEntityByType,
+  rerenderScope: (...args) => projectSubjectsView.rerenderScope(...args),
+  updateSubjectTitle: (...args) => updateSubjectTitleInSupabase(...args)
+});
+
+const {
+  getSubjectTitleEditState,
+  isEditingSubjectTitle,
+  startSubjectTitleEdit,
+  cancelSubjectTitleEdit,
+  syncSubjectTitleDraft,
+  applySubjectTitleSave
+} = projectSubjectsTitle;
+
 const projectSubjectsEvents = createProjectSubjectsEvents({
   store,
   PROJECT_TAB_RESELECTED_EVENT,
@@ -392,6 +413,11 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   startDescriptionEdit,
   clearDescriptionEditState,
   applyDescriptionSave,
+  getSubjectTitleEditState,
+  startSubjectTitleEdit,
+  cancelSubjectTitleEdit,
+  syncSubjectTitleDraft,
+  applySubjectTitleSave,
   syncCommentPreview: (...args) => projectSubjectsView.syncCommentPreview(...args),
   applyCommentAction: (...args) => projectSubjectsView.applyCommentAction(...args),
   getApplyIssueStatusAction: () => applyIssueStatusAction,
@@ -457,6 +483,8 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   getEffectiveSituationStatus,
   getEntityReviewMeta,
   getReviewTitleStateClass,
+  getSubjectTitleEditState,
+  isEditingSubjectTitle,
   entityDisplayLinkHtml: (...args) => projectSubjectsView.entityDisplayLinkHtml(...args),
   problemsCountsHtml: (...args) => projectSubjectsView.problemsCountsHtml(...args),
   renderSubjectBlockedByHeadHtml: (...args) => projectSubjectsView.renderSubjectBlockedByHeadHtml(...args),

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -8,6 +8,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
     getEffectiveSituationStatus,
     getEntityReviewMeta,
     getReviewTitleStateClass,
+    getSubjectTitleEditState,
+    isEditingSubjectTitle,
     entityDisplayLinkHtml,
     problemsCountsHtml,
     renderSubjectBlockedByHeadHtml,
@@ -26,18 +28,65 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderDocumentRefsCard
   } = config;
 
+  function renderSubjectTitleContent(currentSelection, options = {}) {
+    const item = currentSelection.item;
+    const entityType = getSelectionEntityType(currentSelection.type);
+    const titleSeenClass = getReviewTitleStateClass(entityType, item.id);
+    const editState = getSubjectTitleEditState?.() || {};
+    const isEditing = isEditingSubjectTitle?.(currentSelection) === true;
+    const initialTitleTrimmed = String(editState.initialTitle || item.title || "").trim();
+    const draftValue = String(editState.draft ?? item.title ?? "");
+    const draftTrimmed = draftValue.trim();
+    const isSaving = isEditing && editState.isSaving === true;
+    const hasDraftChange = draftTrimmed && draftTrimmed !== initialTitleTrimmed;
+    const canSave = isEditing && !isSaving && hasDraftChange;
+    const errorHtml = isEditing && String(editState.error || "").trim()
+      ? `<div class="subject-title-edit__error">${escapeHtml(editState.error)}</div>`
+      : "";
+
+    if (!isEditing) {
+      return `
+        <span class="details-title-text ${titleSeenClass}">${escapeHtml(firstNonEmpty(item.title, item.id, "Détail"))}</span>
+        <span class="details-title-inline-ref mono">${entityDisplayLinkHtml(currentSelection.type, item.id)}</span>
+        <button class="gh-btn gh-btn--sm subject-title-edit__action" type="button" data-action="edit-subject-title">Modifier</button>
+      `;
+    }
+
+    return `
+      <div class="subject-title-edit subject-title-edit--inline ${options.compact ? "subject-title-edit--compact" : ""}">
+        <div class="subject-title-edit__row">
+          <div class="subject-title-edit__input-wrap">
+            <input
+              class="subject-title-edit__input"
+              type="text"
+              value="${escapeHtml(draftValue)}"
+              data-subject-title-draft
+              autocomplete="off"
+              ${isSaving ? "disabled" : ""}
+            />
+          </div>
+          <span class="details-title-inline-ref mono">${entityDisplayLinkHtml(currentSelection.type, item.id)}</span>
+          <div class="subject-title-edit__actions">
+            <button class="gh-btn gh-btn--sm subject-title-edit__action" type="button" data-action="cancel-subject-title-edit" ${isSaving ? "disabled" : ""}>Annuler</button>
+            <button class="gh-btn gh-btn--primary gh-btn--sm subject-title-edit__action" type="button" data-action="save-subject-title-edit" ${canSave ? "" : "disabled"}>Enregistrer</button>
+          </div>
+        </div>
+        ${errorHtml}
+      </div>
+    `;
+  }
+
   function renderDetailsTitleWrapHtml(selection) {
     return renderSharedDetailsTitleWrap(selection, {
       emptyText: "Sélectionner un élément",
       buildTitleTextHtml(currentSelection) {
+        if (currentSelection.type === "sujet") {
+          return renderSubjectTitleContent(currentSelection);
+        }
         const item = currentSelection.item;
         const entityType = getSelectionEntityType(currentSelection.type);
         const titleSeenClass = getReviewTitleStateClass(entityType, item.id);
-        const titleHtml = `<span class="details-title-text ${titleSeenClass}">${escapeHtml(firstNonEmpty(item.title, item.id, "Détail"))}</span>`;
-        if (currentSelection.type === "sujet") {
-          return `${titleHtml} <span class="details-title-inline-ref mono">${entityDisplayLinkHtml(currentSelection.type, item.id)}</span>`;
-        }
-        return titleHtml;
+        return `<span class="details-title-text ${titleSeenClass}">${escapeHtml(firstNonEmpty(item.title, item.id, "Détail"))}</span>`;
       },
       buildIdHtml(currentSelection) {
         if (currentSelection.type === "sujet") return "";
@@ -74,7 +123,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
               reviewState: getEntityReviewMeta("sujet", item.id).review_state,
               entityType: "sujet"
             }),
-            topHtml: titleTextHtml,
+            topHtml: renderSubjectTitleContent(currentSelection, { compact: true }),
             bottomHtml: `${countsHtml}${blockedByHtml}${parentHtml}`
           };
         }

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -59,6 +59,11 @@ export function createProjectSubjectsEvents(config) {
     startDescriptionEdit,
     clearDescriptionEditState,
     applyDescriptionSave,
+    getSubjectTitleEditState,
+    startSubjectTitleEdit,
+    cancelSubjectTitleEdit,
+    syncSubjectTitleDraft,
+    applySubjectTitleSave,
     syncCommentPreview,
     applyCommentAction,
     getApplyIssueStatusAction,
@@ -782,6 +787,76 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async () => {
         await applyDescriptionSave(root);
       };
+    });
+
+    const titleBindingRoots = [root];
+    const detailsHead = document.getElementById("situationsDetailsTitle");
+    const modalTitle = document.getElementById("detailsTitleModal");
+    if (detailsHead && !titleBindingRoots.includes(detailsHead)) titleBindingRoots.push(detailsHead);
+    if (modalTitle && !titleBindingRoots.includes(modalTitle)) titleBindingRoots.push(modalTitle);
+
+    const getVisibleTitleInput = () => {
+      const inputs = titleBindingRoots
+        .flatMap((scopeRoot) => Array.from(scopeRoot?.querySelectorAll?.("[data-subject-title-draft]") || []));
+      return inputs.find((input) => {
+        if (!(input instanceof HTMLElement)) return false;
+        if (input.disabled) return false;
+        const rect = input.getBoundingClientRect?.();
+        return !!(input.offsetParent || (rect && rect.width > 0 && rect.height > 0));
+      }) || inputs[0] || null;
+    };
+
+    titleBindingRoots.forEach((scopeRoot) => {
+      if (!(scopeRoot instanceof HTMLElement || scopeRoot === document)) return;
+      scopeRoot.querySelectorAll("[data-action='edit-subject-title']").forEach((btn) => {
+        btn.onclick = () => {
+          const didStart = startSubjectTitleEdit?.(root);
+          if (!didStart) return;
+          requestAnimationFrame(() => {
+            const input = getVisibleTitleInput();
+            if (!input) return;
+            input.focus();
+            const len = String(input.value || "").length;
+            input.setSelectionRange?.(len, len);
+          });
+        };
+      });
+
+      scopeRoot.querySelectorAll("[data-action='cancel-subject-title-edit']").forEach((btn) => {
+        btn.onclick = () => {
+          cancelSubjectTitleEdit?.(root);
+        };
+      });
+
+      scopeRoot.querySelectorAll("[data-action='save-subject-title-edit']").forEach((btn) => {
+        btn.onclick = async () => {
+          const state = getSubjectTitleEditState?.() || {};
+          if (state.isSaving) return;
+          await applySubjectTitleSave?.(root);
+        };
+      });
+
+      scopeRoot.querySelectorAll("[data-subject-title-draft]").forEach((input) => {
+        input.oninput = () => {
+          syncSubjectTitleDraft?.(scopeRoot);
+          rerenderScope(root);
+        };
+        input.onkeydown = async (event) => {
+          if (event.key !== "Enter") return;
+          event.preventDefault();
+          event.stopPropagation();
+          syncSubjectTitleDraft?.(scopeRoot);
+          const state = getSubjectTitleEditState?.() || {};
+          const initialTitle = String(state.initialTitle || "").trim();
+          const draftTitle = String(state.draft || "").trim();
+          if (state.isSaving) return;
+          if (!draftTitle || draftTitle === initialTitle) {
+            cancelSubjectTitleEdit?.(root);
+            return;
+          }
+          await applySubjectTitleSave?.(root);
+        };
+      });
     });
 
     root.querySelectorAll("[data-action='toggle-description-versions']").forEach((btn) => {

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -106,6 +106,18 @@ export function createProjectSubjectsState({ store }) {
     if (!Array.isArray(v.descriptionEdit.attachments)) v.descriptionEdit.attachments = [];
     if (typeof v.descriptionEdit.isSaving !== "boolean") v.descriptionEdit.isSaving = false;
     if (typeof v.descriptionEdit.error !== "string") v.descriptionEdit.error = "";
+    if (!v.subjectTitleEdit || typeof v.subjectTitleEdit !== "object") {
+      v.subjectTitleEdit = {
+        entityType: null,
+        entityId: null,
+        draft: "",
+        initialTitle: "",
+        isSaving: false,
+        error: ""
+      };
+    }
+    if (typeof v.subjectTitleEdit.isSaving !== "boolean") v.subjectTitleEdit.isSaving = false;
+    if (typeof v.subjectTitleEdit.error !== "string") v.subjectTitleEdit.error = "";
     if (!v.drilldown || typeof v.drilldown !== "object") {
       v.drilldown = {
         isOpen: false,
@@ -232,6 +244,14 @@ export function createProjectSubjectsState({ store }) {
       previewMode: false,
       uploadSessionId: "",
       attachments: [],
+      isSaving: false,
+      error: ""
+    };
+    v.subjectTitleEdit = {
+      entityType: null,
+      entityId: null,
+      draft: "",
+      initialTitle: "",
       isSaving: false,
       error: ""
     };

--- a/apps/web/js/views/project-subjects/project-subjects-title.js
+++ b/apps/web/js/views/project-subjects/project-subjects-title.js
@@ -1,0 +1,222 @@
+export function createProjectSubjectsTitle(config = {}) {
+  const {
+    store,
+    ensureViewUiState,
+    currentDecisionTarget,
+    getSelectionEntityType,
+    getEntityByType,
+    rerenderScope,
+    updateSubjectTitle
+  } = config;
+
+  function getSubjectsViewStore() {
+    ensureViewUiState?.();
+    if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") {
+      store.projectSubjectsView = {};
+    }
+    return store.projectSubjectsView;
+  }
+
+  function ensureSubjectTitleEditState() {
+    const view = getSubjectsViewStore();
+    view.subjectTitleEdit ??= {
+      entityType: null,
+      entityId: null,
+      draft: "",
+      initialTitle: "",
+      isSaving: false,
+      error: ""
+    };
+    if (typeof view.subjectTitleEdit.isSaving !== "boolean") view.subjectTitleEdit.isSaving = false;
+    if (typeof view.subjectTitleEdit.error !== "string") view.subjectTitleEdit.error = "";
+    if (typeof view.subjectTitleEdit.initialTitle !== "string") view.subjectTitleEdit.initialTitle = "";
+    return view.subjectTitleEdit;
+  }
+
+  function getSubjectTitleEditState() {
+    return ensureSubjectTitleEditState();
+  }
+
+  function clearSubjectTitleEditState() {
+    const view = getSubjectsViewStore();
+    view.subjectTitleEdit = {
+      entityType: null,
+      entityId: null,
+      draft: "",
+      initialTitle: "",
+      isSaving: false,
+      error: ""
+    };
+  }
+
+  function getCurrentTitle(entityType, entityId, targetItem = null) {
+    const fromTarget = String(targetItem?.title || "");
+    if (fromTarget) return fromTarget;
+    const entity = getEntityByType?.(entityType, entityId);
+    return String(entity?.title || "");
+  }
+
+  function isEditingSubjectTitle(selection = null) {
+    const edit = ensureSubjectTitleEditState();
+    if (edit.entityType !== "sujet") return false;
+    if (!selection?.item?.id) return false;
+    const entityType = getSelectionEntityType?.(selection.type);
+    return entityType === "sujet" && String(edit.entityId || "") === String(selection.item.id || "");
+  }
+
+  function startSubjectTitleEdit(root) {
+    const target = currentDecisionTarget?.(root);
+    if (!target) return false;
+    const entityType = getSelectionEntityType?.(target.type);
+    if (entityType !== "sujet") return false;
+
+    const currentTitle = getCurrentTitle(entityType, target.id, target.item);
+    const view = getSubjectsViewStore();
+    view.subjectTitleEdit = {
+      entityType,
+      entityId: target.id,
+      draft: currentTitle,
+      initialTitle: currentTitle,
+      isSaving: false,
+      error: ""
+    };
+    rerenderScope?.(root);
+    return true;
+  }
+
+  function cancelSubjectTitleEdit(root = null) {
+    clearSubjectTitleEditState();
+    if (root) rerenderScope?.(root);
+  }
+
+  function syncSubjectTitleDraft(root) {
+    if (!root || typeof root.querySelector !== "function") return;
+    const input = root.querySelector("[data-subject-title-draft]");
+    if (!input) return;
+    const edit = ensureSubjectTitleEditState();
+    edit.draft = String(input.value || "");
+    edit.error = "";
+  }
+
+  function applySubjectTitleToLocalState(subjectId, payload = {}, target = null) {
+    const subjectKey = String(subjectId || "").trim();
+    if (!subjectKey) return;
+    const nextTitle = String(payload?.title || "");
+    const nextNormalizedTitle = String(payload?.normalized_title || "");
+    const nextUpdatedAt = String(payload?.updated_at || "");
+
+    if (target?.item && typeof target.item === "object") {
+      target.item.title = nextTitle;
+      if (Object.prototype.hasOwnProperty.call(target.item, "normalized_title") || nextNormalizedTitle) {
+        target.item.normalized_title = nextNormalizedTitle;
+      }
+      if (nextUpdatedAt) target.item.updated_at = nextUpdatedAt;
+      if (target.item.raw && typeof target.item.raw === "object") {
+        target.item.raw.title = nextTitle;
+        if (Object.prototype.hasOwnProperty.call(target.item.raw, "normalized_title") || nextNormalizedTitle) {
+          target.item.raw.normalized_title = nextNormalizedTitle;
+        }
+        if (nextUpdatedAt) target.item.raw.updated_at = nextUpdatedAt;
+      }
+    }
+
+    const rawSubjectsResult = store.projectSubjectsView?.rawSubjectsResult;
+    const rawSubject = rawSubjectsResult?.subjectsById?.[subjectKey];
+    if (rawSubject && typeof rawSubject === "object") {
+      rawSubject.title = nextTitle;
+      rawSubject.normalized_title = nextNormalizedTitle;
+      if (nextUpdatedAt) rawSubject.updated_at = nextUpdatedAt;
+      if (rawSubject.raw && typeof rawSubject.raw === "object") {
+        rawSubject.raw.title = nextTitle;
+        rawSubject.raw.normalized_title = nextNormalizedTitle;
+        if (nextUpdatedAt) rawSubject.raw.updated_at = nextUpdatedAt;
+      }
+    }
+
+    const subjectsData = Array.isArray(store.projectSubjectsView?.subjectsData)
+      ? store.projectSubjectsView.subjectsData
+      : [];
+    const stack = [...subjectsData];
+    while (stack.length) {
+      const node = stack.pop();
+      if (!node || typeof node !== "object") continue;
+      if (String(node.id || "") === subjectKey) {
+        node.title = nextTitle;
+        if (Object.prototype.hasOwnProperty.call(node, "normalized_title") || nextNormalizedTitle) {
+          node.normalized_title = nextNormalizedTitle;
+        }
+        if (nextUpdatedAt) node.updated_at = nextUpdatedAt;
+        if (node.raw && typeof node.raw === "object") {
+          node.raw.title = nextTitle;
+          if (Object.prototype.hasOwnProperty.call(node.raw, "normalized_title") || nextNormalizedTitle) {
+            node.raw.normalized_title = nextNormalizedTitle;
+          }
+          if (nextUpdatedAt) node.raw.updated_at = nextUpdatedAt;
+        }
+      }
+      if (Array.isArray(node.sujets)) stack.push(...node.sujets);
+      if (Array.isArray(node.subjects)) stack.push(...node.subjects);
+      if (Array.isArray(node.children)) stack.push(...node.children);
+    }
+  }
+
+  async function applySubjectTitleSave(root) {
+    const target = currentDecisionTarget?.(root);
+    if (!target) return;
+    const entityType = getSelectionEntityType?.(target.type);
+    if (entityType !== "sujet") return;
+
+    const edit = ensureSubjectTitleEditState();
+    if (edit.isSaving) return;
+
+    const subjectId = String(target.id || "");
+    const initialTitle = String(edit.initialTitle || getCurrentTitle(entityType, subjectId, target.item) || "");
+    const draftTitle = String(edit.draft || "");
+    const trimmedInitial = initialTitle.trim();
+    const trimmedDraft = draftTitle.trim();
+
+    if (!trimmedDraft) {
+      edit.error = "Le titre du sujet ne peut pas être vide.";
+      rerenderScope?.(root);
+      return;
+    }
+
+    if (trimmedDraft === trimmedInitial) {
+      cancelSubjectTitleEdit(root);
+      return;
+    }
+
+    edit.isSaving = true;
+    edit.error = "";
+    rerenderScope?.(root);
+
+    try {
+      const payload = await updateSubjectTitle?.({
+        subjectId,
+        title: trimmedDraft
+      });
+      const nextTitle = String(payload?.title || trimmedDraft);
+      applySubjectTitleToLocalState(subjectId, {
+        ...payload,
+        title: nextTitle
+      }, target);
+      clearSubjectTitleEditState();
+      rerenderScope?.(root);
+    } catch (error) {
+      edit.isSaving = false;
+      edit.error = String(error?.message || error || "Impossible d'enregistrer le titre.");
+      rerenderScope?.(root);
+    }
+  }
+
+  return {
+    ensureSubjectTitleEditState,
+    getSubjectTitleEditState,
+    isEditingSubjectTitle,
+    startSubjectTitleEdit,
+    cancelSubjectTitleEdit,
+    syncSubjectTitleDraft,
+    applySubjectTitleSave,
+    applySubjectTitleToLocalState
+  };
+}

--- a/apps/web/js/views/project-subjects/project-subjects-title.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-title.test.mjs
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProjectSubjectsTitle } from "./project-subjects-title.js";
+
+function createRootWithInput(value = "") {
+  const input = { value };
+  return {
+    querySelector: (selector) => selector === "[data-subject-title-draft]" ? input : null
+  };
+}
+
+test("subject title edit: Enter with unchanged draft cancels edit", async () => {
+  const store = { projectSubjectsView: {} };
+  let rerenderCount = 0;
+  let updateCalls = 0;
+
+  const api = createProjectSubjectsTitle({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-1", item: { id: "subject-1", title: "Titre initial" } }),
+    getSelectionEntityType: (type) => type,
+    getEntityByType: () => ({ id: "subject-1", title: "Titre initial" }),
+    rerenderScope: () => { rerenderCount += 1; },
+    updateSubjectTitle: async () => { updateCalls += 1; return {}; }
+  });
+
+  const root = createRootWithInput("Titre initial");
+  assert.equal(api.startSubjectTitleEdit(root), true);
+  api.syncSubjectTitleDraft(root);
+  await api.applySubjectTitleSave(root);
+
+  const editState = api.getSubjectTitleEditState();
+  assert.equal(editState.entityType, null);
+  assert.equal(editState.entityId, null);
+  assert.equal(updateCalls, 0);
+  assert.ok(rerenderCount >= 2);
+});
+
+test("subject title edit: Enter with changed draft saves via RPC", async () => {
+  const store = { projectSubjectsView: {} };
+  const targetItem = { id: "subject-2", title: "Ancien titre", raw: { title: "Ancien titre" } };
+  const rpcCalls = [];
+
+  const api = createProjectSubjectsTitle({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-2", item: targetItem }),
+    getSelectionEntityType: (type) => type,
+    getEntityByType: () => targetItem,
+    rerenderScope: () => {},
+    updateSubjectTitle: async (payload) => {
+      rpcCalls.push(payload);
+      return {
+        id: "subject-2",
+        project_id: "project-1",
+        title: "Nouveau titre",
+        normalized_title: "nouveau titre",
+        updated_at: "2026-04-21T10:00:00.000Z"
+      };
+    }
+  });
+
+  api.startSubjectTitleEdit(createRootWithInput("Ancien titre"));
+  const editState = api.getSubjectTitleEditState();
+  editState.draft = "Nouveau titre";
+  await api.applySubjectTitleSave({ querySelector: () => null });
+
+  assert.equal(rpcCalls.length, 1);
+  assert.deepEqual(rpcCalls[0], { subjectId: "subject-2", title: "Nouveau titre" });
+  assert.equal(targetItem.title, "Nouveau titre");
+  assert.equal(targetItem.raw.title, "Nouveau titre");
+});
+
+test("subject title edit: local canonical mutation updates subjectsById entry", () => {
+  const store = {
+    projectSubjectsView: {
+      rawSubjectsResult: {
+        subjectsById: {
+          "subject-3": {
+            id: "subject-3",
+            title: "Avant",
+            raw: { title: "Avant" }
+          }
+        }
+      },
+      subjectsData: [
+        {
+          id: "situation-1",
+          sujets: [
+            { id: "subject-3", title: "Avant", raw: { title: "Avant" } }
+          ]
+        }
+      ]
+    }
+  };
+
+  const api = createProjectSubjectsTitle({
+    store,
+    ensureViewUiState: () => {},
+    currentDecisionTarget: () => null,
+    getSelectionEntityType: (type) => type,
+    getEntityByType: () => null,
+    rerenderScope: () => {},
+    updateSubjectTitle: async () => ({})
+  });
+
+  api.applySubjectTitleToLocalState("subject-3", {
+    title: "Après",
+    normalized_title: "apres",
+    updated_at: "2026-04-21T11:00:00.000Z"
+  });
+
+  assert.equal(store.projectSubjectsView.rawSubjectsResult.subjectsById["subject-3"].title, "Après");
+  assert.equal(store.projectSubjectsView.rawSubjectsResult.subjectsById["subject-3"].raw.title, "Après");
+  assert.equal(store.projectSubjectsView.subjectsData[0].sujets[0].title, "Après");
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3350,6 +3350,26 @@ body.is-resizing{
 .details-title--expanded .details-title-topline{display:flex;align-items:center;gap:4px;min-width:0;}
 .details-title--expanded .details-title-bottomline{display:flex;align-items:center;gap:10px;min-width:0;flex-wrap:wrap;}
 .details-title--expanded .details-title-id{font-size:28px;font-weight:100;font-family:inherit;white-space:nowrap;text-overflow:ellipsis;}
+.subject-title-edit{min-width:0;display:flex;flex-direction:column;gap:6px;max-width:100%;}
+.subject-title-edit__row{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;}
+.subject-title-edit__input-wrap{min-width:0;flex:1 1 auto;}
+.subject-title-edit__input{
+  width:100%;
+  min-height:34px;
+  border:1px solid var(--border2);
+  border-radius:8px;
+  background:var(--panel);
+  color:var(--text);
+  padding:6px 10px;
+  font:inherit;
+}
+.subject-title-edit__input:disabled{opacity:.65;cursor:not-allowed;}
+.subject-title-edit__actions{display:inline-flex;align-items:center;gap:6px;flex:0 0 auto;}
+.subject-title-edit__action{white-space:nowrap;}
+.subject-title-edit__error{font-size:12px;line-height:1.35;color:var(--danger-fg,#f85149);}
+.details-title--expanded .subject-title-edit__input{font-size:24px;line-height:1.35;}
+.details-title--compact .subject-title-edit__input{min-height:28px;font-size:14px;line-height:1.2;}
+.details-title--compact .subject-title-edit__actions .gh-btn{min-height:28px;}
 
 /* Sub-issues: keep Problems pill readable; at narrow widths stack icon + text and hide verdict legend */
 .subissues-counts--problems{flex:0 0 auto;min-width:auto;}

--- a/supabase/migrations/202606150024_update_subject_title_rpc.sql
+++ b/supabase/migrations/202606150024_update_subject_title_rpc.sql
@@ -1,0 +1,68 @@
+create or replace function public.update_subject_title(
+  p_subject_id uuid,
+  p_title text,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_next_title text := trim(coalesce(p_title, ''));
+  v_result jsonb;
+begin
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject title';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  if v_next_title = '' then
+    raise exception 'Subject title cannot be empty';
+  end if;
+
+  update public.subjects s
+  set
+    title = v_next_title,
+    normalized_title = v_next_title,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'title', coalesce(v_subject.title, ''),
+    'normalized_title', coalesce(v_subject.normalized_title, ''),
+    'updated_at', v_subject.updated_at
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+grant execute on function public.update_subject_title(uuid, text, uuid) to authenticated;
+revoke all on function public.update_subject_title(uuid, text, uuid) from public;


### PR DESCRIPTION
### Motivation

- Permettre l’édition inline du titre d’un `sujet` dans le détail en réutilisant strictement les patterns existants (séparation renderer/state/events/service Supabase). 
- Fournir un point d’écrite backend dédié pour préparer proprement l’ajout futur de la timeline sans introduire de versionning maintenant.

### Description

- Nouveau module front `apps/web/js/views/project-subjects/project-subjects-title.js` gérant l’état d’édition (`subjectTitleEdit`), helpers (`ensureSubjectTitleEditState`, `startSubjectTitleEdit`, `cancelSubjectTitleEdit`, `syncSubjectTitleDraft`, `applySubjectTitleSave`) et la mutation locale canonique après succès.
- Nouveau RPC SQL `supabase/migrations/202606150024_update_subject_title_rpc.sql` : `public.update_subject_title(p_subject_id uuid, p_title text, p_actor_person_id uuid default null)` avec contrôle d’accès, résolution d’acteur (`coalesce(p_actor_person_id, public.current_person_id())`), trim/validation (titre non vide), update `title`, `normalized_title`, `updated_at` et payload JSON minimal en retour.
- Service front ajouté `updateSubjectTitle({ subjectId, title })` dans `apps/web/js/services/project-subjects-supabase.js` suivant le pattern de `updateSubjectDescription` (normalisation id, résolution `actorPersonId`, appel RPC, erreurs explicites, retour normalisé).
- Wiring et UI : injection du module/service dans `apps/web/js/views/project-subjects.js`, rendu header modifié (`project-subjects-details-renderer.js`) pour afficher `Modifier` puis input + `Annuler`/`Enregistrer` en inline (expanded & compact), bindings robustes dans `project-subjects-events.js` (détail latéral + modale), focus auto et comportement `Enter` (inchangé => annule, modifié => enregistre), et CSS minimal ajouté dans `apps/web/style.css`.
- State global étendu et reset transient géré dans `apps/web/js/views/project-subjects/project-subjects-state.js` et mutation locale mise à jour pour `selection.item`, `rawSubjectsResult.subjectsById` et `subjectsData`.
- Tests ciblés ajoutés `apps/web/js/views/project-subjects/project-subjects-title.test.mjs` (logic: Enter annule si inchangé, Enter enregistre si modifié, mutation locale post-save).

### Testing

- Tests unitaires exécutés : `node --test apps/web/js/views/project-subjects/project-subjects-title.test.mjs apps/web/js/views/project-subjects/project-subjects-imports.test.mjs` et tous les cas inclus sont passés (5/5 ok).
- Aucun test E2E navigateur automatisé exécuté dans cet environnement; changements UI manuels à valider visuellement en intégration (détail latéral + modale + compact/expanded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74362bde4832993a8f74508a3f3a5)