### PR TITLE
Ajouter bouton “Nouveau sujet” en détail et contexte d’ouverture du formulaire de création

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -507,7 +507,8 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   renderDetailedMetaForSelection: (...args) => projectSubjectsView.renderDetailedMetaForSelection(...args),
   renderSubjectMetaControls: (...args) => projectSubjectsView.renderSubjectMetaControls(...args),
   priorityBadge: (...args) => projectSubjectsView.priorityBadge(...args),
-  renderDocumentRefsCard: (...args) => projectSubjectsView.renderDocumentRefsCard(...args)
+  renderDocumentRefsCard: (...args) => projectSubjectsView.renderDocumentRefsCard(...args),
+  canRenderCreateFromDetailAction: () => !store.situationsView?.createSubjectForm?.isOpen
 });
 
 const {

--- a/apps/web/js/views/project-subjects/project-subject-detail.js
+++ b/apps/web/js/views/project-subjects/project-subject-detail.js
@@ -96,7 +96,10 @@ export function createProjectSubjectDetailController(config) {
 
   function renderNormalDetailsChromeHeadHtml(selectionOverride = null, options = {}) {
     const selection = selectionOverride || getActiveSelection();
-    return renderDetailsChromeHeadHtml(selection, options);
+    return renderDetailsChromeHeadHtml(selection, {
+      ...options,
+      showCreateFromDetailAction: true
+    });
   }
 
   function openDetailsModal() {

--- a/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const detailsRendererPath = path.resolve(__dirname, "./project-subjects-details-renderer.js");
+const detailsRendererSource = fs.readFileSync(detailsRendererPath, "utf8");
+const detailControllerPath = path.resolve(__dirname, "./project-subject-detail.js");
+const detailControllerSource = fs.readFileSync(detailControllerPath, "utf8");
+const drilldownPath = path.resolve(__dirname, "./project-subject-drilldown.js");
+const drilldownSource = fs.readFileSync(drilldownPath, "utf8");
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+const viewPath = path.resolve(__dirname, "./project-subjects-view.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+const statePath = path.resolve(__dirname, "./project-subjects-state.js");
+const stateSource = fs.readFileSync(statePath, "utf8");
+
+test("le header normal de détail sujet expose le bouton Nouveau sujet via actionsHtml", () => {
+  assert.match(detailsRendererSource, /data-action="open-create-subject-from-detail"/);
+  assert.match(detailsRendererSource, /class="gh-btn gh-action__main gh-btn--primary gh-btn--md"/);
+  assert.match(detailControllerSource, /showCreateFromDetailAction: true/);
+});
+
+test("le drilldown ne rend pas le bouton Nouveau sujet", () => {
+  assert.doesNotMatch(drilldownSource, /open-create-subject-from-detail/);
+});
+
+test("openCreateSubjectForm accepte un contexte explicite origin\/sourceSubjectId", () => {
+  assert.match(viewSource, /function openCreateSubjectForm\(options = \{\}\)/);
+  assert.match(viewSource, /const origin = requestedOrigin === "detail" \? "detail" : "table";/);
+  assert.match(viewSource, /sourceSubjectId/);
+  assert.match(stateSource, /origin: "table"/);
+  assert.match(stateSource, /sourceSubjectId: null/);
+});
+
+test("le clic depuis le détail ouvre le formulaire en mode detail avec le sujet source", () => {
+  assert.match(eventsSource, /\[data-action='open-create-subject-from-detail'\]/);
+  assert.match(eventsSource, /openCreateSubjectForm\(\{ origin: "detail", sourceSubjectId: activeSubjectId \}\);/);
+});
+
+test("Annuler depuis une création ouverte depuis le détail restaure le sujet source", () => {
+  assert.match(eventsSource, /const formOrigin = String\(formContext\.origin \|\| ""\)\.trim\(\)\.toLowerCase\(\) === "detail" \? "detail" : "table";/);
+  assert.match(eventsSource, /if \(formOrigin === "detail" && sourceSubjectId && getNestedSujet\(sourceSubjectId\)\) \{/);
+  assert.match(eventsSource, /selectSubject\(sourceSubjectId\) \|\| selectSujet\(sourceSubjectId\);/);
+});
+
+test("Ajouter conserve En ajouter d'autres et distingue le flux detail/table", () => {
+  assert.match(eventsSource, /openCreateSubjectForm\(\{\s*origin: formOrigin,\s*sourceSubjectId\s*\}\);/);
+  assert.match(eventsSource, /if \(formOrigin === "detail"\) \{\s*store\.situationsView\.showTableOnly = false;/);
+  assert.match(eventsSource, /openCreateSubjectForm\(\{ origin: "table", sourceSubjectId: null \}\);/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -25,7 +25,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderDetailedMetaForSelection,
     renderSubjectMetaControls,
     priorityBadge,
-    renderDocumentRefsCard
+    renderDocumentRefsCard,
+    canRenderCreateFromDetailAction
   } = config;
 
   function renderSubjectTitleContent(currentSelection, options = {}) {
@@ -162,11 +163,27 @@ export function createProjectSubjectsDetailsRenderer(config) {
   }
 
   function renderDetailsChromeHeadHtml(selection, options = {}) {
+    const showCreateFromDetailAction = options.showCreateFromDetailAction === true;
+    const shouldRenderCreateFromDetailAction = showCreateFromDetailAction
+      && selection?.type === "sujet"
+      && (typeof canRenderCreateFromDetailAction === "function"
+        ? canRenderCreateFromDetailAction(selection)
+        : true);
+    const createFromDetailActionHtml = shouldRenderCreateFromDetailAction
+      ? `
+        <button
+          type="button"
+          class="gh-btn gh-action__main gh-btn--primary gh-btn--md"
+          data-action="open-create-subject-from-detail"
+        >Nouveau sujet</button>
+      `
+      : "";
     return renderSharedDetailsChromeHeadHtml(selection, {
       headId: options.headId || "",
       headClassName: options.headClassName || "",
       closeId: options.closeId || "",
       closeLabel: options.closeLabel || "Fermer",
+      actionsHtml: createFromDetailActionHtml,
       titleWrapHtml: renderDetailsTitleWrapHtml(selection),
       emptyPanelTitle: "Sélectionner un élément",
       buildMetaHtml(currentSelection) {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -4957,7 +4957,7 @@ export function createProjectSubjectsEvents(config) {
       if (!action) return;
       if (action === "add-sujet") {
         event.preventDefault();
-        openCreateSubjectForm();
+        openCreateSubjectForm({ origin: "table", sourceSubjectId: null });
         rerenderPanels();
         return;
       }
@@ -5147,6 +5147,9 @@ export function createProjectSubjectsEvents(config) {
       const createSubjectCancelButton = event.target.closest("[data-create-subject-cancel]");
       if (createSubjectCancelButton && store.situationsView.createSubjectForm?.isOpen) {
         event.preventDefault();
+        const formContext = store.situationsView.createSubjectForm || {};
+        const formOrigin = String(formContext.origin || "").trim().toLowerCase() === "detail" ? "detail" : "table";
+        const sourceSubjectId = String(formContext.sourceSubjectId || "").trim();
         dropdownController().closeMeta();
         const mentionUi = typeof getMentionUiState === "function" ? getMentionUiState() : store?.situationsView?.mentionUi;
         if (mentionUi && typeof mentionUi === "object") {
@@ -5179,6 +5182,28 @@ export function createProjectSubjectsEvents(config) {
           subjectRefUi.composerKey = "";
         }
         resetCreateSubjectForm({ keepCreateMore: true });
+        if (formOrigin === "detail" && sourceSubjectId && getNestedSujet(sourceSubjectId)) {
+          selectSubject(sourceSubjectId) || selectSujet(sourceSubjectId);
+          store.situationsView.showTableOnly = false;
+          store.projectSubjectsView.showTableOnly = false;
+          return;
+        }
+        rerenderPanels();
+        return;
+      }
+
+      const openCreateSubjectFromDetailButton = event.target.closest("[data-action='open-create-subject-from-detail']");
+      if (openCreateSubjectFromDetailButton) {
+        event.preventDefault();
+        const activeSubjectId = String(
+          store.situationsView.selectedSubjectId
+          || store.situationsView.selectedSujetId
+          || store.projectSubjectsView.selectedSubjectId
+          || store.projectSubjectsView.selectedSujetId
+          || ""
+        ).trim();
+        if (!activeSubjectId || !getNestedSujet(activeSubjectId)) return;
+        openCreateSubjectForm({ origin: "detail", sourceSubjectId: activeSubjectId });
         rerenderPanels();
         return;
       }
@@ -5190,7 +5215,10 @@ export function createProjectSubjectsEvents(config) {
           return;
         }
 
-        const keepCreateMore = !!store.situationsView.createSubjectForm?.createMore;
+        const formContext = store.situationsView.createSubjectForm || {};
+        const keepCreateMore = !!formContext.createMore;
+        const formOrigin = String(formContext.origin || "").trim().toLowerCase() === "detail" ? "detail" : "table";
+        const sourceSubjectId = String(formContext.sourceSubjectId || "").trim() || null;
 
         (async () => {
           const submitPromise = createSubjectFromDraft();
@@ -5202,9 +5230,16 @@ export function createProjectSubjectsEvents(config) {
           }
 
           if (keepCreateMore) {
-            openCreateSubjectForm();
+            openCreateSubjectForm({
+              origin: formOrigin,
+              sourceSubjectId
+            });
           } else {
             resetCreateSubjectForm({ keepCreateMore: true });
+            if (formOrigin === "detail") {
+              store.situationsView.showTableOnly = false;
+              store.projectSubjectsView.showTableOnly = false;
+            }
           }
           rerenderPanels();
         })().catch((error) => {

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -228,12 +228,17 @@ export function createProjectSubjectsState({ store }) {
         validationError: "",
         isSubmitting: false,
         uploadSessionId: "",
-        attachments: []
+        attachments: [],
+        origin: "table",
+        sourceSubjectId: null
       };
     }
     if (typeof v.createSubjectForm.isSubmitting !== "boolean") v.createSubjectForm.isSubmitting = false;
     if (typeof v.createSubjectForm.uploadSessionId !== "string") v.createSubjectForm.uploadSessionId = "";
     if (!Array.isArray(v.createSubjectForm.attachments)) v.createSubjectForm.attachments = [];
+    if (String(v.createSubjectForm.origin || "").trim().toLowerCase() !== "detail") v.createSubjectForm.origin = "table";
+    const sourceSubjectId = String(v.createSubjectForm.sourceSubjectId || "").trim();
+    v.createSubjectForm.sourceSubjectId = sourceSubjectId || null;
     return v;
   }
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -487,6 +487,7 @@ function buildDefaultDraftSubjectMeta() {
 function resetCreateSubjectForm(options = {}) {
   ensureViewUiState();
   const keepCreateMore = !!options.keepCreateMore;
+  const keepContext = !!options.keepContext;
   const previous = store.situationsView.createSubjectForm || {};
   clearCreateSubjectDraftAttachments(previous.attachments);
   store.situationsView.createSubjectForm = {
@@ -499,16 +500,23 @@ function resetCreateSubjectForm(options = {}) {
     validationError: "",
     isSubmitting: false,
     uploadSessionId: "",
-    attachments: []
+    attachments: [],
+    origin: keepContext ? (previous.origin === "detail" ? "detail" : "table") : "table",
+    sourceSubjectId: keepContext ? (String(previous.sourceSubjectId || "").trim() || null) : null
   };
 }
 
-function openCreateSubjectForm() {
+function openCreateSubjectForm(options = {}) {
   resetObjectiveEditState();
   closeSubjectMetaDropdown();
   closeSubjectKanbanDropdown();
   ensureViewUiState();
   const previousCreateMore = !!store.situationsView.createSubjectForm?.createMore;
+  const requestedOrigin = String(options.origin || "").trim().toLowerCase();
+  const origin = requestedOrigin === "detail" ? "detail" : "table";
+  const sourceSubjectId = origin === "detail"
+    ? (String(options.sourceSubjectId || "").trim() || null)
+    : null;
   store.situationsView.subjectsSubview = "subjects";
   store.situationsView.showTableOnly = true;
   store.situationsView.createSubjectForm = {
@@ -521,7 +529,9 @@ function openCreateSubjectForm() {
     validationError: "",
     isSubmitting: false,
     uploadSessionId: "",
-    attachments: []
+    attachments: [],
+    origin,
+    sourceSubjectId
   };
 }
 


### PR DESCRIPTION
### Motivation
- Permettre d’ouvrir le formulaire de création depuis le panneau de détail (mode normal) en réutilisant la même UI/logic que depuis le tableau tout en conservant un contexte explicite pour gérer correctement «Annuler», «Ajouter» et «En ajouter d’autres». 

### Description
- Ajout d’un contexte explicite dans l’état `createSubjectForm` avec les champs `origin: "table" | "detail"` et `sourceSubjectId: string | null`, et normalisation par défaut à `"table"` dans `project-subjects-state.js` et l’initialisation vue. 
- Évolution de `openCreateSubjectForm(options)` dans `project-subjects-view.js` pour accepter `options.origin` et `options.sourceSubjectId` et initialiser le formulaire sans heuristiques DOM. 
- Injection du bouton `Nouveau sujet` (classes exactes : `gh-btn gh-action__main gh-btn--primary gh-btn--md`) dans le head du détail normal via le mécanisme `actionsHtml` (fichier `project-subjects-details-renderer.js`) et activation uniquement pour une sélection de type sujet; le drilldown n’est pas affecté. 
- Ajout d’un handler action `data-action="open-create-subject-from-detail"` dans `project-subjects-events.js` qui appelle `openCreateSubjectForm({ origin: "detail", sourceSubjectId })`, et mises à jour des flows `Annuler` et `Ajouter` pour respecter le `origin` et préserver le comportement `createMore`. 

### Testing
- Tests structurels ajoutés et exécutés : `apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs` (vérifie rendu du bouton dans le head, non-impact drilldown, signature de `openCreateSubjectForm`, clic depuis le détail et restauration sur Annuler). 
- Tests exécutés manuellement via `node --test` :
  - `node --test apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs` — passed.
  - `node --test apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subjects-selection-scope.test.mjs` — passed (régression drilldown/selection couverte).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8aae6f8548329b98f9c244b6f70c9)