### PR TITLE
Ajuste l’affichage de l’activité de modification de titre

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1446,9 +1446,11 @@ priority=${firstNonEmpty(subject.priority, "")}`
           );
           const richNoteHtml = buildBusinessRichNoteHtml(e);
           const titleUpdateInlineHtml = isSubjectTitleUpdated && nextTitle
-            ? `${previousTitle
-              ? `<span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="tl-note-inline-text"> en </span>`
-              : ""}<span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span>`
+            ? `<div class="tl-note-inline-block tl-note-inline-block--title-update">${
+              previousTitle
+                ? `<span class="tl-note-inline-text tl-note-inline-text--quote">"</span><span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="tl-note-inline-text tl-note-inline-text--quote">"</span><span class="tl-note-inline-text"> en </span>`
+                : ""
+            }<span class="tl-note-inline-text tl-note-inline-text--quote">"</span><span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span><span class="tl-note-inline-text tl-note-inline-text--quote">"</span></div>`
             : "";
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml
@@ -1456,7 +1458,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const shouldRenderInlineBeforeTimestamp = (
             (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed" || eventType === "subject_situations_changed")
             && (action === "added" || action === "removed")
-          );
+          ) || isSubjectTitleUpdated;
           const shouldRenderInlineBelow = (
             (eventType === "subject_parent_added")
             || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3937,6 +3937,9 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:6px;}
 .tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
+.tl-note-inline-block{display:block;width:100%;white-space:normal;line-height:1.5;}
+.tl-note-inline-block .tl-note-inline-text{display:inline-block;}
+.tl-note-inline-text--quote{padding-inline:1px;}
 .tl-note-inline-text--strikethrough{text-decoration:line-through;}
 .tl-time-inline{display:inline-flex;align-items:center;gap:6px;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:0;vertical-align:middle;}


### PR DESCRIPTION
### Motivation
- Rendre l’affichage de l’activité `subject_title_updated` lisible sur toute la largeur et permettre le retour à la ligne pour former une phrase continue comme un paragraphe.

### Description
- Remplace le fragment inline du rendu du changement de titre par un bloc pleine largeur en encapsulant le détail dans un `<div>` avec la classe `tl-note-inline-block` pour permettre le wrapping et le retour à la ligne (`apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Construis la phrase avec des `span` en `inline-block` pour l’ancien titre barré (`tl-note-inline-text--strikethrough`), le séparateur `en`, et le nouveau titre; ajoute des guillemets visuels via `tl-note-inline-text--quote`.
- Force le rendu de ce bloc avant l’horodatage afin que la lecture forme une phrase continue (condition `shouldRenderInlineBeforeTimestamp` inclut maintenant les updates de titre).
- Ajoute les styles CSS associés (`tl-note-inline-block`, `tl-note-inline-block .tl-note-inline-text`, `tl-note-inline-text--quote`) dans `apps/web/style.css` pour gérer le comportement de bloc, le wrapping et l’espacement.

### Testing
- Exécuté le test unitaire `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs` et tous les tests sont passés (4/4 réussis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7aba1ae408329a1738d89fa2b7278)