### PR TITLE
feat(subjects): complete step 3 create-subject composer integration

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -860,7 +860,8 @@ const projectSubjectsView = createProjectSubjectsView({
   replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
   replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
   replaceSubjectObjectivesInSupabase: (...args) => replaceSubjectObjectivesInSupabase(...args),
-  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args)
+  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args),
+  uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1007,6 +1007,7 @@ export function createProjectSubjectsEvents(config) {
       if (composerKey === "reply" && messageId) return `[data-thread-reply-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "edit" && messageId) return `[data-thread-edit-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "description" && messageId) return `[data-description-draft="${selectorValue(messageId)}"]`;
+      if (composerKey === "create-subject") return "[data-create-subject-description]";
       return "";
     };
 
@@ -3895,6 +3896,80 @@ export function createProjectSubjectsEvents(config) {
       textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
     });
 
+    root.querySelectorAll("[data-create-subject-description]").forEach((textarea) => {
+      bindComposerAutosizeLifecycle(textarea);
+      scheduleAutosizeAfterVisibility(textarea, "create-subject-bind");
+      textarea.addEventListener("keydown", (event) => {
+        const composerKey = "create-subject";
+        const mentionState = getMentionState();
+        const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
+        if (event.key === "Escape") {
+          if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeMentionPopup({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (emojiState.open && String(emojiState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeEmojiPopup({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeSubjectRefPopup();
+            return;
+          }
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+          event.preventDefault();
+          const delta = event.key === "ArrowDown" ? 1 : -1;
+          mentionState.activeIndex = (Number(mentionState.activeIndex || 0) + delta + mentionState.suggestions.length) % mentionState.suggestions.length;
+          rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+          return;
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length && event.key === "Enter") {
+          event.preventDefault();
+          pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0], composerKey);
+          return;
+        }
+        if (emojiState.open && String(emojiState.composerKey || "") === composerKey && Array.isArray(emojiState.suggestions) && emojiState.suggestions.length) {
+          if (event.key === "ArrowDown") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) + EMOJI_GRID_COLUMNS) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowUp") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) - EMOJI_GRID_COLUMNS + emojiState.suggestions.length) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowRight") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) + 1) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowLeft") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) - 1 + emojiState.suggestions.length) % emojiState.suggestions.length; }
+          else if (event.key === "Enter") {
+            event.preventDefault();
+            const result = applyInlineEmojiSuggestion(textarea, emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
+            store.situationsView.createSubjectForm.description = String(result.nextText || "");
+            scheduleAutosizeAfterRender(textarea, "create-subject-emoji");
+          } else {
+            return;
+          }
+          rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+          return;
+        }
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey && Array.isArray(subjectRefState.suggestions) && subjectRefState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            subjectRefState.activeIndex = (Number(subjectRefState.activeIndex || 0) + delta + subjectRefState.suggestions.length) % subjectRefState.suggestions.length;
+            rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickSubjectRefSuggestion(subjectRefState.suggestions[Number(subjectRefState.activeIndex || 0)] || subjectRefState.suggestions[0], composerKey);
+            return;
+          }
+        }
+        if (CARET_NAVIGATION_KEYS.has(event.key)) requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
+      });
+      textarea.addEventListener("click", () => { void syncInlineAutocomplete(textarea, "create-subject"); });
+      textarea.addEventListener("keyup", () => { void syncInlineAutocomplete(textarea, "create-subject"); });
+      textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
+    });
+
     root.querySelectorAll("[data-action='thread-reply-tab-write']").forEach((btn) => {
       btn.onclick = () => {
         const messageId = String(btn.closest("[data-inline-reply-editor]")?.dataset.inlineReplyEditor || "").trim();
@@ -4162,13 +4237,34 @@ export function createProjectSubjectsEvents(config) {
       };
     });
     root.querySelectorAll("[data-role='create-subject-file-input']").forEach((input) => {
+      const toObjectUrl = (file) => {
+        try {
+          return file && window?.URL?.createObjectURL ? String(window.URL.createObjectURL(file)) : "";
+        } catch {
+          return "";
+        }
+      };
       const appendFiles = (files = []) => {
         if (!store.situationsView.createSubjectForm?.isOpen) return;
         const existing = Array.isArray(store.situationsView.createSubjectForm.attachments) ? store.situationsView.createSubjectForm.attachments : [];
-        const next = files.map((file) => ({
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          name: String(file?.name || "Pièce jointe")
-        }));
+        const next = files
+          .filter((file) => file instanceof File || file instanceof Blob)
+          .map((file) => {
+            const localPreviewUrl = String(file?.type || "").toLowerCase().startsWith("image/") ? toObjectUrl(file) : "";
+            return {
+              id: "",
+              tempId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              file,
+              file_name: String(file?.name || "Pièce jointe"),
+              mime_type: String(file?.type || ""),
+              size_bytes: Number(file?.size || 0),
+              isImage: String(file?.type || "").toLowerCase().startsWith("image/"),
+              localPreviewUrl,
+              previewUrl: localPreviewUrl,
+              uploadStatus: "draft",
+              error: ""
+            };
+          });
         store.situationsView.createSubjectForm.attachments = [...existing, ...next];
         rerenderPanels();
       };
@@ -4198,6 +4294,25 @@ export function createProjectSubjectsEvents(config) {
         const files = Array.from(event?.dataTransfer?.files || []);
         if (files.length) appendFiles(files);
       });
+    });
+    root.querySelectorAll("[data-action='create-subject-attachment-remove']").forEach((btn) => {
+      btn.onclick = () => {
+        if (!store.situationsView.createSubjectForm?.isOpen) return;
+        const attachmentId = String(btn.dataset.attachmentId || "").trim();
+        const tempId = String(btn.dataset.tempId || "").trim();
+        const attachments = Array.isArray(store.situationsView.createSubjectForm.attachments)
+          ? store.situationsView.createSubjectForm.attachments
+          : [];
+        const index = attachments.findIndex((entry) => String(entry?.id || "") === attachmentId || String(entry?.tempId || "") === tempId);
+        if (index < 0) return;
+        const [removed] = attachments.splice(index, 1);
+        try {
+          if (removed?.localPreviewUrl && window?.URL?.revokeObjectURL) {
+            window.URL.revokeObjectURL(String(removed.localPreviewUrl));
+          }
+        } catch {}
+        rerenderPanels();
+      };
     });
     root.querySelectorAll("[data-action='description-attachments-pick']").forEach((btn) => {
       btn.onclick = () => {
@@ -5081,6 +5196,8 @@ export function createProjectSubjectsEvents(config) {
       const createSubjectDescription = event.target.closest?.("[data-create-subject-description]");
       if (createSubjectDescription && store.situationsView.createSubjectForm?.isOpen) {
         store.situationsView.createSubjectForm.description = String(createSubjectDescription.value || "");
+        runAutosize(createSubjectDescription, "create-subject-input");
+        void syncInlineAutocomplete(createSubjectDescription, "create-subject");
         if (store.situationsView.createSubjectForm.previewMode) rerenderPanels();
         return;
       }

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -227,10 +227,12 @@ export function createProjectSubjectsState({ store }) {
         },
         validationError: "",
         isSubmitting: false,
+        uploadSessionId: "",
         attachments: []
       };
     }
     if (typeof v.createSubjectForm.isSubmitting !== "boolean") v.createSubjectForm.isSubmitting = false;
+    if (typeof v.createSubjectForm.uploadSessionId !== "string") v.createSubjectForm.uploadSessionId = "";
     if (!Array.isArray(v.createSubjectForm.attachments)) v.createSubjectForm.attachments = [];
     return v;
   }

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -95,7 +95,8 @@ export function createProjectSubjectsView(deps) {
     replaceSubjectLabelsInSupabase,
     replaceSubjectSituationsInSupabase,
     replaceSubjectObjectivesInSupabase,
-    updateSubjectDescriptionInSupabase
+    updateSubjectDescriptionInSupabase,
+    uploadAttachmentFile
   } = deps;
 
   const {
@@ -432,6 +433,42 @@ function getDraftSubjectSelection() {
   };
 }
 
+function createSubjectUploadSessionId() {
+  try {
+    if (window?.crypto?.randomUUID) return String(window.crypto.randomUUID());
+  } catch {}
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function revokeObjectUrl(url = "") {
+  try {
+    if (url && window?.URL?.revokeObjectURL) window.URL.revokeObjectURL(url);
+  } catch {}
+}
+
+function normalizeCreateSubjectDraftAttachments(attachments = []) {
+  return (Array.isArray(attachments) ? attachments : []).map((attachment, index) => ({
+    id: String(attachment?.id || ""),
+    tempId: String(attachment?.tempId || `${Date.now()}-${index}-${Math.random().toString(16).slice(2)}`),
+    file: attachment?.file || null,
+    file_name: String(attachment?.file_name || attachment?.name || attachment?.fileName || "Pièce jointe"),
+    mime_type: String(attachment?.mime_type || attachment?.mimeType || attachment?.file?.type || ""),
+    size_bytes: Number(attachment?.size_bytes || attachment?.sizeBytes || attachment?.file?.size || 0) || 0,
+    isImage: Boolean(attachment?.isImage || String(attachment?.mime_type || attachment?.mimeType || attachment?.file?.type || "").toLowerCase().startsWith("image/")),
+    localPreviewUrl: String(attachment?.localPreviewUrl || ""),
+    remoteObjectUrl: String(attachment?.remoteObjectUrl || attachment?.object_url || ""),
+    previewUrl: String(attachment?.previewUrl || attachment?.localPreviewUrl || attachment?.remoteObjectUrl || attachment?.object_url || ""),
+    uploadStatus: String(attachment?.uploadStatus || "draft"),
+    error: String(attachment?.error || "")
+  }));
+}
+
+function clearCreateSubjectDraftAttachments(attachments = []) {
+  normalizeCreateSubjectDraftAttachments(attachments).forEach((attachment) => {
+    revokeObjectUrl(String(attachment?.localPreviewUrl || ""));
+  });
+}
+
 function buildDefaultDraftSubjectMeta() {
   const selectedSituationId = String(
     ""
@@ -449,6 +486,7 @@ function resetCreateSubjectForm(options = {}) {
   ensureViewUiState();
   const keepCreateMore = !!options.keepCreateMore;
   const previous = store.situationsView.createSubjectForm || {};
+  clearCreateSubjectDraftAttachments(previous.attachments);
   store.situationsView.createSubjectForm = {
     isOpen: false,
     title: "",
@@ -458,7 +496,7 @@ function resetCreateSubjectForm(options = {}) {
     meta: buildDefaultDraftSubjectMeta(),
     validationError: "",
     isSubmitting: false,
-    attachments: [],
+    uploadSessionId: "",
     attachments: []
   };
 }
@@ -479,7 +517,9 @@ function openCreateSubjectForm() {
     createMore: previousCreateMore,
     meta: buildDefaultDraftSubjectMeta(),
     validationError: "",
-    isSubmitting: false
+    isSubmitting: false,
+    uploadSessionId: "",
+    attachments: []
   };
 }
 
@@ -541,6 +581,7 @@ async function createSubjectFromDraft() {
   };
 
   const description = String(formState.description || "").trim();
+  const draftAttachments = normalizeCreateSubjectDraftAttachments(formState.attachments);
 
   store.situationsView.createSubjectForm.validationError = "";
   store.situationsView.createSubjectForm.isSubmitting = true;
@@ -573,10 +614,31 @@ async function createSubjectFromDraft() {
       await replaceSubjectObjectivesInSupabase(subjectId, nextMeta.objectiveIds);
     }
 
-    if (description) {
+    const hasDraftAttachments = draftAttachments.length > 0;
+    let uploadSessionId = String(formState.uploadSessionId || "").trim();
+    if (hasDraftAttachments && !uploadSessionId) {
+      uploadSessionId = createSubjectUploadSessionId();
+      store.situationsView.createSubjectForm.uploadSessionId = uploadSessionId;
+    }
+
+    if (hasDraftAttachments) {
+      for (let index = 0; index < draftAttachments.length; index += 1) {
+        const attachment = draftAttachments[index];
+        if (!(attachment?.file instanceof Blob)) continue;
+        await uploadAttachmentFile({
+          subjectId,
+          uploadSessionId,
+          file: attachment.file,
+          sortOrder: index
+        });
+      }
+    }
+
+    if (description || uploadSessionId) {
       await updateSubjectDescriptionInSupabase({
         subjectId,
-        description
+        description,
+        uploadSessionId
       });
     }
 
@@ -2914,7 +2976,12 @@ function renderCreateSubjectFormHtml() {
               footerHtml: `
                 <input type="file" class="subject-composer-file-input" data-role="create-subject-file-input" multiple />
                 <div class="subject-composer-attachments-preview ${(Array.isArray(form.attachments) && form.attachments.length) ? "" : "hidden"}" data-role="create-subject-attachments-preview" aria-live="polite">
-                  ${Array.isArray(form.attachments) ? form.attachments.map((attachment) => `<div class="subject-attachment-tile"><span class="subject-attachment__name">${escapeHtml(String(attachment?.name || "Pièce jointe"))}</span></div>`).join("") : ""}
+                  ${renderSubjectAttachmentsPreviewList({
+                    attachments: normalizeCreateSubjectDraftAttachments(form.attachments),
+                    removeAction: "create-subject-attachment-remove",
+                    escapeHtml,
+                    svgIcon
+                  })}
                 </div>
               `
             })}


### PR DESCRIPTION
### Motivation
- Remplacer l’éditeur simplifié du formulaire de création par le vrai composer mutualisé et supporter les pièces jointes en draft sans créer de sujet fantôme en base.
- Gérer proprement les fichiers en local (preview, suppression, drag & drop) puis les uploader seulement après la création réelle du sujet pour réutiliser le pipeline existant.

### Description
- Ajout d’un état `uploadSessionId` et d’une gestion d’attachements draft dans le store et initialisation sécurisée dans `createProjectSubjectsState` et le formulaire de création (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-state.js`).
- Introduit des helpers pour normaliser/vider les attachments draft (`normalizeCreateSubjectDraftAttachments`, `clearCreateSubjectDraftAttachments`, `createSubjectUploadSessionId`, `revokeObjectUrl`) et nettoyage des object URLs au reset du formulaire (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-view.js`).
- Branché `uploadAttachmentFile` dans le graphe de dépendances de la vue (`apps/web/js/views/project-subjects.js`) et utilisé le service existant pour uploader les fichiers draft après que `createManualSubject(...)` a renvoyé l’`id` du sujet (fichiers modifiés : `apps/web/js/views/project-subjects.js`, `apps/web/js/views/project-subjects/project-subjects-view.js`).
- Pendant la création, les attachments draft sont uploadés puis la description est persistée via `updateSubjectDescription(..., uploadSessionId)` pour lier les pièces jointes, puis on recharge les sujets existants (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-view.js`).
- Mutualisation du rendu des previews d’attachements via `renderSubjectAttachmentsPreviewList(...)` et gestion complète de l’UI (pick file, drag/drop, suppression locale) pour le create form (fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-view.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Activé le routage autocomplete pour le composer de création (`composerKey = "create-subject"`) en réutilisant les logiques existantes `:`, `#`, `@` avec navigation clavier cohérente et positionnement des popups (fichier modifié : `apps/web/js/views/project-subjects/project-subjects-events.js`).

### Testing
- Vérification de syntaxe JS via `node --check` sur les fichiers impactés: `apps/web/js/views/project-subjects/project-subjects-view.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/project-subjects/project-subjects-state.js` et `apps/web/js/views/project-subjects.js`, tous passés avec succès.
- Changements committés (`feat(subjects): wire create-form composer attachments and autocomplete`) et PR préparée; aucune suite de tests unitaires additionnelle n’a été exécutée dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8864ca798832995515213533e1f24)