### PR TITLE
UI: singular/plural versions label, compact title layout, document name normalization, and save-button shortcut

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -153,7 +153,7 @@ test("description versions: un rerender pendant le chargement ne bloque pas isLo
   api.renderDescriptionVersionsDropdownHost(root);
   const hostHtml = (globalThis.document?.getElementById?.("descriptionVersionsDropdownHost")?.innerHTML || "");
 
-  assert.match(html, /Versions \(1\)/);
+  assert.match(html, />Version</);
   assert.doesNotMatch(hostHtml, /Chargement des versions/);
   assert.match(hostHtml, /Ada Lovelace/);
   assert.match(hostHtml, /il y a/);

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -663,6 +663,7 @@ export function createProjectSubjectsDescription(config = {}) {
     const isTarget = ui.entityType === entityType && ui.entityId === entityId;
     const isOpen = isTarget && ui.isOpen;
     const count = isTarget && Array.isArray(ui.versions) ? ui.versions.length : 0;
+    const versionsLabel = count > 1 ? "Versions" : "Version";
     const anchorKey = `${entityType}::${entityId}`;
     return `
       <div class="issues-head-menu description-versions-dropdown ${isOpen ? "is-open" : ""}">
@@ -675,7 +676,7 @@ export function createProjectSubjectsDescription(config = {}) {
           aria-haspopup="menu"
           title="Versions"
         >
-          <span>Versions${count ? ` (${count})` : ""}</span>
+          <span>${versionsLabel}</span>
           <span class="description-versions-dropdown__caret">${svgIcon("chevron-down")}</span>
         </button>
       </div>

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -32,6 +32,17 @@ export function createProjectSubjectsDetailsRenderer(config) {
     const item = currentSelection.item;
     const entityType = getSelectionEntityType(currentSelection.type);
     const titleSeenClass = getReviewTitleStateClass(entityType, item.id);
+    if (options.compact) {
+      return `
+        <div class="subject-title-display subject-title-display--compact">
+          <div class="subject-title-display__main">
+            <span class="details-title-text ${titleSeenClass}">${escapeHtml(firstNonEmpty(item.title, item.id, "Détail"))}</span>
+            <span class="details-title-inline-ref">${entityDisplayLinkHtml(currentSelection.type, item.id)}</span>
+          </div>
+        </div>
+      `;
+    }
+
     const editState = getSubjectTitleEditState?.() || {};
     const isEditing = isEditingSubjectTitle?.(currentSelection) === true;
     const initialTitleTrimmed = String(editState.initialTitle || item.title || "").trim();
@@ -74,7 +85,10 @@ export function createProjectSubjectsDetailsRenderer(config) {
           </div>
           <div class="subject-title-edit__actions">
             <button class="gh-btn gh-btn--sm subject-title-edit__action" type="button" data-action="cancel-subject-title-edit" ${isSaving ? "disabled" : ""}>Annuler</button>
-            <button class="gh-btn gh-btn--primary gh-btn--sm subject-title-edit__action" type="button" data-action="save-subject-title-edit" ${canSave ? "" : "disabled"}>Enregistrer</button>
+            <button class="gh-btn gh-btn--primary gh-btn--sm subject-title-edit__action subject-title-edit__save-btn" type="button" data-action="save-subject-title-edit" ${canSave ? "" : "disabled"}>
+              <span>Enregistrer</span>
+              <span class="subject-title-edit__shortcut" aria-hidden="true">⏎</span>
+            </button>
           </div>
         </div>
         ${errorHtml}

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -229,6 +229,20 @@ function entityDisplayLinkHtml(type, id) {
   return entityLinkHtml(type, id, escapeHtml(getEntityDisplayRef(type, id)));
 }
 
+function getDocumentDisplayName(document = {}) {
+  const fileName = String(document?.fileName || "").trim();
+  const title = String(document?.title || "").trim();
+  const name = String(document?.name || "").trim();
+  const id = String(document?.id || "").trim();
+  const extension = String(document?.extension || "").trim().replace(/^\./, "");
+  const baseName = fileName || title || name || id || "Document";
+  if (!baseName) return "Document";
+  if (!extension) return baseName;
+  const lowered = baseName.toLowerCase();
+  const normalizedExtension = extension.toLowerCase();
+  return lowered.endsWith(`.${normalizedExtension}`) ? baseName : `${baseName}.${normalizedExtension}`;
+}
+
 
 function renderDocumentRefsCard(selection) {
   const refs = getSelectionDocumentRefs(selection);
@@ -240,7 +254,7 @@ function renderDocumentRefsCard(selection) {
       <div class="details-document-refs__list">
         ${refs.map((doc) => `
           <span class="details-document-ref">
-            <span class="details-document-ref__name">${escapeHtml(doc.name)}</span>
+            <span class="details-document-ref__name">${escapeHtml(getDocumentDisplayName(doc))}</span>
             <span class="details-document-ref__phase">${escapeHtml(doc.phaseCode)}${doc.phaseLabel ? ` · ${escapeHtml(doc.phaseLabel)}` : ""}</span>
           </span>
         `).join("")}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3201,18 +3201,18 @@ body.is-resizing{
   display:grid;
   grid-template-columns:auto 1fr;
   gap:10px;
-  align-items:start;
+  align-items:center;
   min-width:0;
 }
 .details-title--compact .details-title-compact-col1{display:flex;align-items:center;}
-.details-title--compact .details-title-compact-col2{min-width:0;}
+.details-title--compact .details-title-compact-col2{min-width:0;display:flex;flex-direction:column;justify-content:center;gap:2px;}
 .details-title--compact .details-title-compact--inline{display:flex;align-items:center;gap:8px 2px;min-width:0;flex-wrap:nowrap;}
 .details-title--compact .details-title-compact--inline .verdict-badge,
 .details-title--compact .details-title-compact--inline .details-title-status,
 .details-title--compact .details-title-compact--inline .details-title-id{flex:0 0 auto;}
 .details-title--compact .details-title-compact--inline .details-title-text{min-width:0;}
-.details-title--compact .details-title-compact-top{display:flex;align-items:baseline;gap:0px 4px;min-width:0;flex-wrap:wrap;}
-.details-title--compact .details-title-compact-bottom{display:flex;align-items:center;gap:8px;min-width:0;height:16px;}
+.details-title--compact .details-title-compact-top{display:flex;align-items:center;gap:0px 4px;min-width:0;flex-wrap:wrap;}
+.details-title--compact .details-title-compact-bottom{display:flex;align-items:center;gap:8px;min-width:0;min-height:16px;}
 .details-title--compact .details-title-compact-bottom .subissues-counts--problems{flex:0 0 auto;margin:0px;border:none;padding:0px 6px 0px 0px;font-weight:400;font-size:12px;line-height:16px;gap:4px;background:transparent;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge{display:inline-flex;align-items:center;gap:4px;font-size:12px;line-height:16px;color:var(--muted);min-width:0;}
 .details-title--compact .details-title-compact-bottom .details-parent-badge__icon{display:inline-flex;align-items:center;flex:0 0 auto;}
@@ -3387,6 +3387,23 @@ body.is-resizing{
 .subject-title-edit__input:disabled{opacity:.65;cursor:not-allowed;}
 .subject-title-edit__actions{display:inline-flex;align-items:center;gap:6px;flex:0 0 auto;}
 .subject-title-edit__action{white-space:nowrap;}
+.subject-title-edit__save-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+}
+.subject-title-edit__shortcut{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:20px;
+  height:20px;
+  border:solid 1px rgba(4, 38, 15, 0.1);
+  border-radius:var(--radius);
+  background-color:rgba(4, 38, 15, 0.2);
+  font-size:12px;
+  line-height:1;
+}
 .subject-title-edit__error{font-size:12px;line-height:1.35;color:var(--danger-fg,#f85149);}
 .details-title--compact .subject-title-edit__input{min-height:28px;font-size:14px;line-height:1.2;}
 .details-title--compact .subject-title-edit__actions .gh-btn{min-height:28px;}


### PR DESCRIPTION
### Motivation

- Make the description-versions trigger more user-friendly by showing a singular label for one version and a plural label otherwise, and remove the inline count from the trigger to rely on the dropdown content for details.
- Provide a compact rendering mode for subject titles for tighter layouts and improve alignment in compact title CSS.
- Normalize displayed document names so filenames/extensions are consistent and readable.
- Improve the subject title edit save button UI by adding an explicit save label and a visible keyboard shortcut indicator.

### Description

- Update `renderDescriptionVersionsTrigger` to use a computed label (`Version` vs `Versions`) and remove the inline count from the trigger button.
- Adjust the test `project-subjects-description-versions.test.mjs` to expect the new label rendering in the trigger.
- Add a `compact` option to `renderSubjectTitleContent` so subject titles can be rendered in a compact layout and return early when requested by callers.
- Modify the subject title edit markup to add a save button wrapper with a visible shortcut element and add a CSS class for the save button (`subject-title-edit__save-btn`) and shortcut (`subject-title-edit__shortcut`).
- Add `getDocumentDisplayName` to compute a normalized document display name (prefer `fileName`, `title`, `name`, or `id` and ensure the extension is present only once) and use it inside `renderDocumentRefsCard`.
- Tweak compact title CSS (`.details-title--compact` and related rules) to adjust vertical alignment and layout, and add styles for the save-button shortcut.

### Testing

- Updated unit test `apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` to reflect the new trigger label, and the test suite for that file passes.
- Ran the relevant `project-subjects` view renderer tests (including the description versions tests) and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75caf77008329b9040de12ee845a0)