### PR TITLE
Add attachment support and inline autocomplete bindings for Create Subject form

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -860,7 +860,8 @@ const projectSubjectsView = createProjectSubjectsView({
   replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
   replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
   replaceSubjectObjectivesInSupabase: (...args) => replaceSubjectObjectivesInSupabase(...args),
-  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args)
+  updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args),
+  uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args)
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1007,6 +1007,7 @@ export function createProjectSubjectsEvents(config) {
       if (composerKey === "reply" && messageId) return `[data-thread-reply-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "edit" && messageId) return `[data-thread-edit-draft="${selectorValue(messageId)}"]`;
       if (composerKey === "description" && messageId) return `[data-description-draft="${selectorValue(messageId)}"]`;
+      if (composerKey === "create-subject") return "[data-create-subject-description]";
       return "";
     };
 
@@ -3895,6 +3896,80 @@ export function createProjectSubjectsEvents(config) {
       textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
     });
 
+    root.querySelectorAll("[data-create-subject-description]").forEach((textarea) => {
+      bindComposerAutosizeLifecycle(textarea);
+      scheduleAutosizeAfterVisibility(textarea, "create-subject-bind");
+      textarea.addEventListener("keydown", (event) => {
+        const composerKey = "create-subject";
+        const mentionState = getMentionState();
+        const emojiState = getEmojiState();
+        const subjectRefState = getSubjectRefState();
+        if (event.key === "Escape") {
+          if (mentionState.open && String(mentionState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeMentionPopup({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (emojiState.open && String(emojiState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeEmojiPopup({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey) {
+            event.preventDefault();
+            closeSubjectRefPopup();
+            return;
+          }
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+          event.preventDefault();
+          const delta = event.key === "ArrowDown" ? 1 : -1;
+          mentionState.activeIndex = (Number(mentionState.activeIndex || 0) + delta + mentionState.suggestions.length) % mentionState.suggestions.length;
+          rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+          return;
+        }
+        if (mentionState.open && String(mentionState.composerKey || "") === composerKey && Array.isArray(mentionState.suggestions) && mentionState.suggestions.length && event.key === "Enter") {
+          event.preventDefault();
+          pickMentionSuggestion(mentionState.suggestions[Number(mentionState.activeIndex || 0)] || mentionState.suggestions[0], composerKey);
+          return;
+        }
+        if (emojiState.open && String(emojiState.composerKey || "") === composerKey && Array.isArray(emojiState.suggestions) && emojiState.suggestions.length) {
+          if (event.key === "ArrowDown") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) + EMOJI_GRID_COLUMNS) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowUp") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) - EMOJI_GRID_COLUMNS + emojiState.suggestions.length) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowRight") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) + 1) % emojiState.suggestions.length; }
+          else if (event.key === "ArrowLeft") { event.preventDefault(); emojiState.activeIndex = (Number(emojiState.activeIndex || 0) - 1 + emojiState.suggestions.length) % emojiState.suggestions.length; }
+          else if (event.key === "Enter") {
+            event.preventDefault();
+            const result = applyInlineEmojiSuggestion(textarea, emojiState.suggestions[Number(emojiState.activeIndex || 0)] || emojiState.suggestions[0]);
+            store.situationsView.createSubjectForm.description = String(result.nextText || "");
+            scheduleAutosizeAfterRender(textarea, "create-subject-emoji");
+          } else {
+            return;
+          }
+          rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+          return;
+        }
+        if (subjectRefState.open && String(subjectRefState.composerKey || "") === composerKey && Array.isArray(subjectRefState.suggestions) && subjectRefState.suggestions.length) {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            const delta = event.key === "ArrowDown" ? 1 : -1;
+            subjectRefState.activeIndex = (Number(subjectRefState.activeIndex || 0) + delta + subjectRefState.suggestions.length) % subjectRefState.suggestions.length;
+            rerenderAutocompleteUi({ selector: getTextareaSelector({ composerKey }), shouldFocus: true, caretStart: Number(textarea.selectionStart || 0), caretEnd: Number(textarea.selectionEnd || 0) });
+            return;
+          }
+          if (event.key === "Enter") {
+            event.preventDefault();
+            pickSubjectRefSuggestion(subjectRefState.suggestions[Number(subjectRefState.activeIndex || 0)] || subjectRefState.suggestions[0], composerKey);
+            return;
+          }
+        }
+        if (CARET_NAVIGATION_KEYS.has(event.key)) requestAnimationFrame(() => { void syncInlineAutocomplete(textarea, composerKey); });
+      });
+      textarea.addEventListener("click", () => { void syncInlineAutocomplete(textarea, "create-subject"); });
+      textarea.addEventListener("keyup", () => { void syncInlineAutocomplete(textarea, "create-subject"); });
+      textarea.addEventListener("scroll", () => positionAllAutocompletePopups());
+    });
+
     root.querySelectorAll("[data-action='thread-reply-tab-write']").forEach((btn) => {
       btn.onclick = () => {
         const messageId = String(btn.closest("[data-inline-reply-editor]")?.dataset.inlineReplyEditor || "").trim();
@@ -4162,13 +4237,34 @@ export function createProjectSubjectsEvents(config) {
       };
     });
     root.querySelectorAll("[data-role='create-subject-file-input']").forEach((input) => {
+      const toObjectUrl = (file) => {
+        try {
+          return file && window?.URL?.createObjectURL ? String(window.URL.createObjectURL(file)) : "";
+        } catch {
+          return "";
+        }
+      };
       const appendFiles = (files = []) => {
         if (!store.situationsView.createSubjectForm?.isOpen) return;
         const existing = Array.isArray(store.situationsView.createSubjectForm.attachments) ? store.situationsView.createSubjectForm.attachments : [];
-        const next = files.map((file) => ({
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          name: String(file?.name || "Pièce jointe")
-        }));
+        const next = files
+          .filter((file) => file instanceof File || file instanceof Blob)
+          .map((file) => {
+            const localPreviewUrl = String(file?.type || "").toLowerCase().startsWith("image/") ? toObjectUrl(file) : "";
+            return {
+              id: "",
+              tempId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+              file,
+              file_name: String(file?.name || "Pièce jointe"),
+              mime_type: String(file?.type || ""),
+              size_bytes: Number(file?.size || 0),
+              isImage: String(file?.type || "").toLowerCase().startsWith("image/"),
+              localPreviewUrl,
+              previewUrl: localPreviewUrl,
+              uploadStatus: "draft",
+              error: ""
+            };
+          });
         store.situationsView.createSubjectForm.attachments = [...existing, ...next];
         rerenderPanels();
       };
@@ -4198,6 +4294,25 @@ export function createProjectSubjectsEvents(config) {
         const files = Array.from(event?.dataTransfer?.files || []);
         if (files.length) appendFiles(files);
       });
+    });
+    root.querySelectorAll("[data-action='create-subject-attachment-remove']").forEach((btn) => {
+      btn.onclick = () => {
+        if (!store.situationsView.createSubjectForm?.isOpen) return;
+        const attachmentId = String(btn.dataset.attachmentId || "").trim();
+        const tempId = String(btn.dataset.tempId || "").trim();
+        const attachments = Array.isArray(store.situationsView.createSubjectForm.attachments)
+          ? store.situationsView.createSubjectForm.attachments
+          : [];
+        const index = attachments.findIndex((entry) => String(entry?.id || "") === attachmentId || String(entry?.tempId || "") === tempId);
+        if (index < 0) return;
+        const [removed] = attachments.splice(index, 1);
+        try {
+          if (removed?.localPreviewUrl && window?.URL?.revokeObjectURL) {
+            window.URL.revokeObjectURL(String(removed.localPreviewUrl));
+          }
+        } catch {}
+        rerenderPanels();
+      };
     });
     root.querySelectorAll("[data-action='description-attachments-pick']").forEach((btn) => {
       btn.onclick = () => {
@@ -4883,6 +4998,9 @@ export function createProjectSubjectsEvents(config) {
       if (createSubjectCancelButton && store.situationsView.createSubjectForm?.isOpen) {
         event.preventDefault();
         dropdownController().closeMeta();
+        closeMentionPopup({ rerender: false });
+        closeEmojiPopup({ rerender: false });
+        closeSubjectRefPopup({ rerender: false });
         resetCreateSubjectForm({ keepCreateMore: true });
         rerenderPanels();
         return;
@@ -5081,6 +5199,8 @@ export function createProjectSubjectsEvents(config) {
       const createSubjectDescription = event.target.closest?.("[data-create-subject-description]");
       if (createSubjectDescription && store.situationsView.createSubjectForm?.isOpen) {
         store.situationsView.createSubjectForm.description = String(createSubjectDescription.value || "");
+        runAutosize(createSubjectDescription, "create-subject-input");
+        void syncInlineAutocomplete(createSubjectDescription, "create-subject");
         if (store.situationsView.createSubjectForm.previewMode) rerenderPanels();
         return;
       }

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -227,10 +227,12 @@ export function createProjectSubjectsState({ store }) {
         },
         validationError: "",
         isSubmitting: false,
+        uploadSessionId: "",
         attachments: []
       };
     }
     if (typeof v.createSubjectForm.isSubmitting !== "boolean") v.createSubjectForm.isSubmitting = false;
+    if (typeof v.createSubjectForm.uploadSessionId !== "string") v.createSubjectForm.uploadSessionId = "";
     if (!Array.isArray(v.createSubjectForm.attachments)) v.createSubjectForm.attachments = [];
     return v;
   }

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -16,6 +16,7 @@ import {
 import { extractStructuredMentions } from "../../utils/subject-mentions.js";
 import { renderCommentComposer } from "../ui/comment-composer.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+import { renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 export function createProjectSubjectsView(deps) {
   const {
     store,
@@ -95,7 +96,8 @@ export function createProjectSubjectsView(deps) {
     replaceSubjectLabelsInSupabase,
     replaceSubjectSituationsInSupabase,
     replaceSubjectObjectivesInSupabase,
-    updateSubjectDescriptionInSupabase
+    updateSubjectDescriptionInSupabase,
+    uploadAttachmentFile
   } = deps;
 
   const {
@@ -432,6 +434,42 @@ function getDraftSubjectSelection() {
   };
 }
 
+function createSubjectUploadSessionId() {
+  try {
+    if (window?.crypto?.randomUUID) return String(window.crypto.randomUUID());
+  } catch {}
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function revokeObjectUrl(url = "") {
+  try {
+    if (url && window?.URL?.revokeObjectURL) window.URL.revokeObjectURL(url);
+  } catch {}
+}
+
+function normalizeCreateSubjectDraftAttachments(attachments = []) {
+  return (Array.isArray(attachments) ? attachments : []).map((attachment, index) => ({
+    id: String(attachment?.id || ""),
+    tempId: String(attachment?.tempId || `${Date.now()}-${index}-${Math.random().toString(16).slice(2)}`),
+    file: attachment?.file || null,
+    file_name: String(attachment?.file_name || attachment?.name || attachment?.fileName || "Pièce jointe"),
+    mime_type: String(attachment?.mime_type || attachment?.mimeType || attachment?.file?.type || ""),
+    size_bytes: Number(attachment?.size_bytes || attachment?.sizeBytes || attachment?.file?.size || 0) || 0,
+    isImage: Boolean(attachment?.isImage || String(attachment?.mime_type || attachment?.mimeType || attachment?.file?.type || "").toLowerCase().startsWith("image/")),
+    localPreviewUrl: String(attachment?.localPreviewUrl || ""),
+    remoteObjectUrl: String(attachment?.remoteObjectUrl || attachment?.object_url || ""),
+    previewUrl: String(attachment?.previewUrl || attachment?.localPreviewUrl || attachment?.remoteObjectUrl || attachment?.object_url || ""),
+    uploadStatus: String(attachment?.uploadStatus || "draft"),
+    error: String(attachment?.error || "")
+  }));
+}
+
+function clearCreateSubjectDraftAttachments(attachments = []) {
+  normalizeCreateSubjectDraftAttachments(attachments).forEach((attachment) => {
+    revokeObjectUrl(String(attachment?.localPreviewUrl || ""));
+  });
+}
+
 function buildDefaultDraftSubjectMeta() {
   const selectedSituationId = String(
     ""
@@ -449,6 +487,7 @@ function resetCreateSubjectForm(options = {}) {
   ensureViewUiState();
   const keepCreateMore = !!options.keepCreateMore;
   const previous = store.situationsView.createSubjectForm || {};
+  clearCreateSubjectDraftAttachments(previous.attachments);
   store.situationsView.createSubjectForm = {
     isOpen: false,
     title: "",
@@ -458,7 +497,7 @@ function resetCreateSubjectForm(options = {}) {
     meta: buildDefaultDraftSubjectMeta(),
     validationError: "",
     isSubmitting: false,
-    attachments: [],
+    uploadSessionId: "",
     attachments: []
   };
 }
@@ -479,7 +518,9 @@ function openCreateSubjectForm() {
     createMore: previousCreateMore,
     meta: buildDefaultDraftSubjectMeta(),
     validationError: "",
-    isSubmitting: false
+    isSubmitting: false,
+    uploadSessionId: "",
+    attachments: []
   };
 }
 
@@ -541,6 +582,7 @@ async function createSubjectFromDraft() {
   };
 
   const description = String(formState.description || "").trim();
+  const draftAttachments = normalizeCreateSubjectDraftAttachments(formState.attachments);
 
   store.situationsView.createSubjectForm.validationError = "";
   store.situationsView.createSubjectForm.isSubmitting = true;
@@ -573,10 +615,31 @@ async function createSubjectFromDraft() {
       await replaceSubjectObjectivesInSupabase(subjectId, nextMeta.objectiveIds);
     }
 
-    if (description) {
+    const hasDraftAttachments = draftAttachments.length > 0;
+    let uploadSessionId = String(formState.uploadSessionId || "").trim();
+    if (hasDraftAttachments && !uploadSessionId) {
+      uploadSessionId = createSubjectUploadSessionId();
+      store.situationsView.createSubjectForm.uploadSessionId = uploadSessionId;
+    }
+
+    if (hasDraftAttachments) {
+      for (let index = 0; index < draftAttachments.length; index += 1) {
+        const attachment = draftAttachments[index];
+        if (!(attachment?.file instanceof Blob)) continue;
+        await uploadAttachmentFile({
+          subjectId,
+          uploadSessionId,
+          file: attachment.file,
+          sortOrder: index
+        });
+      }
+    }
+
+    if (description || uploadSessionId) {
       await updateSubjectDescriptionInSupabase({
         subjectId,
-        description
+        description,
+        uploadSessionId
       });
     }
 
@@ -2037,7 +2100,7 @@ function renderSubjectMetaControls(subject) {
       })}
       ${renderSubjectMetaField({
         field: "situations",
-        label: "Situations",
+        label: "Situation",
         valueHtml: renderSubjectSituationsValue(subject.id)
       })}
       ${renderSubjectMetaField({
@@ -2860,7 +2923,7 @@ function renderCreateSubjectMetaControls() {
       })}
       ${renderSubjectMetaField({
         field: "situations",
-        label: "Situations",
+        label: "Situation",
         valueHtml: renderSubjectSituationsValue(subject.id)
       })}
       ${renderSubjectMetaField({
@@ -2882,17 +2945,17 @@ function renderCreateSubjectFormHtml() {
       <div class="subject-create-layout">
         <div class="subject-create-main">
           <div class="subject-create-header">
-            <img src="${escapeHtml(avatar)}" alt="Avatar" class="subject-create-header__avatar">
-            <div class="subject-create-header__title">Create new issue</div>
+            <img src="${escapeHtml(avatar)}" alt="Auteur" class="subject-create-header__avatar">
+            <div class="subject-create-header__title">Créer un nouveau sujet</div>
           </div>
 
           <label class="subject-create-field">
-            <span class="subject-create-field__label">Add a title <span class="subject-create-field__required">*</span></span>
-            <input type="text" class="subject-create-input" data-create-subject-title value="${escapeHtml(String(form.title || ""))}" placeholder="Title" autocomplete="off">
+            <span class="subject-create-field__label">Ajouter un titre<span class="subject-create-field__required">*</span></span>
+            <input type="text" class="subject-create-input" data-create-subject-title value="${escapeHtml(String(form.title || ""))}" placeholder="Titre du sujet" autocomplete="off">
           </label>
 
           <div class="subject-create-field subject-create-field--editor">
-            <div class="subject-create-field__label">Add a description</div>
+            <div class="subject-create-field__label">Ajouter une description</div>
             ${renderCommentComposer({
               hideAvatar: true,
               hideTitle: true,
@@ -2903,18 +2966,23 @@ function renderCreateSubjectFormHtml() {
               textareaAttributes: {
                 "data-create-subject-description": "true"
               },
-              placeholder: "Type your description here...",
+              placeholder: "Décrivez le sujet...",
               tabWriteAction: "create-subject-tab-write",
               tabPreviewAction: "create-subject-tab-preview",
               tabsClassName: "comment-composer__tabs--thread-reply",
               composerClassName: "comment-composer--thread-reply-editor",
               toolbarHtml: renderSubjectMarkdownToolbar({ buttonAction: "create-subject-format", svgIcon }),
               previewHtml: previewHtml || "",
-              previewEmptyHint: "Use Markdown to format your comment",
+              previewEmptyHint: "Utilisez Markdown pour formater votre description",
               footerHtml: `
                 <input type="file" class="subject-composer-file-input" data-role="create-subject-file-input" multiple />
                 <div class="subject-composer-attachments-preview ${(Array.isArray(form.attachments) && form.attachments.length) ? "" : "hidden"}" data-role="create-subject-attachments-preview" aria-live="polite">
-                  ${Array.isArray(form.attachments) ? form.attachments.map((attachment) => `<div class="subject-attachment-tile"><span class="subject-attachment__name">${escapeHtml(String(attachment?.name || "Pièce jointe"))}</span></div>`).join("") : ""}
+                  ${renderSubjectAttachmentsPreviewList({
+                    attachments: normalizeCreateSubjectDraftAttachments(form.attachments),
+                    removeAction: "create-subject-attachment-remove",
+                    escapeHtml,
+                    svgIcon
+                  })}
                 </div>
               `
             })}
@@ -2925,7 +2993,7 @@ function renderCreateSubjectFormHtml() {
             <div class="subject-create-footer__left">
               <label class="subject-create-checkbox">
                 <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
-                <span>En ajouter d'autres</span>
+                <span>En ajouter d’autres</span>
               </label>
             </div>
             <div class="subject-create-footer__right">


### PR DESCRIPTION
### Motivation
- Enable users to attach files when creating a new subject, show local previews for images, and upload attachments as part of subject creation.
- Improve the create-subject composer UX by wiring autocomplete/mention/emoji/subject-ref interactions and autosizing for the create form textarea.

### Description
- Add client-side attachment handling for the create subject flow including drag-and-drop, file input handling, temp attachment objects with `localPreviewUrl`, preview rendering and removal with safe `createObjectURL`/`revokeObjectURL` usage.
- Introduce `uploadSessionId` state and generation via `createSubjectUploadSessionId`, persist it to the create form state, and wire `uploadAttachmentFile` to perform per-file uploads before finalizing the subject description update.
- Normalize attachment data with `normalizeCreateSubjectDraftAttachments`, clear attachments on reset with `clearCreateSubjectDraftAttachments`, and integrate a new `renderSubjectAttachmentsPreviewList` into the create form UI for consistent preview markup.
- Wire create-subject composer interactions: autosize scheduling, inline autocomplete sync for mentions/emojis/subjectRefs, keyboard navigation and popup closing, preview mode toggles, and polish of labels/placeholders/localized strings.
- Update state defaults to include `uploadSessionId` and attachments arrays and ensure existing attachments are cleaned up when resetting the form.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8864ca798832995515213533e1f24)