### PR TITLE
Quote subject title updates inline and render them before timestamp

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1447,8 +1447,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const richNoteHtml = buildBusinessRichNoteHtml(e);
           const titleUpdateInlineHtml = isSubjectTitleUpdated && nextTitle
             ? `${previousTitle
-              ? `<span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="tl-note-inline-text"> en </span>`
-              : ""}<span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span>`
+              ? `<span class="mono-small">"</span><span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="mono-small">" en </span>`
+              : ""}<span class="tl-note-inline-text tl-note-inline-text--quote">"</span><span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span><span class="tl-note-inline-text tl-note-inline-text--quote">"</span>`
             : "";
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml
@@ -1456,7 +1456,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const shouldRenderInlineBeforeTimestamp = (
             (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed" || eventType === "subject_situations_changed")
             && (action === "added" || action === "removed")
-          );
+          ) || isSubjectTitleUpdated;
           const shouldRenderInlineBelow = (
             (eventType === "subject_parent_added")
             || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3937,6 +3937,7 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:6px;}
 .tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
+.tl-note-inline-text--quote{padding-inline:1px;}
 .tl-note-inline-text--strikethrough{text-decoration:line-through;}
 .tl-time-inline{display:inline-flex;align-items:center;gap:6px;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:0;vertical-align:middle;}


### PR DESCRIPTION
### Motivation
- Clarify subject title updates in the activity thread by adding visible quotation marks and preserving the strikethrough for the previous title.
- Ensure title update events are rendered inline before the timestamp so they appear in the compact activity line.

### Description
- Wrap previous and next subject titles in explicit quote markers and add the `tl-note-inline-text--quote` class for the quoted fragments, while keeping the previous title strikethrough styling.
- Add `isSubjectTitleUpdated` to the `shouldRenderInlineBeforeTimestamp` condition so title-update events render inline before the timestamp.
- Add a CSS rule `.tl-note-inline-text--quote{padding-inline:1px;}` to adjust spacing for the quoted fragments.

### Testing
- Ran JavaScript linting (`eslint`) and style linting (`stylelint`) against the modified files with no errors.
- Executed the frontend unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7aba1ae408329a1738d89fa2b7278)