### PR TITLE
Ajuste l’UI de création de sujet pour se rapprocher du mock

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2942,51 +2942,55 @@ function renderCreateSubjectFormHtml() {
   const previewHtml = mdToHtml(String(form.description || "").trim());
   return `
     <section class="subject-create-shell" data-create-subject-form>
+      <div class="subject-create-header">
+        <div class="subject-create-header__title">Créer un nouveau sujet</div>
+      </div>
       <div class="subject-create-layout">
         <div class="subject-create-main">
-          <div class="subject-create-header">
-            <img src="${escapeHtml(avatar)}" alt="Auteur" class="subject-create-header__avatar">
-            <div class="subject-create-header__title">Créer un nouveau sujet</div>
-          </div>
+          <div class="subject-create-content">
+            <img src="${escapeHtml(avatar)}" alt="Auteur" class="subject-create-content__avatar">
+            <div class="subject-create-content__fields">
+              <label class="subject-create-field">
+                <span class="subject-create-field__label">Ajouter un titre<span class="subject-create-field__required">*</span></span>
+                <input type="text" class="subject-create-input" data-create-subject-title value="${escapeHtml(String(form.title || ""))}" placeholder="Titre du sujet" autocomplete="off">
+              </label>
 
-          <label class="subject-create-field">
-            <span class="subject-create-field__label">Ajouter un titre<span class="subject-create-field__required">*</span></span>
-            <input type="text" class="subject-create-input" data-create-subject-title value="${escapeHtml(String(form.title || ""))}" placeholder="Titre du sujet" autocomplete="off">
-          </label>
-
-          <div class="subject-create-field subject-create-field--editor">
-            <div class="subject-create-field__label">Ajouter une description</div>
-            ${renderCommentComposer({
-              hideAvatar: true,
-              hideTitle: true,
-              previewMode: !!form.previewMode,
-              textareaId: "createSubjectDescriptionBox",
-              previewId: "createSubjectDescriptionPreview",
-              textareaValue: String(form.description || ""),
-              textareaAttributes: {
-                "data-create-subject-description": "true"
-              },
-              placeholder: "Décrivez le sujet...",
-              tabWriteAction: "create-subject-tab-write",
-              tabPreviewAction: "create-subject-tab-preview",
-              tabsClassName: "comment-composer__tabs--thread-reply",
-              composerClassName: "comment-composer--thread-reply-editor",
-              toolbarHtml: renderSubjectMarkdownToolbar({ buttonAction: "create-subject-format", svgIcon }),
-              previewHtml: previewHtml || "",
-              previewEmptyHint: "Utilisez Markdown pour formater votre description",
-              footerHtml: `
-                <input type="file" class="subject-composer-file-input" data-role="create-subject-file-input" multiple />
-                <div class="subject-composer-attachments-preview ${(Array.isArray(form.attachments) && form.attachments.length) ? "" : "hidden"}" data-role="create-subject-attachments-preview" aria-live="polite">
-                  ${renderSubjectAttachmentsPreviewList({
-                    attachments: normalizeCreateSubjectDraftAttachments(form.attachments),
-                    removeAction: "create-subject-attachment-remove",
-                    escapeHtml,
-                    svgIcon
-                  })}
-                </div>
-              `
-            })}
-            ${form.validationError ? `<div class="subject-create-form__error">${escapeHtml(form.validationError)}</div>` : ""}
+              <div class="subject-create-field subject-create-field--editor">
+                <div class="subject-create-field__label">Ajouter une description</div>
+                ${renderCommentComposer({
+                  hideAvatar: true,
+                  hideTitle: true,
+                  hideActions: true,
+                  previewMode: !!form.previewMode,
+                  textareaId: "createSubjectDescriptionBox",
+                  previewId: "createSubjectDescriptionPreview",
+                  textareaValue: String(form.description || ""),
+                  textareaAttributes: {
+                    "data-create-subject-description": "true"
+                  },
+                  placeholder: "Décrivez le sujet...",
+                  tabWriteAction: "create-subject-tab-write",
+                  tabPreviewAction: "create-subject-tab-preview",
+                  tabsClassName: "comment-composer__tabs--thread-reply",
+                  composerClassName: "comment-composer--thread-reply-editor comment-composer--create-subject",
+                  toolbarHtml: renderSubjectMarkdownToolbar({ buttonAction: "create-subject-format", svgIcon }),
+                  previewHtml: previewHtml || "",
+                  previewEmptyHint: "Utilisez Markdown pour formater votre description",
+                  footerHtml: `
+                    <input type="file" class="subject-composer-file-input" data-role="create-subject-file-input" multiple />
+                    <div class="subject-composer-attachments-preview ${(Array.isArray(form.attachments) && form.attachments.length) ? "" : "hidden"}" data-role="create-subject-attachments-preview" aria-live="polite">
+                      ${renderSubjectAttachmentsPreviewList({
+                        attachments: normalizeCreateSubjectDraftAttachments(form.attachments),
+                        removeAction: "create-subject-attachment-remove",
+                        escapeHtml,
+                        svgIcon
+                      })}
+                    </div>
+                  `
+                })}
+                ${form.validationError ? `<div class="subject-create-form__error">${escapeHtml(form.validationError)}</div>` : ""}
+              </div>
+            </div>
           </div>
 
           <div class="subject-create-footer">

--- a/apps/web/js/views/ui/comment-composer.js
+++ b/apps/web/js/views/ui/comment-composer.js
@@ -22,7 +22,8 @@ export function renderCommentComposer({
   tabWriteAction = "tab-write",
   tabPreviewAction = "tab-preview",
   previewHtml = "",
-  previewEmptyHint = "Use Markdown to format your comment"
+  previewEmptyHint = "Use Markdown to format your comment",
+  hideActions = false
 } = {}) {
   const textareaAttributesHtml = Object.entries(
     textareaAttributes && typeof textareaAttributes === "object" ? textareaAttributes : {}
@@ -66,12 +67,14 @@ export function renderCommentComposer({
           ${footerHtml || ""}
         </div>
 
-        <div class="actions-row actions-row--details comment-composer__actions" style="margin-top:10px;">
-          ${hintHtml || ""}
-          <div class="actions-row__right comment-composer__actions-right" style="display:flex; align-items:center; gap:8px; justify-content:flex-end; flex:0 0 auto;">
-            ${actionsHtml || ""}
+        ${hideActions ? "" : `
+          <div class="actions-row actions-row--details comment-composer__actions" style="margin-top:10px;">
+            ${hintHtml || ""}
+            <div class="actions-row__right comment-composer__actions-right" style="display:flex; align-items:center; gap:8px; justify-content:flex-end; flex:0 0 auto;">
+              ${actionsHtml || ""}
+            </div>
           </div>
-        </div>
+        `}
       </div>
     </div>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10558,18 +10558,30 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   margin-bottom:18px;
 }
 
-.subject-create-header__avatar{
+.subject-create-header__title{
+  font-size:16px;
+  font-weight:600;
+  color:var(--text);
+}
+
+.subject-create-content{
+  display:flex;
+  align-items:flex-start;
+  gap:12px;
+}
+
+.subject-create-content__avatar{
   width:32px;
   height:32px;
   border-radius:50%;
   object-fit:cover;
   border:1px solid var(--border);
+  flex:0 0 32px;
 }
 
-.subject-create-header__title{
-  font-size:24px;
-  font-weight:600;
-  color:var(--text);
+.subject-create-content__fields{
+  flex:1 1 auto;
+  min-width:0;
 }
 
 .subject-create-field{
@@ -10580,6 +10592,9 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 }
 
 .subject-create-field__label{
+  display:inline-flex;
+  align-items:center;
+  gap:3px;
   font-size:14px;
   font-weight:600;
   color:var(--text);
@@ -10587,6 +10602,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 
 .subject-create-field__required{
   color:#f85149;
+  margin-left:0;
 }
 
 .subject-create-input{
@@ -10671,7 +10687,31 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 }
 
 .subject-create-aside{
-  padding-top:10px;
+  padding-top:0;
+}
+
+.comment-composer--create-subject{
+  margin-top:0;
+}
+.comment-composer--create-subject .comment-box{
+  margin-top:0;
+}
+.comment-composer--create-subject .gh-comment-boxwrap{
+  background:rgba(13,17,23,.92);
+}
+.comment-composer--create-subject .comment-editor{
+  background:var(--bg);
+}
+.comment-composer--create-subject .comment-composer__preview-wrap,
+.comment-composer--create-subject .comment-composer__preview{
+  background:rgba(22,27,34,.25);
+}
+.comment-composer--create-subject .comment-composer__tabs.light-tabs .light-tabs__item.is-active{
+  background:var(--bg);
+  border-bottom-color:var(--bg);
+}
+.comment-composer--create-subject .comment-composer__textarea{
+  min-height:452px;
 }
 
 .subject-meta-controls--create{


### PR DESCRIPTION
### Motivation
- Rendre l’écran de création d’un sujet conforme au screenshot en déplaçant l’avatar à gauche, ajustant la taille du titre, l’alignement de l’aside et l’espacement des labels. 
- Supprimer la row d’actions inutile pour cet écran et harmoniser les couleurs/tailles de la zone de description.

### Description
- Réorganise le HTML de la page de création pour séparer le header (`.subject-create-header`) et introduire `subject-create-content` contenant l’avatar (`.subject-create-content__avatar`) à gauche des champs. 
- Passe le label `Créer un nouveau sujet` à `font-size:16px` via `.subject-create-header__title` et ajoute `display:inline-flex` + `gap:3px` sur `.subject-create-field__label` pour espacer l’astérisque requis. 
- Ajoute la classe dédiée `comment-composer--create-subject` au composer de création et des règles CSS ciblées pour appliquer `margin-top:0`, harmoniser la couleur de la `comment-box` avec la discussion et fixer la textarea par défaut à `min-height:452px`. 
- Ajoute l’option `hideActions` à `renderCommentComposer` et active `hideActions: true` pour le composer de création afin de retirer du DOM la `div` `actions-row actions-row--details comment-composer__actions` uniquement sur cet écran. 

### Testing
- Exécution de `git -C /workspace/Mdall diff --check` a réussi sans erreurs.
- Vérification de l’état avec `git -C /workspace/Mdall status --short` a confirmé les modifications prêtes à commit.
- Les modifications ont été commitées avec le message `Ajuste le style de création de sujet pour matcher l'écran cible` et la PR a été préparée via l’outil interne. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e899043eac8329b8dbb73a561e8d54)