### PR TITLE
Hydrate and cache project collaborators for subject mentions; add debug and resilient loading

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -460,6 +460,7 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getComposerAttachmentsState: (...args) => getComposerAttachmentsState(...args),
   mdToHtml,
   listCollaboratorsForMentions: (...args) => subjectMessagesService.listCollaboratorsForMentions(...args),
+  ensureProjectCollaboratorsLoaded: (...args) => ensureSubjectsCollaboratorsLoaded(...args),
   uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args),
   removeTemporaryAttachment: (...args) => subjectMessagesService.removeTemporaryAttachment(...args),
   getNestedSujet: (...args) => getNestedSujet(...args),
@@ -944,17 +945,21 @@ let collaboratorsHydrationInFlight = null;
 
 function ensureSubjectsCollaboratorsLoaded() {
   const collaborators = Array.isArray(store.projectForm?.collaborators) ? store.projectForm.collaborators : [];
-  if (collaborators.length || collaboratorsHydrationInFlight) return;
+  if (collaborators.length) return Promise.resolve(collaborators);
+  if (collaboratorsHydrationInFlight) return collaboratorsHydrationInFlight;
   collaboratorsHydrationInFlight = syncProjectCollaboratorsFromSupabase({ force: false })
     .then(() => {
       rerenderPanels();
+      return Array.isArray(store.projectForm?.collaborators) ? store.projectForm.collaborators : [];
     })
     .catch((error) => {
       console.warn("[project-subjects] collaborators preload failed", error);
+      return [];
     })
     .finally(() => {
       collaboratorsHydrationInFlight = null;
     });
+  return collaboratorsHydrationInFlight;
 }
 
 

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -100,6 +100,7 @@ export function createProjectSubjectsEvents(config) {
     getComposerAttachmentsState,
     mdToHtml,
     listCollaboratorsForMentions,
+    ensureProjectCollaboratorsLoaded,
     uploadAttachmentFile,
     removeTemporaryAttachment,
     getNestedSujet,
@@ -998,11 +999,7 @@ export function createProjectSubjectsEvents(config) {
       else syncAutocompletePopups();
     };
 
-    const AUTOCOMPLETE_LOG_PREFIX = "[subject-autocomplete]";
-
-    const logAutocompleteEvent = (eventName, payload = {}) => {
-      console.log(`${AUTOCOMPLETE_LOG_PREFIX} ${eventName}`, payload);
-    };
+    const logAutocompleteEvent = () => {};
 
     const getTextareaSelector = ({ composerKey = "main", messageId = "" } = {}) => {
       if (composerKey === "main") return "#humanCommentBox";
@@ -1285,6 +1282,7 @@ export function createProjectSubjectsEvents(config) {
     let mentionCollaborators = [];
     let mentionCollaboratorsLoaded = false;
     let mentionLoadPromise = null;
+    let mentionCacheProjectKey = "";
 
     const getMentionState = () => {
       if (typeof getMentionUiState === "function") return getMentionUiState();
@@ -1318,33 +1316,161 @@ export function createProjectSubjectsEvents(config) {
       else syncAutocompletePopups();
     };
 
-    const ensureMentionCollaboratorsLoaded = async () => {
-      if (mentionCollaboratorsLoaded) return mentionCollaborators;
-      if (mentionLoadPromise) return mentionLoadPromise;
-      const selection = getScopedSelection(root);
-      const projectId = String(
-        selection?.item?.project_id
-        || selection?.item?.projectId
-        || store?.projectForm?.id
+    const isSubjectMentionsDebugEnabled = () => {
+      try {
+        const search = String(window?.location?.search || "");
+        if (search.includes("debugSubjectMentions=1")) return true;
+        const storageValue = String(window?.localStorage?.getItem?.("mdall:debug-subject-mentions") || "").trim().toLowerCase();
+        const sessionStorageValue = String(window?.sessionStorage?.getItem?.("mdall:debug-subject-mentions") || "").trim().toLowerCase();
+        const globalFlag = String(window?.__MDALL_DEBUG_SUBJECT_MENTIONS__ || "").trim().toLowerCase();
+        return storageValue === "1" || storageValue === "true" || sessionStorageValue === "1" || sessionStorageValue === "true" || globalFlag === "1" || globalFlag === "true";
+      } catch {
+        return false;
+      }
+    };
+
+    const debugSubjectMentions = (eventName, payload = {}) => {
+      if (!isSubjectMentionsDebugEnabled()) return;
+      console.debug(`[subject-mentions] ${eventName}`, payload);
+    };
+
+    const resolveMentionProjectKey = () => {
+      const scopedSelection = getScopedSelection(root);
+      const projectKey = String(
+        store?.projectForm?.id
         || store?.projectForm?.projectId
+        || store?.currentProjectId
+        || store?.currentProject?.id
         || store?.project?.id
+        || scopedSelection?.item?.project_id
+        || scopedSelection?.item?.projectId
         || ""
       ).trim();
-      if (!projectId || typeof listCollaboratorsForMentions !== "function") {
+      debugSubjectMentions("resolve source", {
+        projectKey,
+        scopedSelectionType: String(scopedSelection?.type || ""),
+        hasProjectFormCollaborators: Array.isArray(store?.projectForm?.collaborators),
+        projectFormCollaboratorsCount: Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators.length : 0
+      });
+      return projectKey;
+    };
+
+    const resetMentionCollaboratorsCache = (reason = "manual", projectKey = "") => {
+      mentionCollaborators = [];
+      mentionCollaboratorsLoaded = false;
+      mentionLoadPromise = null;
+      mentionCacheProjectKey = String(projectKey || "").trim();
+      debugSubjectMentions("cache reset", { reason, projectKey: mentionCacheProjectKey });
+    };
+
+    const normalizeMentionCollaborator = (entry = {}) => {
+      const personId = String(entry?.personId || entry?.person_id || entry?.id || "").trim();
+      if (!personId) return null;
+      const userId = String(entry?.userId || entry?.linkedUserId || entry?.collaborator_user_id || "").trim();
+      const email = String(entry?.email || entry?.collaborator_email || "").trim();
+      const label = String(
+        entry?.label
+        || entry?.name
+        || entry?.full_name
+        || [entry?.firstName || entry?.first_name, entry?.lastName || entry?.last_name].filter(Boolean).join(" ")
+        || email
+        || "Utilisateur"
+      ).trim();
+      return {
+        personId,
+        userId,
+        email,
+        label,
+        roleGroupCode: String(entry?.roleGroupCode || entry?.role_group_code || "").trim().toLowerCase(),
+        roleGroupLabel: String(entry?.roleGroupLabel || entry?.role_group_label || "").trim()
+      };
+    };
+
+    const buildMentionSuggestions = (entries = []) => entries
+      .filter((entry) => String(entry?.status || "Actif").trim().toLowerCase() !== "retiré")
+      .map((entry) => normalizeMentionCollaborator(entry))
+      .filter((entry) => !!entry?.personId);
+
+    const syncMentionCollaboratorsFromProjectStore = ({ projectKey = "", composerKey = "" } = {}) => {
+      const storeRows = Array.isArray(store?.projectForm?.collaborators) ? store.projectForm.collaborators : [];
+      if (!storeRows.length) return [];
+      const normalized = buildMentionSuggestions(storeRows);
+      mentionCollaborators = normalized;
+      mentionCollaboratorsLoaded = true;
+      mentionCacheProjectKey = String(projectKey || "").trim();
+      debugSubjectMentions("use store.projectForm.collaborators", {
+        composerKey,
+        projectKey: mentionCacheProjectKey,
+        collaboratorsCount: storeRows.length,
+        suggestionsCount: normalized.length
+      });
+      return normalized;
+    };
+
+    const ensureMentionCollaboratorsLoaded = async ({ composerKey = "" } = {}) => {
+      const projectKey = resolveMentionProjectKey();
+      if (projectKey !== mentionCacheProjectKey) {
+        resetMentionCollaboratorsCache("project-changed", projectKey);
+      }
+      if (mentionCollaboratorsLoaded) return mentionCollaborators;
+      if (mentionLoadPromise) return mentionLoadPromise;
+
+      const cachedFromStore = syncMentionCollaboratorsFromProjectStore({ projectKey, composerKey });
+      if (cachedFromStore.length) return cachedFromStore;
+
+      if (typeof ensureProjectCollaboratorsLoaded === "function") {
+        debugSubjectMentions("fetch collaborators fallback", {
+          composerKey,
+          projectKey,
+          source: "ensureProjectCollaboratorsLoaded"
+        });
+        await Promise.resolve(ensureProjectCollaboratorsLoaded());
+        const hydratedFromStore = syncMentionCollaboratorsFromProjectStore({ projectKey, composerKey });
+        if (hydratedFromStore.length) return hydratedFromStore;
+      }
+
+      if (!projectKey || typeof listCollaboratorsForMentions !== "function") {
+        debugSubjectMentions("fetch collaborators fallback", {
+          composerKey,
+          projectKey,
+          source: "none",
+          reason: "missing-project-or-provider"
+        });
         mentionCollaborators = [];
         mentionCollaboratorsLoaded = true;
+        mentionCacheProjectKey = projectKey;
         return mentionCollaborators;
       }
-      mentionLoadPromise = listCollaboratorsForMentions(projectId)
+      debugSubjectMentions("fetch collaborators fallback", {
+        composerKey,
+        projectKey,
+        source: "listCollaboratorsForMentions"
+      });
+      mentionLoadPromise = listCollaboratorsForMentions(projectKey)
         .then((rows) => {
-          mentionCollaborators = Array.isArray(rows) ? rows : [];
+          mentionCollaborators = buildMentionSuggestions(Array.isArray(rows) ? rows : []);
           mentionCollaboratorsLoaded = true;
+          mentionCacheProjectKey = projectKey;
+          debugSubjectMentions("suggestions computed", {
+            composerKey,
+            projectKey,
+            collaboratorsCount: Array.isArray(rows) ? rows.length : 0,
+            suggestionsCount: mentionCollaborators.length,
+            source: "listCollaboratorsForMentions"
+          });
           return mentionCollaborators;
         })
         .catch((error) => {
           console.warn("[subject-mentions] collaborators load failed", error);
+          debugSubjectMentions("fetch collaborators fallback", {
+            composerKey,
+            projectKey,
+            source: "listCollaboratorsForMentions",
+            error: String(error?.message || error || "")
+          });
           mentionCollaborators = [];
           mentionCollaboratorsLoaded = true;
+          mentionCacheProjectKey = projectKey;
           return mentionCollaborators;
         })
         .finally(() => {
@@ -1386,7 +1512,7 @@ export function createProjectSubjectsEvents(config) {
           caretStart: Number(textarea.selectionStart || 0),
           caretEnd: Number(textarea.selectionEnd || 0)
         });
-        void ensureMentionCollaboratorsLoaded().then(() => {
+        void ensureMentionCollaboratorsLoaded({ composerKey }).then(() => {
           const activeTextarea = getTextareaForComposerKey(composerKey);
           if (activeTextarea) void syncMentionPopupForTextarea(activeTextarea, composerKey, { forceOpen: true });
         });
@@ -1402,6 +1528,13 @@ export function createProjectSubjectsEvents(config) {
           ].some((field) => field.includes(query));
         })
         .slice(0, 8);
+      debugSubjectMentions("suggestions computed", {
+        composerKey,
+        projectKey: mentionCacheProjectKey,
+        query,
+        collaboratorsCount: mentionCollaborators.length,
+        suggestionsCount: suggestions.length
+      });
 
       mentionState.triggerStart = Number(context?.triggerStart ?? -1);
       mentionState.triggerEnd = Number(context?.triggerEnd ?? -1);


### PR DESCRIPTION
### Motivation
- Ensure collaborator lists are available for subject message mentions and avoid duplicate inflight hydrations when opening the subjects view.
- Make mention suggestion loading more resilient to different project id sources and allow using pre-hydrated collaborators from the project store.
- Add optional debug logging and stabilize autocomplete logging behavior.

### Description
- Added `ensureProjectCollaboratorsLoaded` to the events config mapping and implemented `ensureSubjectsCollaboratorsLoaded` to return a `Promise`, early-resolve when collaborators exist, avoid duplicate inflight requests, and return an array on completion or error.
- On initial render (`renderProjectSubjects`) call `ensureSubjectsCollaboratorsLoaded()` to proactively hydrate collaborators.
- Replaced noisy `logAutocompleteEvent` console logging with a noop and introduced a gated debug logger `debugSubjectMentions` controlled via query string, local/session storage, or a global flag.
- Reworked mention loading flow: introduced `resolveMentionProjectKey`, `resetMentionCollaboratorsCache`, `normalizeMentionCollaborator`, `buildMentionSuggestions`, and `syncMentionCollaboratorsFromProjectStore` to normalize rows, cache suggestions per-project, and use `store.projectForm.collaborators` when available.
- Updated `ensureMentionCollaboratorsLoaded` to use the project-key cache, prefer store-backed collaborators, fall back to `ensureProjectCollaboratorsLoaded` (if provided) to hydrate the store, and finally call `listCollaboratorsForMentions` as a last-resort source; errors return an empty list but mark the cache as loaded.
- Added debug/info calls at key points to aid investigation when debug mode is enabled and passed `composerKey` through mention flows to improve context-aware behavior.
- Adjusted `syncMentionPopupForTextarea` to pass `{ composerKey }` to `ensureMentionCollaboratorsLoaded` so suggestions load with context.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8941b45188329b24e95144c832330)