### PR TITLE
Ajuste libellés et rendus inline pour activités situations/objectifs

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -34,6 +34,22 @@ export function summarizeCollectionChange(payload = {}, entityLabel = "élément
   return "";
 }
 
+function summarizeSituationChange(payload = {}, firstNonEmpty = defaultFirstNonEmpty) {
+  const added = readDeltaEntries(payload, "added", firstNonEmpty);
+  const removed = readDeltaEntries(payload, "removed", firstNonEmpty);
+  if (added.length === 1 && !removed.length) return `a ajouté le sujet à la situation ${added[0]}`;
+  if (removed.length === 1 && !added.length) return `a supprimé le sujet de la situation ${removed[0]}`;
+  return summarizeCollectionChange(payload, "situation", firstNonEmpty);
+}
+
+function summarizeObjectiveChange(payload = {}, firstNonEmpty = defaultFirstNonEmpty) {
+  const added = readDeltaEntries(payload, "added", firstNonEmpty);
+  const removed = readDeltaEntries(payload, "removed", firstNonEmpty);
+  if (added.length === 1 && !removed.length) return `a ajouté l'objectif ${added[0]}`;
+  if (removed.length === 1 && !added.length) return `a retiré l'objectif ${removed[0]}`;
+  return summarizeCollectionChange(payload, "objectif", firstNonEmpty);
+}
+
 export const BUSINESS_ACTIVITY_CONFIG = {
   subject_title_updated: { icon: "pencil", tone: "business-edit", verb: "a modifié le titre" },
   subject_description_updated: { icon: "note", tone: "business-edit", verb: "a modifié la description" },
@@ -53,13 +69,13 @@ export const BUSINESS_ACTIVITY_CONFIG = {
     icon: "table",
     tone: "business-rel",
     verb: "a mis à jour les situations",
-    summarize: (payload, firstNonEmpty) => summarizeCollectionChange(payload, "situation", firstNonEmpty)
+    summarize: (payload, firstNonEmpty) => summarizeSituationChange(payload, firstNonEmpty)
   },
   subject_objectives_changed: {
     icon: "milestone",
     tone: "business-rel",
     verb: "a mis à jour les objectifs",
-    summarize: (payload, firstNonEmpty) => summarizeCollectionChange(payload, "objectif", firstNonEmpty)
+    summarize: (payload, firstNonEmpty) => summarizeObjectiveChange(payload, firstNonEmpty)
   },
   subject_parent_added: { icon: "issue-tracked-by", tone: "business-rel", verb: "a ajouté un parent" },
   subject_parent_removed: { icon: "arrow-up", tone: "business-rel", verb: "a retiré un parent" },

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1270,7 +1270,24 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const title = firstNonEmpty(objective?.title, fallbackLabel, "Objectif");
     return `
       <span class="subject-meta-objective-card subject-meta-objective-card--inline">
+        <span class="subject-meta-objective-card__count" aria-hidden="true">${svgIcon("milestone", { className: "ui-icon octicon octicon-milestone" })}</span>
         <span class="subject-meta-objective-card__title">${escapeHtml(title)}</span>
+      </span>
+    `;
+  }
+
+  function renderSituationInline(situationId = "", fallbackLabel = "") {
+    const raw = getRawSubjectsResult();
+    const situationsById = raw?.situationsById && typeof raw.situationsById === "object" ? raw.situationsById : {};
+    const situationsList = Array.isArray(raw?.situations) ? raw.situations : [];
+    const situation = situationsById[situationId] || situationsList.find((item) => normalizeId(item?.id) === normalizeId(situationId)) || null;
+    const status = String(situation?.status || "open").toLowerCase();
+    const isClosedSituation = status === "closed";
+    const title = firstNonEmpty(situation?.title, fallbackLabel, "Situation");
+    return `
+      <span class="tl-note-inline-link">
+        <span class="subject-meta-situation-card__icon" aria-hidden="true">${svgIcon(isClosedSituation ? "table-check" : "table", { className: "ui-icon octicon octicon-table" })}</span>
+        <span class="tl-note-inline-text">${escapeHtml(title)}</span>
       </span>
     `;
   }
@@ -1354,6 +1371,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return `${renderObjectiveInline(objective?.id, objective?.label)}`;
     }
 
+    if (eventType === "subject_situations_changed" && String(payload?.action || "").toLowerCase() === "added" && added.length === 1) {
+      const situation = added[0] || {};
+      return `${renderSituationInline(situation?.id, situation?.label)}`;
+    }
+
+    if (eventType === "subject_situations_changed" && String(payload?.action || "").toLowerCase() === "removed" && removed.length === 1) {
+      const situation = removed[0] || {};
+      return `${renderSituationInline(situation?.id, situation?.label)}`;
+    }
+
     if (eventType === "subject_blocked_by_added" && counterpartId) {
       return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
@@ -1414,12 +1441,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
             ? "a retiré un assigné"
             : eventType === "subject_labels_changed" && action === "removed"
               ? "a retiré le label"
-              : eventType === "subject_labels_changed" && action === "added"
+                : eventType === "subject_labels_changed" && action === "added"
                 ? "a ajouté le label"
                 : eventType === "subject_objectives_changed" && action === "removed"
-                  ? "a retiré un objectif"
+                  ? "a retiré l'objectif"
                   : eventType === "subject_objectives_changed" && action === "added"
-                    ? "a ajouté un objectif"
+                    ? "a ajouté l'objectif"
+                  : eventType === "subject_situations_changed" && action === "removed"
+                    ? "a supprimé le sujet de la situation"
+                  : eventType === "subject_situations_changed" && action === "added"
+                    ? "a ajouté le sujet à la situation"
             : (eventType === "subject_parent_added" ? "a ajouté le sujet parent" : appearance.verb);
           const note = buildBusinessActivitySummary({
             payload,
@@ -1432,7 +1463,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
             ? richNoteHtml
             : (note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
           const shouldRenderInlineBeforeTimestamp = (
-            (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed")
+            (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed" || eventType === "subject_situations_changed")
             && (action === "added" || action === "removed")
           );
           const shouldRenderInlineBelow = (


### PR DESCRIPTION
### Motivation
- Rendre les activités timeline plus explicites quand un sujet est ajouté/retiré d'une situation et améliorer le rendu des objectifs en ligne pour une meilleure lisibilité.

### Description
- Distingue `subject_situations_changed` en deux verbes explicites `a ajouté le sujet à la situation` et `a supprimé le sujet de la situation` et aligne les résumés associés.
- Ajoute `renderSituationInline` pour afficher le nom de la situation avec une icône dynamique `table` (ouverte) ou `table-check` (fermée) dans le fil d'activité.
- Modifie le rendu des objectifs pour préfixer le libellé par l'icône `milestone` et remplace les verbes génériques par les formes singulières `a ajouté l'objectif` / `a retiré l'objectif`.
- Introduit `summarizeSituationChange` et `summarizeObjectiveChange` et met à jour `BUSINESS_ACTIVITY_CONFIG` pour utiliser ces résumés spécifiques.

### Testing
- Vérifications de syntaxe JavaScript exécutées avec `node --check apps/web/js/views/project-subjects/project-subjects-thread.js` et `node --check apps/web/js/views/project-subjects/project-subjects-thread-business-events.js` (succès).
- Vérification d'intégrité avec `git diff --check` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79b7dc6308329965c6ce7458d35e5)