### PR TITLE
Support file attachments in Create Subject flow (preview, upload session, drag/drop)

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -860,7 +860,8 @@ const projectSubjectsView = createProjectSubjectsView({
   replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
   replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
   replaceSubjectObjectivesInSupabase: (...args) => replaceSubjectObjectivesInSupabase(...args),
-  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args)
+  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args),
+  uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1007,6 +1007,7 @@ export function createProjectSubjectsEvents(config) {
       if (composerKey === "reply" && messageId) return `[data-thread-reply-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "edit" && messageId) return `[data-thread-edit-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "description" && messageId) return `[data-description-draft="${selectorValue(messageId)}"]`;
+      if (composerKey === "create-subject") return "[data-create-subject-description]";
       return "";
     };
 
@@ -3895,6 +3896,80 @@ export function createProjectSubjectsEvents(config) {
       textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
     });
 
+    root.querySelectorAll("[data-create-subject-description]").forEach((textarea) => {
+      bindComposerAutosizeLifecycle(textarea);
+      scheduleAutosizeAfterVisibility(textarea, "create-subject-bind");
+      textarea.addEventListener("keydown", (event) => {
+        const composerKey = "create-subject";
+        const mentionState = getMentionState();
+        const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
+        if (event.key === "Escape") {
+          if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeMentionPopup({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (emojiState.open && String(emojiState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeEmojiPopup({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeSubjectRefPopup();
+            return;
+          }
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+          event.preventDefault();
+          const delta = event.key === "ArrowDown" ? 1 : -1;
+          mentionState.activeIndex = (Number(mentionState.activeIndex || 0) + delta + mentionState.suggestions.length) % mentionState.suggestions.length;
+          rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+          return;
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length && event.key === "Enter") {
+          event.preventDefault();
+          pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0], composerKey);
+          return;
+        }
+        if (emojiState.open && String(emojiState.composerKey || "") === composerKey && Array.isArray(emojiState.suggestions) && emojiState.suggestions.length) {
+          if (event.key === "ArrowDown") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) + EMOJI_GRID_COLUMNS) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowUp") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) - EMOJI_GRID_COLUMNS + emojiState.suggestions.length) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowRight") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) + 1) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowLeft") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) - 1 + emojiState.suggestions.length) % emojiState.suggestions.length; }
+          else if (event.key === "Enter") {
+            event.preventDefault();
+            const result = applyInlineEmojiSuggestion(textarea, emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
+            store.situationsView.createSubjectForm.description = String(result.nextText || "");
+            scheduleAutosizeAfterRender(textarea, "create-subject-emoji");
+          } else {
+            return;
+          }
+          rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+          return;
+        }
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey && Array.isArray(subjectRefState.suggestions) && subjectRefState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            subjectRefState.activeIndex = (Number(subjectRefState.activeIndex || 0) + delta + subjectRefState.suggestions.length) % subjectRefState.suggestions.length;
+            rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickSubjectRefSuggestion(subjectRefState.suggestions[Number(subjectRefState.activeIndex || 0)] || subjectRefState.suggestions[0], composerKey);
+            return;
+          }
+        }
+        if (CARET_NAVIGATION_KEYS.has(event.key)) requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
+      });
+      textarea.addEventListener("click", () => { void syncInlineAutocomplete(textarea, "create-subject"); });
+      textarea.addEventListener("keyup", () => { void syncInlineAutocomplete(textarea, "create-subject"); });
+      textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
+    });
+
     root.querySelectorAll("[data-action='thread-reply-tab-write']").forEach((btn) => {
       btn.onclick = () => {
         const messageId = String(btn.closest("[data-inline-reply-editor]")?.dataset.inlineReplyEditor || "").trim();
@@ -4162,13 +4237,34 @@ export function createProjectSubjectsEvents(config) {
       };
     });
     root.querySelectorAll("[data-role='create-subject-file-input']").forEach((input) => {
+      const toObjectUrl = (file) => {
+        try {
+          return file && window?.URL?.createObjectURL ? String(window.URL.createObjectURL(file)) : "";
+        } catch {
+          return "";
+        }
+      };
       const appendFiles = (files = []) => {
         if (!store.situationsView.createSubjectForm?.isOpen) return;
         const existing = Array.isArray(store.situationsView.createSubjectForm.attachments) ? store.situationsView.createSubjectForm.attachments : [];
-        const next = files.map((file) => ({
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          name: String(file?.name || "Pièce jointe")
-        }));
+        const next = files
+          .filter((file) => file instanceof File || file instanceof Blob)
+          .map((file) => {
+            const localPreviewUrl = String(file?.type || "").toLowerCase().startsWith("image/") ? toObjectUrl(file) : "";
+            return {
+              id: "",
+              tempId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              file,
+              file_name: String(file?.name || "Pièce jointe"),
+              mime_type: String(file?.type || ""),
+              size_bytes: Number(file?.size || 0),
+              isImage: String(file?.type || "").toLowerCase().startsWith("image/"),
+              localPreviewUrl,
+              previewUrl: localPreviewUrl,
+              uploadStatus: "draft",
+              error: ""
+            };
+          });
         store.situationsView.createSubjectForm.attachments = [...existing, ...next];
         rerenderPanels();
       };
@@ -4198,6 +4294,25 @@ export function createProjectSubjectsEvents(config) {
         const files = Array.from(event?.dataTransfer?.files || []);
         if (files.length) appendFiles(files);
       });
+    });
+    root.querySelectorAll("[data-action='create-subject-attachment-remove']").forEach((btn) => {
+      btn.onclick = () => {
+        if (!store.situationsView.createSubjectForm?.isOpen) return;
+        const attachmentId = String(btn.dataset.attachmentId || "").trim();
+        const tempId = String(btn.dataset.tempId || "").trim();
+        const attachments = Array.isArray(store.situationsView.createSubjectForm.attachments)
+          ? store.situationsView.createSubjectForm.attachments
+          : [];
+        const index = attachments.findIndex((entry) => String(entry?.id || "") === attachmentId || String(entry?.tempId || "") === tempId);
+        if (index < 0) return;
+        const [removed] = attachments.splice(index, 1);
+        try {
+          if (removed?.localPreviewUrl && window?.URL?.revokeObjectURL) {
+            window.URL.revokeObjectURL(String(removed.localPreviewUrl));
+          }
+        } catch {}
+        rerenderPanels();
+      };
     });
     root.querySelectorAll("[data-action='description-attachments-pick']").forEach((btn) => {
       btn.onclick = () => {
@@ -5081,6 +5196,8 @@ export function createProjectSubjectsEvents(config) {
       const createSubjectDescription = event.target.closest?.("[data-create-subject-description]");
       if (createSubjectDescription && store.situationsView.createSubjectForm?.isOpen) {
         store.situationsView.createSubjectForm.description = String(createSubjectDescription.value || "");
+        runAutosize(createSubjectDescription, "create-subject-input");
+        void syncInlineAutocomplete(createSubjectDescription, "create-subject");
         if (store.situationsView.createSubjectForm.previewMode) rerenderPanels();
         return;
       }

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -227,10 +227,12 @@ export function createProjectSubjectsState({ store }) {
         },
         validationError: "",
         isSubmitting: false,
+        uploadSessionId: "",
         attachments: []
       };
     }
     if (typeof v.createSubjectForm.isSubmitting !== "boolean") v.createSubjectForm.isSubmitting = false;
+    if (typeof v.createSubjectForm.uploadSessionId !== "string") v.createSubjectForm.uploadSessionId = "";
     if (!Array.isArray(v.createSubjectForm.attachments)) v.createSubjectForm.attachments = [];
     return v;
   }

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -16,6 +16,7 @@ import {
 import { extractStructuredMentions } from "../../utils/subject-mentions.js";
 import { renderCommentComposer } from "../ui/comment-composer.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+import { renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 export function createProjectSubjectsView(deps) {
   const {
     store,
@@ -95,7 +96,8 @@ export function createProjectSubjectsView(deps) {
     replaceSubjectLabelsInSupabase,
     replaceSubjectSituationsInSupabase,
     replaceSubjectObjectivesInSupabase,
-    updateSubjectDescriptionInSupabase
+    updateSubjectDescriptionInSupabase,
+    uploadAttachmentFile
   } = deps;
 
   const {
@@ -432,6 +434,42 @@ function getDraftSubjectSelection() {
   };
 }
 
+function createSubjectUploadSessionId() {
+  try {
+    if (window?.crypto?.randomUUID) return String(window.crypto.randomUUID());
+  } catch {}
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function revokeObjectUrl(url = "") {
+  try {
+    if (url && window?.URL?.revokeObjectURL) window.URL.revokeObjectURL(url);
+  } catch {}
+}
+
+function normalizeCreateSubjectDraftAttachments(attachments = []) {
+  return (Array.isArray(attachments) ? attachments : []).map((attachment, index) => ({
+    id: String(attachment?.id || ""),
+    tempId: String(attachment?.tempId || `${Date.now()}-${index}-${Math.random().toString(16).slice(2)}`),
+    file: attachment?.file || null,
+    file_name: String(attachment?.file_name || attachment?.name || attachment?.fileName || "Pièce jointe"),
+    mime_type: String(attachment?.mime_type || attachment?.mimeType || attachment?.file?.type || ""),
+    size_bytes: Number(attachment?.size_bytes || attachment?.sizeBytes || attachment?.file?.size || 0) || 0,
+    isImage: Boolean(attachment?.isImage || String(attachment?.mime_type || attachment?.mimeType || attachment?.file?.type || "").toLowerCase().startsWith("image/")),
+    localPreviewUrl: String(attachment?.localPreviewUrl || ""),
+    remoteObjectUrl: String(attachment?.remoteObjectUrl || attachment?.object_url || ""),
+    previewUrl: String(attachment?.previewUrl || attachment?.localPreviewUrl || attachment?.remoteObjectUrl || attachment?.object_url || ""),
+    uploadStatus: String(attachment?.uploadStatus || "draft"),
+    error: String(attachment?.error || "")
+  }));
+}
+
+function clearCreateSubjectDraftAttachments(attachments = []) {
+  normalizeCreateSubjectDraftAttachments(attachments).forEach((attachment) => {
+    revokeObjectUrl(String(attachment?.localPreviewUrl || ""));
+  });
+}
+
 function buildDefaultDraftSubjectMeta() {
   const selectedSituationId = String(
     ""
@@ -449,6 +487,7 @@ function resetCreateSubjectForm(options = {}) {
   ensureViewUiState();
   const keepCreateMore = !!options.keepCreateMore;
   const previous = store.situationsView.createSubjectForm || {};
+  clearCreateSubjectDraftAttachments(previous.attachments);
   store.situationsView.createSubjectForm = {
     isOpen: false,
     title: "",
@@ -458,7 +497,7 @@ function resetCreateSubjectForm(options = {}) {
     meta: buildDefaultDraftSubjectMeta(),
     validationError: "",
     isSubmitting: false,
-    attachments: [],
+    uploadSessionId: "",
     attachments: []
   };
 }
@@ -479,7 +518,9 @@ function openCreateSubjectForm() {
     createMore: previousCreateMore,
     meta: buildDefaultDraftSubjectMeta(),
     validationError: "",
-    isSubmitting: false
+    isSubmitting: false,
+    uploadSessionId: "",
+    attachments: []
   };
 }
 
@@ -541,6 +582,7 @@ async function createSubjectFromDraft() {
   };
 
   const description = String(formState.description || "").trim();
+  const draftAttachments = normalizeCreateSubjectDraftAttachments(formState.attachments);
 
   store.situationsView.createSubjectForm.validationError = "";
   store.situationsView.createSubjectForm.isSubmitting = true;
@@ -573,10 +615,31 @@ async function createSubjectFromDraft() {
       await replaceSubjectObjectivesInSupabase(subjectId, nextMeta.objectiveIds);
     }
 
-    if (description) {
+    const hasDraftAttachments = draftAttachments.length > 0;
+    let uploadSessionId = String(formState.uploadSessionId || "").trim();
+    if (hasDraftAttachments && !uploadSessionId) {
+      uploadSessionId = createSubjectUploadSessionId();
+      store.situationsView.createSubjectForm.uploadSessionId = uploadSessionId;
+    }
+
+    if (hasDraftAttachments) {
+      for (let index = 0; index < draftAttachments.length; index += 1) {
+        const attachment = draftAttachments[index];
+        if (!(attachment?.file instanceof Blob)) continue;
+        await uploadAttachmentFile({
+          subjectId,
+          uploadSessionId,
+          file: attachment.file,
+          sortOrder: index
+        });
+      }
+    }
+
+    if (description || uploadSessionId) {
       await updateSubjectDescriptionInSupabase({
         subjectId,
-        description
+        description,
+        uploadSessionId
       });
     }
 
@@ -2914,7 +2977,12 @@ function renderCreateSubjectFormHtml() {
               footerHtml: `
                 <input type="file" class="subject-composer-file-input" data-role="create-subject-file-input" multiple />
                 <div class="subject-composer-attachments-preview ${(Array.isArray(form.attachments) && form.attachments.length) ? "" : "hidden"}" data-role="create-subject-attachments-preview" aria-live="polite">
-                  ${Array.isArray(form.attachments) ? form.attachments.map((attachment) => `<div class="subject-attachment-tile"><span class="subject-attachment__name">${escapeHtml(String(attachment?.name || "Pièce jointe"))}</span></div>`).join("") : ""}
+                  ${renderSubjectAttachmentsPreviewList({
+                    attachments: normalizeCreateSubjectDraftAttachments(form.attachments),
+                    removeAction: "create-subject-attachment-remove",
+                    escapeHtml,
+                    svgIcon
+                  })}
                 </div>
               `
             })}


### PR DESCRIPTION
### Motivation
- Enable users to attach files when creating a subject and ensure attachments are uploaded and associated with the created subject.
- Improve UX by adding local previews, drag-and-drop, and keyboard/autocomplete support for the create-subject composer.

### Description
- Added a new dependency mapping `uploadAttachmentFile` to the project subjects view and imported `renderSubjectAttachmentsPreviewList` for attachment previews in the composer.
- Extended state with `createSubjectForm.uploadSessionId` and richer `attachments` entries, plus helper functions `createSubjectUploadSessionId`, `normalizeCreateSubjectDraftAttachments`, `clearCreateSubjectDraftAttachments`, and `revokeObjectUrl` to manage draft attachments and local previews.
- Enhanced the `createSubjectFromDraft` flow to normalize draft attachments, generate an `uploadSessionId` when needed, call `uploadAttachmentFile` for each attachment, and include `uploadSessionId` when updating the subject description via `updateSubjectDescriptionInSupabase`.
- Added UI/event handling for the create-subject composer including autosize and inline-autocomplete binding, file input `change` handling, drag/drop support, preview rendering, and attachment removal (`create-subject-attachment-remove`).

### Testing
- Ran the project's JavaScript linter with `npm run lint` and the test suite with `npm test`; both completed successfully on the modified code.
- Verified that the create-subject composer accepts files via picker and drag/drop, renders local previews, and that attachments are uploaded as part of the create flow in manual testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8864ca798832995515213533e1f24)