### PR TITLE
Fix subject timeline close/reopen legacy rendering and timestamp spacing

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -663,13 +663,6 @@ export function createProjectSubjectsThread(config = {}) {
     });
   }
 
-  function decisionStatus(decision) {
-    const d = String(decision || "").toUpperCase();
-    if (d === "CLOSED") return "closed";
-    if (d === "REOPENED" || d === "OPEN") return "open";
-    return null;
-  }
-
   function setDecision(entityType, entityId, decision, note = "", options = {}) {
     const actor = options.actor || "Human";
     const agent = options.agent || "human";
@@ -679,31 +672,15 @@ export function createProjectSubjectsThread(config = {}) {
 
     persistRunBucket((bucket) => {
       bucket.decisions[entityType] = bucket.decisions[entityType] || {};
-      const prev = bucket.decisions[entityType][entityId] || null;
       bucket.decisions[entityType][entityId] = {
         ts,
         actor,
         decision: nextDecision,
         note: nextNote
       };
-
-      const prevStatus = decisionStatus(prev?.decision);
-      const nextStatus = decisionStatus(nextDecision);
-      if ((entityType === "sujet" || entityType === "situation") && nextStatus && nextStatus !== prevStatus) {
-        const parentSituation = entityType === "sujet" ? getSituationBySujetId(entityId) : null;
-        const targetId = entityType === "sujet" ? (parentSituation?.id || entityId) : entityId;
-        bucket.activities.push({
-          ts,
-          entity_type: "situation",
-          entity_id: targetId,
-          type: "ACTIVITY",
-          kind: nextStatus === "closed" ? "issue_closed" : "issue_reopened",
-          actor,
-          agent,
-          message: nextNote,
-          meta: entityType === "sujet" ? { problem_id: entityId } : { situation_id: entityId }
-        });
-      }
+      // Legacy local timeline activities (issue_closed / issue_reopened) were
+      // intentionally removed; status changes are now rendered from
+      // subject_history business events (subject_closed / subject_reopened).
     });
   }
 
@@ -1423,7 +1400,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
       if (type === "ACTIVITY") {
         const kind = String(e?.kind || "").toLowerCase();
-        if (kind === "message_deleted") return "";
+        if (kind === "message_deleted" || kind === "issue_closed" || kind === "issue_reopened") return "";
         if (String(e?.meta?.source || "") === "subject_history") {
           const activityIdentity = getAuthorIdentity({
             author: e?.actor,
@@ -1458,10 +1435,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
             fallbackMessage: e?.message,
             firstNonEmpty
           });
+          const shouldSuppressInlineText = eventType === "subject_closed" || eventType === "subject_reopened";
           const richNoteHtml = buildBusinessRichNoteHtml(e);
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml
-            : (note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
+            : (!shouldSuppressInlineText && note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
           const shouldRenderInlineBeforeTimestamp = (
             (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed" || eventType === "subject_situations_changed")
             && (action === "added" || action === "removed")
@@ -1490,7 +1468,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
               <span class="tl-author-name">${escapeHtml(activityIdentity.displayName)}</span>
               <span class="mono-small"> ${escapeHtml(resolvedVerb)} </span>
               ${inlineBeforeTimestampHtml}
-              <span class="mono-small">· ${escapeHtml(ts)}</span>
+              <span class="mono-small tl-time-inline"><span aria-hidden="true">·</span><span>${escapeHtml(ts)}</span></span>
               ${inlineAfterTimestampHtml}
               ${secondLineInlineHtml}
             `,

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3936,6 +3936,7 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:6px;}
 .tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
+.tl-time-inline{display:inline-flex;align-items:center;gap:6px;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:0;vertical-align:middle;}
 .subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:inline-flex;flex-direction:row;align-items:center;gap:6px;line-height:18px;height:18px;;}
 .subject-meta-assignee-row--inline .subject-meta-assignee-row__name,


### PR DESCRIPTION
### Motivation
- Supprimer le code legacy qui créait/affichait des activités locales `issue_closed` / `issue_reopened` depuis la gestion des décisions, et s'appuyer sur les événements métier `subject_history` (`subject_closed` / `subject_reopened`).
- Empêcher l'injection de texte inline pour les événements de fermeture/réouverture et améliorer l'espacement entre le séparateur "·" et la date pour une présentation stable.

### Description
- Retiré la génération d'activités locales legacy `issue_closed` / `issue_reopened` dans `setDecision` (conserver uniquement la décision en mémoire). (`apps/web/js/views/project-subjects/project-subjects-thread.js`)
- Ignorés les items restants `issue_closed` / `issue_reopened` lors du rendu du thread pour éviter doublons. (`apps/web/js/views/project-subjects/project-subjects-thread.js`)
- Empêché l'ajout de `<span class="tl-note-inline-text">` pour les événements `subject_closed` et `subject_reopened` (suppression de l'inline detail pour ces types). (`apps/web/js/views/project-subjects/project-subjects-thread.js`)
- Remplacé le rendu texte `· ${ts}` par une structure inline flex sécurisée et ajouté la classe CSS `.tl-time-inline` avec `gap: 6px` pour garantir l'espace entre le point et la date. (`apps/web/js/views/project-subjects/project-subjects-thread.js`, `apps/web/style.css`)

### Testing
- Exécuté `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs` et tous les tests unitaires du fichier sont passés (4 tests, 0 échecs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a01721688329a990ce67fff13959)