### PR TITLE
Timeline: afficher les détails d’activité inline et supprimer les backgrounds

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -40,7 +40,7 @@ export const BUSINESS_ACTIVITY_CONFIG = {
   subject_assignees_changed: {
     icon: "person-add",
     tone: "business-people",
-    verb: "a mis à jour les assignés",
+    verb: "a ajouté un assigné",
     summarize: (payload, firstNonEmpty) => summarizeCollectionChange(payload, "assigné", firstNonEmpty)
   },
   subject_labels_changed: {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1294,7 +1294,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
       const fullName = firstNonEmpty(collaborator?.displayName, collaborator?.name, assignee?.label, "Collaborateur");
       const role = firstNonEmpty(collaborator?.role, collaborator?.roleGroupLabel, "Collaborateur");
       return `
-        <span class="tl-note-inline">a ajouté un assigné</span>
         <span class="subject-meta-assignee-row subject-meta-assignee-row--inline">
           <span class="subject-meta-assignee-row__avatar subject-meta-assignee-avatar-inline">${renderCollaboratorAvatarInline(collaborator, fullName)}</span>
           <span class="subject-meta-assignee-row__content">
@@ -1307,24 +1306,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     if (eventType === "subject_labels_changed" && String(payload?.action || "").toLowerCase() === "added" && added.length === 1) {
       const label = added[0] || {};
-      return `
-        <span class="tl-note-inline">a ajouté un label</span>
-        ${renderSubjectLabelBadgeInline(label?.id, label?.label)}
-      `;
+      return `${renderSubjectLabelBadgeInline(label?.id, label?.label)}`;
     }
 
     if (eventType === "subject_objectives_changed" && String(payload?.action || "").toLowerCase() === "added" && added.length === 1) {
       const objective = added[0] || {};
-      return `
-        <span class="tl-note-inline">a ajouté un objectif</span>
-        ${renderObjectiveInline(objective?.id, objective?.label)}
-      `;
+      return `${renderObjectiveInline(objective?.id, objective?.label)}`;
     }
 
     if (eventType === "subject_blocked_by_added" && counterpartId) {
       const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
       return `
-        <span class="tl-note-inline">a indiqué que le sujet est bloqué par</span>
         <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
       `;
     }
@@ -1332,7 +1324,6 @@ priority=${firstNonEmpty(subject.priority, "")}`
     if (eventType === "subject_blocking_for_added" && counterpartId) {
       const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
       return `
-        <span class="tl-note-inline">a indiqué que le sujet est bloquant pour</span>
         <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
       `;
     }
@@ -1386,9 +1377,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
             firstNonEmpty
           });
           const richNoteHtml = buildBusinessRichNoteHtml(e);
-          const noteHtml = richNoteHtml
-            ? `<div class="tl-note">${richNoteHtml}</div>`
-            : (note ? `<div class="tl-note">${escapeHtml(note)}</div>` : "");
+          const inlineDetailHtml = richNoteHtml
+            ? richNoteHtml
+            : (note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
 
           return renderMessageThreadActivity({
             idx,
@@ -1400,9 +1391,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
             textHtml: `
               <span class="tl-author-name">${escapeHtml(activityIdentity.displayName)}</span>
               <span class="mono-small"> ${escapeHtml(appearance.verb)} </span>
+              ${inlineDetailHtml ? `<span class="tl-note-inline">${inlineDetailHtml}</span>` : ""}
               <span class="mono-small">· ${escapeHtml(ts)}</span>
             `,
-            noteHtml
+            noteHtml: ""
           });
         }
         const agent = e?.agent || "system";

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3875,9 +3875,9 @@ body.drilldown-open .drilldown__inner,
 .tl-note{
   margin:0 12px 8px 127px; /* align with .tl-activity__text */
   padding:8px 10px;
-  border:1px solid var(--border2);
-  border-radius:6px;
-  background:rgba(22,27,34,.35);
+  border:none;
+  border-radius:0;
+  background:transparent;
   color:var(--text);
   font-size:13px;
   position:relative;
@@ -3909,6 +3909,7 @@ body.drilldown-open .drilldown__inner,
   border-radius:8px;
   margin:0 8px 0 46px;
   padding:6px 12px;
+  background:transparent;
 }
 .thread-item--business .tl-note{
   margin-left:108px;
@@ -3923,13 +3924,6 @@ body.drilldown-open .drilldown__inner,
 .tl-ico--business-alert{background:rgba(207, 34, 46, .9);}
 .tl-ico--business-open{background:rgba(31, 136, 61, .9);}
 .tl-ico--business-neutral{background:rgba(110,118,129,.7);}
-.thread-item--business-edit .tl-activity{background:rgba(9, 105, 218, .08);}
-.thread-item--business-people .tl-activity{background:rgba(26, 127, 55, .08);}
-.thread-item--business-labels .tl-activity{background:rgba(130, 80, 223, .08);}
-.thread-item--business-rel .tl-activity{background:rgba(140, 75, 31, .08);}
-.thread-item--business-alert .tl-activity{background:rgba(207, 34, 46, .08);}
-.thread-item--business-open .tl-activity{background:rgba(31, 136, 61, .08);}
-.thread-item--business-neutral .tl-activity{background:rgba(110,118,129,.08);}
 .thread-item--event-subject_closed .tl-activity{border:1px solid rgba(207, 34, 46, .3);}
 .thread-item--event-subject_reopened .tl-activity{border:1px solid rgba(31, 136, 61, .3);}
 .thread-item--event-subject_parent_added .tl-activity,
@@ -3940,6 +3934,7 @@ body.drilldown-open .drilldown__inner,
 }
 .tl-note-inline{display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-weight:600;}
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:4px;}
+.tl-note-inline-text{display:inline;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:8px;vertical-align:middle;}
 .subject-meta-assignee-avatar-inline{
   width:22px;height:22px;border-radius:999px;overflow:hidden;background:rgba(110,118,129,.16);display:inline-flex;align-items:center;justify-content:center;


### PR DESCRIPTION
### Motivation
- Uniformiser l’affichage des activités timeline en supprimant les blocs notes visuels et en affichant les détails directement sur la ligne d’activité.
- Rendre le libellé des changements d’assignés plus générique et permettre d’afficher le rendu riche (avatar / badge / lien) en ligne.

### Description
- CSS: supprime le `border` et le `background` de ` .tl-note` et rend son fond transparent, supprime les backgrounds colorés des variantes business de ` .tl-activity` et ajoute la classe utilitaire ` .tl-note-inline-text` (fichier `apps/web/style.css`).
- JS: modifie `buildBusinessRichNoteHtml` pour retourner uniquement le rendu riche inline (avatars, badges, liens) sans wrapper ` .tl-note` et retire les labels textuels dupliqués pour les cas pris en charge (fichier `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- JS: remplace le rendu séparé `noteHtml` par un `inlineDetailHtml` utilisé dans la `textHtml` principale afin d’afficher le détail d’activité en ligne et met `noteHtml` à `""` pour les activités métier (fichier `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Config: change le verb pour `subject_assignees_changed` à `"a ajouté un assigné"` afin d’afficher le texte générique dans la ligne (fichier `apps/web/js/views/project-subjects/project-subjects-thread-business-events.js`).

### Testing
- Exécuté `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs`, tous les tests unitaires ont réussi (`4` tests passés, `0` échoués).
- Les fichiers modifiés sont `apps/web/style.css`, `apps/web/js/views/project-subjects/project-subjects-thread.js` et `apps/web/js/views/project-subjects/project-subjects-thread-business-events.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7808c081483299fce33d6c21c4fcc)