### PR TITLE
Fix create-subject autosize ReferenceError and restore @ help autocomplete

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -112,6 +112,33 @@ export function createProjectSubjectsEvents(config) {
   let subjectsTabResetBound = false;
   let descriptionVersionsPositionBound = false;
 
+  function getTextareaAutosizeMeta(textarea) {
+    const type = textarea?.matches?.("#humanCommentBox")
+      ? "main-comment"
+      : textarea?.matches?.("[data-description-draft]")
+        ? "description"
+        : textarea?.matches?.("[data-thread-edit-draft]")
+          ? "inline-edit"
+          : textarea?.matches?.("[data-thread-reply-draft]")
+            ? "inline-reply"
+            : "unknown";
+    const minHeightFallback = type === "main-comment" ? 170 : 110;
+    return { type, minHeightFallback };
+  }
+
+  function runAutosize(textarea, cause = "manual") {
+    if (!textarea) return null;
+    const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
+    return autosizeTextarea(textarea, {
+      minHeightFallback,
+      comfortLines: 3,
+      log: true,
+      logPrefix: "[textarea-autosize]",
+      cause,
+      textareaType: type
+    });
+  }
+
   function isSubissuesDndDebugEnabled() {
     try {
       const search = String(window?.location?.search || "");
@@ -631,31 +658,6 @@ export function createProjectSubjectsEvents(config) {
 
   function wireDetailsInteractive(root) {
     if (!root) return;
-    const getTextareaAutosizeMeta = (textarea) => {
-      const type = textarea?.matches?.("#humanCommentBox")
-        ? "main-comment"
-        : textarea?.matches?.("[data-description-draft]")
-          ? "description"
-          : textarea?.matches?.("[data-thread-edit-draft]")
-            ? "inline-edit"
-            : textarea?.matches?.("[data-thread-reply-draft]")
-              ? "inline-reply"
-              : "unknown";
-      const minHeightFallback = type === "main-comment" ? 170 : 110;
-      return { type, minHeightFallback };
-    };
-    const runAutosize = (textarea, cause = "manual") => {
-      if (!textarea) return null;
-      const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
-      return autosizeTextarea(textarea, {
-        minHeightFallback,
-        comfortLines: 3,
-        log: true,
-        logPrefix: "[textarea-autosize]",
-        cause,
-        textareaType: type
-      });
-    };
     const isAutosizeDebugEnabled = () => typeof window !== "undefined" && window?.__MDALL_DEBUG_TEXTAREA_AUTOSIZE__ === true;
     const isElementMeasurable = (element) => {
       if (!element || element.isConnected === false) return false;


### PR DESCRIPTION
### Motivation

- Typing into the "new subject" description triggered `ReferenceError: runAutosize is not defined`, breaking autosize and preventing inline autocomplete from populating the `@` help menu. 
- Reduce duplicated textarea-autosize logic and ensure the same helper is available to multiple event handlers.

### Description

- Move `getTextareaAutosizeMeta` and `runAutosize` into the shared scope of `createProjectSubjectsEvents` so they are accessible from multiple functions. 
- Remove the duplicate local autosize definitions from `wireDetailsInteractive` and reuse the shared `runAutosize` helper. 
- Ensure the `input` handler for the create-subject form calls the shared `runAutosize` and then `syncInlineAutocomplete` without throwing. 
- Changed file: `apps/web/js/views/project-subjects/project-subjects-events.js` with no behavioral changes intended beyond fixing the scoping/runtime issue.

### Testing

- Ran `node apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` which passed all tests. 
- Ran `node apps/web/js/views/project-subjects/project-subjects-attachments-ui.test.mjs` which passed all tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88fe381fc8329a967f2a70bbd5edc)