### PR TITLE
Harmonise le rendu inline des situations avec les objectifs et ajuste l’affichage du changement de titre

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1262,9 +1262,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const isClosedSituation = status === "closed";
     const title = firstNonEmpty(situation?.title, fallbackLabel, "Situation");
     return `
-      <span class="tl-note-inline-link">
-        <span class="subject-meta-situation-card__icon" aria-hidden="true">${svgIcon(isClosedSituation ? "table-check" : "table", { className: "ui-icon octicon octicon-table" })}</span>
-        <span class="tl-note-inline-text">${escapeHtml(title)}</span>
+      <span class="subject-meta-objective-card subject-meta-objective-card--inline">
+        <span class="subject-meta-objective-card__count" aria-hidden="true">${svgIcon(isClosedSituation ? "table-check" : "table", { className: "ui-icon octicon octicon-table" })}</span>
+        <span class="subject-meta-objective-card__title">${escapeHtml(title)}</span>
       </span>
     `;
   }
@@ -1446,10 +1446,9 @@ priority=${firstNonEmpty(subject.priority, "")}`
           );
           const richNoteHtml = buildBusinessRichNoteHtml(e);
           const titleUpdateInlineHtml = isSubjectTitleUpdated && nextTitle
-            ? `<span class="tl-note-inline-text">"</span>
-                ${previousTitle ? `<span class="tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span>` : ""}
-                ${previousTitle ? `<span class="tl-note-inline-text">" en </span>` : ""}
-                <span class="tl-note-inline-text">"${escapeHtml(nextTitle)}"</span>`
+            ? `${previousTitle
+              ? `<span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="tl-note-inline-text"> en </span>`
+              : ""}<span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span>`
             : "";
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml


### PR DESCRIPTION
### Motivation
- Uniformiser le DOM des puces inline pour que la présentation de la `situation` soit identique à celle de l’`objective` pour faciliter le style et la réutilisation CSS.
- Améliorer la lisibilité du cas « a modifié le titre » en affichant l’ancien titre barré suivi de `en` puis du nouveau titre sur une seule ligne.

### Description
- Remplace la structure retournée par `renderSituationInline` pour utiliser la même arborescence que l’objectif (`subject-meta-objective-card` avec `__count` et `__title`) tout en conservant l’icône `table` / `table-check` (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Modifie le rendu pour `subject_title_updated` afin d’afficher l’ancien titre avec `class="mono-small"` et `text-decoration: line-through` puis ` en ` puis le nouveau titre sur la même ligne.

### Testing
- Exécuté : `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs` which passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a940aa888329b79eb1e82f7c77e0)