### PR TITLE
Do not surface technical/system documents as UI documentary references

### DIFF
--- a/apps/web/js/services/project-document-selectors.js
+++ b/apps/web/js/services/project-document-selectors.js
@@ -17,21 +17,38 @@ function getRawSubjectsResult() {
 function normalizeEntityDocumentRefs(entity = {}) {
   const directRefs = Array.isArray(entity?.document_ref_ids) ? entity.document_ref_ids : [];
   const rawRefs = Array.isArray(entity?.raw?.document_ref_ids) ? entity.raw.document_ref_ids : [];
-  const singleDocumentIds = [entity?.document_id, entity?.raw?.document_id].filter(Boolean);
-  return [...new Set([...directRefs, ...rawRefs, ...singleDocumentIds].map((value) => String(value || "")).filter(Boolean))];
+  return [...new Set([...directRefs, ...rawRefs].map((value) => String(value || "")).filter(Boolean))];
 }
 
-function buildDocumentRefFallback(documentId = "") {
-  const id = String(documentId || "").trim();
-  if (!id) return null;
-  return {
-    id,
-    name: id,
-    title: id,
-    phaseCode: "",
-    phaseLabel: "",
-    __unresolved: true
-  };
+function normalizeEntityTechnicalDocumentIds(entity = {}) {
+  return [...new Set([entity?.document_id, entity?.raw?.document_id]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean))];
+}
+
+function isDebugDocumentRefsEnabled() {
+  if (typeof window === "undefined") return false;
+  try {
+    const search = String(window?.location?.search || "");
+    if (search.includes("debugDocumentRefs=1")) return true;
+    const localValue = String(window?.localStorage?.getItem?.("mdall:debug-document-refs") || "").trim().toLowerCase();
+    const sessionValue = String(window?.sessionStorage?.getItem?.("mdall:debug-document-refs") || "").trim().toLowerCase();
+    const globalValue = String(window?.__MDALL_DEBUG_DOCUMENT_REFS__ || "").trim().toLowerCase();
+    return ["1", "true", "yes", "on"].includes(localValue)
+      || ["1", "true", "yes", "on"].includes(sessionValue)
+      || ["1", "true", "yes", "on"].includes(globalValue);
+  } catch {
+    return false;
+  }
+}
+
+function debugDocumentRefs(eventName, payload = {}) {
+  if (!isDebugDocumentRefsEnabled()) return;
+  console.debug("[document-refs]", String(eventName || "event"), payload);
+}
+
+function isSystemTechnicalDocument(document = {}) {
+  return String(document?.documentKind || document?.note || "").toLowerCase() === "manual_subjects_system";
 }
 
 function isEntityCounted(entity = {}) {
@@ -123,15 +140,27 @@ function getBlockedByCount(subjectId) {
 export function getSelectionDocumentRefs(selection) {
   const item = selection?.item || null;
   if (!item) return [];
-  const normalizedRefIds = normalizeEntityDocumentRefs(item);
+  const explicitRefIds = normalizeEntityDocumentRefs(item);
+  const technicalDocumentIds = normalizeEntityTechnicalDocumentIds(item);
 
-  const resolvedDocs = resolveDocumentRefs(normalizedRefIds);
+  const resolvedDocs = resolveDocumentRefs(explicitRefIds)
+    .filter((doc) => !isSystemTechnicalDocument(doc));
   const resolvedById = new Map(resolvedDocs.map((doc) => [String(doc?.id || ""), doc]));
-  const renderable = normalizedRefIds
-    .map((documentId) => resolvedById.get(String(documentId || "")) || buildDocumentRefFallback(documentId))
+  const renderable = explicitRefIds
+    .map((documentId) => resolvedById.get(String(documentId || "")))
     .filter(Boolean)
     .map(decorateDocumentWithPhase)
     .filter(Boolean);
+
+  const filteredRefIds = explicitRefIds.filter((documentId) => !resolvedById.has(String(documentId || "")));
+  debugDocumentRefs("selection", {
+    entityId: String(item?.id || ""),
+    explicitRefIds,
+    retainedRefIds: renderable.map((doc) => String(doc?.id || "")),
+    filteredRefIds,
+    technicalDocumentIds
+  });
+
   return renderable;
 }
 

--- a/apps/web/js/services/project-document-selectors.test.mjs
+++ b/apps/web/js/services/project-document-selectors.test.mjs
@@ -4,30 +4,84 @@ import assert from "node:assert/strict";
 import { getSelectionDocumentRefs } from "./project-document-selectors.js";
 import { store } from "../store.js";
 
-test("document refs: conserve les refs multiples et garde un fallback quand docs non hydratés", () => {
+function seedProjectDocuments(items = []) {
   store.projectDocuments = {
-    items: [
-      { id: "doc-1", name: "Document 1", phaseCode: "APS", phaseLabel: "Avant Projet Sommaire" }
-    ],
+    items,
     activeDocumentId: null,
     lastAnalysisDocumentIds: []
   };
+}
+
+test("document refs: document_id seul ne doit produire aucune référence UI", () => {
+  seedProjectDocuments([
+    { id: "doc-1", name: "Document 1", phaseCode: "APS", phaseLabel: "Avant Projet Sommaire", documentKind: "user_upload" }
+  ]);
 
   const refs = getSelectionDocumentRefs({
     item: {
       id: "subject-1",
       document_id: "doc-1",
+      document_ref_ids: [],
+      raw: { document_ref_ids: [] }
+    }
+  });
+
+  assert.equal(refs.length, 0);
+});
+
+test("document refs: les document_ref_ids valides sont affichées", () => {
+  seedProjectDocuments([
+    { id: "doc-1", name: "Document 1", phaseCode: "APS", phaseLabel: "Avant Projet Sommaire", documentKind: "user_upload" },
+    { id: "doc-2", name: "Document 2", phaseCode: "APD", phaseLabel: "Avant Projet Définitif", documentKind: "user_upload" }
+  ]);
+
+  const refs = getSelectionDocumentRefs({
+    item: {
+      id: "subject-2",
+      document_id: "doc-1",
       document_ref_ids: ["doc-2", "doc-1"],
+      raw: { document_ref_ids: ["doc-2"] }
+    }
+  });
+
+  assert.equal(refs.length, 2);
+  assert.deepEqual(refs.map((ref) => ref.id), ["doc-2", "doc-1"]);
+  assert.equal(refs.find((ref) => ref.id === "doc-1")?.name, "Document 1");
+  assert.equal(refs.find((ref) => ref.id === "doc-2")?.name, "Document 2");
+});
+
+test("document refs: sujet manuel système sans document_ref_ids ne montre aucune référence", () => {
+  seedProjectDocuments([
+    { id: "doc-system", name: "manual-subjects-system.json", documentKind: "manual_subjects_system" }
+  ]);
+
+  const refs = getSelectionDocumentRefs({
+    item: {
+      id: "subject-manual",
+      document_id: "doc-system",
+      document_ref_ids: [],
       raw: {
-        document_ref_ids: ["doc-3"],
-        document_id: "doc-1"
+        document_id: "doc-system",
+        document_ref_ids: []
       }
     }
   });
 
-  assert.equal(refs.length, 3);
-  assert.deepEqual(refs.map((ref) => ref.id), ["doc-2", "doc-1", "doc-3"]);
-  assert.equal(refs.find((ref) => ref.id === "doc-1")?.name, "Document 1");
-  assert.equal(refs.find((ref) => ref.id === "doc-2")?.name, "doc-2");
-  assert.equal(refs.find((ref) => ref.id === "doc-3")?.name, "doc-3");
+  assert.equal(refs.length, 0);
+});
+
+test("document refs: un document système présent dans document_ref_ids est filtré", () => {
+  seedProjectDocuments([
+    { id: "doc-system", name: "manual-subjects-system.json", documentKind: "manual_subjects_system" },
+    { id: "doc-user", name: "specifications.pdf", documentKind: "user_upload", phaseCode: "PRO", phaseLabel: "Projet" }
+  ]);
+
+  const refs = getSelectionDocumentRefs({
+    item: {
+      id: "subject-3",
+      document_ref_ids: ["doc-system", "doc-user"]
+    }
+  });
+
+  assert.deepEqual(refs.map((ref) => ref.id), ["doc-user"]);
 });

--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -718,6 +718,7 @@ function buildStoragePublicUrl(bucket, path) {
 function mapDocumentRowToViewModel(row = {}) {
   const displayName = safeString(row.original_filename || row.filename || "Document");
   const mimeType = safeString(row.mime_type || "");
+  const documentKind = safeString(row.document_kind || "");
 
   return {
     id: safeString(row.id),
@@ -737,7 +738,8 @@ function mapDocumentRowToViewModel(row = {}) {
     extension: displayName.includes(".") ? displayName.split(".").pop().toLowerCase() : "",
     storageBucket: safeString(row.storage_bucket),
     storagePath: safeString(row.storage_path),
-    uploadStatus: safeString(row.upload_status)
+    uploadStatus: safeString(row.upload_status),
+    documentKind
   };
 }
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -257,6 +257,7 @@ function getDocumentDisplayName(document = {}) {
 
 function renderDocumentRefsCard(selection) {
   const refs = getSelectionDocumentRefs(selection);
+  // Strict UI contract: only explicit, resolved business references are rendered.
   if (!refs.length) return "";
 
   return `

--- a/supabase/migrations/202606150031_manual_subject_creation_column_alignment.sql
+++ b/supabase/migrations/202606150031_manual_subject_creation_column_alignment.sql
@@ -144,6 +144,7 @@ begin
   )
   values (
     v_project.id,
+    -- Technical provenance only (system manual-subject document); never a UI proof reference.
     v_manual_document.id,
     v_manual_analysis_run.id,
     v_subject_type,
@@ -156,6 +157,9 @@ begin
     v_person_id
   )
   returning * into v_subject;
+
+  -- Intentionally does not set document_ref_ids:
+  -- business/UI references must be explicitly associated later.
 
   select coalesce(
     nullif(trim(concat_ws(' ', coalesce(dp.first_name, ''), coalesce(dp.last_name, ''))), ''),


### PR DESCRIPTION
### Motivation
- Corriger un faux-positif où un sujet manuel affichait une « Référence documentaire » parce que la logique UI utilisait `document_id`/`raw.document_id` comme fallback et rendait des artefacts techniques (ex. `manual_subjects_system`).
- Séparer strictement la provenance technique (`document_id`, `analysis_run_id`, documents système) des preuves métier affichables (`document_ref_ids`).

### Description
- Suppression du fallback implicite sur `document_id`/`raw.document_id` dans `normalizeEntityDocumentRefs` pour ne conserver que `document_ref_ids` explicites comme source d’affichage des références UI. (apps/web/js/services/project-document-selectors.js)
- Introduction d’un helper `normalizeEntityTechnicalDocumentIds` et d’une instrumentation debug légère (`debugDocumentRefs`) pour tracer source/filtrage sans impacter le rendu normal. (apps/web/js/services/project-document-selectors.js)
- Filtrage explicite des documents système `manual_subjects_system` lors de la résolution des références UI, et ajout d’un champ `documentKind` au mapping Supabase pour rendre le filtrage fiable. (apps/web/js/services/project-document-selectors.js, apps/web/js/services/project-supabase-sync.js)
- Documentation dans la migration SQL pour clarifier que `create_manual_subject(...)` renseigne `document_id` comme provenance technique et n’écrit volontairement pas `document_ref_ids`. (supabase/migrations/202606150031_manual_subject_creation_column_alignment.sql)
- Rendu détail sujet conservé mais clarifié par commentaire: la carte “Références documentaires” ne s’affiche que si des refs métier explicites existent. (apps/web/js/views/project-subjects/project-subjects-view.js)
- Tests mis à jour et ajoutés pour verrouiller le comportement souhaité et prévenir régressions (nouveau helper `seedProjectDocuments` et 4 cas métier). (apps/web/js/services/project-document-selectors.test.mjs)
- Fichiers modifiés : `project-document-selectors.js`, `project-document-selectors.test.mjs`, `project-supabase-sync.js`, `project-subjects-view.js`, et la migration SQL suscitée.

### Testing
- Tests unitaires exécutés : `node --test apps/web/js/services/project-document-selectors.test.mjs` et la suite complète du fichier a passé les 4 tests ajoutés/modifiés (4 ok, 0 failed). 
- Les modifications n’ajoutent pas de logs en production par défaut et la trace debug est activable via `debugDocumentRefs=1` ou flags de stockage/globales pour diagnostic futur.
- Aucun autre test automatisé n’a été exécuté pendant cette correction (seulement le fichier de tests ciblé ci-dessus).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a6119334832995bc09b34f0e6253)