### PR TITLE
Fix @ mention collaborator loading in create-subject composer

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -460,6 +460,7 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getComposerAttachmentsState: (...args) => getComposerAttachmentsState(...args),
   mdToHtml,
   listCollaboratorsForMentions: (...args) => subjectMessagesService.listCollaboratorsForMentions(...args),
+  ensureProjectCollaboratorsLoaded: (...args) => ensureSubjectsCollaboratorsLoaded(...args),
   uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args),
   removeTemporaryAttachment: (...args) => subjectMessagesService.removeTemporaryAttachment(...args),
   getNestedSujet: (...args) => getNestedSujet(...args),
@@ -944,17 +945,21 @@ let collaboratorsHydrationInFlight = null;
 
 function ensureSubjectsCollaboratorsLoaded() {
   const collaborators = Array.isArray(store.projectForm?.collaborators) ? store.projectForm.collaborators : [];
-  if (collaborators.length || collaboratorsHydrationInFlight) return;
+  if (collaborators.length) return Promise.resolve(collaborators);
+  if (collaboratorsHydrationInFlight) return collaboratorsHydrationInFlight;
   collaboratorsHydrationInFlight = syncProjectCollaboratorsFromSupabase({ force: false })
     .then(() => {
       rerenderPanels();
+      return Array.isArray(store.projectForm?.collaborators) ? store.projectForm.collaborators : [];
     })
     .catch((error) => {
       console.warn("[project-subjects] collaborators preload failed", error);
+      return [];
     })
     .finally(() => {
       collaboratorsHydrationInFlight = null;
     });
+  return collaboratorsHydrationInFlight;
 }
 
 

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -100,6 +100,7 @@ export function createProjectSubjectsEvents(config) {
     getComposerAttachmentsState,
     mdToHtml,
     listCollaboratorsForMentions,
+    ensureProjectCollaboratorsLoaded,
     uploadAttachmentFile,
     removeTemporaryAttachment,
     getNestedSujet,
@@ -1285,6 +1286,7 @@ export function createProjectSubjectsEvents(config) {
     let mentionCollaborators = [];
     let mentionCollaboratorsLoaded = false;
     let mentionLoadPromise = null;
+    let mentionCacheProjectKey = "";
 
     const getMentionState = () => {
       if (typeof getMentionUiState === "function") return getMentionUiState();
@@ -1318,33 +1320,161 @@ export function createProjectSubjectsEvents(config) {
       else syncAutocompletePopups();
     };
 
-    const ensureMentionCollaboratorsLoaded = async () => {
-      if (mentionCollaboratorsLoaded) return mentionCollaborators;
-      if (mentionLoadPromise) return mentionLoadPromise;
-      const selection = getScopedSelection(root);
-      const projectId = String(
-        selection?.item?.project_id
-        || selection?.item?.projectId
-        || store?.projectForm?.id
+    const isSubjectMentionsDebugEnabled = () => {
+      try {
+        const search = String(window?.location?.search || "");
+        if (search.includes("debugSubjectMentions=1")) return true;
+        const storageValue = String(window?.localStorage?.getItem?.("mdall:debug-subject-mentions") || "").trim().toLowerCase();
+        const sessionStorageValue = String(window?.sessionStorage?.getItem?.("mdall:debug-subject-mentions") || "").trim().toLowerCase();
+        const globalFlag = String(window?.__MDALL_DEBUG_SUBJECT_MENTIONS__ || "").trim().toLowerCase();
+        return storageValue === "1" || storageValue === "true" || sessionStorageValue === "1" || sessionStorageValue === "true" || globalFlag === "1" || globalFlag === "true";
+      } catch {
+        return false;
+      }
+    };
+
+    const debugSubjectMentions = (eventName, payload = {}) => {
+      if (!isSubjectMentionsDebugEnabled()) return;
+      console.debug(`[subject-mentions] ${eventName}`, payload);
+    };
+
+    const resolveMentionProjectKey = () => {
+      const scopedSelection = getScopedSelection(root);
+      const projectKey = String(
+        store?.projectForm?.id
         || store?.projectForm?.projectId
+        || store?.currentProjectId
+        || store?.currentProject?.id
         || store?.project?.id
+        || scopedSelection?.item?.project_id
+        || scopedSelection?.item?.projectId
         || ""
       ).trim();
-      if (!projectId || typeof listCollaboratorsForMentions !== "function") {
+      debugSubjectMentions("resolve source", {
+        projectKey,
+        scopedSelectionType: String(scopedSelection?.type || ""),
+        hasProjectFormCollaborators: Array.isArray(store?.projectForm?.collaborators),
+        projectFormCollaboratorsCount: Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators.length : 0
+      });
+      return projectKey;
+    };
+
+    const resetMentionCollaboratorsCache = (reason = "manual", projectKey = "") => {
+      mentionCollaborators = [];
+      mentionCollaboratorsLoaded = false;
+      mentionLoadPromise = null;
+      mentionCacheProjectKey = String(projectKey || "").trim();
+      debugSubjectMentions("cache reset", { reason, projectKey: mentionCacheProjectKey });
+    };
+
+    const normalizeMentionCollaborator = (entry = {}) => {
+      const personId = String(entry?.personId || entry?.person_id || entry?.id || "").trim();
+      if (!personId) return null;
+      const userId = String(entry?.userId || entry?.linkedUserId || entry?.collaborator_user_id || "").trim();
+      const email = String(entry?.email || entry?.collaborator_email || "").trim();
+      const label = String(
+        entry?.label
+        || entry?.name
+        || entry?.full_name
+        || [entry?.firstName || entry?.first_name, entry?.lastName || entry?.last_name].filter(Boolean).join(" ")
+        || email
+        || "Utilisateur"
+      ).trim();
+      return {
+        personId,
+        userId,
+        email,
+        label,
+        roleGroupCode: String(entry?.roleGroupCode || entry?.role_group_code || "").trim().toLowerCase(),
+        roleGroupLabel: String(entry?.roleGroupLabel || entry?.role_group_label || "").trim()
+      };
+    };
+
+    const buildMentionSuggestions = (entries = []) => entries
+      .filter((entry) => String(entry?.status || "Actif").trim().toLowerCase() !== "retiré")
+      .map((entry) => normalizeMentionCollaborator(entry))
+      .filter((entry) => !!entry?.personId);
+
+    const syncMentionCollaboratorsFromProjectStore = ({ projectKey = "", composerKey = "" } = {}) => {
+      const storeRows = Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators : [];
+      if (!storeRows.length) return [];
+      const normalized = buildMentionSuggestions(storeRows);
+      mentionCollaborators = normalized;
+      mentionCollaboratorsLoaded = true;
+      mentionCacheProjectKey = String(projectKey || "").trim();
+      debugSubjectMentions("use store.projectForm.collaborators", {
+        composerKey,
+        projectKey: mentionCacheProjectKey,
+        collaboratorsCount: storeRows.length,
+        suggestionsCount: normalized.length
+      });
+      return normalized;
+    };
+
+    const ensureMentionCollaboratorsLoaded = async ({ composerKey = "" } = {}) => {
+      const projectKey = resolveMentionProjectKey();
+      if (projectKey !== mentionCacheProjectKey) {
+        resetMentionCollaboratorsCache("project-changed", projectKey);
+      }
+      if (mentionCollaboratorsLoaded) return mentionCollaborators;
+      if (mentionLoadPromise) return mentionLoadPromise;
+
+      const cachedFromStore = syncMentionCollaboratorsFromProjectStore({ projectKey, composerKey });
+      if (cachedFromStore.length) return cachedFromStore;
+
+      if (typeof ensureProjectCollaboratorsLoaded === "function") {
+        debugSubjectMentions("fetch collaborators fallback", {
+          composerKey,
+          projectKey,
+          source: "ensureProjectCollaboratorsLoaded"
+        });
+        await Promise.resolve(ensureProjectCollaboratorsLoaded());
+        const hydratedFromStore = syncMentionCollaboratorsFromProjectStore({ projectKey, composerKey });
+        if (hydratedFromStore.length) return hydratedFromStore;
+      }
+
+      if (!projectKey || typeof listCollaboratorsForMentions !== "function") {
+        debugSubjectMentions("fetch collaborators fallback", {
+          composerKey,
+          projectKey,
+          source: "none",
+          reason: "missing-project-or-provider"
+        });
         mentionCollaborators = [];
         mentionCollaboratorsLoaded = true;
+        mentionCacheProjectKey = projectKey;
         return mentionCollaborators;
       }
-      mentionLoadPromise = listCollaboratorsForMentions(projectId)
+      debugSubjectMentions("fetch collaborators fallback", {
+        composerKey,
+        projectKey,
+        source: "listCollaboratorsForMentions"
+      });
+      mentionLoadPromise = listCollaboratorsForMentions(projectKey)
         .then((rows) => {
-          mentionCollaborators = Array.isArray(rows) ? rows : [];
+          mentionCollaborators = buildMentionSuggestions(Array.isArray(rows) ? rows : []);
           mentionCollaboratorsLoaded = true;
+          mentionCacheProjectKey = projectKey;
+          debugSubjectMentions("suggestions computed", {
+            composerKey,
+            projectKey,
+            collaboratorsCount: Array.isArray(rows) ? rows.length : 0,
+            suggestionsCount: mentionCollaborators.length,
+            source: "listCollaboratorsForMentions"
+          });
           return mentionCollaborators;
         })
         .catch((error) => {
           console.warn("[subject-mentions] collaborators load failed", error);
+          debugSubjectMentions("fetch collaborators fallback", {
+            composerKey,
+            projectKey,
+            source: "listCollaboratorsForMentions",
+            error: String(error?.message || error || "")
+          });
           mentionCollaborators = [];
           mentionCollaboratorsLoaded = true;
+          mentionCacheProjectKey = projectKey;
           return mentionCollaborators;
         })
         .finally(() => {
@@ -1386,7 +1516,7 @@ export function createProjectSubjectsEvents(config) {
           caretStart: Number(textarea.selectionStart || 0),
           caretEnd: Number(textarea.selectionEnd || 0)
         });
-        void ensureMentionCollaboratorsLoaded().then(() => {
+        void ensureMentionCollaboratorsLoaded({ composerKey }).then(() => {
           const activeTextarea = getTextareaForComposerKey(composerKey);
           if (activeTextarea) void syncMentionPopupForTextarea(activeTextarea, composerKey, { forceOpen: true });
         });
@@ -1402,6 +1532,13 @@ export function createProjectSubjectsEvents(config) {
           ].some((field) => field.includes(query));
         })
         .slice(0, 8);
+      debugSubjectMentions("suggestions computed", {
+        composerKey,
+        projectKey: mentionCacheProjectKey,
+        query,
+        collaboratorsCount: mentionCollaborators.length,
+        suggestionsCount: suggestions.length
+      });
 
       mentionState.triggerStart = Number(context?.triggerStart ?? -1);
       mentionState.triggerEnd = Number(context?.triggerEnd ?? -1);


### PR DESCRIPTION
### Motivation

- The `@` mention popup could be empty for the “Nouveau sujet” flow because mention loading relied on a fragile selection-based `projectId` resolution and a cache not tied to the current project. 
- The mentions source could diverge from the aside `Assigné à` list (`store.projectForm.collaborators`) and produced stale or missing suggestions after project changes.

### Description

- Prioritize `store.projectForm.collaborators` when building mention suggestions and add a small normalization layer (`normalizeMentionCollaborator`) that ensures each suggestion has `personId`, `userId`, `email`, `label`, `roleGroupCode`, and `roleGroupLabel`.
- Make project resolution for mentions robust via `resolveMentionProjectKey` (use global project context first, scoped selection only as fallback) and add `mentionCacheProjectKey` with `resetMentionCollaboratorsCache` to invalidate cache when the project changes.
- Update `ensureMentionCollaboratorsLoaded` to: (1) use `store.projectForm.collaborators` if present, (2) await `ensureProjectCollaboratorsLoaded()` hydration as a fallback, then (3) finally call `listCollaboratorsForMentions` only if needed; suggestions keep filtering by name/email and keyboard/click behavior unchanged.
- Expose `ensureProjectCollaboratorsLoaded` to the events config and make `ensureSubjectsCollaboratorsLoaded` return a promise so mention loading can reliably await hydration.
- Add gated debug instrumentation (`[subject-mentions] ...`) controllable via query string (`debugSubjectMentions=1`), local/session storage (`mdall:debug-subject-mentions`), or a global flag (`__MDALL_DEBUG_SUBJECT_MENTIONS__`).
- Files changed: `apps/web/js/views/project-subjects/project-subjects-events.js` and `apps/web/js/views/project-subjects.js`.

### Testing

- Ran syntax/type checks with `node --check apps/web/js/views/project-subjects/project-subjects-events.js` and `node --check apps/web/js/views/project-subjects.js`, both succeeded.
- No automated unit tests were added; runtime behavior relies on existing mention selection/insert paths which were not altered beyond source/cache/loading logic and debug logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8941b45188329b24e95144c832330)