### PR TITLE
Add “Ajouter sous-sujet” action entrypoint in subject detail and drilldown

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -500,6 +500,8 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   escapeHtml,
   statePill: (...args) => projectSubjectsView.statePill(...args),
   renderDescriptionCard,
+  getChildSubjectList: (...args) => projectSubjectsView.getChildSubjectList(...args),
+  renderAddSubissueActionButton: (...args) => projectSubjectsView.renderAddSubissueActionButton(...args),
   renderSubIssuesForSujet: (...args) => projectSubjectsView.renderSubIssuesForSujet(...args),
   renderSubIssuesForSituation: (...args) => projectSubjectsView.renderSubIssuesForSituation(...args),
   renderThreadBlock,

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -20,6 +20,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderDescriptionCard,
     renderSubIssuesForSujet,
     renderSubIssuesForSituation,
+    getChildSubjectList,
+    renderAddSubissueActionButton,
     renderThreadBlock,
     renderCommentBox,
     renderDetailedMetaForSelection,
@@ -220,7 +222,12 @@ export function createProjectSubjectsDetailsRenderer(config) {
     }
 
     const item = selection.item;
+    const childSubjects = selection.type === "sujet" ? getChildSubjectList(item) : [];
+    const shouldRenderDescriptionAddSubissueAction = selection.type === "sujet" && childSubjects.length === 0;
     const descCard = renderDescriptionCard(selection);
+    const descriptionAddSubissueActionHtml = shouldRenderDescriptionAddSubissueAction
+      ? renderAddSubissueActionButton(item.id, { placement: "description" })
+      : "";
     const subIssuesHtml = selection.type === "sujet"
       ? renderSubIssuesForSujet(item, options.subissuesOptions || {})
       : renderSubIssuesForSituation(item, options.subissuesOptions || {});
@@ -249,6 +256,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
         <div class="details-main">
           <div class="gh-timeline">
             ${descCard}
+            ${descriptionAddSubissueActionHtml}
             ${renderDocumentRefsCard(selection)}
             ${subIssuesHtml}
             <div class="subject-details-thread-host" data-details-thread-host>

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -765,6 +765,52 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    root.querySelectorAll("[data-action='open-subissue-action-menu']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const targetSubjectId = String(btn.dataset.subjectId || scopedSelection?.item?.id || "");
+        if (!targetSubjectId) return;
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        const isAlreadyOpen = dropdown.field === "subissue-actions" && String(dropdown.subissueActionSubjectId || "") === targetSubjectId;
+        if (isAlreadyOpen) {
+          dropdownController().closeMeta();
+        } else {
+          dropdownController().closeKanban();
+          dropdownController().openMeta({ field: "subissue-actions" });
+          dropdown.subissueActionSubjectId = targetSubjectId;
+          dropdown.subissueActionScopeHost = isDrilldownScope ? "drilldown" : "main";
+          dropdown.subissueActionIntent = "";
+        }
+        rerenderScope(root);
+        if (!isAlreadyOpen) {
+          syncSubjectMetaDropdownPosition(getSubjectMetaScopeRoot());
+        }
+      };
+    });
+
+    root.querySelectorAll("[data-action='open-create-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        dropdownController().closeMeta();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionIntent = "create";
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='open-link-existing-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        dropdownController().closeMeta();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionIntent = "link-existing";
+        rerenderScope(root);
+      };
+    });
+
     root.querySelectorAll(".subject-meta-field").forEach((fieldRoot) => {
       bindSubjectSituationFieldInteractions(root, fieldRoot);
     });

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -198,11 +198,17 @@ export function createProjectSubjectsState({ store }) {
         query: "",
         activeKey: "",
         showClosedSituations: false,
-        relationsView: "menu"
+        relationsView: "menu",
+        subissueActionSubjectId: "",
+        subissueActionScopeHost: "main",
+        subissueActionIntent: ""
       };
     }
     if (typeof v.subjectMetaDropdown.showClosedSituations !== "boolean") v.subjectMetaDropdown.showClosedSituations = false;
     if (typeof v.subjectMetaDropdown.relationsView !== "string") v.subjectMetaDropdown.relationsView = "menu";
+    if (typeof v.subjectMetaDropdown.subissueActionSubjectId !== "string") v.subjectMetaDropdown.subissueActionSubjectId = "";
+    if (typeof v.subjectMetaDropdown.subissueActionScopeHost !== "string") v.subjectMetaDropdown.subissueActionScopeHost = "main";
+    if (typeof v.subjectMetaDropdown.subissueActionIntent !== "string") v.subjectMetaDropdown.subissueActionIntent = "";
     if (!v.subjectKanbanDropdown || typeof v.subjectKanbanDropdown !== "object") {
       v.subjectKanbanDropdown = {
         subjectId: "",

--- a/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const viewPath = path.resolve(__dirname, "./project-subjects-view.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+const detailsRendererPath = path.resolve(__dirname, "./project-subjects-details-renderer.js");
+const detailsRendererSource = fs.readFileSync(detailsRendererPath, "utf8");
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+const statePath = path.resolve(__dirname, "./project-subjects-state.js");
+const stateSource = fs.readFileSync(statePath, "utf8");
+const stylePath = path.resolve(__dirname, "../../../style.css");
+const styleSource = fs.readFileSync(stylePath, "utf8");
+
+test("rend le bouton Ajouter sous-sujet dans la description quand il n'y a aucun sous-sujet", () => {
+  assert.match(detailsRendererSource, /shouldRenderDescriptionAddSubissueAction = selection\.type === "sujet" && childSubjects\.length === 0/);
+  assert.match(detailsRendererSource, /renderAddSubissueActionButton\(item\.id, \{ placement: "description" \}\)/);
+});
+
+test("rend le bouton Ajouter sous-sujet en bas du panneau des sous-sujets quand il y a des enfants", () => {
+  assert.match(viewSource, /bodyHtml: `\$\{body\}\$\{renderAddSubissueActionButton\(sujet\?\.id, \{ placement: "subissues" \}\)\}`/);
+});
+
+test("le dropdown Ajouter sous-sujet expose exactement les deux actions attendues", () => {
+  assert.match(viewSource, /if \(field === "subissue-actions"\)/);
+  assert.match(viewSource, /data-action="open-create-subissue"/);
+  assert.match(viewSource, /Créer un sous-sujet/);
+  assert.match(viewSource, /data-action="open-link-existing-subissue"/);
+  assert.match(viewSource, /Ajouter un sujet existant/);
+});
+
+test("l'événement d'ouverture du menu sous-sujet utilise le dropdown mutualisé", () => {
+  assert.match(eventsSource, /\[data-action='open-subissue-action-menu'\]/);
+  assert.match(eventsSource, /dropdownController\(\)\.openMeta\(\{ field: "subissue-actions" \}\)/);
+  assert.match(eventsSource, /dropdownController\(\)\.closeKanban\(\);/);
+});
+
+test("les data attributes et l'état UI dédié sont présents", () => {
+  assert.match(viewSource, /data-action="open-subissue-action-menu"/);
+  assert.match(stateSource, /subissueActionSubjectId: ""/);
+  assert.match(stateSource, /subissueActionScopeHost: "main"/);
+  assert.match(stateSource, /subissueActionIntent: ""/);
+});
+
+test("le style du bouton est défini pour les emplacements description et sous-sujets", () => {
+  assert.match(styleSource, /\.subject-add-subissue-action--description/);
+  assert.match(styleSource, /\.subject-add-subissue-action--subissues/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1993,6 +1993,31 @@ function renderSubjectMetaDropdown(subject, field) {
     `;
   }
 
+  if (field === "subissue-actions") {
+    return `
+      <div class="subject-meta-dropdown gh-menu gh-menu--open" role="menu">
+        <div class="subject-meta-dropdown__body">
+          <div class="select-menu__section">
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-action="open-create-subissue">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Créer un sous-sujet</span>
+                </span>
+              </span>
+            </button>
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-action="open-link-existing-subissue">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Ajouter un sujet existant</span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   if (field === "objectives") {
     const { openItems, closedItems } = buildSubjectMetaMenuItems(subject, field);
     return `
@@ -2167,6 +2192,30 @@ function renderSubissueAssigneesCellHtml(subjectId) {
   `;
 }
 
+function renderAddSubissueActionButton(subjectId, options = {}) {
+  const normalizedSubjectId = String(subjectId || "");
+  if (!normalizedSubjectId) return "";
+  const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+  const isOpen = String(dropdown.field || "") === "subissue-actions"
+    && String(dropdown.subissueActionSubjectId || "") === normalizedSubjectId;
+  const placement = String(options.placement || "").trim().toLowerCase() === "subissues" ? "subissues" : "description";
+  return `
+    <div class="subject-add-subissue-action subject-add-subissue-action--${escapeHtml(placement)}">
+      <button
+        type="button"
+        class="gh-btn gh-btn--md subject-add-subissue-action__trigger ${isOpen ? "is-open" : ""}"
+        data-action="open-subissue-action-menu"
+        data-subject-id="${escapeHtml(normalizedSubjectId)}"
+        data-subject-meta-anchor="subissue-actions"
+        aria-expanded="${isOpen ? "true" : "false"}"
+      >
+        <span>Ajouter sous-sujet</span>
+        <span class="subject-add-subissue-action__chevron" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    </div>
+  `;
+}
+
 function renderSubIssuesForSujet(sujet, options = {}) {
   ensureViewUiState();
   const sujetRowClass = options.sujetRowClass || "js-row-sujet";
@@ -2266,7 +2315,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
     title: "Sous-sujets",
     leftMetaHtml: subissuesHeadCountsHtml(childSubjects),
     rightMetaHtml: "",
-    bodyHtml: body,
+    bodyHtml: `${body}${renderAddSubissueActionButton(sujet?.id, { placement: "subissues" })}`,
     isOpen: options.isOpen !== false
   });
 }
@@ -3169,6 +3218,8 @@ function getObjectiveById(objectiveId) {
     renderDetailedMetaForSelection,
     renderSubjectMetaControls,
     renderSubjectMetaFieldValue,
+    getChildSubjectList,
+    renderAddSubissueActionButton,
     renderSubIssuesForSujet,
     renderSubIssuesForSituation,
     closeSubjectMetaDropdown,

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -115,6 +115,9 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.query = "";
   dropdown.activeKey = "";
   dropdown.relationsView = "menu";
+  dropdown.subissueActionSubjectId = "";
+  dropdown.subissueActionScopeHost = "main";
+  dropdown.subissueActionIntent = "";
 }
 
 export function closeKanbanSelectDropdown(getViewState) {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3159,6 +3159,11 @@ body.is-resizing{
 .subissues-table .issues-table__head{border-bottom:1px solid var(--border2);}
 .subissues-table .issues-table__body{max-height:360px;overflow:auto;}
 .subissue-row--selected{outline:1px solid rgba(88,166,255,.45);background:rgba(56,139,253,.08);}
+.subject-add-subissue-action{margin-left:52px;width:calc(100% - 52px);}
+.subject-add-subissue-action--description{margin-top:8px;margin-bottom:8px;}
+.subject-add-subissue-action--subissues{margin:0;padding:10px 12px 12px;border-top:1px solid var(--border2);width:100%;}
+.subject-add-subissue-action__trigger{display:inline-flex;align-items:center;gap:8px;}
+.subject-add-subissue-action__chevron{display:inline-flex;align-items:center;color:var(--muted);}
 
 /* Main table row selection (same visual language as sub-issues selection) */
 .issue-row.selected{


### PR DESCRIPTION
### Motivation
- Provide the UX entrypoint "Ajouter sous-sujet" in the subject detail and drilldown views so users can start the sub-issue flow without yet wiring persistence or final modals.
- Reuse the existing select/dropdown lifecycle to avoid adding a second dropdown implementation and to keep flows consistent with existing meta/relations dropdowns.
- Render the action conditionally depending on whether the subject already has children so placement matches the UX spec.

### Description
- Added lightweight UI state for the new menu to the existing dropdown state: `subissueActionSubjectId`, `subissueActionScopeHost`, and `subissueActionIntent` in `apps/web/js/views/project-subjects/project-subjects-state.js` and reset logic in `apps/web/js/views/ui/select-dropdown-controller.js`.
- Added a dedicated renderer `renderAddSubissueActionButton` in `apps/web/js/views/project-subjects/project-subjects-view.js` that renders the `Ajouter sous-sujet` trigger with `data-action="open-subissue-action-menu"` and proper `data-subject-meta-anchor="subissue-actions"` attributes.
- Hooked the trigger into the detail and drilldown render paths by: adding it below the description when a subject has no children (in `project-subjects-details-renderer.js`) and appending it at the bottom of the subissues panel when children exist (in `project-subjects-view.js`).
- Implemented the first-level dropdown content for the `subissue-actions` field (exactly two items: `Créer un sous-sujet` and `Ajouter un sujet existant`) inside the existing `renderSubjectMetaDropdown` flow to reuse the mutualized dropdown host.
- Wired event handlers in `apps/web/js/views/project-subjects/project-subjects-events.js` to open/close the shared dropdown and set the new UI state, and to set the UI intent when the two menu items are clicked (intent set but not yet persisted or leading to final modals).
- Added minimal CSS in `apps/web/style.css` for placement variants (`--description` and `--subissues`) and integrated the new renderers into the module assembly so the details renderer can call them.
- Added focused unit tests in `apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs` checking presence, conditional placement, dropdown items, event wiring, and style hooks.

### Testing
- Ran the new and existing view/unit tests with: `node --test apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs` and all tests passed (12 assertions in the combined run).
- No browser screenshots or end-to-end UI automation were executed in this change; handlers set UI state and `data-action` attributes ready for the next steps (view transition / modal hookup).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c42f9efc83299d42993122a5f5b9)