### PR TITLE
Ajuster le format des activités assignés, labels et objectifs

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1327,8 +1327,18 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return `${renderSubjectLabelBadgeInline(label?.id, label?.label)}`;
     }
 
+    if (eventType === "subject_labels_changed" && String(payload?.action || "").toLowerCase() === "removed" && removed.length === 1) {
+      const label = removed[0] || {};
+      return `${renderSubjectLabelBadgeInline(label?.id, label?.label)}`;
+    }
+
     if (eventType === "subject_objectives_changed" && String(payload?.action || "").toLowerCase() === "added" && added.length === 1) {
       const objective = added[0] || {};
+      return `${renderObjectiveInline(objective?.id, objective?.label)}`;
+    }
+
+    if (eventType === "subject_objectives_changed" && String(payload?.action || "").toLowerCase() === "removed" && removed.length === 1) {
+      const objective = removed[0] || {};
       return `${renderObjectiveInline(objective?.id, objective?.label)}`;
     }
 
@@ -1396,9 +1406,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const payload = e?.meta?.event_payload && typeof e.meta.event_payload === "object" ? e.meta.event_payload : {};
           const ts = fmtTs(e?.ts || "");
           const eventType = String(e?.meta?.event_type || "").toLowerCase();
-          const assigneesAction = String(payload?.action || "").toLowerCase();
-          const resolvedVerb = eventType === "subject_assignees_changed" && assigneesAction === "removed"
+          const action = String(payload?.action || "").toLowerCase();
+          const resolvedVerb = eventType === "subject_assignees_changed" && action === "removed"
             ? "a retiré un assigné"
+            : eventType === "subject_labels_changed" && action === "removed"
+              ? "a retiré le label"
+              : eventType === "subject_labels_changed" && action === "added"
+                ? "a ajouté le label"
+                : eventType === "subject_objectives_changed" && action === "removed"
+                  ? "a retiré un objectif"
+                  : eventType === "subject_objectives_changed" && action === "added"
+                    ? "a ajouté un objectif"
             : (eventType === "subject_parent_added" ? "a ajouté le sujet parent" : appearance.verb);
           const note = buildBusinessActivitySummary({
             payload,
@@ -1410,12 +1428,18 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml
             : (note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
+          const shouldRenderInlineBeforeTimestamp = (
+            (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed")
+            && (action === "added" || action === "removed")
+          );
           const parentAddedLineHtml = eventType === "subject_parent_added" && inlineDetailHtml
             ? `<span class="tl-note-inline tl-note-inline--parent-added">${inlineDetailHtml}</span>`
             : "";
           const defaultInlineHtml = eventType === "subject_parent_added"
             ? ""
             : (inlineDetailHtml ? `<span class="tl-note-inline">${inlineDetailHtml}</span>` : "");
+          const inlineBeforeTimestampHtml = shouldRenderInlineBeforeTimestamp ? defaultInlineHtml : "";
+          const inlineAfterTimestampHtml = shouldRenderInlineBeforeTimestamp ? "" : defaultInlineHtml;
 
           return renderMessageThreadActivity({
             idx,
@@ -1427,8 +1451,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
             textHtml: `
               <span class="tl-author-name">${escapeHtml(activityIdentity.displayName)}</span>
               <span class="mono-small"> ${escapeHtml(resolvedVerb)} </span>
+              ${inlineBeforeTimestampHtml}
               <span class="mono-small">· ${escapeHtml(ts)}</span>
-              ${defaultInlineHtml}
+              ${inlineAfterTimestampHtml}
               ${parentAddedLineHtml}
             `,
             noteHtml: ""

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3937,9 +3937,9 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:4px;}
 .tl-note-inline-text{display:inline;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:8px;vertical-align:middle;}
-.subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:inline-flex;align-items:baseline;gap:6px;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:flex;flex-direction:column;gap:0;line-height:1.1;}
 .subject-meta-assignee-row--inline .subject-meta-assignee-row__name,
-.subject-meta-assignee-row--inline .subject-meta-assignee-row__role{display:inline;line-height:18px;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__role{display:block;line-height:16px;}
 .subject-meta-assignee-avatar-inline{
   width:22px;height:22px;border-radius:999px;overflow:hidden;background:rgba(110,118,129,.16);display:inline-flex;align-items:center;justify-content:center;
 }


### PR DESCRIPTION
### Motivation
- Rendre les entrées de l’historique métier plus lisibles et conformes aux cas d’usage : distinguer l’ajout/retrait de labels et d’objectifs, et afficher le nom/role de l’assigné sur deux lignes.

### Description
- Ajout du rendu riche pour les cas de suppression de label et de suppression d’objectif dans `buildBusinessRichNoteHtml` en affichant respectivement le badge du label et la carte d’objectif en ligne (`apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Différenciation du verbe affiché pour `subject_labels_changed` et `subject_objectives_changed` afin de produire `a ajouté le label` / `a retiré le label` et `a ajouté un objectif` / `a retiré un objectif` au lieu de l’ancien `a mis à jour ...` (`project-subjects-thread.js`).
- Réordonnancement de l’élément inline pour les labels/objectifs afin d’afficher `verbe + élément + · date` sur une même ligne quand il s’agit d’un ajout/retrait (`project-subjects-thread.js`).
- Adaptation du style inline des assignés pour empiler `prénom nom` puis `rôle` sur la ligne du dessous via une modification CSS (`apps/web/style.css`).

### Testing
- Exécution des tests unitaires avec `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs` et tous les tests ont réussi (4/4 passed).
- Les changements ont été commités (`apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/style.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79221b6fc8329966c6babd48df04e)