### PR TITLE
Add manual subject creation flow with backend RPC and frontend integration

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1178,6 +1178,53 @@ export async function replaceSubjectObjectives(subjectId, objectiveIds = []) {
   return nextObjectiveIds;
 }
 
+
+export async function createManualSubject({ projectId = "", title, subjectType = "explicit_problem" } = {}) {
+  const resolvedProjectId = normalizeUuid(await getResolvedProjectId(projectId));
+  if (!resolvedProjectId) throw new Error("projectId is required");
+
+  const nextTitle = String(title || "").trim();
+  if (!nextTitle) throw new Error("Le titre du sujet est obligatoire.");
+
+  const nextSubjectType = String(subjectType || "explicit_problem").trim() || "explicit_problem";
+
+  let actorPersonId = "";
+  try {
+    actorPersonId = normalizeUuid(await resolveCurrentUserDirectoryPersonId());
+  } catch (error) {
+    throw new Error(`create_manual_subject identity resolution failed: ${String(error?.message || error || "unknown identity resolution error")}`);
+  }
+  if (!actorPersonId) {
+    throw new Error("create_manual_subject identity resolution failed: no linked directory person found for current user");
+  }
+
+  let payload = null;
+  try {
+    payload = await rpcCall("create_manual_subject", {
+      p_project_id: resolvedProjectId,
+      p_title: nextTitle,
+      p_actor_person_id: actorPersonId,
+      p_subject_type: nextSubjectType
+    });
+  } catch (error) {
+    const statusCode = Number(error?.status || 0) || null;
+    const rawError = String(error?.rawBody || error?.message || error || "unknown error");
+    throw new Error(`Impossible de créer le sujet (${statusCode || "unknown"}): ${rawError}`);
+  }
+
+  const row = Array.isArray(payload) ? (payload[0] || {}) : (payload || {});
+  return {
+    id: normalizeUuid(row?.id),
+    project_id: normalizeUuid(row?.project_id || resolvedProjectId),
+    title: String(row?.title || nextTitle),
+    status: String(row?.status || "open"),
+    priority: String(row?.priority || "medium"),
+    created_at: String(row?.created_at || ""),
+    updated_at: String(row?.updated_at || ""),
+    subject_number: Number.isFinite(Number(row?.subject_number)) ? Number(row.subject_number) : null
+  };
+}
+
 export async function updateSubjectDescription({ subjectId, description, uploadSessionId = "" } = {}) {
   const debugEnabled = isSubjectDescriptionDebugEnabled();
   const debugRequestId = debugEnabled ? buildSubjectDescriptionDebugRequestId() : null;

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -19,6 +19,7 @@ import {
   replaceSubjectObjectives as replaceSubjectObjectivesInSupabase,
   updateSubjectDescription as updateSubjectDescriptionInSupabase,
   updateSubjectTitle as updateSubjectTitleInSupabase,
+  createManualSubject as createManualSubjectInSupabase,
   loadSubjectDescriptionVersions as loadSubjectDescriptionVersionsInSupabase
 } from "../services/project-subjects-supabase.js";
 import { loadSituationsForCurrentProject, addSubjectToSituation, removeSubjectFromSituation } from "../services/project-situations-supabase.js";
@@ -851,7 +852,13 @@ const projectSubjectsView = createProjectSubjectsView({
   getSelectionForScope: (...args) => getSelectionForScope(...args),
   getScopedSelection: (...args) => getScopedSelection(...args),
   getInlineReplyUiState: (...args) => getInlineReplyUiState(...args),
-  ensureTimelineLoadedForSelection: (...args) => ensureTimelineLoadedForSelection(...args)
+  ensureTimelineLoadedForSelection: (...args) => ensureTimelineLoadedForSelection(...args),
+  createManualSubject: (...args) => createManualSubjectInSupabase(...args),
+  replaceSubjectAssigneesInSupabase: (...args) => replaceSubjectAssigneesInSupabase(...args),
+  replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
+  replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
+  replaceSubjectObjectivesInSupabase: (...args) => replaceSubjectObjectivesInSupabase(...args),
+  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -188,6 +188,10 @@ export function createProjectSubjectsActions(config) {
       else rerenderPanels();
     }
 
+    if (subjectKey === DRAFT_SUBJECT_ID) {
+      return true;
+    }
+
     try {
       await replaceSubjectAssigneesInSupabase(subjectKey, nextIds);
       return true;
@@ -453,6 +457,10 @@ export function createProjectSubjectsActions(config) {
       if (options.root) rerenderScope(options.root);
     }
 
+    if (subjectKey === DRAFT_SUBJECT_ID) {
+      return true;
+    }
+
     try {
       await replaceSubjectSituationsInSupabase(subjectKey, nextIds);
       await loadSituationsForCurrentProject().catch(() => []);
@@ -517,6 +525,21 @@ export function createProjectSubjectsActions(config) {
     const labelValue = String(label || "").trim();
     const labelKey = normalizeSubjectLabelKey(labelValue);
     if (!subjectKey || !labelKey) return false;
+
+    if (subjectKey === DRAFT_SUBJECT_ID) {
+      const meta = getSubjectSidebarMeta(subjectKey);
+      const previousLabels = Array.isArray(meta.labels) ? [...meta.labels] : [];
+      const hasLabel = previousLabels.some((value) => normalizeSubjectLabelKey(value) === labelKey);
+      const nextLabels = hasLabel
+        ? previousLabels.filter((value) => normalizeSubjectLabelKey(value) !== labelKey)
+        : [...previousLabels, labelValue];
+      setSubjectLabels(subjectKey, nextLabels);
+      if (!options.skipRerender) {
+        if (options.root) rerenderScope(options.root);
+        else rerenderPanels();
+      }
+      return true;
+    }
 
     const labelDefinition = getSubjectLabelDefinition(labelValue);
     const labelId = String(labelDefinition?.id || "").trim();
@@ -630,6 +653,10 @@ export function createProjectSubjectsActions(config) {
     if (!options.skipRerender) {
       if (options.root) rerenderScope(options.root);
       else rerenderPanels();
+    }
+
+    if (subjectKey === DRAFT_SUBJECT_ID) {
+      return true;
     }
 
     try {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -4812,18 +4812,30 @@ export function createProjectSubjectsEvents(config) {
       const createSubjectSubmitButton = event.target.closest("[data-create-subject-submit]");
       if (createSubjectSubmitButton && store.situationsView.createSubjectForm?.isOpen) {
         event.preventDefault();
-        const result = createSubjectFromDraft();
-        if (!result.ok) {
-          rerenderPanels();
+        if (store.situationsView.createSubjectForm?.isSubmitting) {
           return;
         }
+
         const keepCreateMore = !!store.situationsView.createSubjectForm?.createMore;
-        if (keepCreateMore) {
-          openCreateSubjectForm();
-        } else {
-          resetCreateSubjectForm({ keepCreateMore: true });
-        }
         rerenderPanels();
+
+        (async () => {
+          const result = await createSubjectFromDraft();
+          if (!result.ok) {
+            rerenderPanels();
+            return;
+          }
+
+          if (keepCreateMore) {
+            openCreateSubjectForm();
+          } else {
+            resetCreateSubjectForm({ keepCreateMore: true });
+          }
+          rerenderPanels();
+        })().catch((error) => {
+          showError(`Création du sujet impossible : ${String(error?.message || error || "Erreur inconnue")}`);
+          rerenderPanels();
+        });
         return;
       }
 

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -225,9 +225,11 @@ export function createProjectSubjectsState({ store }) {
           situationIds: [],
           relations: []
         },
-        validationError: ""
+        validationError: "",
+        isSubmitting: false
       };
     }
+    if (typeof v.createSubjectForm.isSubmitting !== "boolean") v.createSubjectForm.isSubmitting = false;
     return v;
   }
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -87,7 +87,13 @@ export function createProjectSubjectsView(deps) {
     addComment,
     getSelectionForScope,
     getScopedSelection,
-    ensureTimelineLoadedForSelection
+    ensureTimelineLoadedForSelection,
+    createManualSubject,
+    replaceSubjectAssigneesInSupabase,
+    replaceSubjectLabelsInSupabase,
+    replaceSubjectSituationsInSupabase,
+    replaceSubjectObjectivesInSupabase,
+    updateSubjectDescriptionInSupabase
   } = deps;
 
   const {
@@ -448,7 +454,8 @@ function resetCreateSubjectForm(options = {}) {
     previewMode: false,
     createMore: keepCreateMore ? !!previous.createMore : false,
     meta: buildDefaultDraftSubjectMeta(),
-    validationError: ""
+    validationError: "",
+    isSubmitting: false
   };
 }
 
@@ -467,7 +474,8 @@ function openCreateSubjectForm() {
     previewMode: false,
     createMore: previousCreateMore,
     meta: buildDefaultDraftSubjectMeta(),
-    validationError: ""
+    validationError: "",
+    isSubmitting: false
   };
 }
 
@@ -484,82 +492,106 @@ function getCustomSubjects() {
   }));
 }
 
-function createCustomSubjectId() {
-  const stamp = new Date();
-  const compact = [
-    stamp.getFullYear(),
-    String(stamp.getMonth() + 1).padStart(2, "0"),
-    String(stamp.getDate()).padStart(2, "0"),
-    "-",
-    String(stamp.getHours()).padStart(2, "0"),
-    String(stamp.getMinutes()).padStart(2, "0"),
-    String(stamp.getSeconds()).padStart(2, "0"),
-    "-",
-    Math.random().toString(36).slice(2, 6)
-  ].join("");
-  return `sujet-local-${compact}`;
+function resolveDraftLabelIds(labels = []) {
+  return [...new Set((Array.isArray(labels) ? labels : [])
+    .map((value) => String(value || "").trim())
+    .filter(Boolean)
+    .map((value) => String(getSubjectLabelDefinition(value)?.id || "").trim())
+    .filter(Boolean))];
 }
 
-function createSubjectFromDraft() {
+async function createSubjectFromDraft() {
   ensureViewUiState();
-  const draft = getSubjectsViewState().createSubjectForm || {};
-  const title = String(draft.title || "").trim();
+  const formState = getSubjectsViewState().createSubjectForm || {};
+  if (formState.isSubmitting) {
+    return { ok: false, reason: "in-flight" };
+  }
+
+  const title = String(formState.title || "").trim();
   if (!title) {
     store.situationsView.createSubjectForm.validationError = "Le titre du sujet est obligatoire.";
     return { ok: false, reason: "missing-title" };
   }
 
-  const subjectId = createCustomSubjectId();
   const nextMeta = {
-    assignees: Array.isArray(draft.meta?.assignees) ? draft.meta.assignees.map((value) => String(value || "")).filter(Boolean) : [],
-    labels: normalizeSubjectLabels(draft.meta?.labels),
-    objectiveIds: normalizeSubjectObjectiveIds(draft.meta?.objectiveIds),
-    situationIds: normalizeSubjectSituationIds(draft.meta?.situationIds),
-    relations: Array.isArray(draft.meta?.relations) ? draft.meta.relations.map((value) => String(value || "")).filter(Boolean) : []
+    assignees: Array.isArray(formState.meta?.assignees) ? formState.meta.assignees.map((value) => String(value || "").trim()).filter(Boolean) : [],
+    labels: normalizeSubjectLabels(formState.meta?.labels),
+    objectiveIds: normalizeSubjectObjectiveIds(formState.meta?.objectiveIds),
+    situationIds: normalizeSubjectSituationIds(formState.meta?.situationIds),
+    relations: Array.isArray(formState.meta?.relations) ? formState.meta.relations.map((value) => String(value || "").trim()).filter(Boolean) : []
   };
 
-  persistRunBucket((bucket) => {
-    bucket.customSubjects = Array.isArray(bucket.customSubjects) ? bucket.customSubjects : [];
-    bucket.customSubjects.unshift({
-      id: subjectId,
-      title,
-      status: "open",
-      priority: "P3",
-      agent: "human",
-      raw: {
-        created_by: String(store.user?.id || "human"),
-        created_at: nowIso()
-      },
-      avis: []
-    });
-    bucket.subjectMeta = bucket.subjectMeta && typeof bucket.subjectMeta === "object" ? bucket.subjectMeta : {};
-    bucket.subjectMeta.sujet = bucket.subjectMeta.sujet && typeof bucket.subjectMeta.sujet === "object" ? bucket.subjectMeta.sujet : {};
-    bucket.subjectMeta.sujet[subjectId] = {
-      ...(bucket.subjectMeta.sujet[subjectId] || {}),
-      assignees: nextMeta.assignees,
-      objectiveIds: nextMeta.objectiveIds,
-      situationIds: nextMeta.situationIds,
-      relations: nextMeta.relations
-    };
-  });
+  const description = String(formState.description || "").trim();
 
-  setEntityDescriptionState("sujet", subjectId, {
-    body: String(draft.description || "").trim(),
-    author: firstNonEmpty(store.user?.name, store.user?.firstName, "human"),
-    agent: "human",
-    avatar_type: "human",
-    avatar_initial: "H"
-  }, { actor: "Human", agent: "human" });
-
-  setSubjectObjectiveIds(subjectId, nextMeta.objectiveIds);
-  store.situationsView.selectedSujetId = subjectId;
-  store.situationsView.selectedSubjectId = subjectId;
-  store.situationsView.selectedSituationId = nextMeta.situationIds[0] || store.situationsView.selectedSituationId || null;
-  store.projectSubjectsView.selectedSujetId = subjectId;
-  store.projectSubjectsView.selectedSubjectId = subjectId;
-  store.projectSubjectsView.selectedSituationId = nextMeta.situationIds[0] || store.projectSubjectsView.selectedSituationId || null;
   store.situationsView.createSubjectForm.validationError = "";
-  return { ok: true, subjectId };
+  store.situationsView.createSubjectForm.isSubmitting = true;
+
+  try {
+    const createdSubject = await createManualSubject({
+      title,
+      subjectType: "explicit_problem"
+    });
+
+    const subjectId = String(createdSubject?.id || "").trim();
+    if (!subjectId) {
+      throw new Error("Le backend n'a pas renvoyé d'identifiant de sujet.");
+    }
+
+    if (nextMeta.assignees.length) {
+      await replaceSubjectAssigneesInSupabase(subjectId, nextMeta.assignees);
+    }
+
+    const labelIds = resolveDraftLabelIds(nextMeta.labels);
+    if (labelIds.length) {
+      await replaceSubjectLabelsInSupabase(subjectId, labelIds);
+    }
+
+    if (nextMeta.situationIds.length) {
+      await replaceSubjectSituationsInSupabase(subjectId, nextMeta.situationIds);
+    }
+
+    if (nextMeta.objectiveIds.length) {
+      await replaceSubjectObjectivesInSupabase(subjectId, nextMeta.objectiveIds);
+    }
+
+    if (description) {
+      await updateSubjectDescriptionInSupabase({
+        subjectId,
+        description
+      });
+    }
+
+    await reloadSubjectsFromSupabase(getSubjectsCurrentRoot(), {
+      rerender: false,
+      updateModal: false
+    });
+
+    const persistedSubject = getNestedSujet(subjectId);
+    const selectedSituationId = String(
+      persistedSubject?.situation_id
+      || persistedSubject?.situationId
+      || nextMeta.situationIds[0]
+      || store.situationsView.selectedSituationId
+      || ""
+    ).trim() || null;
+
+    store.situationsView.selectedSujetId = subjectId;
+    store.situationsView.selectedSubjectId = subjectId;
+    store.situationsView.selectedSituationId = selectedSituationId;
+    store.projectSubjectsView.selectedSujetId = subjectId;
+    store.projectSubjectsView.selectedSubjectId = subjectId;
+    store.projectSubjectsView.selectedSituationId = selectedSituationId;
+
+    return { ok: true, subjectId };
+  } catch (error) {
+    const message = String(error?.message || error || "Erreur inconnue");
+    store.situationsView.createSubjectForm.validationError = `Création du sujet impossible : ${message}`;
+    return { ok: false, reason: "create-failed", error };
+  } finally {
+    if (store.situationsView?.createSubjectForm && typeof store.situationsView.createSubjectForm === "object") {
+      store.situationsView.createSubjectForm.isSubmitting = false;
+    }
+  }
 }
 
 function normalizeSujetKanbanStatus(value) {
@@ -2854,12 +2886,12 @@ function renderCreateSubjectFormHtml() {
             <div class="subject-create-footer__left">
               <label class="subject-create-checkbox">
                 <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
-                <span>Create more</span>
+                <span>En ajouter d'autres</span>
               </label>
             </div>
             <div class="subject-create-footer__right">
-              <button type="button" class="gh-btn" data-create-subject-cancel>Cancel</button>
-              <button type="button" class="gh-btn gh-btn--primary" data-create-subject-submit>Create</button>
+              <button type="button" class="gh-btn" data-create-subject-cancel>Annuler</button>
+              <button type="button" class="gh-btn gh-btn--primary" data-create-subject-submit ${form.isSubmitting ? "disabled" : ""}>${form.isSubmitting ? "Création..." : "Ajouter"}</button>
             </div>
           </div>
         </div>

--- a/supabase/migrations/202606150030_create_manual_subject_rpc.sql
+++ b/supabase/migrations/202606150030_create_manual_subject_rpc.sql
@@ -1,0 +1,231 @@
+create or replace function public.create_manual_subject(
+  p_project_id uuid,
+  p_title text,
+  p_actor_person_id uuid,
+  p_subject_type text default 'explicit_problem'
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  title text,
+  status text,
+  priority text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  subject_number bigint
+)
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_project public.projects;
+  v_subject public.subjects;
+  v_manual_document public.documents;
+  v_manual_analysis_run public.analysis_runs;
+  v_person_id uuid;
+  v_title text := trim(coalesce(p_title, ''));
+  v_subject_type text := trim(coalesce(p_subject_type, 'explicit_problem'));
+  v_document_storage_path text;
+  v_actor_label text;
+  v_result_label text;
+begin
+  if p_project_id is null then
+    raise exception 'project_id is required';
+  end if;
+
+  select *
+    into v_project
+  from public.projects p
+  where p.id = p_project_id;
+
+  if v_project.id is null then
+    raise exception 'Project not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_project.id) then
+    raise exception 'Insufficient rights to create manual subject';
+  end if;
+
+  v_person_id := coalesce(p_actor_person_id, public.current_person_id());
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  if not exists (
+    select 1
+    from public.directory_people dp
+    where dp.id = v_person_id
+  ) then
+    raise exception 'Invalid actor person id';
+  end if;
+
+  if v_title = '' then
+    raise exception 'Subject title cannot be empty';
+  end if;
+
+  if v_subject_type not in ('explicit_problem', 'validation_point', 'missing_or_inconsistency') then
+    raise exception 'Invalid subject type';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(v_project.id::text, 0));
+
+  v_document_storage_path := format('system/manual-subjects/%s.json', v_project.id::text);
+
+  select *
+    into v_manual_document
+  from public.documents d
+  where d.project_id = v_project.id
+    and d.document_kind = 'manual_subjects_system'
+  order by d.created_at asc
+  limit 1;
+
+  if v_manual_document.id is null then
+    insert into public.documents (
+      project_id,
+      filename,
+      original_filename,
+      mime_type,
+      storage_bucket,
+      storage_path,
+      upload_status,
+      document_kind
+    )
+    values (
+      v_project.id,
+      'manual-subjects-system.json',
+      'manual-subjects-system.json',
+      'application/json',
+      'documents',
+      v_document_storage_path,
+      'uploaded',
+      'manual_subjects_system'
+    )
+    returning * into v_manual_document;
+  end if;
+
+  select *
+    into v_manual_analysis_run
+  from public.analysis_runs ar
+  where ar.project_id = v_project.id
+    and ar.document_id = v_manual_document.id
+    and ar.trigger_source = 'manual_subjects_system'
+  order by ar.created_at desc
+  limit 1;
+
+  if v_manual_analysis_run.id is null then
+    insert into public.analysis_runs (
+      project_id,
+      document_id,
+      status,
+      trigger_source,
+      started_at,
+      finished_at
+    )
+    values (
+      v_project.id,
+      v_manual_document.id,
+      'succeeded',
+      'manual_subjects_system',
+      now(),
+      now()
+    )
+    returning * into v_manual_analysis_run;
+  end if;
+
+  insert into public.subjects (
+    project_id,
+    document_id,
+    analysis_run_id,
+    subject_type,
+    title,
+    normalized_title,
+    priority,
+    status
+  )
+  values (
+    v_project.id,
+    v_manual_document.id,
+    v_manual_analysis_run.id,
+    v_subject_type,
+    v_title,
+    v_title,
+    'medium',
+    'open'
+  )
+  returning * into v_subject;
+
+  select coalesce(
+    nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),
+    nullif(trim(coalesce(dp.email, '')), ''),
+    'Utilisateur'
+  )
+    into v_actor_label
+  from public.directory_people dp
+  where dp.id = v_person_id;
+
+  v_result_label := format('a créé le sujet « %s »', v_title);
+
+  insert into public.subject_history (
+    project_id,
+    subject_id,
+    analysis_run_id,
+    document_id,
+    subject_observation_id,
+    event_type,
+    actor_type,
+    actor_label,
+    actor_user_id,
+    title,
+    description,
+    event_payload
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    v_subject.analysis_run_id,
+    v_subject.document_id,
+    null,
+    'subject_created',
+    'user',
+    coalesce(v_actor_label, 'Utilisateur'),
+    auth.uid(),
+    'Sujet créé',
+    v_result_label,
+    jsonb_build_object(
+      'action', 'created',
+      'field', 'subject',
+      'before', '{}'::jsonb,
+      'after', jsonb_build_object(
+        'id', v_subject.id,
+        'subject_number', v_subject.subject_number,
+        'title', coalesce(v_subject.title, ''),
+        'status', coalesce(v_subject.status, ''),
+        'priority', coalesce(v_subject.priority, ''),
+        'subject_type', coalesce(v_subject.subject_type, '')
+      ),
+      'delta', jsonb_build_object('created', true),
+      'result_label', v_result_label,
+      'display', jsonb_build_object('result_label', v_result_label),
+      'actor_person_id', v_person_id
+    )
+  );
+
+  return query
+  select
+    v_subject.id,
+    v_subject.project_id,
+    v_subject.title,
+    v_subject.status,
+    v_subject.priority,
+    v_subject.created_at,
+    v_subject.updated_at,
+    v_subject.subject_number;
+end;
+$$;
+
+grant execute on function public.create_manual_subject(uuid, text, uuid, text) to authenticated;
+revoke all on function public.create_manual_subject(uuid, text, uuid, text) from public;
+
+comment on function public.create_manual_subject(uuid, text, uuid, text) is
+  'Creates a manual subject with per-project system document/analysis_run compatibility records, then appends business history event.';


### PR DESCRIPTION
### Motivation
- Provide a supported flow to create manual subjects persisted to the backend (instead of only client-local drafts) and capture business history.
- Ensure created subjects are properly initialized with project/system document/analysis_run links and metadata and are editable immediately from the UI.
- Prevent double-submits and surface submission state in the create-subject UI.

### Description
- Added a new Postgres RPC `create_manual_subject` (migration `202606150030_create_manual_subject_rpc.sql`) which validates access, ensures per-project system `documents` / `analysis_runs` exist, inserts a `subjects` row, appends a `subject_history` entry, and returns the created subject row.
- Implemented `createManualSubject` in `apps/web/js/services/project-subjects-supabase.js` which calls the RPC, normalizes/validates inputs, resolves the current actor person id, and returns a normalized subject object; errors are surfaced with localized messages.
- Integrated the new service into the UI stack by wiring `createManualSubject` into `project-subjects-view.js` and exported via the view's API surface; added mappings for `replaceSubject*` and `updateSubjectDescription` helpers used after creation.
- Reworked client create flow in `project-subjects-view.js`, `project-subjects-actions.js`, `project-subjects-events.js`, and `project-subjects-state.js` to: mark `createSubjectForm.isSubmitting` to prevent duplicate submits, perform async creation via `createManualSubject`, then call `replaceSubjectAssigneesInSupabase`, `replaceSubjectLabelsInSupabase`, `replaceSubjectSituationsInSupabase`, `replaceSubjectObjectivesInSupabase`, and `updateSubjectDescriptionInSupabase` as needed, reload subjects from Supabase, and select the newly created subject in the UI.
- Added client-side helpers: `resolveDraftLabelIds` for mapping draft labels to label IDs and various guards to bypass server calls for the draft subject id (`DRAFT_SUBJECT_ID`); updated some UI copy and submit button states to reflect French localization and in-flight state.

### Testing
- Ran frontend lint and the JS test suite locally; tests and linting passed.
- Performed a local dev build and exercised the create-subject flow against a development Supabase instance with the migration applied, validating subject creation, metadata linking, and UI selection (manual verification automated steps not included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86d48641483299aa647aed7c0676c)