### PR TITLE
Hoist textarea autosize helpers and guard `syncInlineAutocomplete` call

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -112,6 +112,33 @@ export function createProjectSubjectsEvents(config) {
   let subjectsTabResetBound = false;
   let descriptionVersionsPositionBound = false;
 
+  function getTextareaAutosizeMeta(textarea) {
+    const type = textarea?.matches?.("#humanCommentBox")
+      ? "main-comment"
+      : textarea?.matches?.("[data-description-draft]")
+        ? "description"
+        : textarea?.matches?.("[data-thread-edit-draft]")
+          ? "inline-edit"
+          : textarea?.matches?.("[data-thread-reply-draft]")
+            ? "inline-reply"
+            : "unknown";
+    const minHeightFallback = type === "main-comment" ? 170 : 110;
+    return { type, minHeightFallback };
+  }
+
+  function runAutosize(textarea, cause = "manual") {
+    if (!textarea) return null;
+    const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
+    return autosizeTextarea(textarea, {
+      minHeightFallback,
+      comfortLines: 3,
+      log: true,
+      logPrefix: "[textarea-autosize]",
+      cause,
+      textareaType: type
+    });
+  }
+
   function isSubissuesDndDebugEnabled() {
     try {
       const search = String(window?.location?.search || "");
@@ -631,31 +658,6 @@ export function createProjectSubjectsEvents(config) {
 
   function wireDetailsInteractive(root) {
     if (!root) return;
-    const getTextareaAutosizeMeta = (textarea) => {
-      const type = textarea?.matches?.("#humanCommentBox")
-        ? "main-comment"
-        : textarea?.matches?.("[data-description-draft]")
-          ? "description"
-          : textarea?.matches?.("[data-thread-edit-draft]")
-            ? "inline-edit"
-            : textarea?.matches?.("[data-thread-reply-draft]")
-              ? "inline-reply"
-              : "unknown";
-      const minHeightFallback = type === "main-comment" ? 170 : 110;
-      return { type, minHeightFallback };
-    };
-    const runAutosize = (textarea, cause = "manual") => {
-      if (!textarea) return null;
-      const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
-      return autosizeTextarea(textarea, {
-        minHeightFallback,
-        comfortLines: 3,
-        log: true,
-        logPrefix: "[textarea-autosize]",
-        cause,
-        textareaType: type
-      });
-    };
     const isAutosizeDebugEnabled = () => typeof window !== "undefined" && window?.__MDALL_DEBUG_TEXTAREA_AUTOSIZE__ === true;
     const isElementMeasurable = (element) => {
       if (!element || element.isConnected === false) return false;
@@ -5235,7 +5237,9 @@ export function createProjectSubjectsEvents(config) {
       if (createSubjectDescription && store.situationsView.createSubjectForm?.isOpen) {
         store.situationsView.createSubjectForm.description = String(createSubjectDescription.value || "");
         runAutosize(createSubjectDescription, "create-subject-input");
-        void syncInlineAutocomplete(createSubjectDescription, "create-subject");
+        if (typeof syncInlineAutocomplete === "function") {
+          void syncInlineAutocomplete(createSubjectDescription, "create-subject");
+        }
         if (store.situationsView.createSubjectForm.previewMode) rerenderPanels();
         return;
       }


### PR DESCRIPTION
### Motivation
- Make textarea autosize logic reusable across the module and ensure consistent metadata and logging for autosizing. 
- Prevent runtime errors when `syncInlineAutocomplete` is not available in the runtime environment.

### Description
- Hoisted `getTextareaAutosizeMeta` and `runAutosize` out of `wireDetailsInteractive` to module scope so autosize helpers can be reused by multiple functions. 
- Added `getTextareaAutosizeMeta` to centralize textarea type detection and `minHeightFallback` selection. 
- Implemented `runAutosize` wrapper which calls `autosizeTextarea` with consistent options including `comfortLines`, `log`, `logPrefix`, and `cause`. 
- Guarded the call to `syncInlineAutocomplete` with `typeof syncInlineAutocomplete === "function"` to avoid calling an undefined function.

### Testing
- Ran the project's JavaScript unit tests and they completed successfully. 
- Ran linting and build checks and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88fe381fc8329a967f2a70bbd5edc)