### PR TITLE
Fix create-subject layout and initial textarea autosize height

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -116,6 +116,8 @@ export function createProjectSubjectsEvents(config) {
   function getTextareaAutosizeMeta(textarea) {
     const type = textarea?.matches?.("#humanCommentBox")
       ? "main-comment"
+      : textarea?.matches?.("[data-create-subject-description]")
+        ? "create-subject"
       : textarea?.matches?.("[data-description-draft]")
         ? "description"
         : textarea?.matches?.("[data-thread-edit-draft]")
@@ -123,16 +125,21 @@ export function createProjectSubjectsEvents(config) {
           : textarea?.matches?.("[data-thread-reply-draft]")
             ? "inline-reply"
             : "unknown";
-    const minHeightFallback = type === "main-comment" ? 170 : 110;
-    return { type, minHeightFallback };
+    const minHeightFallback = type === "main-comment"
+      ? 170
+      : type === "create-subject"
+        ? 452
+        : 110;
+    const comfortLines = type === "create-subject" ? 0 : 3;
+    return { type, minHeightFallback, comfortLines };
   }
 
   function runAutosize(textarea, cause = "manual") {
     if (!textarea) return null;
-    const { type, minHeightFallback } = getTextareaAutosizeMeta(textarea);
+    const { type, minHeightFallback, comfortLines } = getTextareaAutosizeMeta(textarea);
     return autosizeTextarea(textarea, {
       minHeightFallback,
-      comfortLines: 3,
+      comfortLines,
       log: true,
       logPrefix: "[textarea-autosize]",
       cause,

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2942,9 +2942,6 @@ function renderCreateSubjectFormHtml() {
   const previewHtml = mdToHtml(String(form.description || "").trim());
   return `
     <section class="subject-create-shell" data-create-subject-form>
-      <div class="subject-create-header">
-        <div class="subject-create-header__title">Créer un nouveau sujet</div>
-      </div>
       <div class="subject-create-layout">
         <div class="subject-create-main">
           <div class="subject-create-content">

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10687,7 +10687,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 }
 
 .subject-create-aside{
-  padding-top:0;
+  padding-top:36px;
 }
 
 .comment-composer--create-subject{


### PR DESCRIPTION
### Motivation
- The subject-creation UI showed a redundant top header and had the aside misaligned with the title input, and the description textarea autosize started higher than the CSS `min-height` causing visual jump on the create-subject page.

### Description
- Removed the extra top-level header in the create-subject form render so only the in-form `Créer un nouveau sujet` header remains (`apps/web/js/views/project-subjects/project-subjects-view.js`).
- Aligned the aside with the title input by adding `padding-top: 36px` to `.subject-create-aside` in `apps/web/style.css`.
- Updated textarea autosize logic to treat the create-subject description as its own type by detecting `[data-create-subject-description]`, using `minHeightFallback: 452` and `comfortLines: 0` so the initial inline height matches the CSS `min-height` (`apps/web/js/views/project-subjects/project-subjects-events.js` and autosize integration).

### Testing
- Ran the autosize unit tests with `node --test apps/web/js/utils/textarea-autosize.test.mjs`, and all tests passed (3/3).
- Verified the project files modified are `apps/web/js/views/project-subjects/project-subjects-view.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, and `apps/web/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89de9911883299e5e560f45b4bc2a)