### PR TITLE
Wire subject_history as source of truth for title/description/close/reopen activities

### DIFF
--- a/apps/web/js/services/profile-supabase-sync.js
+++ b/apps/web/js/services/profile-supabase-sync.js
@@ -1345,49 +1345,13 @@ function mapIssueActionToSubjectUpdate(action) {
 
   switch (normalizedAction) {
     case "issue:reopen":
-      return {
-        status: "open",
-        closure_reason: null,
-        closed_at: null,
-        history: {
-          event_type: "subject_reopened",
-          title: "Sujet rouvert",
-          description: "Le sujet a été rouvert depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:reopen" };
     case "issue:close:realized":
-      return {
-        status: "closed",
-        closure_reason: "realized",
-        closed_at: new Date().toISOString(),
-        history: {
-          event_type: "subject_closed",
-          title: "Sujet fermé comme réalisé",
-          description: "Le sujet a été marqué comme réalisé depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:close:realized" };
     case "issue:close:dismissed":
-      return {
-        status: "closed_invalid",
-        closure_reason: "non_pertinent",
-        closed_at: new Date().toISOString(),
-        history: {
-          event_type: "subject_closed",
-          title: "Sujet fermé comme non pertinent",
-          description: "Le sujet a été marqué comme non pertinent depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:close:dismissed" };
     case "issue:close:duplicate":
-      return {
-        status: "closed_duplicate",
-        closure_reason: "duplicate",
-        closed_at: new Date().toISOString(),
-        history: {
-          event_type: "subject_marked_duplicate",
-          title: "Sujet fermé comme dupliqué",
-          description: "Le sujet a été marqué comme dupliqué depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:close:duplicate" };
     default:
       return null;
   }
@@ -1818,9 +1782,6 @@ export async function deleteProjectCollaboratorFromSupabase(projectCollaboratorI
 export async function persistSubjectIssueActionToSupabase(subject = {}, action = "") {
   const actionConfig = mapIssueActionToSubjectUpdate(action);
   const subjectId = safeString(subject?.id || subject?.raw?.id || "");
-  const projectId = safeString(subject?.raw?.project_id || subject?.project_id || "");
-  const analysisRunId = safeString(subject?.raw?.analysis_run_id || subject?.analysis_run_id || "");
-  const documentId = safeString(subject?.raw?.document_id || subject?.document_id || "");
   const situationId = safeString(subject?.raw?.situation_id || subject?.situation_id || "");
 
   if (!actionConfig) {
@@ -1831,40 +1792,13 @@ export async function persistSubjectIssueActionToSupabase(subject = {}, action =
     throw new Error("Subject id missing for Supabase status update.");
   }
 
-  const updatedSubject = await restUpdate(
-    "subjects",
-    { id: subjectId },
-    {
-      status: actionConfig.status,
-      closure_reason: actionConfig.closure_reason,
-      closed_at: actionConfig.closed_at
-    },
-    {
-      select: "id,status,closure_reason,closed_at,updated_at"
-    }
-  );
-
-  if (projectId) {
-    await restInsert("subject_history", {
-      project_id: projectId,
-      subject_id: subjectId,
-      analysis_run_id: analysisRunId || null,
-      document_id: documentId || null,
-      event_type: actionConfig.history.event_type,
-      actor_type: "user",
-      actor_label: String((await getCurrentUser())?.email || "Mdall"),
-      actor_user_id: (await getCurrentUser())?.id || null,
-      title: actionConfig.history.title,
-      description: actionConfig.history.description,
-      event_payload: {
-        source: "mdall_frontend",
-        action: safeString(action),
-        previous_status: safeString(subject?.raw?.status || subject?.status || ""),
-        new_status: actionConfig.status,
-        closure_reason: actionConfig.closure_reason
-      }
-    });
-  }
+  const actorPersonId = safeString(await resolveCurrentUserDirectoryPersonId());
+  const payload = await rpcCall("update_subject_issue_status", {
+    p_subject_id: subjectId,
+    p_action: actionConfig.action,
+    p_actor_person_id: actorPersonId || null
+  });
+  const updatedSubject = Array.isArray(payload) ? (payload[0] || {}) : (payload || {});
 
   if (situationId) {
     try {
@@ -1886,7 +1820,7 @@ export async function persistSubjectIssueActionToSupabase(subject = {}, action =
     section: "subjects",
     subjectId,
     action: safeString(action),
-    status: actionConfig.status
+    status: safeString(updatedSubject?.status || "")
   });
 
   return updatedSubject;

--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -1150,49 +1150,13 @@ function mapIssueActionToSubjectUpdate(action) {
 
   switch (normalizedAction) {
     case "issue:reopen":
-      return {
-        status: "open",
-        closure_reason: null,
-        closed_at: null,
-        history: {
-          event_type: "subject_reopened",
-          title: "Sujet rouvert",
-          description: "Le sujet a été rouvert depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:reopen" };
     case "issue:close:realized":
-      return {
-        status: "closed",
-        closure_reason: "realized",
-        closed_at: new Date().toISOString(),
-        history: {
-          event_type: "subject_closed",
-          title: "Sujet fermé comme réalisé",
-          description: "Le sujet a été marqué comme réalisé depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:close:realized" };
     case "issue:close:dismissed":
-      return {
-        status: "closed_invalid",
-        closure_reason: "non_pertinent",
-        closed_at: new Date().toISOString(),
-        history: {
-          event_type: "subject_closed",
-          title: "Sujet fermé comme non pertinent",
-          description: "Le sujet a été marqué comme non pertinent depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:close:dismissed" };
     case "issue:close:duplicate":
-      return {
-        status: "closed_duplicate",
-        closure_reason: "duplicate",
-        closed_at: new Date().toISOString(),
-        history: {
-          event_type: "subject_marked_duplicate",
-          title: "Sujet fermé comme dupliqué",
-          description: "Le sujet a été marqué comme dupliqué depuis l’interface Mdall."
-        }
-      };
+      return { action: "issue:close:duplicate" };
     default:
       return null;
   }
@@ -1650,9 +1614,6 @@ export async function deleteProjectCollaboratorFromSupabase(projectCollaboratorI
 export async function persistSubjectIssueActionToSupabase(subject = {}, action = "") {
   const actionConfig = mapIssueActionToSubjectUpdate(action);
   const subjectId = safeString(subject?.id || subject?.raw?.id || "");
-  const projectId = safeString(subject?.raw?.project_id || subject?.project_id || "");
-  const analysisRunId = safeString(subject?.raw?.analysis_run_id || subject?.analysis_run_id || "");
-  const documentId = safeString(subject?.raw?.document_id || subject?.document_id || "");
   const situationId = safeString(subject?.raw?.situation_id || subject?.situation_id || "");
 
   if (!actionConfig) {
@@ -1663,40 +1624,13 @@ export async function persistSubjectIssueActionToSupabase(subject = {}, action =
     throw new Error("Subject id missing for Supabase status update.");
   }
 
-  const updatedSubject = await restUpdate(
-    "subjects",
-    { id: subjectId },
-    {
-      status: actionConfig.status,
-      closure_reason: actionConfig.closure_reason,
-      closed_at: actionConfig.closed_at
-    },
-    {
-      select: "id,status,closure_reason,closed_at,updated_at"
-    }
-  );
-
-  if (projectId) {
-    await restInsert("subject_history", {
-      project_id: projectId,
-      subject_id: subjectId,
-      analysis_run_id: analysisRunId || null,
-      document_id: documentId || null,
-      event_type: actionConfig.history.event_type,
-      actor_type: "user",
-      actor_label: String((await getCurrentUser())?.email || "Mdall"),
-      actor_user_id: (await getCurrentUser())?.id || null,
-      title: actionConfig.history.title,
-      description: actionConfig.history.description,
-      event_payload: {
-        source: "mdall_frontend",
-        action: safeString(action),
-        previous_status: safeString(subject?.raw?.status || subject?.status || ""),
-        new_status: actionConfig.status,
-        closure_reason: actionConfig.closure_reason
-      }
-    });
-  }
+  const actorPersonId = safeString(await resolveCurrentUserDirectoryPersonId());
+  const payload = await rpcCall("update_subject_issue_status", {
+    p_subject_id: subjectId,
+    p_action: actionConfig.action,
+    p_actor_person_id: actorPersonId || null
+  });
+  const updatedSubject = Array.isArray(payload) ? (payload[0] || {}) : (payload || {});
 
   if (situationId) {
     try {
@@ -1718,7 +1652,7 @@ export async function persistSubjectIssueActionToSupabase(subject = {}, action =
     section: "subjects",
     subjectId,
     action: safeString(action),
-    status: actionConfig.status
+    status: safeString(updatedSubject?.status || "")
   });
 
   return updatedSubject;

--- a/supabase/migrations/202606150026_subject_history_title_description_close_reopen.sql
+++ b/supabase/migrations/202606150026_subject_history_title_description_close_reopen.sql
@@ -1,0 +1,546 @@
+-- Step 2: wire subject_history business timeline events for title/description/close/reopen.
+-- `public.subject_history` remains the source of truth for business timeline activities.
+
+create or replace function public.update_subject_title(
+  p_subject_id uuid,
+  p_title text,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_previous_title text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_next_title text := trim(coalesce(p_title, ''));
+  v_result_label text;
+  v_result jsonb;
+begin
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject title';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  if v_next_title = '' then
+    raise exception 'Subject title cannot be empty';
+  end if;
+
+  v_previous_title := coalesce(v_subject.title, '');
+  if v_previous_title = v_next_title then
+    return jsonb_build_object(
+      'id', v_subject.id,
+      'project_id', v_subject.project_id,
+      'title', v_previous_title,
+      'normalized_title', coalesce(v_subject.normalized_title, v_previous_title),
+      'updated_at', v_subject.updated_at
+    );
+  end if;
+
+  update public.subjects s
+  set
+    title = v_next_title,
+    normalized_title = v_next_title,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_result_label := format('a modifié le titre en « %s »', v_next_title);
+
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_title_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Titre du sujet modifié',
+    v_result_label,
+    jsonb_build_object(
+      'action', 'updated',
+      'field', 'title',
+      'before', jsonb_build_object('title', v_previous_title),
+      'after', jsonb_build_object('title', coalesce(v_subject.title, '')),
+      'delta', jsonb_build_object('changed', true),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'title', coalesce(v_subject.title, ''),
+    'normalized_title', coalesce(v_subject.normalized_title, ''),
+    'updated_at', v_subject.updated_at
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+grant execute on function public.update_subject_title(uuid, text, uuid) to authenticated;
+revoke all on function public.update_subject_title(uuid, text, uuid) from public;
+
+create or replace function public.update_subject_description(
+  p_subject_id uuid,
+  p_description text,
+  p_upload_session_id uuid default null,
+  p_actor_person_id uuid default null,
+  p_debug_request_id text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_stage text := 'init';
+  v_subject public.subjects;
+  v_previous_description text;
+  v_person_id uuid;
+  v_actor_label text;
+  v_attachment_count integer := 0;
+  v_next_description text := coalesce(p_description, '');
+  v_result jsonb;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_detail text;
+  v_hint text;
+  v_debug_request_id text := nullif(trim(coalesce(p_debug_request_id, '')), '');
+  v_result_label text := 'a modifié la description';
+begin
+  v_stage := 'load subject';
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  v_stage := 'access check';
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject description';
+  end if;
+
+  v_stage := 'resolve actor person';
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_stage := 'capture previous description';
+  v_previous_description := coalesce(v_subject.description, '');
+
+  v_stage := 'update subjects.description';
+  update public.subjects s
+  set
+    description = v_next_description,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if p_upload_session_id is not null then
+    v_stage := 'link description attachments';
+    update public.subject_message_attachments sma
+    set
+      project_id = v_subject.project_id,
+      subject_id = v_subject.id,
+      message_id = null,
+      linked_at = now()
+    where sma.deleted_at is null
+      and sma.upload_session_id = p_upload_session_id
+      and sma.uploaded_by_person_id = v_person_id
+      and sma.subject_id = v_subject.id;
+
+    get diagnostics v_attachment_count = row_count;
+  end if;
+
+  v_stage := 'resolve actor label';
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_stage := 'insert subject_description_versions';
+  insert into public.subject_description_versions (
+    project_id,
+    subject_id,
+    description_markdown,
+    actor_user_id,
+    actor_person_id,
+    created_at
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    coalesce(v_subject.description, ''),
+    auth.uid(),
+    v_person_id,
+    now()
+  );
+
+  v_stage := 'insert subject_history';
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_description_updated',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Description du sujet modifiée',
+    v_result_label,
+    jsonb_build_object(
+      'action', 'updated',
+      'field', 'description',
+      'before', jsonb_build_object('description', v_previous_description),
+      'after', jsonb_build_object('description', coalesce(v_subject.description, '')),
+      'delta', jsonb_build_object(
+        'changed', v_previous_description is distinct from coalesce(v_subject.description, ''),
+        'attachment_count', v_attachment_count
+      ),
+      'result_label', v_result_label,
+      'display', jsonb_build_object(
+        'result_label', v_result_label,
+        'redact_full_text', true
+      ),
+      'upload_session_id', p_upload_session_id,
+      'format', 'markdown',
+      'debug_request_id', v_debug_request_id,
+      'actor_person_id', v_person_id
+    )
+  );
+
+  v_stage := 'build rpc payload';
+  select jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'description', coalesce(v_subject.description, ''),
+    'updated_at', v_subject.updated_at,
+    'debug_request_id', v_debug_request_id,
+    'description_attachments', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', sma.id,
+          'subject_id', sma.subject_id,
+          'project_id', sma.project_id,
+          'file_name', sma.file_name,
+          'mime_type', sma.mime_type,
+          'size_bytes', sma.size_bytes,
+          'storage_bucket', sma.storage_bucket,
+          'storage_path', sma.storage_path,
+          'sort_order', sma.sort_order,
+          'created_at', sma.created_at,
+          'linked_at', sma.linked_at
+        )
+        order by sma.sort_order asc, sma.created_at asc
+      )
+      from public.subject_message_attachments sma
+      where sma.subject_id = v_subject.id
+        and sma.message_id is null
+        and sma.deleted_at is null
+        and sma.linked_at is not null
+    ), '[]'::jsonb)
+  ) into v_result;
+
+  return v_result;
+exception
+  when others then
+    get stacked diagnostics
+      v_sqlstate = returned_sqlstate,
+      v_sqlerrm = message_text,
+      v_detail = pg_exception_detail,
+      v_hint = pg_exception_hint;
+
+    raise exception using
+      message = format(
+        'update_subject_description failed at stage "%s" [debug_request_id=%s]: %s',
+        v_stage,
+        coalesce(v_debug_request_id, 'n/a'),
+        coalesce(v_sqlerrm, 'unknown error')
+      ),
+      detail = format(
+        'sqlstate=%s; detail=%s; hint=%s; debug_request_id=%s',
+        coalesce(v_sqlstate, 'n/a'),
+        coalesce(v_detail, ''),
+        coalesce(v_hint, ''),
+        coalesce(v_debug_request_id, 'n/a')
+      );
+end;
+$$;
+
+grant execute on function public.update_subject_description(uuid, text, uuid, uuid, text) to authenticated;
+revoke all on function public.update_subject_description(uuid, text, uuid, uuid, text) from public;
+
+create or replace function public.update_subject_issue_status(
+  p_subject_id uuid,
+  p_action text,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_actor_label text;
+  v_prev_status text;
+  v_prev_closure_reason text;
+  v_prev_closed_at timestamptz;
+  v_next_status text;
+  v_next_closure_reason text;
+  v_next_closed_at timestamptz;
+  v_event_type text;
+  v_action text;
+  v_result_label text;
+  v_payload jsonb;
+begin
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject status';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_prev_status := coalesce(v_subject.status, 'open');
+  v_prev_closure_reason := v_subject.closure_reason;
+  v_prev_closed_at := v_subject.closed_at;
+
+  case trim(coalesce(p_action, ''))
+    when 'issue:reopen' then
+      v_next_status := 'open';
+      v_next_closure_reason := null;
+      v_next_closed_at := null;
+      v_event_type := 'subject_reopened';
+      v_action := 'reopened';
+      v_result_label := 'a rouvert le sujet';
+    when 'issue:close:realized' then
+      v_next_status := 'closed';
+      v_next_closure_reason := 'realized';
+      v_next_closed_at := now();
+      v_event_type := 'subject_closed';
+      v_action := 'closed';
+      v_result_label := 'a fermé le sujet';
+    when 'issue:close:dismissed' then
+      v_next_status := 'closed_invalid';
+      v_next_closure_reason := 'non_pertinent';
+      v_next_closed_at := now();
+      v_event_type := 'subject_closed';
+      v_action := 'closed';
+      v_result_label := 'a fermé le sujet';
+    when 'issue:close:duplicate' then
+      v_next_status := 'closed_duplicate';
+      v_next_closure_reason := 'duplicate';
+      v_next_closed_at := now();
+      v_event_type := 'subject_closed';
+      v_action := 'closed';
+      v_result_label := 'a fermé le sujet';
+    else
+      raise exception 'Unsupported subject issue action: %', p_action;
+  end case;
+
+  if v_prev_status = v_next_status
+     and coalesce(v_prev_closure_reason, '') = coalesce(v_next_closure_reason, '')
+     and (
+       (v_prev_closed_at is null and v_next_closed_at is null)
+       or (v_prev_closed_at is not null and v_next_closed_at is not null and v_prev_closed_at <= now() and v_next_closed_at <= now())
+     ) then
+    return jsonb_build_object(
+      'id', v_subject.id,
+      'project_id', v_subject.project_id,
+      'status', v_prev_status,
+      'closure_reason', v_prev_closure_reason,
+      'closed_at', v_prev_closed_at,
+      'updated_at', v_subject.updated_at,
+      'history_inserted', false
+    );
+  end if;
+
+  update public.subjects s
+  set
+    status = v_next_status,
+    closure_reason = v_next_closure_reason,
+    closed_at = v_next_closed_at,
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_payload := jsonb_build_object(
+    'action', v_action,
+    'field', 'status',
+    'before', jsonb_build_object(
+      'status', v_prev_status,
+      'closure_reason', v_prev_closure_reason,
+      'closed_at', v_prev_closed_at
+    ),
+    'after', jsonb_build_object(
+      'status', v_subject.status,
+      'closure_reason', v_subject.closure_reason,
+      'closed_at', v_subject.closed_at
+    ),
+    'delta', jsonb_build_object(
+      'from', v_prev_status,
+      'to', coalesce(v_subject.status, ''),
+      'closure_reason_changed', coalesce(v_prev_closure_reason, '') is distinct from coalesce(v_subject.closure_reason, '')
+    ),
+    'closure_reason', v_subject.closure_reason,
+    'result_label', v_result_label,
+    'display', jsonb_build_object('result_label', v_result_label),
+    'actor_person_id', v_person_id
+  );
+
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    v_event_type,
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    case when v_event_type = 'subject_reopened' then 'Sujet rouvert' else 'Sujet fermé' end,
+    v_result_label,
+    v_payload
+  );
+
+  return jsonb_build_object(
+    'id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'status', v_subject.status,
+    'closure_reason', v_subject.closure_reason,
+    'closed_at', v_subject.closed_at,
+    'updated_at', v_subject.updated_at,
+    'history_inserted', true
+  );
+end;
+$$;
+
+grant execute on function public.update_subject_issue_status(uuid, text, uuid) to authenticated;
+revoke all on function public.update_subject_issue_status(uuid, text, uuid) from public;


### PR DESCRIPTION
### Motivation

- Stabiliser le contrat métier de la timeline en faisant de `public.subject_history` la source de vérité pour les activités métier liées au titre, à la description et au cycle de vie (close/reopen). 
- Éviter les écritures partielles et les doublons causés par des inserts historiques côté client et préserver la separation conversation / activités (conversation = `subject_message_events`).
- Préparer un payload normalisé et réductible côté UI (sans exposer le texte complet des descriptions) pour faciliter les étapes suivantes (mappage/renderer/tests). 

### Description

- Ajout d'une migration Supabase `supabase/migrations/202606150026_subject_history_title_description_close_reopen.sql` qui introduit/replace : `update_subject_title`, `update_subject_description` (payload normalisé, `display.redact_full_text` flag) et un nouveau RPC atomic `update_subject_issue_status` qui gère close/reopen et insère systématiquement les lignes dans `subject_history` (évite double-insert et vérifie l'absence de changement réel). 
- Normalisation du `event_payload` pour ces événements pour contenir au minimum `action`, `field`, `before`, `after`, `delta`, `result_label` et `display` (avec intention de ne pas exposer le texte complet de la description dans la timeline). 
- Côté frontend, les services de synchronisation ont été modifiés pour appeler l'RPC centralisé : `apps/web/js/services/project-supabase-sync.js` et `apps/web/js/services/profile-supabase-sync.js` désormais utilisent `rpcCall('update_subject_issue_status', ...)` au lieu de faire `restUpdate(subjects)` + `restInsert(subject_history)` côté client, et `mapIssueActionToSubjectUpdate` a été adapté pour passer l'action au RPC.

### Testing

- Exécuté un check syntaxique JavaScript avec `node --check apps/web/js/services/project-supabase-sync.js && node --check apps/web/js/services/profile-supabase-sync.js`, qui a réussi. 
- Les modifications ont été staged and committed in the repository (migration + JS changes) as part of the rollout (commit succeeded).
- No database migration was applied in this environment; recommend running the migration and integration tests in a staging environment to validate end-to-end behavior (RPCs, permission checks, timeline reads).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76ab4f3588329b05e2d7c527168e2)