### PR TITLE
Ajuste l’UI des versions, références documentaires et bouton Enregistrer

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -153,7 +153,7 @@ test("description versions: un rerender pendant le chargement ne bloque pas isLo
   api.renderDescriptionVersionsDropdownHost(root);
   const hostHtml = (globalThis.document?.getElementById?.("descriptionVersionsDropdownHost")?.innerHTML || "");
 
-  assert.match(html, /Versions \(1\)/);
+  assert.match(html, />Version</);
   assert.doesNotMatch(hostHtml, /Chargement des versions/);
   assert.match(hostHtml, /Ada Lovelace/);
   assert.match(hostHtml, /il y a/);

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -663,6 +663,7 @@ export function createProjectSubjectsDescription(config = {}) {
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
     const isOpen = isTarget && ui.isOpen;
     const count = isTarget && Array.isArray(ui.versions) ? ui.versions.length : 0;
+    const versionsLabel = count > 1 ? "Versions" : "Version";
     const anchorKey = `${entityType}::${entityId}`;
     return `
       <div class="issues-head-menu description-versions-dropdown ${isOpen ? "is-open" : ""}">
@@ -675,7 +676,7 @@ export function createProjectSubjectsDescription(config = {}) {
           aria-haspopup="menu"
           title="Versions"
         >
-          <span>Versions${count ? ` (${count})` : ""}</span>
+          <span>${versionsLabel}</span>
           <span class="description-versions-dropdown__caret">${svgIcon("chevron-down")}</span>
         </button>
       </div>

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -74,7 +74,10 @@ export function createProjectSubjectsDetailsRenderer(config) {
           </div>
           <div class="subject-title-edit__actions">
             <button class="gh-btn gh-btn--sm subject-title-edit__action" type="button" data-action="cancel-subject-title-edit" ${isSaving ? "disabled" : ""}>Annuler</button>
-            <button class="gh-btn gh-btn--primary gh-btn--sm subject-title-edit__action" type="button" data-action="save-subject-title-edit" ${canSave ? "" : "disabled"}>Enregistrer</button>
+            <button class="gh-btn gh-btn--primary gh-btn--sm subject-title-edit__action subject-title-edit__save-btn" type="button" data-action="save-subject-title-edit" ${canSave ? "" : "disabled"}>
+              <span>Enregistrer</span>
+              <span class="subject-title-edit__shortcut" aria-hidden="true">⏎</span>
+            </button>
           </div>
         </div>
         ${errorHtml}

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -229,6 +229,20 @@ function entityDisplayLinkHtml(type, id) {
   return entityLinkHtml(type, id, escapeHtml(getEntityDisplayRef(type, id)));
 }
 
+function getDocumentDisplayName(document = {}) {
+  const fileName = String(document?.fileName || "").trim();
+  const title = String(document?.title || "").trim();
+  const name = String(document?.name || "").trim();
+  const id = String(document?.id || "").trim();
+  const extension = String(document?.extension || "").trim().replace(/^\./, "");
+  const baseName = fileName || title || name || id || "Document";
+  if (!baseName) return "Document";
+  if (!extension) return baseName;
+  const lowered = baseName.toLowerCase();
+  const normalizedExtension = extension.toLowerCase();
+  return lowered.endsWith(`.${normalizedExtension}`) ? baseName : `${baseName}.${normalizedExtension}`;
+}
+
 
 function renderDocumentRefsCard(selection) {
   const refs = getSelectionDocumentRefs(selection);
@@ -240,7 +254,7 @@ function renderDocumentRefsCard(selection) {
       <div class="details-document-refs__list">
         ${refs.map((doc) => `
           <span class="details-document-ref">
-            <span class="details-document-ref__name">${escapeHtml(doc.name)}</span>
+            <span class="details-document-ref__name">${escapeHtml(getDocumentDisplayName(doc))}</span>
             <span class="details-document-ref__phase">${escapeHtml(doc.phaseCode)}${doc.phaseLabel ? ` · ${escapeHtml(doc.phaseLabel)}` : ""}</span>
           </span>
         `).join("")}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3387,6 +3387,23 @@ body.is-resizing{
 .subject-title-edit__input:disabled{opacity:.65;cursor:not-allowed;}
 .subject-title-edit__actions{display:inline-flex;align-items:center;gap:6px;flex:0 0 auto;}
 .subject-title-edit__action{white-space:nowrap;}
+.subject-title-edit__save-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+}
+.subject-title-edit__shortcut{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:20px;
+  height:20px;
+  border:solid 1px rgba(4, 38, 15, 0.1);
+  border-radius:var(--radius);
+  background-color:rgba(4, 38, 15, 0.2);
+  font-size:12px;
+  line-height:1;
+}
 .subject-title-edit__error{font-size:12px;line-height:1.35;color:var(--danger-fg,#f85149);}
 .details-title--compact .subject-title-edit__input{min-height:28px;font-size:14px;line-height:1.2;}
 .details-title--compact .subject-title-edit__actions .gh-btn{min-height:28px;}


### PR DESCRIPTION
### Motivation
- Corriger le libellé affiché dans l’entête des versions de description pour respecter le singulier/pluriel et retirer le compteur entre parenthèses. 
- Rendre les « Références documentaires » lisibles en affichant le nom de fichier (avec extension) plutôt que l’identifiant brut lorsque les métadonnées sont disponibles. 
- Rendre le bouton d’enregistrement du titre plus explicite en ajoutant une mise en page en deux colonnes et un indicateur visuel du raccourci clavier.

### Description
- Modifie `renderDescriptionVersionsTrigger` dans `apps/web/js/views/project-subjects/project-subjects-description.js` pour afficher `Version` (1) ou `Versions` (>1) au lieu de `Versions (x)` et retire l’affichage du compteur. 
- Met à jour le test `apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` pour refléter le nouveau libellé singulier. 
- Ajoute la fonction utilitaire `getDocumentDisplayName` dans `apps/web/js/views/project-subjects/project-subjects-view.js` et remplace l’affichage précédent par `getDocumentDisplayName(doc)` dans `renderDocumentRefsCard` pour privilégier `fileName`/`title`/`name` + extension. 
- Adapte le rendu du bouton d’enregistrement dans `apps/web/js/views/project-subjects/project-subjects-details-renderer.js` pour inclure deux spans (`<span>Enregistrer</span>` et `<span class="subject-title-edit__shortcut">⏎</span>`) et ajoute les styles associés dans `apps/web/style.css` (`.subject-title-edit__save-btn` et `.subject-title-edit__shortcut`).

### Testing
- Exécuté `node --test apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs apps/web/js/views/project-subjects/project-subjects-title.test.mjs apps/web/js/services/project-document-selectors.test.mjs` et tous les tests unitaires sont passés (11 tests, 0 échecs). 
- Les modifications ont été intégrées et commitées localement (`Ajuste libellés versions, refs documentaires et bouton Enregistrer`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75caf77008329b9040de12ee845a0)