### PR TITLE
Ajuste l’affichage des activités de sujet (assignés, objectifs, relations)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1268,14 +1268,26 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const objectivesList = Array.isArray(raw?.objectives) ? raw.objectives : [];
     const objective = objectivesById[objectiveId] || objectivesList.find((item) => normalizeId(item?.id) === normalizeId(objectiveId)) || null;
     const title = firstNonEmpty(objective?.title, fallbackLabel, "Objectif");
-    const dueDate = firstNonEmpty(objective?.dueDate, objective?.due_date, "");
-    const dueLabel = dueDate ? fmtTs(dueDate) : "Pas de date";
-    const linkedCount = Array.isArray(objective?.subjectIds) ? objective.subjectIds.length : Number(objective?.subjectsCount || 0);
     return `
       <span class="subject-meta-objective-card subject-meta-objective-card--inline">
-        <span class="subject-meta-objective-card__count">${escapeHtml(String(linkedCount || 0))}</span>
         <span class="subject-meta-objective-card__title">${escapeHtml(title)}</span>
-        <span class="subject-meta-objective-card__date">${escapeHtml(dueLabel)}</span>
+      </span>
+    `;
+  }
+
+  function renderLinkedSubjectInline(counterpartId = "", fallbackTitle = "") {
+    const subject = counterpartId ? getNestedSujet(counterpartId) : null;
+    const status = String(getEffectiveSujetStatus(counterpartId) || subject?.status || "open").toLowerCase();
+    const isClosed = status === "closed";
+    const iconSvg = isClosed
+      ? svgIcon("check-circle", { style: "color: var(--fgColor-done)" })
+      : svgIcon("issue-opened", { style: "color: var(--fgColor-open)" });
+    const title = firstNonEmpty(subject?.title, fallbackTitle, "");
+    const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
+    return `
+      <span class="tl-note-inline-link">
+        <span class="tl-note-inline-subject-status" aria-hidden="true">${iconSvg}</span>
+        ${title ? `${escapeHtml(title)} ` : ""}${linkedSubject}
       </span>
     `;
   }
@@ -1343,24 +1355,15 @@ priority=${firstNonEmpty(subject.priority, "")}`
     }
 
     if (eventType === "subject_blocked_by_added" && counterpartId) {
-      const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
-      return `
-        <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
-      `;
+      return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
     if (eventType === "subject_blocking_for_added" && counterpartId) {
-      const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
-      return `
-        <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
-      `;
+      return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
     if (eventType === "subject_parent_added" && counterpartId) {
-      const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
-      return `
-        <span class="tl-note-inline-link">${counterpartTitle ? `${escapeHtml(counterpartTitle)} ` : ""}${linkedSubject}</span>
-      `;
+      return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
     return "";
@@ -1432,14 +1435,18 @@ priority=${firstNonEmpty(subject.priority, "")}`
             (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed")
             && (action === "added" || action === "removed")
           );
-          const parentAddedLineHtml = eventType === "subject_parent_added" && inlineDetailHtml
+          const shouldRenderInlineBelow = (
+            (eventType === "subject_parent_added")
+            || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))
+          );
+          const secondLineInlineHtml = shouldRenderInlineBelow && inlineDetailHtml
             ? `<span class="tl-note-inline tl-note-inline--parent-added">${inlineDetailHtml}</span>`
             : "";
           const defaultInlineHtml = eventType === "subject_parent_added"
             ? ""
             : (inlineDetailHtml ? `<span class="tl-note-inline">${inlineDetailHtml}</span>` : "");
           const inlineBeforeTimestampHtml = shouldRenderInlineBeforeTimestamp ? defaultInlineHtml : "";
-          const inlineAfterTimestampHtml = shouldRenderInlineBeforeTimestamp ? "" : defaultInlineHtml;
+          const inlineAfterTimestampHtml = shouldRenderInlineBeforeTimestamp || shouldRenderInlineBelow ? "" : defaultInlineHtml;
 
           return renderMessageThreadActivity({
             idx,
@@ -1454,7 +1461,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
               ${inlineBeforeTimestampHtml}
               <span class="mono-small">· ${escapeHtml(ts)}</span>
               ${inlineAfterTimestampHtml}
-              ${parentAddedLineHtml}
+              ${secondLineInlineHtml}
             `,
             noteHtml: ""
           });

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3935,11 +3935,13 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline{display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-weight:500;font-size:14px;}
 .tl-note-inline--parent-added{display:flex;margin-top:4px;margin-right:0;}
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:4px;}
+.tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
-.subject-meta-assignee-row--inline{display:inline-flex;margin-left:8px;vertical-align:middle;}
-.subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:flex;flex-direction:column;gap:0;line-height:1.1;}
+.subject-meta-assignee-row--inline{display:inline-flex;margin-left:0;vertical-align:middle;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:inline-flex;flex-direction:row;align-items:center;gap:6px;line-height:1.2;}
 .subject-meta-assignee-row--inline .subject-meta-assignee-row__name,
-.subject-meta-assignee-row--inline .subject-meta-assignee-row__role{display:block;line-height:16px;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__role{display:inline;line-height:16px;}
+.subject-meta-assignee-row--inline .subject-meta-assignee-row__role{opacity:.85;}
 .subject-meta-assignee-avatar-inline{
   width:22px;height:22px;border-radius:999px;overflow:hidden;background:rgba(110,118,129,.16);display:inline-flex;align-items:center;justify-content:center;
 }
@@ -3947,7 +3949,7 @@ body.drilldown-open .drilldown__inner,
 .subject-meta-assignee-avatar-inline__fallback{font-size:10px;font-weight:700;color:var(--text);}
 .subject-meta-objective-card--inline{
   display:inline-grid;
-  margin-left:8px;
+  margin-left:0;
   vertical-align:middle;
   min-width:0;
 }


### PR DESCRIPTION
### Motivation
- Harmoniser l'affichage des activités métier pour améliorer la lisibilité des notifications d'activité sur les sujets (assignations, objectifs, relations).

### Description
- Modifie `renderObjectiveInline` pour ne conserver que le nom de l'objectif (suppression du compteur et de la date d'échéance) afin d'afficher uniquement le titre de l'objectif en contexte inline.
- Ajoute `renderLinkedSubjectInline` et remplace les rendus précédents pour les relations `subject_parent_added`, `subject_blocked_by_added` et `subject_blocking_for_added` afin d'afficher une icône d'état (ouvert/fermé) devant le titre du sujet lié, avec la couleur adaptée (`issue-opened` pour ouvert, `check-circle` pour fermé).
- Change la logique de rendu des activités pour `subject_assignees_changed` (ajout/suppression) afin de déplacer le bloc de détail (avatar + nom + rôle) sur une seconde ligne tout en conservant ce bloc en rendu inline (`subject-meta-assignee-row--inline`).
- Met à jour le style CSS correspondant (`.tl-note-inline-subject-status`, `.subject-meta-assignee-row--inline`, `.subject-meta-objective-card--inline`) pour supporter le placement inline et le second-ligne visuel demandé.

### Testing
- Tests unitaires exécutés : `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs apps/web/js/views/project-subjects/project-subjects-head-blocked-by.test.mjs` et tous les cas sont passés (8 tests, 0 échecs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e794fcd6348329a5fdd8fc73b6a804)