### PR TITLE
Adjust subject detail and comment typography styles

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -847,12 +847,12 @@ export function createProjectSubjectsDescription(config = {}) {
     });
     const authorHtml = waitingForCurrentAuthor
       ? `
-        <div class="gh-comment-author mono">
+        <div class="gh-comment-author">
           <span class="anim-rotate" aria-hidden="true">${svgIcon("attachment-upload-spinner", { className: "subject-attachment__spinner" })}</span>
           <span>Chargement auteur…</span>
         </div>
       `
-      : `<div class="gh-comment-author mono">${escapeHtml(identity.displayName)}</div>`;
+      : `<div class="gh-comment-author">${escapeHtml(identity.displayName)}</div>`;
     const versionsTriggerHtml = entityType === "sujet" ? renderDescriptionVersionsTrigger(null, entityType, entityId) : "";
     const editButtonHtml = `
       <button class="icon-btn icon-btn--sm gh-comment-edit-btn" data-action="edit-description" type="button" aria-label="Modifier la description" title="Modifier la description">

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -39,7 +39,7 @@ export function renderCommentComposer({
       ${hideAvatar ? "" : `<div class="gh-avatar gh-avatar--human comment-composer__avatar" aria-hidden="true">${avatarHtml}</div>`}
 
       <div class="comment-general-block comment-composer__main">
-        ${hideTitle ? "" : `<div class="gh-timeline-title mono comment-composer__title">${escapeHtml(title)}</div>`}
+        ${hideTitle ? "" : `<div class="gh-timeline-title comment-composer__title">${escapeHtml(title)}</div>`}
 
         <div class="comment-box gh-comment-boxwrap comment-composer__box ${helpMode ? "gh-comment-box--help" : ""}">
           ${contextHtml || ""}

--- a/apps/web/js/views/ui/message-thread.js
+++ b/apps/web/js/views/ui/message-thread.js
@@ -40,7 +40,7 @@ export function renderMessageCard({
       <div class="gh-comment-box ${boxClassName}">
         <div class="gh-comment-header ${headerClassName}">
           <div class="gh-comment-header-main">
-            <div class="gh-comment-author mono">${escapeHtml(author)}</div>
+            <div class="gh-comment-author">${escapeHtml(author)}</div>
             ${tsHtml || ""}
           </div>
           ${headerRightHtml || ""}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -576,7 +576,15 @@ body.sidebar-collapsed #sidebar{overflow:hidden;width:0;min-width:0;padding:0;ma
 .subject-sidebar-priority__value{display:inline-flex;align-items:center;flex:0 0 auto;}
 
 .subject-meta-controls{display:flex;flex-direction:column;gap:8px;margin-bottom:24px;}
-.subject-meta-field{position:relative;padding:0 0 10px 0;border-bottom:1px solid var(--border);}
+.subject-meta-field{position:relative;padding:0 0 10px 0;}
+.subject-meta-field::after{
+  content:"";
+  position:absolute;
+  left:8px;
+  right:8px;
+  bottom:0;
+  border-bottom:1px solid var(--border);
+}
 
 .subject-meta-field__trigger{width:100%;display:block;border:none;background:transparent;padding:8px 0px;border-radius:var(--radius);text-align:left;cursor:pointer;}
 
@@ -3357,7 +3365,7 @@ body.is-resizing{
 .details-title--expanded .details-title-bottomline{display:flex;align-items:center;gap:10px;min-width:0;flex-wrap:wrap;}
 .details-title--expanded .details-title-id{font-size:28px;font-weight:100;font-family:inherit;white-space:nowrap;text-overflow:ellipsis;}
 .subject-title-edit{min-width:0;display:flex;flex-direction:column;gap:6px;max-width:100%;flex:1;}
-.subject-title-display{min-width:0;max-width:100%;display:flex;align-items:flex-start;gap:10px;flex:1 auto;}
+.subject-title-display{min-width:0;max-width:100%;display:flex;align-items:center;gap:10px;flex:1 auto;}
 .subject-title-display__main{min-width:0;display:flex;align-items:baseline;gap:4px;flex:1 1 auto;}
 .subject-title-display__spacer{flex:1 1 auto;min-width:0;}
 .subject-title-display__actions{flex:0 0 auto;display:flex;align-items:center;justify-content:flex-end;margin-left:auto;}


### PR DESCRIPTION
### Motivation

- Standardize comment typography by removing the `mono` utility class from composer title and comment author labels to improve visual consistency.
- Vertically center the expanded subject title content for better alignment in the details view.
- Replace the hard `border-bottom` on `.subject-meta-field` with an inset separator so the bottom rule can be padded horizontally without altering layout.

### Description

- Removed the `mono` class from the comment composer title in `apps/web/js/views/ui/comment-composer.js` so the title is now `<div class="gh-timeline-title comment-composer__title">`.
- Removed the `mono` class from comment author markup in `apps/web/js/views/ui/message-thread.js` and `apps/web/js/views/project-subjects/project-subjects-description.js` so author containers are `<div class="gh-comment-author">`.
- Changed `.subject-title-display` alignment from `align-items:flex-start` to `align-items:center` in `apps/web/style.css` to vertically center its content in expanded subject details.
- Replaced the direct `border-bottom` on `.subject-meta-field` with a `::after` pseudo-element inset by `left:8px` and `right:8px` in `apps/web/style.css` to implement the requested padded bottom border.

### Testing

- Ran the style unit test `node apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs`, which completed successfully (`1..1`, all tests passed).
- No other automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e754b87d2083299bca9f03439cdca5)