### PR TITLE
Display quoted subject titles and adjust inline layout for title-updated events

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1447,8 +1447,8 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const richNoteHtml = buildBusinessRichNoteHtml(e);
           const titleUpdateInlineHtml = isSubjectTitleUpdated && nextTitle
             ? `${previousTitle
-              ? `<span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="tl-note-inline-text"> en </span>`
-              : ""}<span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span>`
+              ? `<span class="mono-small">"</span><span class="mono-small tl-note-inline-text tl-note-inline-text--strikethrough">${escapeHtml(previousTitle)}</span><span class="mono-small">" en </span>`
+              : ""}<span class="tl-note-inline-text tl-note-inline-text--quote">"</span><span class="tl-note-inline-text">${escapeHtml(nextTitle)}</span><span class="tl-note-inline-text tl-note-inline-text--quote">"</span>`
             : "";
           const inlineDetailHtml = richNoteHtml
             ? richNoteHtml
@@ -1456,7 +1456,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const shouldRenderInlineBeforeTimestamp = (
             (eventType === "subject_labels_changed" || eventType === "subject_objectives_changed" || eventType === "subject_situations_changed")
             && (action === "added" || action === "removed")
-          );
+          ) || isSubjectTitleUpdated;
           const shouldRenderInlineBelow = (
             (eventType === "subject_parent_added")
             || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))
@@ -1464,9 +1464,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const secondLineInlineHtml = shouldRenderInlineBelow && inlineDetailHtml
             ? `<span class="tl-note-inline tl-note-inline--parent-added">${inlineDetailHtml}</span>`
             : "";
+          const inlineClassName = isSubjectTitleUpdated
+            ? "tl-note-inline tl-note-inline--title-updated"
+            : "tl-note-inline";
           const defaultInlineHtml = eventType === "subject_parent_added"
             ? ""
-            : (inlineDetailHtml ? `<span class="tl-note-inline">${inlineDetailHtml}</span>` : "");
+            : (inlineDetailHtml ? `<span class="${inlineClassName}">${inlineDetailHtml}</span>` : "");
           const inlineBeforeTimestampHtml = shouldRenderInlineBeforeTimestamp ? defaultInlineHtml : "";
           const inlineAfterTimestampHtml = shouldRenderInlineBeforeTimestamp || shouldRenderInlineBelow ? "" : defaultInlineHtml;
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3933,10 +3933,12 @@ body.drilldown-open .drilldown__inner,
   box-shadow:inset 0 0 0 1px rgba(31, 35, 40, .12);
 }
 .tl-note-inline{display:inline-flex;align-items:center;gap:6px;margin-right:8px;font-weight:500;font-size:14px;}
+.tl-note-inline--title-updated{display:inline;}
 .tl-note-inline--parent-added{display:flex;margin-top:4px;margin-right:0;}
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:6px;}
 .tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
+.tl-note-inline-text--quote{padding-inline:1px;}
 .tl-note-inline-text--strikethrough{text-decoration:line-through;}
 .tl-time-inline{display:inline-flex;align-items:center;gap:6px;}
 .subject-meta-assignee-row--inline{display:inline-flex;margin-left:0;vertical-align:middle;}


### PR DESCRIPTION
### Motivation
- Improve readability of subject title updates by showing old and new titles with quotation marks and ensuring the inline note layout renders correctly for title-change events.

### Description
- Add quotation marks around previous and next subject titles and introduce a `tl-note-inline-text--quote` class in `apps/web/js/views/project-subjects/project-subjects-thread.js` to control quote spacing.
- Force title-updated events to render their inline text before the timestamp and add a `tl-note-inline--title-updated` wrapper class so the inline element can be styled separately.
- Update `apps/web/style.css` to add `.tl-note-inline--title-updated` and `.tl-note-inline-text--quote` rules to adjust display and padding for quoted title fragments.
- Preserve existing escaping and fallback logic for inline notes and rich notes when rendering activity threads.

### Testing
- Ran the JavaScript test suite with `yarn test`, and tests passed.
- Ran linters with `yarn lint`, and no lint errors were reported.
- Performed a frontend build with `yarn build:web`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7aba1ae408329a1738d89fa2b7278)