### PR TITLE
Use RPCs for subject collection updates and add history-aware relation RPCs

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1110,62 +1110,16 @@ export async function replaceSubjectAssignees(subjectId, personIds = []) {
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
   const uniquePersonIds = [...new Set(normalizeAssigneeIds(personIds).map((value) => normalizeUuid(value)).filter(Boolean))];
-  const projectId = await fetchSubjectProjectId(normalizedSubjectId);
+  const actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("replace_subject_assignees identity resolution failed: no linked directory person found for current user");
+  }
 
-  const deleteUrl = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);
-  deleteUrl.searchParams.set("subject_id", `eq.${normalizedSubjectId}`);
-
-  const deleteRes = await fetch(deleteUrl.toString(), {
-    method: "DELETE",
-    headers: await getSupabaseAuthHeaders({
-      Accept: "application/json",
-      Prefer: "return=minimal"
-    })
+  await rpcCall("replace_subject_assignees", {
+    p_subject_id: normalizedSubjectId,
+    p_person_ids: uniquePersonIds,
+    p_actor_person_id: actorPersonId
   });
-
-  if (!deleteRes.ok) {
-    const txt = await deleteRes.text().catch(() => "");
-    throw new Error(`subject_assignees delete failed (${deleteRes.status}): ${txt}`);
-  }
-
-  if (uniquePersonIds.length) {
-    const insertUrl = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);
-    insertUrl.searchParams.set("on_conflict", "subject_id,person_id");
-    const insertRes = await fetch(insertUrl.toString(), {
-      method: "POST",
-      headers: await getSupabaseAuthHeaders({
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        Prefer: "resolution=merge-duplicates,return=representation"
-      }),
-      body: JSON.stringify(uniquePersonIds.map((personId) => ({
-        project_id: projectId,
-        subject_id: normalizedSubjectId,
-        person_id: personId
-      })))
-    });
-
-    if (!insertRes.ok) {
-      const txt = await insertRes.text().catch(() => "");
-      throw new Error(`subject_assignees insert failed (${insertRes.status}): ${txt}`);
-    }
-  }
-
-  const primaryPersonId = uniquePersonIds[0] || null;
-  const patchRes = await fetch(`${SUPABASE_URL}/rest/v1/subjects?id=eq.${normalizedSubjectId}`, {
-    method: "PATCH",
-    headers: await getSupabaseAuthHeaders({
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Prefer: "return=minimal"
-    }),
-    body: JSON.stringify({ assignee_person_id: primaryPersonId })
-  });
-
-  if (!patchRes.ok) {
-    const txt = await patchRes.text().catch(() => "");
-    throw new Error(`subjects assignee_person_id update failed (${patchRes.status}): ${txt}`);
-  }
 
   return uniquePersonIds;
 }
@@ -1173,25 +1127,55 @@ export async function replaceSubjectAssignees(subjectId, personIds = []) {
 export async function replaceSubjectLabels(subjectId, labelIds = []) {
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
+  const actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("replace_subject_labels identity resolution failed: no linked directory person found for current user");
+  }
 
   const nextLabelIds = [...new Set((Array.isArray(labelIds) ? labelIds : []).map((value) => normalizeUuid(value)).filter(Boolean))];
-  const currentLabelIds = [
-    ...new Set((store.projectSubjectsView?.rawSubjectsResult?.labelIdsBySubjectId?.[normalizedSubjectId] || []).map((value) => normalizeUuid(value)).filter(Boolean))
-  ];
+  await rpcCall("replace_subject_labels", {
+    p_subject_id: normalizedSubjectId,
+    p_label_ids: nextLabelIds,
+    p_actor_person_id: actorPersonId
+  });
 
-  const currentSet = new Set(currentLabelIds);
-  const nextSet = new Set(nextLabelIds);
-  const labelIdsToRemove = currentLabelIds.filter((labelId) => !nextSet.has(labelId));
-  const labelIdsToAdd = nextLabelIds.filter((labelId) => !currentSet.has(labelId));
+  return nextLabelIds;
+}
 
-  for (const labelId of labelIdsToRemove) {
-    await removeLabelFromSubject(normalizedSubjectId, labelId);
+export async function replaceSubjectSituations(subjectId, situationIds = []) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  const actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("replace_subject_situations identity resolution failed: no linked directory person found for current user");
   }
-  for (const labelId of labelIdsToAdd) {
-    await addLabelToSubject(normalizedSubjectId, labelId);
+
+  const nextSituationIds = [...new Set((Array.isArray(situationIds) ? situationIds : []).map((value) => normalizeUuid(value)).filter(Boolean))];
+  await rpcCall("replace_subject_situations", {
+    p_subject_id: normalizedSubjectId,
+    p_situation_ids: nextSituationIds,
+    p_actor_person_id: actorPersonId
+  });
+
+  return nextSituationIds;
+}
+
+export async function replaceSubjectObjectives(subjectId, objectiveIds = []) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  const actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("replace_subject_objectives identity resolution failed: no linked directory person found for current user");
   }
 
-  return true;
+  const nextObjectiveIds = [...new Set((Array.isArray(objectiveIds) ? objectiveIds : []).map((value) => normalizeUuid(value)).filter(Boolean))];
+  await rpcCall("replace_subject_objectives", {
+    p_subject_id: normalizedSubjectId,
+    p_objective_ids: nextObjectiveIds,
+    p_actor_person_id: actorPersonId
+  });
+
+  return nextObjectiveIds;
 }
 
 export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {

--- a/apps/web/js/services/subject-blocking-relation-service.js
+++ b/apps/web/js/services/subject-blocking-relation-service.js
@@ -1,4 +1,5 @@
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+import { resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 
@@ -66,33 +67,23 @@ export async function createBlockedByRelationInSupabase({ subjectId, blockedBySu
     rawSubjectsResult
   });
 
-  const sourceSubject = getSubject(rawSubjectsResult, sourceKey);
-  const projectId = normalizeProjectId(sourceSubject);
-  if (!projectId) {
-    throw new Error("project_id introuvable pour le sujet source.");
+  const actorPersonId = normalizeId(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("Impossible de résoudre l'identité utilisateur pour historiser la relation bloquante.");
   }
 
-  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_links`);
-  url.searchParams.set("on_conflict", "project_id,source_subject_id,target_subject_id,link_type");
-
-  const headers = await buildSupabaseAuthHeaders({
-    "Content-Type": "application/json",
-    Accept: "application/json",
-    Prefer: "resolution=merge-duplicates,return=representation"
-  });
-
-  const payload = [{
-    project_id: projectId,
-    source_subject_id: sourceKey,
-    target_subject_id: targetKey,
-    link_type: "blocked_by"
-  }];
-
-  const res = await fetch(url.toString(), {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/set_subject_blocked_by_relation_with_history`, {
     method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-    cache: "no-store"
+    headers: await buildSupabaseAuthHeaders({
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    }),
+    body: JSON.stringify({
+      p_subject_id: sourceKey,
+      p_blocked_by_subject_id: targetKey,
+      p_should_exist: true,
+      p_actor_person_id: actorPersonId
+    })
   });
 
   if (!res.ok) {
@@ -100,29 +91,40 @@ export async function createBlockedByRelationInSupabase({ subjectId, blockedBySu
     throw new Error(`Ajout de la relation bloquante impossible (${res.status}) : ${text}`);
   }
 
-  const rows = await res.json().catch(() => []);
-  return rows[0] || null;
+  return await res.json().catch(() => ({}));
 }
 
-export async function deleteBlockedByRelationInSupabase({ subjectId, blockedBySubjectId } = {}) {
+export async function deleteBlockedByRelationInSupabase({ subjectId, blockedBySubjectId, rawSubjectsResult = null } = {}) {
   const sourceKey = normalizeId(subjectId);
   const targetKey = normalizeId(blockedBySubjectId);
   if (!sourceKey) throw new Error("subjectId est requis.");
   if (!targetKey) throw new Error("blockedBySubjectId est requis.");
 
-  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_links`);
-  url.searchParams.set("source_subject_id", `eq.${sourceKey}`);
-  url.searchParams.set("target_subject_id", `eq.${targetKey}`);
-  url.searchParams.set("link_type", "eq.blocked_by");
+  if (rawSubjectsResult) {
+    assertBlockingRelationAllowed({
+      subjectId: sourceKey,
+      blockedBySubjectId: targetKey,
+      rawSubjectsResult
+    });
+  }
 
-  const headers = await buildSupabaseAuthHeaders({
-    Accept: "application/json"
-  });
+  const actorPersonId = normalizeId(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("Impossible de résoudre l'identité utilisateur pour historiser la relation bloquante.");
+  }
 
-  const res = await fetch(url.toString(), {
-    method: "DELETE",
-    headers,
-    cache: "no-store"
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/set_subject_blocked_by_relation_with_history`, {
+    method: "POST",
+    headers: await buildSupabaseAuthHeaders({
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    }),
+    body: JSON.stringify({
+      p_subject_id: sourceKey,
+      p_blocked_by_subject_id: targetKey,
+      p_should_exist: false,
+      p_actor_person_id: actorPersonId
+    })
   });
 
   if (!res.ok) {
@@ -130,5 +132,5 @@ export async function deleteBlockedByRelationInSupabase({ subjectId, blockedBySu
     throw new Error(`Suppression de la relation bloquante impossible (${res.status}) : ${text}`);
   }
 
-  return true;
+  return await res.json().catch(() => ({}));
 }

--- a/apps/web/js/services/subject-parent-relation-service.js
+++ b/apps/web/js/services/subject-parent-relation-service.js
@@ -1,4 +1,5 @@
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+import { resolveCurrentUserDirectoryPersonId } from "./project-supabase-sync.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 
@@ -48,34 +49,6 @@ function assertSameProject(subject, parentSubject) {
   }
 }
 
-async function fetchNextParentChildOrder(parentSubjectId) {
-  const normalizedParentSubjectId = normalizeId(parentSubjectId);
-  if (!normalizedParentSubjectId) return null;
-
-  const url = new URL(`${SUPABASE_URL}/rest/v1/subjects`);
-  url.searchParams.set("select", "parent_child_order");
-  url.searchParams.set("parent_subject_id", `eq.${normalizedParentSubjectId}`);
-  url.searchParams.set("order", "parent_child_order.desc.nullslast");
-  url.searchParams.set("limit", "1");
-
-  const headers = await buildSupabaseAuthHeaders({ Accept: "application/json" });
-  const res = await fetch(url.toString(), {
-    method: "GET",
-    headers,
-    cache: "no-store"
-  });
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`Impossible de calculer l'ordre des sous-sujets (${res.status}) : ${text}`);
-  }
-
-  const rows = await res.json().catch(() => []);
-  const row = (Array.isArray(rows) ? rows[0] : rows) || null;
-  const lastOrder = Number(row?.parent_child_order);
-  return Number.isFinite(lastOrder) && lastOrder > 0 ? lastOrder + 1 : 1;
-}
-
 export async function setSubjectParentRelationInSupabase({ subjectId, parentSubjectId = null, rawSubjectsResult = null } = {}) {
   const normalizedSubjectId = normalizeId(subjectId);
   const normalizedParentSubjectId = normalizeId(parentSubjectId);
@@ -99,24 +72,21 @@ export async function setSubjectParentRelationInSupabase({ subjectId, parentSubj
     assertSameProject(subject, subjectsById[normalizedParentSubjectId]);
   }
 
-  const headers = await buildSupabaseAuthHeaders({
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Prefer: "return=representation"
-  });
+  const actorPersonId = normalizeId(await resolveCurrentUserDirectoryPersonId());
+  if (!actorPersonId) {
+    throw new Error("Impossible de résoudre l'identité utilisateur pour historiser la relation parent.");
+  }
 
-  const nowIso = new Date().toISOString();
-  const nextOrder = normalizedParentSubjectId
-    ? await fetchNextParentChildOrder(normalizedParentSubjectId)
-    : null;
-
-  const res = await fetch(`${SUPABASE_URL}/rest/v1/subjects?id=eq.${encodeURIComponent(normalizedSubjectId)}`, {
-    method: "PATCH",
-    headers,
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/set_subject_parent_with_history`, {
+    method: "POST",
+    headers: await buildSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }),
     body: JSON.stringify({
-      parent_subject_id: normalizedParentSubjectId || null,
-      parent_linked_at: normalizedParentSubjectId ? nowIso : null,
-      parent_child_order: normalizedParentSubjectId ? nextOrder : null
+      p_subject_id: normalizedSubjectId,
+      p_parent_subject_id: normalizedParentSubjectId || null,
+      p_actor_person_id: actorPersonId
     })
   });
 
@@ -125,11 +95,15 @@ export async function setSubjectParentRelationInSupabase({ subjectId, parentSubj
     throw new Error(`Mise à jour du sujet parent impossible (${res.status}) : ${text}`);
   }
 
-  const rows = await res.json().catch(() => []);
-  const updatedRow = (Array.isArray(rows) ? rows[0] : rows) || null;
+  const rpcPayload = await res.json().catch(() => ({}));
+  const updatedRow = {
+    parent_subject_id: normalizeId(rpcPayload?.next_parent_subject_id) || null,
+    parent_linked_at: rpcPayload?.parent_linked_at || null,
+    parent_child_order: rpcPayload?.parent_child_order ?? null
+  };
   return {
     subjectId: normalizedSubjectId,
-    parentSubjectId: normalizeId(updatedRow?.parent_subject_id),
+    parentSubjectId: normalizeId(updatedRow.parent_subject_id),
     updatedRow
   };
 }

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -14,6 +14,9 @@ import {
   addLabelToSubject as addLabelToSubjectInSupabase,
   removeLabelFromSubject as removeLabelFromSubjectInSupabase,
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase,
+  replaceSubjectLabels as replaceSubjectLabelsInSupabase,
+  replaceSubjectSituations as replaceSubjectSituationsInSupabase,
+  replaceSubjectObjectives as replaceSubjectObjectivesInSupabase,
   updateSubjectDescription as updateSubjectDescriptionInSupabase,
   updateSubjectTitle as updateSubjectTitleInSupabase,
   loadSubjectDescriptionVersions as loadSubjectDescriptionVersionsInSupabase
@@ -654,6 +657,9 @@ const projectSubjectsActions = createProjectSubjectsActions({
   addLabelToSubjectInSupabase: (...args) => addLabelToSubjectInSupabase(...args),
   removeLabelFromSubjectInSupabase: (...args) => removeLabelFromSubjectInSupabase(...args),
   replaceSubjectAssigneesInSupabase: (...args) => replaceSubjectAssigneesInSupabase(...args),
+  replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
+  replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
+  replaceSubjectObjectivesInSupabase: (...args) => replaceSubjectObjectivesInSupabase(...args),
   addSubjectToObjectiveInSupabase: (...args) => addSubjectToObjectiveInSupabase(...args),
   removeSubjectFromObjectiveInSupabase: (...args) => removeSubjectFromObjectiveInSupabase(...args),
   setSubjectParentInSupabase: (subjectId, parentSubjectId) => setSubjectParentRelationInSupabaseService({
@@ -668,7 +674,8 @@ const projectSubjectsActions = createProjectSubjectsActions({
   }),
   deleteBlockedByRelationInSupabase: (subjectId, blockedBySubjectId) => deleteBlockedByRelationInSupabaseService({
     subjectId,
-    blockedBySubjectId
+    blockedBySubjectId,
+    rawSubjectsResult: store.projectSubjectsView?.rawSubjectsResult || null
   }),
   reorderSubjectChildrenInSupabase: (parentSubjectId, orderedChildIds) => reorderSubjectChildrenInSupabaseService({
     parentSubjectId,

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -27,8 +27,6 @@ export function createProjectSubjectsActions(config) {
     rerenderScope,
     reloadSubjectsFromSupabase,
     loadSituationsForCurrentProject,
-    addSubjectToSituation,
-    removeSubjectFromSituation,
     persistSubjectIssueActionToSupabase,
     showError,
     getSubjectSidebarMeta,
@@ -38,11 +36,10 @@ export function createProjectSubjectsActions(config) {
     normalizeSubjectLabelKey,
     getSubjectLabelDefinition,
     getObjectives,
-    addLabelToSubjectInSupabase,
-    removeLabelFromSubjectInSupabase,
+    replaceSubjectLabelsInSupabase,
     replaceSubjectAssigneesInSupabase,
-    addSubjectToObjectiveInSupabase,
-    removeSubjectFromObjectiveInSupabase,
+    replaceSubjectSituationsInSupabase,
+    replaceSubjectObjectivesInSupabase,
     setSubjectParentInSupabase,
     createBlockedByRelationInSupabase,
     deleteBlockedByRelationInSupabase,
@@ -457,8 +454,7 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      if (wasLinked) await removeSubjectFromSituation(situationKey, subjectKey);
-      else await addSubjectToSituation(situationKey, subjectKey);
+      await replaceSubjectSituationsInSupabase(subjectKey, nextIds);
       await loadSituationsForCurrentProject().catch(() => []);
       return true;
     } catch (error) {
@@ -553,8 +549,10 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      if (hasLabel) await removeLabelFromSubjectInSupabase(subjectKey, labelId);
-      else await addLabelToSubjectInSupabase(subjectKey, labelId);
+      const nextLabelIds = Array.isArray(store.projectSubjectsView?.rawSubjectsResult?.labelIdsBySubjectId?.[subjectKey])
+        ? store.projectSubjectsView.rawSubjectsResult.labelIdsBySubjectId[subjectKey].map((value) => String(value || "").trim()).filter(Boolean)
+        : [];
+      await replaceSubjectLabelsInSupabase(subjectKey, nextLabelIds);
 
       await reloadSubjectsFromSupabase(options.root, {
         rerender: options.skipRerender ? false : true,
@@ -635,12 +633,7 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      for (const removedId of removedObjectiveIds) {
-        await removeSubjectFromObjectiveInSupabase(removedId, subjectKey);
-      }
-      for (const addedId of addedObjectiveIds) {
-        await addSubjectToObjectiveInSupabase(addedId, subjectKey);
-      }
+      await replaceSubjectObjectivesInSupabase(subjectKey, nextIds);
       return true;
     } catch (error) {
       setSubjectObjectiveIds(subjectKey, previousIds);

--- a/supabase/migrations/202606150027_subject_history_metadata_collections.sql
+++ b/supabase/migrations/202606150027_subject_history_metadata_collections.sql
@@ -1,0 +1,620 @@
+-- Step 3: wire subject_history business timeline events for metadata collections.
+-- `public.subject_history` is the single source of truth for business timeline activities.
+
+create or replace function public.subject_history_actor_label(p_person_id uuid)
+returns text
+language sql
+stable
+as $$
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+  from public.directory_people dp
+  where dp.id = p_person_id;
+$$;
+
+create or replace function public.subject_history_collection_action(
+  p_added_count integer,
+  p_removed_count integer
+)
+returns text
+language sql
+immutable
+as $$
+  select case
+    when coalesce(p_added_count, 0) > 0 and coalesce(p_removed_count, 0) = 0 then 'added'
+    when coalesce(p_added_count, 0) = 0 and coalesce(p_removed_count, 0) > 0 then 'removed'
+    else 'replaced'
+  end;
+$$;
+
+create or replace function public.replace_subject_assignees(
+  p_subject_id uuid,
+  p_person_ids uuid[] default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_actor_label text;
+  v_before_ids uuid[] := '{}';
+  v_after_ids uuid[] := '{}';
+  v_added_ids uuid[] := '{}';
+  v_removed_ids uuid[] := '{}';
+  v_added_count integer := 0;
+  v_removed_count integer := 0;
+  v_action text;
+  v_result_label text;
+begin
+  select * into v_subject from public.subjects s where s.id = p_subject_id;
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject assignees';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (select 1 from public.directory_people dp where dp.id = v_person_id) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  select array_agg(sa.person_id order by sa.person_id)
+    into v_before_ids
+  from public.subject_assignees sa
+  where sa.subject_id = v_subject.id;
+
+  select array_agg(person_id order by person_id)
+    into v_after_ids
+  from (
+    select distinct x as person_id
+    from unnest(coalesce(p_person_ids, '{}'::uuid[])) as x
+    where x is not null
+  ) dedup;
+
+  v_before_ids := coalesce(v_before_ids, '{}');
+  v_after_ids := coalesce(v_after_ids, '{}');
+
+  if v_before_ids = v_after_ids then
+    return jsonb_build_object('changed', false, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+  end if;
+
+  v_added_ids := array(
+    select x
+    from unnest(v_after_ids) as x
+    where not (x = any(v_before_ids))
+    order by x
+  );
+
+  v_removed_ids := array(
+    select x
+    from unnest(v_before_ids) as x
+    where not (x = any(v_after_ids))
+    order by x
+  );
+
+  delete from public.subject_assignees sa
+  where sa.subject_id = v_subject.id
+    and not (sa.person_id = any(v_after_ids));
+
+  insert into public.subject_assignees (project_id, subject_id, person_id)
+  select v_subject.project_id, v_subject.id, x
+  from unnest(v_after_ids) as x
+  on conflict (subject_id, person_id) do nothing;
+
+  update public.subjects s
+  set
+    assignee_person_id = v_after_ids[1],
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  v_added_count := cardinality(coalesce(v_added_ids, '{}'));
+  v_removed_count := cardinality(coalesce(v_removed_ids, '{}'));
+  v_action := public.subject_history_collection_action(v_added_count, v_removed_count);
+
+  v_result_label := case
+    when v_action = 'added' and v_added_count = 1 then 'a ajouté un assigné'
+    when v_action = 'added' then format('a ajouté %s assignés', v_added_count)
+    when v_action = 'removed' and v_removed_count = 1 then 'a retiré un assigné'
+    when v_action = 'removed' then format('a retiré %s assignés', v_removed_count)
+    else 'a remplacé les assignés'
+  end;
+
+  v_actor_label := public.subject_history_actor_label(v_person_id);
+
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_assignees_changed',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Assignés modifiés',
+    v_result_label,
+    jsonb_build_object(
+      'action', v_action,
+      'field', 'assignees',
+      'before', jsonb_build_object('ids', coalesce(to_jsonb(v_before_ids), '[]'::jsonb)),
+      'after', jsonb_build_object('ids', coalesce(to_jsonb(v_after_ids), '[]'::jsonb)),
+      'delta', jsonb_build_object(
+        'added', coalesce((
+          select jsonb_agg(jsonb_build_object(
+            'id', dp.id,
+            'label', coalesce(nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''), dp.email, dp.id::text)
+          ) order by dp.id)
+          from public.directory_people dp
+          where dp.id = any(v_added_ids)
+        ), '[]'::jsonb),
+        'removed', coalesce((
+          select jsonb_agg(jsonb_build_object(
+            'id', dp.id,
+            'label', coalesce(nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''), dp.email, dp.id::text)
+          ) order by dp.id)
+          from public.directory_people dp
+          where dp.id = any(v_removed_ids)
+        ), '[]'::jsonb)
+      ),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  return jsonb_build_object('changed', true, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+end;
+$$;
+
+grant execute on function public.replace_subject_assignees(uuid, uuid[], uuid) to authenticated;
+revoke all on function public.replace_subject_assignees(uuid, uuid[], uuid) from public;
+
+create or replace function public.replace_subject_labels(
+  p_subject_id uuid,
+  p_label_ids uuid[] default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_actor_label text;
+  v_before_ids uuid[] := '{}';
+  v_after_ids uuid[] := '{}';
+  v_added_ids uuid[] := '{}';
+  v_removed_ids uuid[] := '{}';
+  v_added_count integer := 0;
+  v_removed_count integer := 0;
+  v_action text;
+  v_result_label text;
+begin
+  select * into v_subject from public.subjects s where s.id = p_subject_id;
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject labels';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (select 1 from public.directory_people dp where dp.id = v_person_id) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  select array_agg(sl.label_id order by sl.label_id)
+    into v_before_ids
+  from public.subject_labels sl
+  where sl.subject_id = v_subject.id;
+
+  select array_agg(label_id order by label_id)
+    into v_after_ids
+  from (
+    select distinct x as label_id
+    from unnest(coalesce(p_label_ids, '{}'::uuid[])) as x
+    where x is not null
+  ) dedup;
+
+  v_before_ids := coalesce(v_before_ids, '{}');
+  v_after_ids := coalesce(v_after_ids, '{}');
+
+  if v_before_ids = v_after_ids then
+    return jsonb_build_object('changed', false, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+  end if;
+
+  v_added_ids := array(select x from unnest(v_after_ids) as x where not (x = any(v_before_ids)) order by x);
+  v_removed_ids := array(select x from unnest(v_before_ids) as x where not (x = any(v_after_ids)) order by x);
+
+  delete from public.subject_labels sl
+  where sl.subject_id = v_subject.id
+    and not (sl.label_id = any(v_after_ids));
+
+  insert into public.subject_labels (project_id, subject_id, label_id)
+  select v_subject.project_id, v_subject.id, x
+  from unnest(v_after_ids) as x
+  on conflict (subject_id, label_id) do nothing;
+
+  update public.subjects s set updated_at = now() where s.id = v_subject.id returning * into v_subject;
+
+  v_added_count := cardinality(coalesce(v_added_ids, '{}'));
+  v_removed_count := cardinality(coalesce(v_removed_ids, '{}'));
+  v_action := public.subject_history_collection_action(v_added_count, v_removed_count);
+
+  v_result_label := case
+    when v_action = 'added' and v_added_count = 1 then 'a ajouté un label'
+    when v_action = 'added' then format('a ajouté %s labels', v_added_count)
+    when v_action = 'removed' and v_removed_count = 1 then 'a retiré un label'
+    when v_action = 'removed' then format('a retiré %s labels', v_removed_count)
+    else 'a remplacé les labels'
+  end;
+
+  v_actor_label := public.subject_history_actor_label(v_person_id);
+
+  insert into public.subject_history (
+    project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+    event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_labels_changed',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Labels modifiés',
+    v_result_label,
+    jsonb_build_object(
+      'action', v_action,
+      'field', 'labels',
+      'before', jsonb_build_object('ids', coalesce(to_jsonb(v_before_ids), '[]'::jsonb)),
+      'after', jsonb_build_object('ids', coalesce(to_jsonb(v_after_ids), '[]'::jsonb)),
+      'delta', jsonb_build_object(
+        'added', coalesce((
+          select jsonb_agg(jsonb_build_object('id', pl.id, 'label', coalesce(nullif(trim(pl.name), ''), pl.label_key, pl.id::text)) order by pl.id)
+          from public.project_labels pl
+          where pl.id = any(v_added_ids)
+        ), '[]'::jsonb),
+        'removed', coalesce((
+          select jsonb_agg(jsonb_build_object('id', pl.id, 'label', coalesce(nullif(trim(pl.name), ''), pl.label_key, pl.id::text)) order by pl.id)
+          from public.project_labels pl
+          where pl.id = any(v_removed_ids)
+        ), '[]'::jsonb)
+      ),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  return jsonb_build_object('changed', true, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+end;
+$$;
+
+grant execute on function public.replace_subject_labels(uuid, uuid[], uuid) to authenticated;
+revoke all on function public.replace_subject_labels(uuid, uuid[], uuid) from public;
+
+create or replace function public.replace_subject_situations(
+  p_subject_id uuid,
+  p_situation_ids uuid[] default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_actor_label text;
+  v_before_ids uuid[] := '{}';
+  v_after_ids uuid[] := '{}';
+  v_added_ids uuid[] := '{}';
+  v_removed_ids uuid[] := '{}';
+  v_added_count integer := 0;
+  v_removed_count integer := 0;
+  v_action text;
+  v_result_label text;
+begin
+  select * into v_subject from public.subjects s where s.id = p_subject_id;
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject situations';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (select 1 from public.directory_people dp where dp.id = v_person_id) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  select array_agg(ss.situation_id order by ss.situation_id)
+    into v_before_ids
+  from public.situation_subjects ss
+  where ss.subject_id = v_subject.id;
+
+  select array_agg(situation_id order by situation_id)
+    into v_after_ids
+  from (
+    select distinct x as situation_id
+    from unnest(coalesce(p_situation_ids, '{}'::uuid[])) as x
+    where x is not null
+  ) dedup;
+
+  v_before_ids := coalesce(v_before_ids, '{}');
+  v_after_ids := coalesce(v_after_ids, '{}');
+
+  if v_before_ids = v_after_ids then
+    return jsonb_build_object('changed', false, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+  end if;
+
+  v_added_ids := array(select x from unnest(v_after_ids) as x where not (x = any(v_before_ids)) order by x);
+  v_removed_ids := array(select x from unnest(v_before_ids) as x where not (x = any(v_after_ids)) order by x);
+
+  delete from public.situation_subjects ss
+  where ss.subject_id = v_subject.id
+    and not (ss.situation_id = any(v_after_ids));
+
+  insert into public.situation_subjects (project_id, situation_id, subject_id)
+  select v_subject.project_id, x, v_subject.id
+  from unnest(v_after_ids) as x
+  on conflict (situation_id, subject_id) do nothing;
+
+  update public.subjects s set updated_at = now() where s.id = v_subject.id returning * into v_subject;
+
+  v_added_count := cardinality(coalesce(v_added_ids, '{}'));
+  v_removed_count := cardinality(coalesce(v_removed_ids, '{}'));
+  v_action := public.subject_history_collection_action(v_added_count, v_removed_count);
+
+  v_result_label := case
+    when v_action = 'added' and v_added_count = 1 then 'a ajouté une situation'
+    when v_action = 'added' then format('a ajouté %s situations', v_added_count)
+    when v_action = 'removed' and v_removed_count = 1 then 'a retiré une situation'
+    when v_action = 'removed' then format('a retiré %s situations', v_removed_count)
+    else 'a remplacé les situations'
+  end;
+
+  v_actor_label := public.subject_history_actor_label(v_person_id);
+
+  insert into public.subject_history (
+    project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+    event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_situations_changed',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Situations modifiées',
+    v_result_label,
+    jsonb_build_object(
+      'action', v_action,
+      'field', 'situations',
+      'before', jsonb_build_object('ids', coalesce(to_jsonb(v_before_ids), '[]'::jsonb)),
+      'after', jsonb_build_object('ids', coalesce(to_jsonb(v_after_ids), '[]'::jsonb)),
+      'delta', jsonb_build_object(
+        'added', coalesce((
+          select jsonb_agg(jsonb_build_object('id', si.id, 'label', coalesce(nullif(trim(si.title), ''), si.id::text)) order by si.id)
+          from public.situations si
+          where si.id = any(v_added_ids)
+        ), '[]'::jsonb),
+        'removed', coalesce((
+          select jsonb_agg(jsonb_build_object('id', si.id, 'label', coalesce(nullif(trim(si.title), ''), si.id::text)) order by si.id)
+          from public.situations si
+          where si.id = any(v_removed_ids)
+        ), '[]'::jsonb)
+      ),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  return jsonb_build_object('changed', true, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+end;
+$$;
+
+grant execute on function public.replace_subject_situations(uuid, uuid[], uuid) to authenticated;
+revoke all on function public.replace_subject_situations(uuid, uuid[], uuid) from public;
+
+create or replace function public.replace_subject_objectives(
+  p_subject_id uuid,
+  p_objective_ids uuid[] default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_actor_label text;
+  v_before_ids uuid[] := '{}';
+  v_after_ids uuid[] := '{}';
+  v_added_ids uuid[] := '{}';
+  v_removed_ids uuid[] := '{}';
+  v_added_count integer := 0;
+  v_removed_count integer := 0;
+  v_action text;
+  v_result_label text;
+begin
+  select * into v_subject from public.subjects s where s.id = p_subject_id;
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject objectives';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (select 1 from public.directory_people dp where dp.id = v_person_id) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  select array_agg(ms.milestone_id order by ms.milestone_id)
+    into v_before_ids
+  from public.milestone_subjects ms
+  where ms.subject_id = v_subject.id;
+
+  select array_agg(objective_id order by objective_id)
+    into v_after_ids
+  from (
+    select distinct x as objective_id
+    from unnest(coalesce(p_objective_ids, '{}'::uuid[])) as x
+    where x is not null
+  ) dedup;
+
+  v_before_ids := coalesce(v_before_ids, '{}');
+  v_after_ids := coalesce(v_after_ids, '{}');
+
+  if v_before_ids = v_after_ids then
+    return jsonb_build_object('changed', false, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+  end if;
+
+  v_added_ids := array(select x from unnest(v_after_ids) as x where not (x = any(v_before_ids)) order by x);
+  v_removed_ids := array(select x from unnest(v_before_ids) as x where not (x = any(v_after_ids)) order by x);
+
+  delete from public.milestone_subjects ms
+  where ms.subject_id = v_subject.id
+    and not (ms.milestone_id = any(v_after_ids));
+
+  insert into public.milestone_subjects (milestone_id, subject_id)
+  select x, v_subject.id
+  from unnest(v_after_ids) as x
+  on conflict (milestone_id, subject_id) do nothing;
+
+  update public.subjects s
+  set
+    milestone_id = v_after_ids[1],
+    updated_at = now()
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  v_added_count := cardinality(coalesce(v_added_ids, '{}'));
+  v_removed_count := cardinality(coalesce(v_removed_ids, '{}'));
+  v_action := public.subject_history_collection_action(v_added_count, v_removed_count);
+
+  v_result_label := case
+    when v_action = 'added' and v_added_count = 1 then 'a ajouté un objectif'
+    when v_action = 'added' then format('a ajouté %s objectifs', v_added_count)
+    when v_action = 'removed' and v_removed_count = 1 then 'a retiré un objectif'
+    when v_action = 'removed' then format('a retiré %s objectifs', v_removed_count)
+    else 'a remplacé les objectifs'
+  end;
+
+  v_actor_label := public.subject_history_actor_label(v_person_id);
+
+  insert into public.subject_history (
+    project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+    event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_objectives_changed',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Objectifs modifiés',
+    v_result_label,
+    jsonb_build_object(
+      'action', v_action,
+      'field', 'objectives',
+      'before', jsonb_build_object('ids', coalesce(to_jsonb(v_before_ids), '[]'::jsonb)),
+      'after', jsonb_build_object('ids', coalesce(to_jsonb(v_after_ids), '[]'::jsonb)),
+      'delta', jsonb_build_object(
+        'added', coalesce((
+          select jsonb_agg(jsonb_build_object('id', m.id, 'label', coalesce(nullif(trim(m.title), ''), m.id::text)) order by m.id)
+          from public.milestones m
+          where m.id = any(v_added_ids)
+        ), '[]'::jsonb),
+        'removed', coalesce((
+          select jsonb_agg(jsonb_build_object('id', m.id, 'label', coalesce(nullif(trim(m.title), ''), m.id::text)) order by m.id)
+          from public.milestones m
+          where m.id = any(v_removed_ids)
+        ), '[]'::jsonb)
+      ),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  return jsonb_build_object('changed', true, 'before_ids', v_before_ids, 'after_ids', v_after_ids);
+end;
+$$;
+
+grant execute on function public.replace_subject_objectives(uuid, uuid[], uuid) to authenticated;
+revoke all on function public.replace_subject_objectives(uuid, uuid[], uuid) from public;
+
+comment on function public.replace_subject_assignees(uuid, uuid[], uuid) is
+  'Remplace les assignés d''un sujet et écrit une activité consolidée dans subject_history (source de vérité timeline métier).';
+
+comment on function public.replace_subject_labels(uuid, uuid[], uuid) is
+  'Remplace les labels d''un sujet et écrit une activité consolidée dans subject_history (source de vérité timeline métier).';
+
+comment on function public.replace_subject_situations(uuid, uuid[], uuid) is
+  'Remplace les situations d''un sujet et écrit une activité consolidée dans subject_history (source de vérité timeline métier).';
+
+comment on function public.replace_subject_objectives(uuid, uuid[], uuid) is
+  'Remplace les objectifs d''un sujet et écrit une activité consolidée dans subject_history (source de vérité timeline métier).';

--- a/supabase/migrations/202606150028_subject_history_relations_double_sided.sql
+++ b/supabase/migrations/202606150028_subject_history_relations_double_sided.sql
@@ -1,0 +1,476 @@
+-- Step 4: relation timeline activities (double-sens) for parent/child and blocked_by/blocking_for.
+-- `public.subject_history` remains the source of truth for business timeline activities.
+
+create or replace function public.set_subject_parent_with_history(
+  p_subject_id uuid,
+  p_parent_subject_id uuid default null,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_previous_parent public.subjects;
+  v_next_parent public.subjects;
+  v_actor_person_id uuid;
+  v_actor_label text;
+  v_now timestamptz := now();
+  v_next_child_order integer := null;
+begin
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id
+  for update;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Insufficient rights to update subject parent';
+  end if;
+
+  v_actor_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_actor_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (select 1 from public.directory_people p where p.id = v_actor_person_id) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_actor_label := public.subject_history_actor_label(v_actor_person_id);
+
+  if v_subject.parent_subject_id is not null then
+    select * into v_previous_parent
+    from public.subjects s
+    where s.id = v_subject.parent_subject_id;
+  end if;
+
+  if p_parent_subject_id is not null then
+    select * into v_next_parent
+    from public.subjects s
+    where s.id = p_parent_subject_id
+    for update;
+
+    if v_next_parent.id is null then
+      raise exception 'Parent subject not found';
+    end if;
+
+    if v_next_parent.id = v_subject.id then
+      raise exception 'A subject cannot be its own parent';
+    end if;
+
+    if v_next_parent.project_id is distinct from v_subject.project_id then
+      raise exception 'Parent subject must belong to the same project';
+    end if;
+
+    if exists (
+      with recursive ancestors as (
+        select s.id, s.parent_subject_id
+        from public.subjects s
+        where s.id = v_next_parent.id
+        union all
+        select parent.id, parent.parent_subject_id
+        from public.subjects parent
+        join ancestors a on a.parent_subject_id = parent.id
+      )
+      select 1
+      from ancestors
+      where id = v_subject.id
+    ) then
+      raise exception 'Parent relation would create a cycle';
+    end if;
+  end if;
+
+  if v_subject.parent_subject_id is not distinct from p_parent_subject_id then
+    return jsonb_build_object(
+      'changed', false,
+      'subject_id', v_subject.id,
+      'previous_parent_subject_id', v_subject.parent_subject_id,
+      'next_parent_subject_id', p_parent_subject_id
+    );
+  end if;
+
+  if p_parent_subject_id is not null then
+    select coalesce(max(s.parent_child_order), 0) + 1
+      into v_next_child_order
+    from public.subjects s
+    where s.parent_subject_id = p_parent_subject_id;
+  end if;
+
+  update public.subjects s
+  set
+    parent_subject_id = p_parent_subject_id,
+    parent_linked_at = case when p_parent_subject_id is null then null else v_now end,
+    parent_child_order = case when p_parent_subject_id is null then null else v_next_child_order end,
+    updated_at = v_now
+  where s.id = v_subject.id
+  returning * into v_subject;
+
+  if v_previous_parent.id is not null and v_previous_parent.id is distinct from p_parent_subject_id then
+    insert into public.subject_history (
+      project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+      event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+    )
+    values (
+      v_subject.project_id,
+      v_subject.id,
+      v_subject.analysis_run_id,
+      v_subject.document_id,
+      null,
+      'subject_parent_removed',
+      'user',
+      coalesce(v_actor_label, 'Utilisateur'),
+      auth.uid(),
+      'Parent supprimé',
+      format('a retiré le sujet #%s des parents', coalesce(v_previous_parent.subject_number::text, '')),
+      jsonb_build_object(
+        'action', 'removed',
+        'field', 'parent',
+        'before', jsonb_build_object('parent_subject_id', v_previous_parent.id),
+        'after', jsonb_build_object('parent_subject_id', null),
+        'counterpart_subject_id', v_previous_parent.id,
+        'counterpart_subject_number', v_previous_parent.subject_number,
+        'counterpart_subject_title', v_previous_parent.title,
+        'result_label', format('a retiré le sujet %s des parents', coalesce(v_previous_parent.title, concat('#', coalesce(v_previous_parent.subject_number::text, '')))),
+        'display', jsonb_build_object('result_label', format('a retiré le sujet %s des parents', coalesce(v_previous_parent.title, concat('#', coalesce(v_previous_parent.subject_number::text, ''))))),
+        'actor_person_id', v_actor_person_id
+      )
+    );
+
+    insert into public.subject_history (
+      project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+      event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+    )
+    values (
+      v_previous_parent.project_id,
+      v_previous_parent.id,
+      v_previous_parent.analysis_run_id,
+      v_previous_parent.document_id,
+      null,
+      'subject_child_removed',
+      'user',
+      coalesce(v_actor_label, 'Utilisateur'),
+      auth.uid(),
+      'Sous-sujet supprimé',
+      format('a retiré le sujet #%s des sous-sujets', coalesce(v_subject.subject_number::text, '')),
+      jsonb_build_object(
+        'action', 'removed',
+        'field', 'child',
+        'before', jsonb_build_object('child_subject_id', v_subject.id),
+        'after', jsonb_build_object('child_subject_id', null),
+        'counterpart_subject_id', v_subject.id,
+        'counterpart_subject_number', v_subject.subject_number,
+        'counterpart_subject_title', v_subject.title,
+        'result_label', format('a retiré le sujet %s des sous-sujets', coalesce(v_subject.title, concat('#', coalesce(v_subject.subject_number::text, '')))),
+        'display', jsonb_build_object('result_label', format('a retiré le sujet %s des sous-sujets', coalesce(v_subject.title, concat('#', coalesce(v_subject.subject_number::text, ''))))),
+        'actor_person_id', v_actor_person_id
+      )
+    );
+  end if;
+
+  if v_next_parent.id is not null and v_next_parent.id is distinct from coalesce(v_previous_parent.id, '00000000-0000-0000-0000-000000000000'::uuid) then
+    insert into public.subject_history (
+      project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+      event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+    )
+    values (
+      v_subject.project_id,
+      v_subject.id,
+      v_subject.analysis_run_id,
+      v_subject.document_id,
+      null,
+      'subject_parent_added',
+      'user',
+      coalesce(v_actor_label, 'Utilisateur'),
+      auth.uid(),
+      'Parent ajouté',
+      format('a ajouté le sujet #%s comme parent', coalesce(v_next_parent.subject_number::text, '')),
+      jsonb_build_object(
+        'action', 'added',
+        'field', 'parent',
+        'before', jsonb_build_object('parent_subject_id', v_previous_parent.id),
+        'after', jsonb_build_object('parent_subject_id', v_next_parent.id),
+        'counterpart_subject_id', v_next_parent.id,
+        'counterpart_subject_number', v_next_parent.subject_number,
+        'counterpart_subject_title', v_next_parent.title,
+        'result_label', format('a ajouté le sujet %s comme parent', coalesce(v_next_parent.title, concat('#', coalesce(v_next_parent.subject_number::text, '')))),
+        'display', jsonb_build_object('result_label', format('a ajouté le sujet %s comme parent', coalesce(v_next_parent.title, concat('#', coalesce(v_next_parent.subject_number::text, ''))))),
+        'actor_person_id', v_actor_person_id
+      )
+    );
+
+    insert into public.subject_history (
+      project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+      event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+    )
+    values (
+      v_next_parent.project_id,
+      v_next_parent.id,
+      v_next_parent.analysis_run_id,
+      v_next_parent.document_id,
+      null,
+      'subject_child_added',
+      'user',
+      coalesce(v_actor_label, 'Utilisateur'),
+      auth.uid(),
+      'Sous-sujet ajouté',
+      format('a ajouté le sujet #%s comme sous-sujet', coalesce(v_subject.subject_number::text, '')),
+      jsonb_build_object(
+        'action', 'added',
+        'field', 'child',
+        'before', jsonb_build_object('child_subject_id', null),
+        'after', jsonb_build_object('child_subject_id', v_subject.id),
+        'counterpart_subject_id', v_subject.id,
+        'counterpart_subject_number', v_subject.subject_number,
+        'counterpart_subject_title', v_subject.title,
+        'result_label', format('a ajouté le sujet %s comme sous-sujet', coalesce(v_subject.title, concat('#', coalesce(v_subject.subject_number::text, '')))),
+        'display', jsonb_build_object('result_label', format('a ajouté le sujet %s comme sous-sujet', coalesce(v_subject.title, concat('#', coalesce(v_subject.subject_number::text, ''))))),
+        'actor_person_id', v_actor_person_id
+      )
+    );
+  end if;
+
+  return jsonb_build_object(
+    'changed', true,
+    'subject_id', v_subject.id,
+    'previous_parent_subject_id', v_previous_parent.id,
+    'next_parent_subject_id', p_parent_subject_id,
+    'parent_child_order', v_subject.parent_child_order,
+    'parent_linked_at', v_subject.parent_linked_at
+  );
+end;
+$$;
+
+grant execute on function public.set_subject_parent_with_history(uuid, uuid, uuid) to authenticated;
+revoke all on function public.set_subject_parent_with_history(uuid, uuid, uuid) from public;
+
+create or replace function public.set_subject_blocked_by_relation_with_history(
+  p_subject_id uuid,
+  p_blocked_by_subject_id uuid,
+  p_should_exist boolean,
+  p_actor_person_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_source public.subjects;
+  v_target public.subjects;
+  v_actor_person_id uuid;
+  v_actor_label text;
+  v_exists boolean := false;
+  v_now timestamptz := now();
+begin
+  if p_subject_id is null or p_blocked_by_subject_id is null then
+    raise exception 'Both p_subject_id and p_blocked_by_subject_id are required';
+  end if;
+
+  if p_subject_id = p_blocked_by_subject_id then
+    raise exception 'A subject cannot block itself';
+  end if;
+
+  select * into v_source from public.subjects s where s.id = p_subject_id for update;
+  select * into v_target from public.subjects s where s.id = p_blocked_by_subject_id for update;
+
+  if v_source.id is null or v_target.id is null then
+    raise exception 'Source and target subjects must exist';
+  end if;
+
+  if v_source.project_id is distinct from v_target.project_id then
+    raise exception 'Blocked_by relation must use subjects from the same project';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_source.project_id) then
+    raise exception 'Insufficient rights to update blocked_by relation';
+  end if;
+
+  v_actor_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_actor_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (select 1 from public.directory_people p where p.id = v_actor_person_id) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  v_actor_label := public.subject_history_actor_label(v_actor_person_id);
+
+  select exists (
+    select 1
+    from public.subject_links l
+    where l.source_subject_id = p_subject_id
+      and l.target_subject_id = p_blocked_by_subject_id
+      and l.link_type = 'blocked_by'
+  ) into v_exists;
+
+  if p_should_exist then
+    if exists (
+      select 1
+      from public.subject_links l
+      where l.source_subject_id = p_blocked_by_subject_id
+        and l.target_subject_id = p_subject_id
+        and l.link_type = 'blocked_by'
+    ) then
+      raise exception 'This relation is invalid because reverse blocked_by already exists';
+    end if;
+
+    if v_exists then
+      return jsonb_build_object('changed', false, 'exists', true);
+    end if;
+
+    insert into public.subject_links (project_id, source_subject_id, target_subject_id, link_type, created_at)
+    values (v_source.project_id, p_subject_id, p_blocked_by_subject_id, 'blocked_by', v_now)
+    on conflict do nothing;
+
+    insert into public.subject_history (
+      project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+      event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+    )
+    values (
+      v_source.project_id,
+      v_source.id,
+      v_source.analysis_run_id,
+      v_source.document_id,
+      null,
+      'subject_blocked_by_added',
+      'user',
+      coalesce(v_actor_label, 'Utilisateur'),
+      auth.uid(),
+      'Relation bloqué par ajoutée',
+      format('a ajouté le sujet #%s dans « bloqué par »', coalesce(v_target.subject_number::text, '')),
+      jsonb_build_object(
+        'action', 'added',
+        'field', 'blocked_by',
+        'before', jsonb_build_object('linked', false),
+        'after', jsonb_build_object('linked', true),
+        'counterpart_subject_id', v_target.id,
+        'counterpart_subject_number', v_target.subject_number,
+        'counterpart_subject_title', v_target.title,
+        'result_label', format('a ajouté le sujet %s dans « bloqué par »', coalesce(v_target.title, concat('#', coalesce(v_target.subject_number::text, '')))),
+        'display', jsonb_build_object('result_label', format('a ajouté le sujet %s dans « bloqué par »', coalesce(v_target.title, concat('#', coalesce(v_target.subject_number::text, ''))))),
+        'actor_person_id', v_actor_person_id
+      )
+    );
+
+    insert into public.subject_history (
+      project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+      event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+    )
+    values (
+      v_target.project_id,
+      v_target.id,
+      v_target.analysis_run_id,
+      v_target.document_id,
+      null,
+      'subject_blocking_for_added',
+      'user',
+      coalesce(v_actor_label, 'Utilisateur'),
+      auth.uid(),
+      'Relation bloquant pour ajoutée',
+      format('a ajouté le sujet #%s dans « bloquant pour »', coalesce(v_source.subject_number::text, '')),
+      jsonb_build_object(
+        'action', 'added',
+        'field', 'blocking_for',
+        'before', jsonb_build_object('linked', false),
+        'after', jsonb_build_object('linked', true),
+        'counterpart_subject_id', v_source.id,
+        'counterpart_subject_number', v_source.subject_number,
+        'counterpart_subject_title', v_source.title,
+        'result_label', format('a ajouté le sujet %s dans « bloquant pour »', coalesce(v_source.title, concat('#', coalesce(v_source.subject_number::text, '')))),
+        'display', jsonb_build_object('result_label', format('a ajouté le sujet %s dans « bloquant pour »', coalesce(v_source.title, concat('#', coalesce(v_source.subject_number::text, ''))))),
+        'actor_person_id', v_actor_person_id
+      )
+    );
+
+    return jsonb_build_object('changed', true, 'exists', true);
+  end if;
+
+  if not v_exists then
+    return jsonb_build_object('changed', false, 'exists', false);
+  end if;
+
+  delete from public.subject_links l
+  where l.source_subject_id = p_subject_id
+    and l.target_subject_id = p_blocked_by_subject_id
+    and l.link_type = 'blocked_by';
+
+  insert into public.subject_history (
+    project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+    event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+  )
+  values (
+    v_source.project_id,
+    v_source.id,
+    v_source.analysis_run_id,
+    v_source.document_id,
+    null,
+    'subject_blocked_by_removed',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Relation bloqué par supprimée',
+    format('a retiré le sujet #%s de « bloqué par »', coalesce(v_target.subject_number::text, '')),
+    jsonb_build_object(
+      'action', 'removed',
+      'field', 'blocked_by',
+      'before', jsonb_build_object('linked', true),
+      'after', jsonb_build_object('linked', false),
+      'counterpart_subject_id', v_target.id,
+      'counterpart_subject_number', v_target.subject_number,
+      'counterpart_subject_title', v_target.title,
+      'result_label', format('a retiré le sujet %s de « bloqué par »', coalesce(v_target.title, concat('#', coalesce(v_target.subject_number::text, '')))),
+      'display', jsonb_build_object('result_label', format('a retiré le sujet %s de « bloqué par »', coalesce(v_target.title, concat('#', coalesce(v_target.subject_number::text, ''))))),
+      'actor_person_id', v_actor_person_id
+    )
+  );
+
+  insert into public.subject_history (
+    project_id, subject_id, analysis_run_id, document_id, subject_observation_id,
+    event_type, actor_type, actor_label, actor_user_id, title, description, event_payload
+  )
+  values (
+    v_target.project_id,
+    v_target.id,
+    v_target.analysis_run_id,
+    v_target.document_id,
+    null,
+    'subject_blocking_for_removed',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Relation bloquant pour supprimée',
+    format('a retiré le sujet #%s de « bloquant pour »', coalesce(v_source.subject_number::text, '')),
+    jsonb_build_object(
+      'action', 'removed',
+      'field', 'blocking_for',
+      'before', jsonb_build_object('linked', true),
+      'after', jsonb_build_object('linked', false),
+      'counterpart_subject_id', v_source.id,
+      'counterpart_subject_number', v_source.subject_number,
+      'counterpart_subject_title', v_source.title,
+      'result_label', format('a retiré le sujet %s de « bloquant pour »', coalesce(v_source.title, concat('#', coalesce(v_source.subject_number::text, '')))),
+      'display', jsonb_build_object('result_label', format('a retiré le sujet %s de « bloquant pour »', coalesce(v_source.title, concat('#', coalesce(v_source.subject_number::text, ''))))),
+      'actor_person_id', v_actor_person_id
+    )
+  );
+
+  return jsonb_build_object('changed', true, 'exists', false);
+end;
+$$;
+
+grant execute on function public.set_subject_blocked_by_relation_with_history(uuid, uuid, boolean, uuid) to authenticated;
+revoke all on function public.set_subject_blocked_by_relation_with_history(uuid, uuid, boolean, uuid) from public;
+
+comment on function public.set_subject_parent_with_history(uuid, uuid, uuid) is
+  'Met à jour la relation parent/sous-sujet et écrit les événements double-sens atomiques dans subject_history.';
+
+comment on function public.set_subject_blocked_by_relation_with_history(uuid, uuid, boolean, uuid) is
+  'Ajoute/supprime une relation blocked_by et écrit les événements double-sens atomiques dans subject_history.';


### PR DESCRIPTION
### Motivation

- Centralize and atomicize updates to subject collections (assignees, labels, situations, objectives) to ensure consistent state and consolidated timeline history.
- Record the acting user (directory person) for collection and relation changes so actions are auditable in `subject_history`.
- Replace multiple client-side INSERT/DELETE/PATCH sequences with single server-side RPCs for simpler client logic and fewer race conditions.
- Provide double-sided timeline events for parent/child and blocked_by/blocking_for relations.

### Description

- Replaced client-side multi-step collection updates with RPC calls: client code now calls `rpcCall` (or REST `rpc` endpoints) for `replace_subject_assignees`, `replace_subject_labels`, `replace_subject_situations`, and `replace_subject_objectives`, and handles actor resolution via `resolveCurrentUserDirectoryPersonId` before calling RPCs.
- Updated blocking and parent relation services to call new RPC endpoints `set_subject_blocked_by_relation_with_history` and `set_subject_parent_with_history`, and to require resolving the actor person id for history recording.
- Adjusted view/action code to invoke the new `replaceSubject*` client functions instead of performing individual add/remove operations, and wired these into the UI action flows (`project-subjects.js`, `project-subjects-actions.js`).
- Added Supabase migration SQL files that create server-side functions implementing the new RPCs (`replace_subject_assignees`, `replace_subject_labels`, `replace_subject_situations`, `replace_subject_objectives`, `set_subject_parent_with_history`, `set_subject_blocked_by_relation_with_history`) which perform atomic updates and insert consolidated timeline entries into `subject_history`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76cd576608329b0561c615bec9774)