### PR TITLE
Ajuste le rendu des activités métier (fermeture, titre, description)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -52,7 +52,7 @@ function summarizeObjectiveChange(payload = {}, firstNonEmpty = defaultFirstNonE
 
 export const BUSINESS_ACTIVITY_CONFIG = {
   subject_title_updated: { icon: "pencil", tone: "business-edit", verb: "a modifié le titre" },
-  subject_description_updated: { icon: "note", tone: "business-edit", verb: "a modifié la description" },
+  subject_description_updated: { icon: "pencil", tone: "business-edit", verb: "a modifié la description" },
   subject_assignees_changed: {
     icon: "person",
     tone: "business-people",
@@ -85,7 +85,7 @@ export const BUSINESS_ACTIVITY_CONFIG = {
   subject_blocked_by_removed: { icon: "blocked", tone: "business-alert", verb: "a retiré un blocage entrant" },
   subject_blocking_for_added: { icon: "blocked", tone: "business-alert", verb: "a ajouté un blocage sortant" },
   subject_blocking_for_removed: { icon: "blocked", tone: "business-alert", verb: "a retiré un blocage sortant" },
-  subject_closed: { icon: "check-circle", tone: "business-alert", verb: "a fermé le sujet" },
+  subject_closed: { icon: "check-circle", tone: "business-closed", verb: "a fermé le sujet" },
   subject_reopened: { icon: "issue-reopened", tone: "business-open", verb: "a rouvert le sujet" }
 };
 

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1435,11 +1435,25 @@ priority=${firstNonEmpty(subject.priority, "")}`
             fallbackMessage: e?.message,
             firstNonEmpty
           });
-          const shouldSuppressInlineText = eventType === "subject_closed" || eventType === "subject_reopened";
+          const previousTitle = firstNonEmpty(payload?.before?.title);
+          const nextTitle = firstNonEmpty(payload?.after?.title);
+          const isSubjectTitleUpdated = eventType === "subject_title_updated";
+          const shouldSuppressInlineText = (
+            eventType === "subject_closed"
+            || eventType === "subject_reopened"
+            || eventType === "subject_description_updated"
+            || isSubjectTitleUpdated
+          );
           const richNoteHtml = buildBusinessRichNoteHtml(e);
+          const titleUpdateInlineHtml = isSubjectTitleUpdated && nextTitle
+            ? `<span class="tl-note-inline-text">"</span>
+                ${previousTitle ? `<span class="tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span>` : ""}
+                ${previousTitle ? `<span class="tl-note-inline-text">" en </span>` : ""}
+                <span class="tl-note-inline-text">"${escapeHtml(nextTitle)}"</span>`
+            : "";
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml
-            : (!shouldSuppressInlineText && note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : "");
+            : (titleUpdateInlineHtml || (!shouldSuppressInlineText && note ? `<span class="tl-note-inline-text">${escapeHtml(note)}</span>` : ""));
           const shouldRenderInlineBeforeTimestamp = (
             (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed" || eventType === "subject_situations_changed")
             && (action === "added" || action === "removed")

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3916,11 +3916,12 @@ body.drilldown-open .drilldown__inner,
 .tl-ico--business{
   color:#fff;
 }
-.tl-ico--business-edit{background:rgba(9, 105, 218, .8);}
+.tl-ico--business-edit{background:rgb(33, 40, 48);color:rgb(145, 152, 161);fill:rgb(145, 152, 161)}
 .tl-ico--business-people{background:rgb(33, 40, 48);color:rgb(145, 152, 161);fill:rgb(145, 152, 161)}
 .tl-ico--business-labels{background:rgb(33, 40, 48);color:rgb(145, 152, 161);fill:rgb(145, 152, 161)}
 .tl-ico--business-rel{background:rgb(33, 40, 48);color:rgb(145, 152, 161);fill:rgb(145, 152, 161)}
 .tl-ico--business-alert{background:rgb(33, 40, 48);color:rgb(145, 152, 161);fill:rgb(145, 152, 161)}
+.tl-ico--business-closed{background:rgb(137, 87, 229);color:#ffff;}
 .tl-ico--business-open{background:rgba(31, 136, 61, .9);}
 .tl-ico--business-neutral{background:rgba(110,118,129,.7);}
 .thread-item--event-subject_closed .tl-activity{/*border:1px solid rgba(207, 34, 46, .3);*/}
@@ -3936,6 +3937,7 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:6px;}
 .tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
+.tl-note-inline-text--strikethrough{text-decoration:line-through;}
 .tl-time-inline{display:inline-flex;align-items:center;gap:6px;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:0;vertical-align:middle;}
 .subject-meta-assignee-row--inline .subject-meta-assignee-row__content{display:inline-flex;flex-direction:row;align-items:center;gap:6px;line-height:18px;height:18px;;}


### PR DESCRIPTION
### Motivation
- Harmoniser l'affichage des événements métier dans le fil: afficher une icône dédiée pour la fermeture (fond violet), utiliser l'icône `pencil` pour les modifications de description et rendre les modifications de titre avec l'ancien titre barré et le nouveau titre en ligne avec l'horodatage.

### Description
- Met à jour la configuration des activités (`BUSINESS_ACTIVITY_CONFIG`) pour utiliser l'icône `pencil` pour `subject_description_updated` et introduit le ton `business-closed` pour `subject_closed`.
- Adapte le rendu du thread dans `apps/web/js/views/project-subjects/project-subjects-thread.js` pour calculer `previousTitle`/`nextTitle`, supprimer le texte inline pour certains événements, et construire un fragment inline pour `subject_title_updated` affichant l'ancien titre barré, `en` et le nouveau titre.
- Modifie les styles dans `apps/web/style.css` en ajustant `.tl-ico--business-edit` aux couleurs demandées, en ajoutant `.tl-ico--business-closed{background:rgb(137, 87, 229);color:#ffff;}` et en ajoutant `.tl-note-inline-text--strikethrough` pour barrer l'ancien titre.

### Testing
- Exécuté `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs` et tous les tests unitaires ont réussi (4 tests passés).
- Les modifications ont été intégrées et les tests automatisés ciblés sont verts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6b00d1483299e76970f38c21574)