### PR TITLE
Afficher l'auteur initial et métadonnées d'édition dans la description du sujet

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -390,7 +390,7 @@ test("description versions: la version système affiche Heimdall sans fallback b
   cleanupFakeDom();
 });
 
-test("description versions: l'auteur de la carte est réaligné sur la dernière version chargée", async () => {
+test("description versions: la carte affiche l'auteur de la première version et le dernier éditeur", async () => {
   installFakeDom({
     "sujet::subject-1": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) }
   });
@@ -431,14 +431,28 @@ test("description versions: l'auteur de la carte est réaligné sur la dernière
     rerenderScope: () => {},
     markEntityValidated: () => {},
     updateSubjectDescription: async () => ({}),
-    loadSubjectDescriptionVersions: async () => [{
-      id: "v-last",
-      actor_name: "Nouveau Auteur",
-      actor_user_id: "u2",
-      actor_person_id: "p2",
-      description_markdown: "new",
-      created_at: new Date().toISOString()
-    }]
+    loadSubjectDescriptionVersions: async () => [
+      {
+        id: "v-last",
+        actor_name: "Nouveau Auteur",
+        actor_first_name: "Nouveau",
+        actor_last_name: "Auteur",
+        actor_user_id: "u2",
+        actor_person_id: "p2",
+        description_markdown: "new",
+        created_at: new Date().toISOString()
+      },
+      {
+        id: "v-first",
+        actor_name: "Ancien Auteur",
+        actor_first_name: "Ancien",
+        actor_last_name: "Auteur",
+        actor_user_id: "u3",
+        actor_person_id: "p3",
+        description_markdown: "old",
+        created_at: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString()
+      }
+    ]
   });
 
   api.toggleDescriptionVersionsDropdown({});
@@ -447,8 +461,10 @@ test("description versions: l'auteur de la carte est réaligné sur la dernière
     type: "sujet",
     item: { id: "subject-1", title: "Sujet", raw: { description: "Description initiale" } }
   });
-  assert.match(html, /Nouveau Auteur/);
-  assert.doesNotMatch(html, /Ancien auteur/);
+  assert.match(html, /Ancien Auteur/);
+  assert.match(html, /ouvert il y a/);
+  assert.match(html, /modifié par Nouveau Auteur/);
+  assert.doesNotMatch(html, /Ancien auteur<\/div>/);
 
   cleanupFakeDom();
 });

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -113,6 +113,34 @@ export function createProjectSubjectsDescription(config = {}) {
     return `il y a ${Math.abs(deltaYears)} an${Math.abs(deltaYears) > 1 ? "s" : ""}`;
   }
 
+  function formatOpenedRelativeTimeFromNow(ts = "") {
+    const target = new Date(String(ts || ""));
+    if (Number.isNaN(target.getTime())) return "ouvert à l'instant";
+    const deltaMs = Date.now() - target.getTime();
+    const future = deltaMs < 0;
+    const absSeconds = Math.max(1, Math.round(Math.abs(deltaMs) / 1000));
+    const units = [
+      [31536000, "an"],
+      [2592000, "mois"],
+      [86400, "jour"],
+      [3600, "heure"],
+      [60, "minute"],
+      [1, "seconde"]
+    ];
+    let value = 1;
+    let unit = "seconde";
+    for (const [seconds, label] of units) {
+      if (absSeconds >= seconds) {
+        value = Math.floor(absSeconds / seconds);
+        unit = label;
+        break;
+      }
+    }
+    const plural = value > 1 && unit !== "mois" ? "s" : "";
+    if (future) return `ouvert dans ${value} ${unit}${plural}`;
+    return `ouvert il y a ${value} ${unit}${plural}`;
+  }
+
   function formatVersionTimestamp(ts = "") {
     return typeof fmtTs === "function" ? fmtTs(ts) : String(ts || "—");
   }
@@ -171,6 +199,19 @@ export function createProjectSubjectsDescription(config = {}) {
       humanAvatarHtml: SVG_AVATAR_HUMAN,
       fallbackName: "Utilisateur"
     });
+  }
+
+  function getVersionDisplayName(version = {}, options = {}) {
+    const preferFirstLast = options.preferFirstLast !== false;
+    if (isSystemDescriptionVersionActor(version)) return "Mdall";
+    const firstName = String(version?.actor_first_name || "").trim();
+    const lastName = String(version?.actor_last_name || "").trim();
+    if (preferFirstLast && (firstName || lastName)) {
+      return `${firstName} ${lastName}`.trim();
+    }
+    const actorName = String(version?.actor_name || "").trim();
+    if (actorName) return actorName;
+    return `${firstName} ${lastName}`.trim() || "Utilisateur";
   }
 
   function buildVersionInitials(version = {}) {
@@ -846,6 +887,21 @@ export function createProjectSubjectsDescription(config = {}) {
       humanAvatarHtml: SVG_AVATAR_HUMAN,
       fallbackName: "System"
     });
+    const versions = isVersionsTarget && Array.isArray(versionsUi.versions) ? versionsUi.versions : [];
+    const latestVersion = versions.length ? versions[0] : null;
+    const firstVersion = versions.length ? versions[versions.length - 1] : null;
+    const firstVersionIdentity = firstVersion
+      ? getVersionAuthorIdentity({
+          ...firstVersion,
+          actor_name: getVersionDisplayName(firstVersion, { preferFirstLast: true })
+        })
+      : null;
+    const firstAuthorDisplayName = firstVersionIdentity?.displayName || identity.displayName;
+    const openedLabel = firstVersion?.created_at ? formatOpenedRelativeTimeFromNow(firstVersion.created_at) : "";
+    const editedByLabel = versions.length > 1 && latestVersion
+      ? ` · modifié par ${getVersionDisplayName(latestVersion, { preferFirstLast: true })}`
+      : "";
+    const authorMetaLabel = `${openedLabel}${editedByLabel}`.trim();
     const authorHtml = waitingForCurrentAuthor
       ? `
         <div class="gh-comment-author">
@@ -853,7 +909,12 @@ export function createProjectSubjectsDescription(config = {}) {
           <span>Chargement auteur…</span>
         </div>
       `
-      : `<div class="gh-comment-author">${escapeHtml(identity.displayName)}</div>`;
+      : `
+        <div class="gh-comment-author">
+          <span>${escapeHtml(firstAuthorDisplayName)}</span>
+          ${authorMetaLabel ? `<span class="gh-comment-author-meta">${escapeHtml(authorMetaLabel)}</span>` : ""}
+        </div>
+      `;
     const versionsTriggerHtml = entityType === "sujet" ? renderDescriptionVersionsTrigger(null, entityType, entityId) : "";
     const editButtonHtml = `
       <button class="icon-btn icon-btn--sm gh-comment-edit-btn" data-action="edit-description" type="button" aria-label="Modifier la description" title="Modifier la description">
@@ -931,11 +992,12 @@ export function createProjectSubjectsDescription(config = {}) {
         </div>
       `;
 
+    const displayIdentity = firstVersionIdentity || identity;
     return `
       <div class="gh-comment gh-comment--description">
-        ${identity.avatarHtml
-          ? `<div class="gh-avatar ${identity.avatarType === "human" ? "gh-avatar--human" : ""}" aria-hidden="true">${identity.avatarHtml}</div>`
-          : `<div class="gh-avatar" aria-hidden="true"><span class="gh-avatar-initial">${escapeHtml(identity.avatarInitial || description.avatar_initial || "S")}</span></div>`}
+        ${displayIdentity.avatarHtml
+          ? `<div class="gh-avatar ${displayIdentity.avatarType === "human" ? "gh-avatar--human" : ""}" aria-hidden="true">${displayIdentity.avatarHtml}</div>`
+          : `<div class="gh-avatar" aria-hidden="true"><span class="gh-avatar-initial">${escapeHtml(displayIdentity.avatarInitial || description.avatar_initial || "S")}</span></div>`}
         <div class="gh-comment-box">
           ${headerHtml}
           ${bodyHtml}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2525,6 +2525,9 @@ body.is-resizing{
   letter-spacing:.02em;
   padding-right:8px;
 }
+.gh-comment-author-meta{
+  color:var(--muted);
+}
 .gh-comment-body{
   padding:0px;
   white-space:inherit;


### PR DESCRIPTION
### Motivation
- Remplacer l’affichage actuel (avatar + nom de l’auteur de la dernière version) par l’avatar et le prénom+nom de l’auteur de la première version, avec comportement spécial pour les versions système (Heimdall + nom « Mdall »). 
- Ajouter à droite du nom un libellé de métadonnées en français indiquant quand le sujet a été ouvert et, si plusieurs versions existent, qui l’a modifié en dernier, en style « muted » mais en conservant la même taille de police.

### Description
- Affichage: le header de la description utilise désormais l’identité de la première version (`firstVersionIdentity`) pour l’avatar et le nom, et tombe sur l’identité courante si les versions ne sont pas disponibles (fichier modifié: `apps/web/js/views/project-subjects/project-subjects-description.js`).
- Métadonnées temporelles: ajout de `formatOpenedRelativeTimeFromNow` pour produire « ouvert il y a … » en français et concaténation conditionnelle de `· modifié par …` lorsque `versions.length > 1`.
- Utilitaires: ajout de `getVersionDisplayName` pour privilégier le format `Prénom Nom` quand `actor_first_name`/`actor_last_name` existent, et réutilisation de `getVersionAuthorIdentity` pour rendre l’avatar/fallback système correctement.
- Style: ajout de la classe `.gh-comment-author-meta` en `apps/web/style.css` pour rendre la partie méta en couleur muted tout en gardant la même taille de police.
- Tests: mise à jour du test `project-subjects-description-versions.test.mjs` pour vérifier l’affichage de l’auteur initial, le libellé « ouvert il y a … » et le texte « · modifié par … ».

### Testing
- Exécution des tests unitaires ciblés avec `node --test apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` (7 tests exécutés). 
- Résultat: tous les tests ciblés ont réussi (7 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76186ee7483299a0de11732fbb8e7)