### PR TITLE
Render business activity details inline and improve assignee/parent event display

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -40,7 +40,7 @@ export const BUSINESS_ACTIVITY_CONFIG = {
   subject_assignees_changed: {
     icon: "person-add",
     tone: "business-people",
-    verb: "a mis à jour les assignés",
+    verb: "a ajouté un assigné",
     summarize: (payload, firstNonEmpty) => summarizeCollectionChange(payload, "assigné", firstNonEmpty)
   },
   subject_labels_changed: {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1284,6 +1284,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const eventType = String(entry?.meta?.event_type || "").toLowerCase();
     const payload = entry?.meta?.event_payload && typeof entry.meta.event_payload === "object" ? entry.meta.event_payload : {};
     const added = Array.isArray(payload?.delta?.added) ? payload.delta.added : [];
+    const removed = Array.isArray(payload?.delta?.removed) ? payload.delta.removed : [];
     const counterpartTitle = firstNonEmpty(payload?.counterpart_subject_title, "");
     const counterpartId = normalizeId(payload?.counterpart_subject_id);
 
@@ -1294,7 +1295,23 @@ priority=${firstNonEmpty(subject.priority, "")}`
       const fullName = firstNonEmpty(collaborator?.displayName, collaborator?.name, assignee?.label, "Collaborateur");
       const role = firstNonEmpty(collaborator?.role, collaborator?.roleGroupLabel, "Collaborateur");
       return `
-        <span class="tl-note-inline">a ajouté un assigné</span>
+        <span class="subject-meta-assignee-row subject-meta-assignee-row--inline">
+          <span class="subject-meta-assignee-row__avatar subject-meta-assignee-avatar-inline">${renderCollaboratorAvatarInline(collaborator, fullName)}</span>
+          <span class="subject-meta-assignee-row__content">
+            <span class="subject-meta-assignee-row__name">${escapeHtml(fullName)}</span>
+            <span class="subject-meta-assignee-row__role">${escapeHtml(role)}</span>
+          </span>
+        </span>
+      `;
+    }
+
+    if (eventType === "subject_assignees_changed" && String(payload?.action || "").toLowerCase() === "removed" && removed.length === 1) {
+      const assignee = removed[0] || {};
+      const assigneeId = normalizeId(assignee?.id);
+      const collaborator = findCollaboratorByPersonId(assigneeId);
+      const fullName = firstNonEmpty(collaborator?.displayName, collaborator?.name, assignee?.label, "Collaborateur");
+      const role = firstNonEmpty(collaborator?.role, collaborator?.roleGroupLabel, "Collaborateur");
+      return `
         <span class="subject-meta-assignee-row subject-meta-assignee-row--inline">
           <span class="subject-meta-assignee-row__avatar subject-meta-assignee-avatar-inline">${renderCollaboratorAvatarInline(collaborator, fullName)}</span>
           <span class="subject-meta-assignee-row__content">
@@ -1307,24 +1324,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
     if (eventType === "subject_labels_changed" && String(payload?.action || "").toLowerCase() === "added" && added.length === 1) {
       const label = added[0] || {};
-      return `
-        <span class="tl-note-inline">a ajouté un label</span>
-        ${renderSubjectLabelBadgeInline(label?.id, label?.label)}
-      `;
+      return `${renderSubjectLabelBadgeInline(label?.id, label?.label)}`;
     }
 
     if (eventType === "subject_objectives_changed" && String(payload?.action || "").toLowerCase() === "added" && added.length === 1) {
       const objective = added[0] || {};
-      return `
-        <span class="tl-note-inline">a ajouté un objectif</span>
-        ${renderObjectiveInline(objective?.id, objective?.label)}
-      `;
+      return `${renderObjectiveInline(objective?.id, objective?.label)}`;
     }
 
     if (eventType === "subject_blocked_by_added" && counterpartId) {
       const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
       return `
-        <span class="tl-note-inline">a indiqué que le sujet est bloqué par</span>
         <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
       `;
     }
@@ -1332,8 +1342,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
     if (eventType === "subject_blocking_for_added" && counterpartId) {
       const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
       return `
-        <span class="tl-note-inline">a indiqué que le sujet est bloquant pour</span>
         <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
+      `;
+    }
+
+    if (eventType === "subject_parent_added" && counterpartId) {
+      const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
+      const status = String(getEffectiveSujetStatus(counterpartId) || getNestedSujet(counterpartId)?.status || "open").toLowerCase();
+      const statusIcon = status.startsWith("closed") ? "check-circle" : "issue-reopened";
+      return `
+        <span class="tl-note-inline-link">${svgIcon(statusIcon)}${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
+        <span class="mono-small">comme parent</span>
       `;
     }
 
@@ -1379,6 +1398,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const appearance = getBusinessActivityAppearance(e?.meta?.event_type || kind);
           const payload = e?.meta?.event_payload && typeof e.meta.event_payload === "object" ? e.meta.event_payload : {};
           const ts = fmtTs(e?.ts || "");
+          const eventType = String(e?.meta?.event_type || "").toLowerCase();
+          const assigneesAction = String(payload?.action || "").toLowerCase();
+          const resolvedVerb = eventType === "subject_assignees_changed" && assigneesAction === "removed"
+            ? "a retiré un assigné"
+            : (eventType === "subject_parent_added" ? "a ajouté le sujet" : appearance.verb);
           const note = buildBusinessActivitySummary({
             payload,
             appearance,
@@ -1386,9 +1410,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
             firstNonEmpty
           });
           const richNoteHtml = buildBusinessRichNoteHtml(e);
-          const noteHtml = richNoteHtml
-            ? `<div class="tl-note">${richNoteHtml}</div>`
-            : (note ? `<div class="tl-note">${escapeHtml(note)}</div>` : "");
+          const inlineDetailHtml = richNoteHtml
+            ? richNoteHtml
+            : (note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
 
           return renderMessageThreadActivity({
             idx,
@@ -1399,10 +1423,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
               : miniAuthorIconHtml("human"),
             textHtml: `
               <span class="tl-author-name">${escapeHtml(activityIdentity.displayName)}</span>
-              <span class="mono-small"> ${escapeHtml(appearance.verb)} </span>
+              <span class="mono-small"> ${escapeHtml(resolvedVerb)} </span>
+              ${inlineDetailHtml ? `<span class="tl-note-inline">${inlineDetailHtml}</span>` : ""}
               <span class="mono-small">· ${escapeHtml(ts)}</span>
             `,
-            noteHtml
+            noteHtml: ""
           });
         }
         const agent = e?.agent || "system";

--- a/apps/web/js/views/ui/message-thread.js
+++ b/apps/web/js/views/ui/message-thread.js
@@ -106,7 +106,7 @@ export function renderMessageThreadActivity({
         <div class="tl-activity">
           ${iconHtml}
           ${authorIconHtml}
-          <div class="tl-activity__text mono">${textHtml}</div>
+          <div class="tl-activity__text">${textHtml}</div>
         </div>
         ${noteHtml || ""}
       </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3871,13 +3871,13 @@ body.drilldown-open .drilldown__inner,
 .tl-author--agent{font-size:11px;color:var(--text);line-height:1;}
 
 .tl-activity__text{min-width:0;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word;}
-.tl-author-name{font-weight:700;color:var(--text);font-size:14px;}
+.tl-author-name{font-weight:400;color:var(--text);font-size:14px;}
 .tl-note{
   margin:0 12px 8px 127px; /* align with .tl-activity__text */
   padding:8px 10px;
-  border:1px solid var(--border2);
-  border-radius:6px;
-  background:rgba(22,27,34,.35);
+  border:none;
+  border-radius:0;
+  background:transparent;
   color:var(--text);
   font-size:13px;
   position:relative;
@@ -3909,6 +3909,7 @@ body.drilldown-open .drilldown__inner,
   border-radius:8px;
   margin:0 8px 0 46px;
   padding:6px 12px;
+  background:transparent;
 }
 .thread-item--business .tl-note{
   margin-left:108px;
@@ -3923,13 +3924,6 @@ body.drilldown-open .drilldown__inner,
 .tl-ico--business-alert{background:rgba(207, 34, 46, .9);}
 .tl-ico--business-open{background:rgba(31, 136, 61, .9);}
 .tl-ico--business-neutral{background:rgba(110,118,129,.7);}
-.thread-item--business-edit .tl-activity{background:rgba(9, 105, 218, .08);}
-.thread-item--business-people .tl-activity{background:rgba(26, 127, 55, .08);}
-.thread-item--business-labels .tl-activity{background:rgba(130, 80, 223, .08);}
-.thread-item--business-rel .tl-activity{background:rgba(140, 75, 31, .08);}
-.thread-item--business-alert .tl-activity{background:rgba(207, 34, 46, .08);}
-.thread-item--business-open .tl-activity{background:rgba(31, 136, 61, .08);}
-.thread-item--business-neutral .tl-activity{background:rgba(110,118,129,.08);}
 .thread-item--event-subject_closed .tl-activity{border:1px solid rgba(207, 34, 46, .3);}
 .thread-item--event-subject_reopened .tl-activity{border:1px solid rgba(31, 136, 61, .3);}
 .thread-item--event-subject_parent_added .tl-activity,
@@ -3938,9 +3932,13 @@ body.drilldown-open .drilldown__inner,
 .thread-item--event-subject_blocking_for_added .tl-activity{
   box-shadow:inset 0 0 0 1px rgba(31, 35, 40, .12);
 }
-.tl-note-inline{display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-weight:600;}
+.tl-note-inline{display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-weight:600;font-size:14px;}
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:4px;}
+.tl-note-inline-text{display:inline;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:8px;vertical-align:middle;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:inline-flex;align-items:baseline;gap:6px;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__name,
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__role{display:inline;line-height:18px;}
 .subject-meta-assignee-avatar-inline{
   width:22px;height:22px;border-radius:999px;overflow:hidden;background:rgba(110,118,129,.16);display:inline-flex;align-items:center;justify-content:center;
 }


### PR DESCRIPTION
### Motivation

- Improve readability of business activity entries by rendering details inline and showing assignee/parent specifics with avatars and icons. 
- Make verb text for assignee/parent events more precise for added/removed actions. 

### Description

- Updated business activity rendering to inline detail content instead of separate note blocks and moved event detail HTML into the activity text. 
- Added handling for `subject_assignees_changed` removed action to display the removed assignee with avatar and role, and changed the default assignee verb to "a ajouté un assigné". 
- Added inline rendering for added labels and objectives and improved `subject_parent_added` display to include subject status icon and "comme parent" indicator. 
- Adjusted CSS: removed boxed background/border from `.tl-note`, relaxed author weight, removed business-tone background fills, and added inline layout styles for assignee/name/role and note text sizing. 

### Testing

- Ran frontend lint checks (`yarn lint`) and they passed. 
- Ran unit tests (`yarn test`) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7808c081483299fce33d6c21c4fcc)