### PR TITLE
Add 'Add subissue' action and subissue-actions dropdown to subject details and subissues panel

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -500,6 +500,8 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   escapeHtml,
   statePill: (...args) => projectSubjectsView.statePill(...args),
   renderDescriptionCard,
+  getChildSubjectList: (...args) => projectSubjectsView.getChildSubjectList(...args),
+  renderAddSubissueActionButton: (...args) => projectSubjectsView.renderAddSubissueActionButton(...args),
   renderSubIssuesForSujet: (...args) => projectSubjectsView.renderSubIssuesForSujet(...args),
   renderSubIssuesForSituation: (...args) => projectSubjectsView.renderSubIssuesForSituation(...args),
   renderThreadBlock,

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -857,7 +857,7 @@ export function createProjectSubjectsDescription(config = {}) {
     return host;
   }
 
-  function renderDescriptionCard(selection) {
+  function renderDescriptionCard(selection, options = {}) {
     const entityType = getSelectionEntityType(selection.type);
     const entityId = selection.item.id;
     const versionsUi = ensureDescriptionVersionsUiState();
@@ -993,6 +993,7 @@ export function createProjectSubjectsDescription(config = {}) {
       `;
 
     const displayIdentity = firstVersionIdentity || identity;
+    const footerActionsHtml = String(options.footerActionsHtml || "").trim();
     return `
       <div class="gh-comment gh-comment--description">
         ${displayIdentity.avatarHtml
@@ -1001,6 +1002,7 @@ export function createProjectSubjectsDescription(config = {}) {
         <div class="gh-comment-box">
           ${headerHtml}
           ${bodyHtml}
+          ${footerActionsHtml}
         </div>
       </div>
     `;

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -20,6 +20,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderDescriptionCard,
     renderSubIssuesForSujet,
     renderSubIssuesForSituation,
+    getChildSubjectList,
+    renderAddSubissueActionButton,
     renderThreadBlock,
     renderCommentBox,
     renderDetailedMetaForSelection,
@@ -220,7 +222,13 @@ export function createProjectSubjectsDetailsRenderer(config) {
     }
 
     const item = selection.item;
-    const descCard = renderDescriptionCard(selection);
+    const childSubjects = selection.type === "sujet" ? getChildSubjectList(item) : [];
+    const shouldRenderDescriptionAddSubissueAction = selection.type === "sujet" && childSubjects.length === 0;
+    const descCard = renderDescriptionCard(selection, {
+      footerActionsHtml: shouldRenderDescriptionAddSubissueAction
+        ? renderAddSubissueActionButton(item.id, { placement: "description" })
+        : ""
+    });
     const subIssuesHtml = selection.type === "sujet"
       ? renderSubIssuesForSujet(item, options.subissuesOptions || {})
       : renderSubIssuesForSituation(item, options.subissuesOptions || {});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -765,6 +765,52 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    root.querySelectorAll("[data-action='open-subissue-action-menu']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const targetSubjectId = String(btn.dataset.subjectId || scopedSelection?.item?.id || "");
+        if (!targetSubjectId) return;
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        const isAlreadyOpen = dropdown.field === "subissue-actions" && String(dropdown.subissueActionSubjectId || "") === targetSubjectId;
+        if (isAlreadyOpen) {
+          dropdownController().closeMeta();
+        } else {
+          dropdownController().closeKanban();
+          dropdownController().openMeta({ field: "subissue-actions" });
+          dropdown.subissueActionSubjectId = targetSubjectId;
+          dropdown.subissueActionScopeHost = isDrilldownScope ? "drilldown" : "main";
+          dropdown.subissueActionIntent = "";
+        }
+        rerenderScope(root);
+        if (!isAlreadyOpen) {
+          syncSubjectMetaDropdownPosition(getSubjectMetaScopeRoot());
+        }
+      };
+    });
+
+    root.querySelectorAll("[data-action='open-create-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        dropdownController().closeMeta();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionIntent = "create";
+        rerenderScope(root);
+      };
+    });
+
+    root.querySelectorAll("[data-action='open-link-existing-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        dropdownController().closeMeta();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionIntent = "link-existing";
+        rerenderScope(root);
+      };
+    });
+
     root.querySelectorAll(".subject-meta-field").forEach((fieldRoot) => {
       bindSubjectSituationFieldInteractions(root, fieldRoot);
     });

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -198,11 +198,17 @@ export function createProjectSubjectsState({ store }) {
         query: "",
         activeKey: "",
         showClosedSituations: false,
-        relationsView: "menu"
+        relationsView: "menu",
+        subissueActionSubjectId: "",
+        subissueActionScopeHost: "main",
+        subissueActionIntent: ""
       };
     }
     if (typeof v.subjectMetaDropdown.showClosedSituations !== "boolean") v.subjectMetaDropdown.showClosedSituations = false;
     if (typeof v.subjectMetaDropdown.relationsView !== "string") v.subjectMetaDropdown.relationsView = "menu";
+    if (typeof v.subjectMetaDropdown.subissueActionSubjectId !== "string") v.subjectMetaDropdown.subissueActionSubjectId = "";
+    if (typeof v.subjectMetaDropdown.subissueActionScopeHost !== "string") v.subjectMetaDropdown.subissueActionScopeHost = "main";
+    if (typeof v.subjectMetaDropdown.subissueActionIntent !== "string") v.subjectMetaDropdown.subissueActionIntent = "";
     if (!v.subjectKanbanDropdown || typeof v.subjectKanbanDropdown !== "object") {
       v.subjectKanbanDropdown = {
         subjectId: "",

--- a/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const viewPath = path.resolve(__dirname, "./project-subjects-view.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+const detailsRendererPath = path.resolve(__dirname, "./project-subjects-details-renderer.js");
+const detailsRendererSource = fs.readFileSync(detailsRendererPath, "utf8");
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+const statePath = path.resolve(__dirname, "./project-subjects-state.js");
+const stateSource = fs.readFileSync(statePath, "utf8");
+const stylePath = path.resolve(__dirname, "../../../style.css");
+const styleSource = fs.readFileSync(stylePath, "utf8");
+
+test("rend le bouton Ajouter sous-sujet dans la description quand il n'y a aucun sous-sujet", () => {
+  assert.match(detailsRendererSource, /shouldRenderDescriptionAddSubissueAction = selection\.type === "sujet" && childSubjects\.length === 0/);
+  assert.match(detailsRendererSource, /renderDescriptionCard\(selection, \{/);
+  assert.match(detailsRendererSource, /footerActionsHtml:[\s\S]*renderAddSubissueActionButton\(item\.id, \{ placement: "description" \}\)/);
+});
+
+test("rend le bouton Ajouter sous-sujet en bas du panneau des sous-sujets quand il y a des enfants", () => {
+  assert.match(viewSource, /bodyHtml: `\$\{body\}\$\{renderAddSubissueActionButton\(sujet\?\.id, \{ placement: "subissues" \}\)\}`/);
+});
+
+test("le dropdown Ajouter sous-sujet expose exactement les deux actions attendues", () => {
+  assert.match(viewSource, /if \(field === "subissue-actions"\)/);
+  assert.match(viewSource, /data-action="open-create-subissue"/);
+  assert.match(viewSource, /Créer un sous-sujet/);
+  assert.match(viewSource, /data-action="open-link-existing-subissue"/);
+  assert.match(viewSource, /Ajouter un sujet existant/);
+});
+
+test("l'événement d'ouverture du menu sous-sujet utilise le dropdown mutualisé", () => {
+  assert.match(eventsSource, /\[data-action='open-subissue-action-menu'\]/);
+  assert.match(eventsSource, /dropdownController\(\)\.openMeta\(\{ field: "subissue-actions" \}\)/);
+  assert.match(eventsSource, /dropdownController\(\)\.closeKanban\(\);/);
+});
+
+test("les data attributes et l'état UI dédié sont présents", () => {
+  assert.match(viewSource, /data-action="open-subissue-action-menu"/);
+  assert.match(stateSource, /subissueActionSubjectId: ""/);
+  assert.match(stateSource, /subissueActionScopeHost: "main"/);
+  assert.match(stateSource, /subissueActionIntent: ""/);
+});
+
+test("le style du bouton est défini pour les emplacements description et sous-sujets", () => {
+  assert.match(styleSource, /\.subject-add-subissue-action--description/);
+  assert.match(styleSource, /\.subject-add-subissue-action--subissues/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-thread-scope.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-scope.test.mjs
@@ -107,6 +107,46 @@ test("renderDetailsDiscussionHtml scope le thread/composer sur la sélection exp
   ]);
 });
 
+test("renderDetailsBody n'utilise pas de variable subissue fantôme et injecte le footer via renderDescriptionCard", () => {
+  const captured = [];
+  const renderer = createProjectSubjectsDetailsRenderer({
+    getActiveSelection: () => ({ type: "sujet", item: { id: "S1", title: "Sujet 1" } }),
+    getSelectionEntityType: () => "sujet",
+    getEffectiveSujetStatus: () => "open",
+    getEffectiveSituationStatus: () => "open",
+    getEntityReviewMeta: () => ({ review_state: "pending" }),
+    getReviewTitleStateClass: () => "",
+    getSubjectTitleEditState: () => ({}),
+    isEditingSubjectTitle: () => false,
+    entityDisplayLinkHtml: () => "",
+    problemsCountsHtml: () => "",
+    renderSubjectBlockedByHeadHtml: () => "",
+    renderSubjectParentHeadHtml: () => "",
+    firstNonEmpty: (...values) => values.find((value) => value !== undefined && value !== null && value !== "") || "",
+    escapeHtml: (value) => String(value || ""),
+    statePill: () => "",
+    renderDescriptionCard: (_selection, options = {}) => {
+      captured.push(String(options.footerActionsHtml || ""));
+      return "<description-card />";
+    },
+    renderSubIssuesForSujet: () => "",
+    renderSubIssuesForSituation: () => "",
+    getChildSubjectList: () => [],
+    renderAddSubissueActionButton: () => "<add-subissue-action />",
+    renderThreadBlock: () => "",
+    renderCommentBox: () => "",
+    renderDetailedMetaForSelection: () => "",
+    renderSubjectMetaControls: () => "",
+    priorityBadge: () => "",
+    renderDocumentRefsCard: () => ""
+  });
+
+  const details = renderer.renderDetailsHtml({ type: "sujet", item: { id: "S1", title: "Sujet 1" } });
+  assert.match(details.bodyHtml, /<description-card \/>/);
+  assert.equal(captured.length, 1);
+  assert.match(captured[0], /<add-subissue-action \/>/);
+});
+
 test("ensureTimelineLoadedForSelection charge le subjectId de la sélection fournie", async () => {
   const loadedSubjectIds = [];
   const rerenderHosts = [];

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1993,6 +1993,31 @@ function renderSubjectMetaDropdown(subject, field) {
     `;
   }
 
+  if (field === "subissue-actions") {
+    return `
+      <div class="subject-meta-dropdown gh-menu gh-menu--open" role="menu">
+        <div class="subject-meta-dropdown__body">
+          <div class="select-menu__section">
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-action="open-create-subissue">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Créer un sous-sujet</span>
+                </span>
+              </span>
+            </button>
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-action="open-link-existing-subissue">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Ajouter un sujet existant</span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   if (field === "objectives") {
     const { openItems, closedItems } = buildSubjectMetaMenuItems(subject, field);
     return `
@@ -2167,6 +2192,30 @@ function renderSubissueAssigneesCellHtml(subjectId) {
   `;
 }
 
+function renderAddSubissueActionButton(subjectId, options = {}) {
+  const normalizedSubjectId = String(subjectId || "");
+  if (!normalizedSubjectId) return "";
+  const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+  const isOpen = String(dropdown.field || "") === "subissue-actions"
+    && String(dropdown.subissueActionSubjectId || "") === normalizedSubjectId;
+  const placement = String(options.placement || "").trim().toLowerCase() === "subissues" ? "subissues" : "description";
+  return `
+    <div class="subject-add-subissue-action subject-add-subissue-action--${escapeHtml(placement)}">
+      <button
+        type="button"
+        class="gh-btn gh-btn--md subject-add-subissue-action__trigger ${isOpen ? "is-open" : ""}"
+        data-action="open-subissue-action-menu"
+        data-subject-id="${escapeHtml(normalizedSubjectId)}"
+        data-subject-meta-anchor="subissue-actions"
+        aria-expanded="${isOpen ? "true" : "false"}"
+      >
+        <span>Ajouter sous-sujet</span>
+        <span class="subject-add-subissue-action__chevron" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    </div>
+  `;
+}
+
 function renderSubIssuesForSujet(sujet, options = {}) {
   ensureViewUiState();
   const sujetRowClass = options.sujetRowClass || "js-row-sujet";
@@ -2266,7 +2315,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
     title: "Sous-sujets",
     leftMetaHtml: subissuesHeadCountsHtml(childSubjects),
     rightMetaHtml: "",
-    bodyHtml: body,
+    bodyHtml: `${body}${renderAddSubissueActionButton(sujet?.id, { placement: "subissues" })}`,
     isOpen: options.isOpen !== false
   });
 }
@@ -3169,6 +3218,8 @@ function getObjectiveById(objectiveId) {
     renderDetailedMetaForSelection,
     renderSubjectMetaControls,
     renderSubjectMetaFieldValue,
+    getChildSubjectList,
+    renderAddSubissueActionButton,
     renderSubIssuesForSujet,
     renderSubIssuesForSituation,
     closeSubjectMetaDropdown,

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -115,6 +115,9 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.query = "";
   dropdown.activeKey = "";
   dropdown.relationsView = "menu";
+  dropdown.subissueActionSubjectId = "";
+  dropdown.subissueActionScopeHost = "main";
+  dropdown.subissueActionIntent = "";
 }
 
 export function closeKanbanSelectDropdown(getViewState) {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3159,6 +3159,11 @@ body.is-resizing{
 .subissues-table .issues-table__head{border-bottom:1px solid var(--border2);}
 .subissues-table .issues-table__body{max-height:360px;overflow:auto;}
 .subissue-row--selected{outline:1px solid rgba(88,166,255,.45);background:rgba(56,139,253,.08);}
+.subject-add-subissue-action{width:100%;}
+.subject-add-subissue-action--description{margin-top:8px;margin-bottom:0;}
+.subject-add-subissue-action--subissues{margin:0;padding:10px 12px 12px;border-top:1px solid var(--border2);width:100%;}
+.subject-add-subissue-action__trigger{display:inline-flex;align-items:center;gap:8px;}
+.subject-add-subissue-action__chevron{display:inline-flex;align-items:center;color:var(--muted);}
 
 /* Main table row selection (same visual language as sub-issues selection) */
 .issue-row.selected{


### PR DESCRIPTION
### Motivation

- Provide a convenient action to create or link subissues from a subject's description and from the subissues panel using the existing meta dropdown UI.

### Description

- Pass an injectable `footerActionsHtml` into `renderDescriptionCard` and render an `Add subissue` action there when a sujet has no children via `renderAddSubissueActionButton`.
- Add `renderAddSubissueActionButton` rendering helper and include the action button at the bottom of the subissues panel via `renderSubIssuesForSujet`.
- Introduce a `subissue-actions` meta dropdown in `renderSubjectMetaDropdown` that exposes the two actions `open-create-subissue` and `open-link-existing-subissue`.
- Wire up event handlers in `project-subjects-events.js` for `open-subissue-action-menu`, `open-create-subissue`, and `open-link-existing-subissue` and reuse the shared meta dropdown controller behavior for open/close and positioning.
- Extend UI state in `project-subjects-state.js` with `subissueActionSubjectId`, `subissueActionScopeHost`, and `subissueActionIntent`, and reset these fields when closing the meta dropdown in `select-dropdown-controller.js`.
- Expose `getChildSubjectList` and `renderAddSubissueActionButton` into the details renderer config so the details renderer can decide whether to inject the footer action.
- Add CSS rules for the new `.subject-add-subissue-action` styles.
- Add unit tests to verify rendering and event wiring (`project-subjects-subissue-action-menu.test.mjs`) and update an existing thread-scope test to assert that the description footer injection path is used (`project-subjects-thread-scope.test.mjs`).

### Testing

- Ran `project-subjects-subissue-action-menu.test.mjs` which checks the dropdown entries, data attributes, view-state fields, and CSS selectors; the test passed.
- Ran updated `project-subjects-thread-scope.test.mjs` which asserts `renderDetailsBody` injects the footer via `renderDescriptionCard`; the test passed.
- Ran the JavaScript unit tests related to project subjects and dropdown controllers; all exercised tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c42f9efc83299d42993122a5f5b9)