### PR TITLE
Add manual subject creation RPC and JS service hook

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1178,6 +1178,53 @@ export async function replaceSubjectObjectives(subjectId, objectiveIds = []) {
   return nextObjectiveIds;
 }
 
+
+export async function createManualSubject({ projectId = "", title, subjectType = "explicit_problem" } = {}) {
+  const resolvedProjectId = normalizeUuid(await getResolvedProjectId(projectId));
+  if (!resolvedProjectId) throw new Error("projectId is required");
+
+  const nextTitle = String(title || "").trim();
+  if (!nextTitle) throw new Error("Le titre du sujet est obligatoire.");
+
+  const nextSubjectType = String(subjectType || "explicit_problem").trim() || "explicit_problem";
+
+  let actorPersonId = "";
+  try {
+    actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  } catch (error) {
+    throw new Error(`create_manual_subject identity resolution failed: ${String(error?.message || error || "unknown identity resolution error")}`);
+  }
+  if (!actorPersonId) {
+    throw new Error("create_manual_subject identity resolution failed: no linked directory person found for current user");
+  }
+
+  let payload = null;
+  try {
+    payload = await rpcCall("create_manual_subject", {
+      p_project_id: resolvedProjectId,
+      p_title: nextTitle,
+      p_actor_person_id: actorPersonId,
+      p_subject_type: nextSubjectType
+    });
+  } catch (error) {
+    const statusCode = Number(error?.status || 0) || null;
+    const rawError = String(error?.rawBody || error?.message || error || "unknown error");
+    throw new Error(`Impossible de créer le sujet (${statusCode || "unknown"}): ${rawError}`);
+  }
+
+  const row = Array.isArray(payload) ? (payload[0] || {}) : (payload || {});
+  return {
+    id: normalizeUuid(row?.id),
+    project_id: normalizeUuid(row?.project_id || resolvedProjectId),
+    title: String(row?.title || nextTitle),
+    status: String(row?.status || "open"),
+    priority: String(row?.priority || "medium"),
+    created_at: String(row?.created_at || ""),
+    updated_at: String(row?.updated_at || ""),
+    subject_number: Number.isFinite(Number(row?.subject_number)) ? Number(row.subject_number) : null
+  };
+}
+
 export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {
   const debugEnabled = isSubjectDescriptionDebugEnabled();
   const debugRequestId = debugEnabled ? buildSubjectDescriptionDebugRequestId() : null;

--- a/supabase/migrations/202606150030_create_manual_subject_rpc.sql
+++ b/supabase/migrations/202606150030_create_manual_subject_rpc.sql
@@ -1,0 +1,231 @@
+create or replace function public.create_manual_subject(
+  p_project_id uuid,
+  p_title text,
+  p_actor_person_id uuid,
+  p_subject_type text default 'explicit_problem'
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  title text,
+  status text,
+  priority text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  subject_number bigint
+)
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_project public.projects;
+  v_subject public.subjects;
+  v_manual_document public.documents;
+  v_manual_analysis_run public.analysis_runs;
+  v_person_id uuid;
+  v_title text := trim(coalesce(p_title, ''));
+  v_subject_type text := trim(coalesce(p_subject_type, 'explicit_problem'));
+  v_document_storage_path text;
+  v_actor_label text;
+  v_result_label text;
+begin
+  if p_project_id is null then
+    raise exception 'project_id is required';
+  end if;
+
+  select *
+    into v_project
+  from public.projects p
+  where p.id = p_project_id;
+
+  if v_project.id is null then
+    raise exception 'Project not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_project.id) then
+    raise exception 'Insufficient rights to create manual subject';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  if v_title = '' then
+    raise exception 'Subject title cannot be empty';
+  end if;
+
+  if v_subject_type not in ('explicit_problem', 'validation_point', 'missing_or_inconsistency') then
+    raise exception 'Invalid subject type';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(v_project.id::text, 0));
+
+  v_document_storage_path := format('system/manual-subjects/%s.json', v_project.id::text);
+
+  select *
+    into v_manual_document
+  from public.documents d
+  where d.project_id = v_project.id
+    and d.document_kind = 'manual_subjects_system'
+  order by d.created_at asc
+  limit 1;
+
+  if v_manual_document.id is null then
+    insert into public.documents (
+      project_id,
+      filename,
+      original_filename,
+      mime_type,
+      storage_bucket,
+      storage_path,
+      upload_status,
+      document_kind
+    )
+    values (
+      v_project.id,
+      'manual-subjects-system.json',
+      'manual-subjects-system.json',
+      'application/json',
+      'documents',
+      v_document_storage_path,
+      'uploaded',
+      'manual_subjects_system'
+    )
+    returning * into v_manual_document;
+  end if;
+
+  select *
+    into v_manual_analysis_run
+  from public.analysis_runs ar
+  where ar.project_id = v_project.id
+    and ar.document_id = v_manual_document.id
+    and ar.trigger_source = 'manual_subjects_system'
+  order by ar.created_at desc
+  limit 1;
+
+  if v_manual_analysis_run.id is null then
+    insert into public.analysis_runs (
+      project_id,
+      document_id,
+      status,
+      trigger_source,
+      started_at,
+      finished_at
+    )
+    values (
+      v_project.id,
+      v_manual_document.id,
+      'succeeded',
+      'manual_subjects_system',
+      now(),
+      now()
+    )
+    returning * into v_manual_analysis_run;
+  end if;
+
+  insert into public.subjects (
+    project_id,
+    document_id,
+    analysis_run_id,
+    subject_type,
+    title,
+    normalized_title,
+    priority,
+    status
+  )
+  values (
+    v_project.id,
+    v_manual_document.id,
+    v_manual_analysis_run.id,
+    v_subject_type,
+    v_title,
+    v_title,
+    'medium',
+    'open'
+  )
+  returning * into v_subject;
+
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_result_label := format('a créé le sujet « %s »', v_title);
+
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_created',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Sujet créé',
+    v_result_label,
+    jsonb_build_object(
+      'action', 'created',
+      'field', 'subject',
+      'before', '{}'::jsonb,
+      'after', jsonb_build_object(
+        'id', v_subject.id,
+        'subject_number', v_subject.subject_number,
+        'title', coalesce(v_subject.title, ''),
+        'status', coalesce(v_subject.status, ''),
+        'priority', coalesce(v_subject.priority, ''),
+        'subject_type', coalesce(v_subject.subject_type, '')
+      ),
+      'delta', jsonb_build_object('created', true),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  return query
+  select
+    v_subject.id,
+    v_subject.project_id,
+    v_subject.title,
+    v_subject.status,
+    v_subject.priority,
+    v_subject.created_at,
+    v_subject.updated_at,
+    v_subject.subject_number;
+end;
+$$;
+
+grant execute on function public.create_manual_subject(uuid, text, uuid, text) to authenticated;
+revoke all on function public.create_manual_subject(uuid, text, uuid, text) from public;
+
+comment on function public.create_manual_subject(uuid, text, uuid, text) is
+  'Creates a manual subject with per-project system document/analysis_run compatibility records, then appends business history event.';


### PR DESCRIPTION
### Motivation
- Provide a robust backend path to create manual subjects compatible with the current schema constraints (non-null `document_id` and `analysis_run_id`) so the UI can create real subjects instead of local mocks.
- Keep changes minimal and non-breaking by adding a targeted RPC that guarantees compatibility records rather than refactoring the subjects schema.

### Description
- Add a new Supabase migration `supabase/migrations/202606150030_create_manual_subject_rpc.sql` that implements `public.create_manual_subject(p_project_id uuid, p_title text, p_actor_person_id uuid, p_subject_type text default 'explicit_problem')` with input validation, access checks, idempotent creation/reuse of a per-project system `documents` and `analysis_runs` records, insertion into `public.subjects` (defaults: `status = 'open'`, `priority = 'medium'`), and an insertion into `public.subject_history` for the creation event, plus `grant/revoke` statements and a function comment.
- Expose a JS service function `createManualSubject({ projectId, title, subjectType })` in `apps/web/js/services/project-subjects-supabase.js` that resolves the backend project id and actor person id using existing helpers, calls the new RPC via `rpcCall`, handles errors in the repository style, and returns a normalized subject row (including `subject_number`).
- Limit scope to only the new migration and the single JS export, reusing existing authorization/actor resolution and history conventions to avoid wide-reaching schema or UI changes.

### Testing
- Ran the subject title UI tests via `node --test apps/web/js/views/project-subjects/project-subjects-title.test.mjs` and they passed.
- Ran related service tests via `node --test apps/web/js/services/subject-assignees-service.test.mjs` and they passed.
- No other automated tests were modified or added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86d48641483299aa647aed7c0676c)