### PR TITLE
Add sub-issue actions UI and subissue creation mode for subjects

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -500,6 +500,8 @@ const projectSubjectsDetailsRenderer = createProjectSubjectsDetailsRenderer({
   escapeHtml,
   statePill: (...args) => projectSubjectsView.statePill(...args),
   renderDescriptionCard,
+  getChildSubjectList: (...args) => projectSubjectsView.getChildSubjectList(...args),
+  renderAddSubissueActionButton: (...args) => projectSubjectsView.renderAddSubissueActionButton(...args),
   renderSubIssuesForSujet: (...args) => projectSubjectsView.renderSubIssuesForSujet(...args),
   renderSubIssuesForSituation: (...args) => projectSubjectsView.renderSubIssuesForSituation(...args),
   renderThreadBlock,
@@ -863,6 +865,7 @@ const projectSubjectsView = createProjectSubjectsView({
   replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
   replaceSubjectObjectivesInSupabase: (...args) => replaceSubjectObjectivesInSupabase(...args),
   updateSubjectDescriptionInSupabase: (...args) => updateSubjectDescriptionInSupabase(...args),
+  loadSubjectDescriptionVersionsInSupabase: (...args) => loadSubjectDescriptionVersionsInSupabase(...args),
   uploadAttachmentFile: (...args) => subjectMessagesService.uploadAttachmentFile(...args)
 });
 

--- a/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
@@ -37,9 +37,12 @@ test("le drilldown ne rend pas le bouton Nouveau sujet", () => {
 
 test("openCreateSubjectForm accepte un contexte explicite origin\/sourceSubjectId", () => {
   assert.match(viewSource, /function openCreateSubjectForm\(options = \{\}\)/);
-  assert.match(viewSource, /const origin = requestedOrigin === "detail" \? "detail" : "table";/);
+  assert.match(viewSource, /const mode = String\(options\.mode \|\| ""\)\.trim\(\)\.toLowerCase\(\) === "subissue" \? "subissue" : "standard";/);
+  assert.match(viewSource, /const origin = mode === "subissue" \? "detail" : \(requestedOrigin === "detail" \? "detail" : "table"\);/);
   assert.match(viewSource, /sourceSubjectId/);
+  assert.match(viewSource, /parentSubjectId/);
   assert.match(stateSource, /origin: "table"/);
+  assert.match(stateSource, /mode: "standard"/);
   assert.match(stateSource, /sourceSubjectId: null/);
 });
 
@@ -58,4 +61,12 @@ test("Ajouter conserve En ajouter d'autres et distingue le flux detail/table", (
   assert.match(eventsSource, /openCreateSubjectForm\(\{\s*origin: formOrigin,\s*sourceSubjectId\s*\}\);/);
   assert.match(eventsSource, /if \(formOrigin === "detail"\) \{\s*store\.situationsView\.showTableOnly = false;/);
   assert.match(eventsSource, /openCreateSubjectForm\(\{ origin: "table", sourceSubjectId: null \}\);/);
+});
+
+test("Créer un sous-sujet ouvre le create form en mode subissue (modale)", () => {
+  assert.match(eventsSource, /openCreateSubjectForm\(\{\s*mode: "subissue",[\s\S]*parentSubjectId,[\s\S]*scopeHost:/);
+  assert.match(viewSource, /function renderCreateSubissueModalHtml\(\)/);
+  assert.match(viewSource, /subjectCreateSubissueModal/);
+  assert.match(stateSource, /mode: "standard"/);
+  assert.match(stateSource, /parentSubjectId: null/);
 });

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -857,7 +857,7 @@ export function createProjectSubjectsDescription(config = {}) {
     return host;
   }
 
-  function renderDescriptionCard(selection) {
+  function renderDescriptionCard(selection, options = {}) {
     const entityType = getSelectionEntityType(selection.type);
     const entityId = selection.item.id;
     const versionsUi = ensureDescriptionVersionsUiState();
@@ -993,6 +993,7 @@ export function createProjectSubjectsDescription(config = {}) {
       `;
 
     const displayIdentity = firstVersionIdentity || identity;
+    const footerActionsHtml = String(options.footerActionsHtml || "").trim();
     return `
       <div class="gh-comment gh-comment--description">
         ${displayIdentity.avatarHtml
@@ -1001,6 +1002,7 @@ export function createProjectSubjectsDescription(config = {}) {
         <div class="gh-comment-box">
           ${headerHtml}
           ${bodyHtml}
+          ${footerActionsHtml}
         </div>
       </div>
     `;

--- a/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
+++ b/apps/web/js/views/project-subjects/project-subjects-details-renderer.js
@@ -20,6 +20,8 @@ export function createProjectSubjectsDetailsRenderer(config) {
     renderDescriptionCard,
     renderSubIssuesForSujet,
     renderSubIssuesForSituation,
+    getChildSubjectList,
+    renderAddSubissueActionButton,
     renderThreadBlock,
     renderCommentBox,
     renderDetailedMetaForSelection,
@@ -220,7 +222,14 @@ export function createProjectSubjectsDetailsRenderer(config) {
     }
 
     const item = selection.item;
-    const descCard = renderDescriptionCard(selection);
+    const childSubjects = selection.type === "sujet" ? getChildSubjectList(item) : [];
+    const shouldRenderDescriptionAddSubissueAction = selection.type === "sujet" && childSubjects.length === 0;
+    const descCard = renderDescriptionCard(selection, {
+      footerActionsHtml: shouldRenderDescriptionAddSubissueAction
+        ? renderAddSubissueActionButton(item.id, { placement: "description" })
+        : ""
+    });
+    const descriptionAddSubissueActionHtml = "";
     const subIssuesHtml = selection.type === "sujet"
       ? renderSubIssuesForSujet(item, options.subissuesOptions || {})
       : renderSubIssuesForSituation(item, options.subissuesOptions || {});
@@ -249,6 +258,7 @@ export function createProjectSubjectsDetailsRenderer(config) {
         <div class="details-main">
           <div class="gh-timeline">
             ${descCard}
+            ${descriptionAddSubissueActionHtml}
             ${renderDocumentRefsCard(selection)}
             ${subIssuesHtml}
             <div class="subject-details-thread-host" data-details-thread-host>

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -112,6 +112,7 @@ export function createProjectSubjectsEvents(config) {
   let modalEventsBound = false;
   let subjectsTabResetBound = false;
   let descriptionVersionsPositionBound = false;
+  let isCreateSubjectSubmitHandling = false;
 
   function getTextareaAutosizeMeta(textarea) {
     const type = textarea?.matches?.("#humanCommentBox")
@@ -137,6 +138,12 @@ export function createProjectSubjectsEvents(config) {
   function runAutosize(textarea, cause = "manual") {
     if (!textarea) return null;
     const { type, minHeightFallback, comfortLines } = getTextareaAutosizeMeta(textarea);
+    const isSubissueCreateTextarea = type === "create-subject"
+      && String(store.situationsView?.createSubjectForm?.mode || "").trim().toLowerCase() === "subissue";
+    if (isSubissueCreateTextarea) {
+      textarea.style.height = "";
+      return null;
+    }
     return autosizeTextarea(textarea, {
       minHeightFallback,
       comfortLines,
@@ -367,6 +374,28 @@ export function createProjectSubjectsEvents(config) {
           const activeKey = String(getSubjectsViewState().subjectMetaDropdown.activeKey || "");
           if (!activeKey) return;
           event.preventDefault();
+          if (field === "subissue-actions") {
+            const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+            const subissueActionsView = String(dropdown.subissueActionsView || "menu");
+            if (subissueActionsView === "existing-subissue") {
+              if (typeof setSubjectParent !== "function") return;
+              const parentSubjectId = String(dropdown.subissueActionSubjectId || subjectSelection.item.id || "");
+              if (!parentSubjectId || activeKey === parentSubjectId) return;
+              const selectedChild = getNestedSujet(activeKey);
+              const selectedChildParentId = String(
+                selectedChild?.parent_subject_id
+                || selectedChild?.parentSubjectId
+                || selectedChild?.raw?.parent_subject_id
+                || ""
+              ).trim();
+              if (selectedChildParentId === parentSubjectId) return;
+              const applied = await setSubjectParent(activeKey, parentSubjectId, { root, skipRerender: true });
+              if (!applied) return;
+              dropdownController().closeMeta();
+              rerenderScope(root);
+              return;
+            }
+          }
           if (field === "relations") {
             const relationsView = String(getSubjectsViewState().subjectMetaDropdown?.relationsView || "");
             if (relationsView === "parent") {
@@ -558,6 +587,84 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    dropdownHost.querySelectorAll("[data-action='subissue-actions-back']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionsView = "menu";
+        dropdown.query = "";
+        dropdown.activeKey = "";
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-action='open-create-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        const parentSubjectId = String(dropdown.subissueActionSubjectId || "");
+        const scopeHost = dropdown.subissueActionScopeHost || (root.closest?.("#drilldownPanel") ? "drilldown" : "main");
+        dropdownController().closeMeta();
+        dropdown.subissueActionIntent = "create";
+        if (parentSubjectId && getNestedSujet(parentSubjectId)) {
+          openCreateSubjectForm({
+            mode: "subissue",
+            parentSubjectId,
+            sourceSubjectId: parentSubjectId,
+            origin: "detail",
+            scopeHost: scopeHost
+          });
+          rerenderScope(root);
+          return;
+        }
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-action='open-link-existing-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionsView = "existing-subissue";
+        dropdown.query = "";
+        dropdown.subissueActionIntent = "link-existing";
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
+        const selection = getScopedSelection(root);
+        const subject = selection?.type === "sujet" ? selection.item : null;
+        const entries = subject ? getSubjectMetaMenuEntries(subject, "subissue-actions") : [];
+        dropdown.activeKey = String(entries[0]?.key || "");
+        dropdownController().focusSearch({ field: "subissue-actions" });
+        syncSubjectMetaDropdownPosition(getSubjectMetaScopeRoot());
+      };
+    });
+
+    dropdownHost.querySelectorAll("[data-subject-subissue-existing-entry]").forEach((btn) => {
+      btn.onclick = async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof setSubjectParent !== "function") return;
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        const parentSubjectId = String(dropdown.subissueActionSubjectId || "");
+        const childSubjectId = String(btn.dataset.subjectSubissueExistingEntry || "");
+        if (!parentSubjectId || !childSubjectId || childSubjectId === parentSubjectId) return;
+        const selectedChild = getNestedSujet(childSubjectId);
+        const selectedChildParentId = String(
+          selectedChild?.parent_subject_id
+          || selectedChild?.parentSubjectId
+          || selectedChild?.raw?.parent_subject_id
+          || ""
+        ).trim();
+        if (selectedChildParentId === parentSubjectId) return;
+        const applied = await setSubjectParent(childSubjectId, parentSubjectId, { root, skipRerender: true });
+        if (!applied) return;
+        dropdownController().closeMeta();
+        rerenderScope(root);
+      };
+    });
+
     dropdownHost.querySelectorAll("[data-subject-kanban-select]").forEach((btn) => {
       btn.onclick = (event) => {
         event.preventDefault();
@@ -663,6 +770,131 @@ export function createProjectSubjectsEvents(config) {
     });
   }
 
+  function handleCloseSubissueCreateModal() {
+    if (!store.situationsView.createSubjectForm?.isOpen) return false;
+    const formContext = store.situationsView.createSubjectForm || {};
+    const isSubissueMode = String(formContext.mode || "").trim().toLowerCase() === "subissue";
+    if (!isSubissueMode) return false;
+    resetCreateSubjectForm({ keepCreateMore: true });
+    rerenderPanels();
+    return true;
+  }
+
+  function handleCreateSubjectCancel() {
+    if (!store.situationsView.createSubjectForm?.isOpen) return false;
+    const formContext = store.situationsView.createSubjectForm || {};
+    const isSubissueMode = String(formContext.mode || "").trim().toLowerCase() === "subissue";
+    const formOrigin = String(formContext.origin || "").trim().toLowerCase() === "detail" ? "detail" : "table";
+    const sourceSubjectId = String(formContext.sourceSubjectId || "").trim();
+    dropdownController().closeMeta();
+    const mentionUi = typeof getMentionUiState === "function" ? getMentionUiState() : store?.situationsView?.mentionUi;
+    if (mentionUi && typeof mentionUi === "object") {
+      mentionUi.open = false;
+      mentionUi.query = "";
+      mentionUi.activeIndex = 0;
+      mentionUi.triggerStart = -1;
+      mentionUi.triggerEnd = -1;
+      mentionUi.suggestions = [];
+      mentionUi.composerKey = "";
+    }
+    const emojiUi = typeof getEmojiUiState === "function" ? getEmojiUiState() : store?.situationsView?.emojiUi;
+    if (emojiUi && typeof emojiUi === "object") {
+      emojiUi.open = false;
+      emojiUi.query = "";
+      emojiUi.activeIndex = 0;
+      emojiUi.triggerStart = -1;
+      emojiUi.triggerEnd = -1;
+      emojiUi.suggestions = [];
+      emojiUi.composerKey = "";
+    }
+    const subjectRefUi = typeof getSubjectRefUiState === "function" ? getSubjectRefUiState() : store?.situationsView?.subjectRefUi;
+    if (subjectRefUi && typeof subjectRefUi === "object") {
+      subjectRefUi.open = false;
+      subjectRefUi.query = "";
+      subjectRefUi.activeIndex = 0;
+      subjectRefUi.triggerStart = -1;
+      subjectRefUi.triggerEnd = -1;
+      subjectRefUi.suggestions = [];
+      subjectRefUi.composerKey = "";
+    }
+    resetCreateSubjectForm({ keepCreateMore: true });
+    if (isSubissueMode) {
+      rerenderPanels();
+      return true;
+    }
+    if (formOrigin === "detail" && sourceSubjectId && getNestedSujet(sourceSubjectId)) {
+      selectSubject(sourceSubjectId) || selectSujet(sourceSubjectId);
+      store.situationsView.showTableOnly = false;
+      store.projectSubjectsView.showTableOnly = false;
+      return true;
+    }
+    rerenderPanels();
+    return true;
+  }
+
+  function handleCreateSubjectSubmit(interactionRoot) {
+    if (!store.situationsView.createSubjectForm?.isOpen) return false;
+    if (isCreateSubjectSubmitHandling) return true;
+    if (store.situationsView.createSubjectForm?.isSubmitting) return true;
+    isCreateSubjectSubmitHandling = true;
+    const formContext = store.situationsView.createSubjectForm || {};
+    const formMode = String(formContext.mode || "").trim().toLowerCase() === "subissue" ? "subissue" : "standard";
+    const keepCreateMore = !!formContext.createMore;
+    const formOrigin = String(formContext.origin || "").trim().toLowerCase() === "detail" ? "detail" : "table";
+    const sourceSubjectId = String(formContext.sourceSubjectId || "").trim() || null;
+    const parentSubjectId = String(formContext.parentSubjectId || "").trim() || null;
+    const scopeHost = String(formContext.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+    const setSubjectParent = getSetSubjectParent?.();
+
+    (async () => {
+      const submitPromise = createSubjectFromDraft();
+      rerenderPanels();
+      const result = await submitPromise;
+      if (!result.ok) {
+        rerenderPanels();
+        return;
+      }
+
+      if (formMode === "subissue") {
+        if (parentSubjectId && typeof setSubjectParent === "function") {
+          const linked = await setSubjectParent(result.subjectId, parentSubjectId, { root: interactionRoot, skipRerender: true });
+          if (!linked) {
+            rerenderPanels();
+            return;
+          }
+        }
+        resetCreateSubjectForm({ keepCreateMore: true });
+        if (scopeHost === "drilldown") {
+          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(result.subjectId);
+        } else {
+          selectSubject(result.subjectId) || selectSujet(result.subjectId);
+        }
+        rerenderPanels();
+        return;
+      }
+
+      if (keepCreateMore) {
+        openCreateSubjectForm({
+          origin: formOrigin,
+          sourceSubjectId
+        });
+      } else {
+        resetCreateSubjectForm({ keepCreateMore: true });
+        if (formOrigin === "detail") {
+          store.situationsView.showTableOnly = false;
+          store.projectSubjectsView.showTableOnly = false;
+        }
+      }
+      rerenderPanels();
+    })().catch((error) => {
+      showError(`Création du sujet impossible : ${String(error?.message || error || "Erreur inconnue")}`);
+      rerenderPanels();
+    }).finally(() => {
+      isCreateSubjectSubmitHandling = false;
+    });
+    return true;
+  }
+
 
   function wireDetailsInteractive(root) {
     if (!root) return;
@@ -765,8 +997,143 @@ export function createProjectSubjectsEvents(config) {
       };
     });
 
+    const syncSubissueActionTriggerUi = () => {
+      const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+      const openedSubjectId = String(dropdown.subissueActionSubjectId || "");
+      const isMenuOpen = String(dropdown.field || "") === "subissue-actions";
+      root.querySelectorAll("[data-action='open-subissue-action-menu'][data-subject-id]").forEach((trigger) => {
+        const subjectId = String(trigger.dataset.subjectId || "");
+        const isOpen = isMenuOpen && subjectId && subjectId === openedSubjectId;
+        trigger.setAttribute("aria-expanded", isOpen ? "true" : "false");
+        trigger.classList.toggle("is-open", isOpen);
+      });
+    };
+
+    root.querySelectorAll("[data-action='open-subissue-action-menu']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const targetSubjectId = String(btn.dataset.subjectId || scopedSelection?.item?.id || "");
+        if (!targetSubjectId) return;
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        const isAlreadyOpen = dropdown.field === "subissue-actions" && String(dropdown.subissueActionSubjectId || "") === targetSubjectId;
+        if (isAlreadyOpen) {
+          dropdownController().closeMeta();
+        } else {
+          dropdownController().closeKanban();
+          dropdownController().openMeta({ field: "subissue-actions" });
+          dropdown.subissueActionsView = "menu";
+          dropdown.query = "";
+          dropdown.activeKey = "";
+          dropdown.subissueActionSubjectId = targetSubjectId;
+          dropdown.subissueActionScopeHost = isDrilldownScope ? "drilldown" : "main";
+          dropdown.subissueActionIntent = "";
+        }
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
+        syncSubissueActionTriggerUi();
+        if (!isAlreadyOpen) {
+          syncSubjectMetaDropdownPosition(getSubjectMetaScopeRoot());
+        }
+      };
+    });
+
+    root.querySelectorAll("[data-action='open-create-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        const parentSubjectId = String(dropdown.subissueActionSubjectId || "");
+        const scopeHost = dropdown.subissueActionScopeHost || (root.closest?.("#drilldownPanel") ? "drilldown" : "main");
+        dropdownController().closeMeta();
+        dropdown.subissueActionIntent = "create";
+        if (parentSubjectId && getNestedSujet(parentSubjectId)) {
+          openCreateSubjectForm({
+            mode: "subissue",
+            parentSubjectId,
+            sourceSubjectId: parentSubjectId,
+            origin: "detail",
+            scopeHost: scopeHost
+          });
+          rerenderScope(root);
+          return;
+        }
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
+        syncSubissueActionTriggerUi();
+      };
+    });
+
+    root.querySelectorAll("[data-action='open-link-existing-subissue']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        dropdown.subissueActionsView = "existing-subissue";
+        dropdown.query = "";
+        dropdown.subissueActionIntent = "link-existing";
+        refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
+        const selection = getScopedSelection(root);
+        const subject = selection?.type === "sujet" ? selection.item : null;
+        const entries = subject ? getSubjectMetaMenuEntries(subject, "subissue-actions") : [];
+        dropdown.activeKey = String(entries[0]?.key || "");
+        dropdownController().focusSearch({ field: "subissue-actions" });
+        syncSubjectMetaDropdownPosition(getSubjectMetaScopeRoot());
+        syncSubissueActionTriggerUi();
+      };
+    });
+
     root.querySelectorAll(".subject-meta-field").forEach((fieldRoot) => {
       bindSubjectSituationFieldInteractions(root, fieldRoot);
+    });
+
+    root.querySelectorAll("[data-close-subissue-create-modal]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        handleCloseSubissueCreateModal();
+      };
+    });
+    root.querySelectorAll("[data-create-subject-cancel]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        handleCreateSubjectCancel();
+      };
+    });
+    root.querySelectorAll("[data-create-subject-submit]").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        handleCreateSubjectSubmit(root);
+      };
+    });
+    root.querySelectorAll("[data-create-subject-tab], [data-action='create-subject-tab-write'], [data-action='create-subject-tab-preview']").forEach((btn) => {
+      btn.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const action = String(btn.dataset.action || "").trim();
+        const explicitTab = String(btn.dataset.createSubjectTab || "").trim();
+        const isPreview = explicitTab === "preview" || action === "create-subject-tab-preview";
+        store.situationsView.createSubjectForm.previewMode = isPreview;
+        rerenderPanels();
+      };
+    });
+    root.querySelectorAll("[data-create-subject-title]").forEach((input) => {
+      input.oninput = () => {
+        store.situationsView.createSubjectForm.title = String(input.value || "");
+        store.situationsView.createSubjectForm.validationError = "";
+      };
+    });
+    root.querySelectorAll("[data-create-subject-description]").forEach((textarea) => {
+      textarea.oninput = () => {
+        store.situationsView.createSubjectForm.description = String(textarea.value || "");
+        runAutosize(textarea, "create-subject-input");
+        if (store.situationsView.createSubjectForm.previewMode) rerenderPanels();
+      };
+    });
+    root.querySelectorAll("[data-create-subject-create-more]").forEach((checkbox) => {
+      checkbox.oninput = () => {
+        store.situationsView.createSubjectForm.createMore = !!checkbox.checked;
+      };
     });
 
     bindDropdownHostInteractiveElements(root, dropdownHost);
@@ -5144,51 +5511,17 @@ export function createProjectSubjectsEvents(config) {
         return;
       }
 
+      const closeSubissueCreateModalTrigger = event.target.closest("[data-close-subissue-create-modal]");
+      if (closeSubissueCreateModalTrigger && store.situationsView.createSubjectForm?.isOpen) {
+        event.preventDefault();
+        handleCloseSubissueCreateModal();
+        return;
+      }
+
       const createSubjectCancelButton = event.target.closest("[data-create-subject-cancel]");
       if (createSubjectCancelButton && store.situationsView.createSubjectForm?.isOpen) {
         event.preventDefault();
-        const formContext = store.situationsView.createSubjectForm || {};
-        const formOrigin = String(formContext.origin || "").trim().toLowerCase() === "detail" ? "detail" : "table";
-        const sourceSubjectId = String(formContext.sourceSubjectId || "").trim();
-        dropdownController().closeMeta();
-        const mentionUi = typeof getMentionUiState === "function" ? getMentionUiState() : store?.situationsView?.mentionUi;
-        if (mentionUi && typeof mentionUi === "object") {
-          mentionUi.open = false;
-          mentionUi.query = "";
-          mentionUi.activeIndex = 0;
-          mentionUi.triggerStart = -1;
-          mentionUi.triggerEnd = -1;
-          mentionUi.suggestions = [];
-          mentionUi.composerKey = "";
-        }
-        const emojiUi = typeof getEmojiUiState === "function" ? getEmojiUiState() : store?.situationsView?.emojiUi;
-        if (emojiUi && typeof emojiUi === "object") {
-          emojiUi.open = false;
-          emojiUi.query = "";
-          emojiUi.activeIndex = 0;
-          emojiUi.triggerStart = -1;
-          emojiUi.triggerEnd = -1;
-          emojiUi.suggestions = [];
-          emojiUi.composerKey = "";
-        }
-        const subjectRefUi = typeof getSubjectRefUiState === "function" ? getSubjectRefUiState() : store?.situationsView?.subjectRefUi;
-        if (subjectRefUi && typeof subjectRefUi === "object") {
-          subjectRefUi.open = false;
-          subjectRefUi.query = "";
-          subjectRefUi.activeIndex = 0;
-          subjectRefUi.triggerStart = -1;
-          subjectRefUi.triggerEnd = -1;
-          subjectRefUi.suggestions = [];
-          subjectRefUi.composerKey = "";
-        }
-        resetCreateSubjectForm({ keepCreateMore: true });
-        if (formOrigin === "detail" && sourceSubjectId && getNestedSujet(sourceSubjectId)) {
-          selectSubject(sourceSubjectId) || selectSujet(sourceSubjectId);
-          store.situationsView.showTableOnly = false;
-          store.projectSubjectsView.showTableOnly = false;
-          return;
-        }
-        rerenderPanels();
+        handleCreateSubjectCancel();
         return;
       }
 
@@ -5211,41 +5544,7 @@ export function createProjectSubjectsEvents(config) {
       const createSubjectSubmitButton = event.target.closest("[data-create-subject-submit]");
       if (createSubjectSubmitButton && store.situationsView.createSubjectForm?.isOpen) {
         event.preventDefault();
-        if (store.situationsView.createSubjectForm?.isSubmitting) {
-          return;
-        }
-
-        const formContext = store.situationsView.createSubjectForm || {};
-        const keepCreateMore = !!formContext.createMore;
-        const formOrigin = String(formContext.origin || "").trim().toLowerCase() === "detail" ? "detail" : "table";
-        const sourceSubjectId = String(formContext.sourceSubjectId || "").trim() || null;
-
-        (async () => {
-          const submitPromise = createSubjectFromDraft();
-          rerenderPanels();
-          const result = await submitPromise;
-          if (!result.ok) {
-            rerenderPanels();
-            return;
-          }
-
-          if (keepCreateMore) {
-            openCreateSubjectForm({
-              origin: formOrigin,
-              sourceSubjectId
-            });
-          } else {
-            resetCreateSubjectForm({ keepCreateMore: true });
-            if (formOrigin === "detail") {
-              store.situationsView.showTableOnly = false;
-              store.projectSubjectsView.showTableOnly = false;
-            }
-          }
-          rerenderPanels();
-        })().catch((error) => {
-          showError(`Création du sujet impossible : ${String(error?.message || error || "Erreur inconnue")}`);
-          rerenderPanels();
-        });
+        handleCreateSubjectSubmit(root);
         return;
       }
 

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -198,11 +198,19 @@ export function createProjectSubjectsState({ store }) {
         query: "",
         activeKey: "",
         showClosedSituations: false,
-        relationsView: "menu"
+        relationsView: "menu",
+        subissueActionsView: "menu",
+        subissueActionSubjectId: "",
+        subissueActionScopeHost: "main",
+        subissueActionIntent: ""
       };
     }
     if (typeof v.subjectMetaDropdown.showClosedSituations !== "boolean") v.subjectMetaDropdown.showClosedSituations = false;
     if (typeof v.subjectMetaDropdown.relationsView !== "string") v.subjectMetaDropdown.relationsView = "menu";
+    if (typeof v.subjectMetaDropdown.subissueActionsView !== "string") v.subjectMetaDropdown.subissueActionsView = "menu";
+    if (typeof v.subjectMetaDropdown.subissueActionSubjectId !== "string") v.subjectMetaDropdown.subissueActionSubjectId = "";
+    if (typeof v.subjectMetaDropdown.subissueActionScopeHost !== "string") v.subjectMetaDropdown.subissueActionScopeHost = "main";
+    if (typeof v.subjectMetaDropdown.subissueActionIntent !== "string") v.subjectMetaDropdown.subissueActionIntent = "";
     if (!v.subjectKanbanDropdown || typeof v.subjectKanbanDropdown !== "object") {
       v.subjectKanbanDropdown = {
         subjectId: "",
@@ -229,6 +237,9 @@ export function createProjectSubjectsState({ store }) {
         isSubmitting: false,
         uploadSessionId: "",
         attachments: [],
+        mode: "standard",
+        parentSubjectId: null,
+        scopeHost: "main",
         origin: "table",
         sourceSubjectId: null
       };
@@ -236,6 +247,9 @@ export function createProjectSubjectsState({ store }) {
     if (typeof v.createSubjectForm.isSubmitting !== "boolean") v.createSubjectForm.isSubmitting = false;
     if (typeof v.createSubjectForm.uploadSessionId !== "string") v.createSubjectForm.uploadSessionId = "";
     if (!Array.isArray(v.createSubjectForm.attachments)) v.createSubjectForm.attachments = [];
+    if (String(v.createSubjectForm.mode || "").trim().toLowerCase() !== "subissue") v.createSubjectForm.mode = "standard";
+    v.createSubjectForm.parentSubjectId = String(v.createSubjectForm.parentSubjectId || "").trim() || null;
+    if (String(v.createSubjectForm.scopeHost || "").trim().toLowerCase() !== "drilldown") v.createSubjectForm.scopeHost = "main";
     if (String(v.createSubjectForm.origin || "").trim().toLowerCase() !== "detail") v.createSubjectForm.origin = "table";
     const sourceSubjectId = String(v.createSubjectForm.sourceSubjectId || "").trim();
     v.createSubjectForm.sourceSubjectId = sourceSubjectId || null;

--- a/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const viewPath = path.resolve(__dirname, "./project-subjects-view.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+const detailsRendererPath = path.resolve(__dirname, "./project-subjects-details-renderer.js");
+const detailsRendererSource = fs.readFileSync(detailsRendererPath, "utf8");
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+const statePath = path.resolve(__dirname, "./project-subjects-state.js");
+const stateSource = fs.readFileSync(statePath, "utf8");
+const stylePath = path.resolve(__dirname, "../../../style.css");
+const styleSource = fs.readFileSync(stylePath, "utf8");
+
+test("rend le bouton Ajouter sous-sujet dans la description quand il n'y a aucun sous-sujet", () => {
+  assert.match(detailsRendererSource, /shouldRenderDescriptionAddSubissueAction = selection\.type === "sujet" && childSubjects\.length === 0/);
+  assert.match(detailsRendererSource, /renderDescriptionCard\(selection, \{/);
+  assert.match(detailsRendererSource, /footerActionsHtml:[\s\S]*renderAddSubissueActionButton\(item\.id, \{ placement: "description" \}\)/);
+  assert.match(detailsRendererSource, /const descriptionAddSubissueActionHtml = "";/);
+});
+
+test("rend le bouton Ajouter sous-sujet en bas du panneau des sous-sujets quand il y a des enfants", () => {
+  assert.match(viewSource, /bodyHtml: `\$\{body\}\$\{renderAddSubissueActionButton\(sujet\?\.id, \{ placement: "subissues" \}\)\}`/);
+});
+
+test("le dropdown Ajouter sous-sujet expose exactement les deux actions attendues", () => {
+  assert.match(viewSource, /if \(field === "subissue-actions"\)/);
+  assert.match(viewSource, /subissueActionsView === "existing-subissue"/);
+  assert.match(viewSource, /data-action="subissue-actions-back"/);
+  assert.match(viewSource, /subject-subissue-existing-entry/);
+  assert.match(viewSource, /data-action="open-create-subissue"/);
+  assert.match(viewSource, /Créer un sous-sujet/);
+  assert.match(viewSource, /data-action="open-link-existing-subissue"/);
+  assert.match(viewSource, /Ajouter un sujet existant/);
+});
+
+test("l'événement d'ouverture du menu sous-sujet utilise le dropdown mutualisé", () => {
+  assert.match(eventsSource, /\[data-action='open-subissue-action-menu'\]/);
+  assert.match(eventsSource, /dropdownController\(\)\.openMeta\(\{ field: "subissue-actions" \}\)/);
+  assert.match(eventsSource, /dropdownController\(\)\.closeKanban\(\);/);
+  assert.match(eventsSource, /dropdown\.subissueActionsView = "menu";/);
+  assert.match(eventsSource, /const syncSubissueActionTriggerUi = \(\) => \{/);
+  assert.match(eventsSource, /refreshSubjectMetaDropdownUi\(root, \{ preserveScroll: true, preserveFocus: false \}\);/);
+});
+
+test("l'action Ajouter un sujet existant ouvre une sous-vue latérale sans fermer le dropdown", () => {
+  assert.match(eventsSource, /\[data-action='open-link-existing-subissue'\]/);
+  assert.match(eventsSource, /dropdownHost\.querySelectorAll\("\[data-action='open-link-existing-subissue'\]"\)/);
+  assert.match(eventsSource, /dropdown\.subissueActionsView = "existing-subissue";/);
+  assert.match(eventsSource, /dropdownController\(\)\.focusSearch\(\{ field: "subissue-actions" \}\);/);
+  assert.match(eventsSource, /\[data-action='open-link-existing-subissue'\][\s\S]{0,600}refreshSubjectMetaDropdownUi\(root, \{ preserveScroll: true, preserveFocus: false \}\);/);
+});
+
+test("la sélection d'un sujet existant utilise setSubjectParent puis referme le dropdown", () => {
+  assert.match(eventsSource, /\[data-subject-subissue-existing-entry\]/);
+  assert.match(eventsSource, /await setSubjectParent\(childSubjectId, parentSubjectId, \{ root, skipRerender: true \}\);/);
+  assert.match(eventsSource, /dropdownController\(\)\.closeMeta\(\);/);
+});
+
+test("les data attributes et l'état UI dédié sont présents", () => {
+  assert.match(viewSource, /data-action="open-subissue-action-menu"/);
+  assert.match(stateSource, /subissueActionSubjectId: ""/);
+  assert.match(stateSource, /subissueActionsView: "menu"/);
+  assert.match(stateSource, /subissueActionScopeHost: "main"/);
+  assert.match(stateSource, /subissueActionIntent: ""/);
+});
+
+test("le style du bouton est défini pour les emplacements description et sous-sujets", () => {
+  assert.match(styleSource, /\.subject-add-subissue-action--description/);
+  assert.match(styleSource, /\.subject-add-subissue-action--subissues/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-thread-scope.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-scope.test.mjs
@@ -107,6 +107,46 @@ test("renderDetailsDiscussionHtml scope le thread/composer sur la sélection exp
   ]);
 });
 
+test("renderDetailsBody n'utilise pas de variable subissue fantôme et injecte le footer via renderDescriptionCard", () => {
+  const captured = [];
+  const renderer = createProjectSubjectsDetailsRenderer({
+    getActiveSelection: () => ({ type: "sujet", item: { id: "S1", title: "Sujet 1" } }),
+    getSelectionEntityType: () => "sujet",
+    getEffectiveSujetStatus: () => "open",
+    getEffectiveSituationStatus: () => "open",
+    getEntityReviewMeta: () => ({ review_state: "pending" }),
+    getReviewTitleStateClass: () => "",
+    getSubjectTitleEditState: () => ({}),
+    isEditingSubjectTitle: () => false,
+    entityDisplayLinkHtml: () => "",
+    problemsCountsHtml: () => "",
+    renderSubjectBlockedByHeadHtml: () => "",
+    renderSubjectParentHeadHtml: () => "",
+    firstNonEmpty: (...values) => values.find((value) => value !== undefined && value !== null && value !== "") || "",
+    escapeHtml: (value) => String(value || ""),
+    statePill: () => "",
+    renderDescriptionCard: (_selection, options = {}) => {
+      captured.push(String(options.footerActionsHtml || ""));
+      return "<description-card />";
+    },
+    renderSubIssuesForSujet: () => "",
+    renderSubIssuesForSituation: () => "",
+    getChildSubjectList: () => [],
+    renderAddSubissueActionButton: () => "<add-subissue-action />",
+    renderThreadBlock: () => "",
+    renderCommentBox: () => "",
+    renderDetailedMetaForSelection: () => "",
+    renderSubjectMetaControls: () => "",
+    priorityBadge: () => "",
+    renderDocumentRefsCard: () => ""
+  });
+
+  const details = renderer.renderDetailsHtml({ type: "sujet", item: { id: "S1", title: "Sujet 1" } });
+  assert.match(details.bodyHtml, /<description-card \/>/);
+  assert.equal(captured.length, 1);
+  assert.match(captured[0], /<add-subissue-action \/>/);
+});
+
 test("ensureTimelineLoadedForSelection charge le subjectId de la sélection fournie", async () => {
   const loadedSubjectIds = [];
   const rerenderHosts = [];

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -17,6 +17,7 @@ import { extractStructuredMentions } from "../../utils/subject-mentions.js";
 import { renderCommentComposer } from "../ui/comment-composer.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 import { renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
+import { renderSettingsModal } from "../ui/settings-modal.js";
 export function createProjectSubjectsView(deps) {
   const {
     store,
@@ -97,6 +98,7 @@ export function createProjectSubjectsView(deps) {
     replaceSubjectSituationsInSupabase,
     replaceSubjectObjectivesInSupabase,
     updateSubjectDescriptionInSupabase,
+    loadSubjectDescriptionVersionsInSupabase,
     uploadAttachmentFile
   } = deps;
 
@@ -484,6 +486,19 @@ function buildDefaultDraftSubjectMeta() {
   };
 }
 
+function buildSubissueDraftMeta(parentSubjectId = "") {
+  const subjectId = String(parentSubjectId || "").trim();
+  if (!subjectId) return buildDefaultDraftSubjectMeta();
+  const parentMeta = getSubjectSidebarMeta(subjectId);
+  return {
+    assignees: [],
+    labels: [],
+    objectiveIds: normalizeSubjectObjectiveIds(parentMeta?.objectiveIds),
+    situationIds: normalizeSubjectSituationIds(parentMeta?.situationIds),
+    relations: []
+  };
+}
+
 function resetCreateSubjectForm(options = {}) {
   ensureViewUiState();
   const keepCreateMore = !!options.keepCreateMore;
@@ -501,6 +516,9 @@ function resetCreateSubjectForm(options = {}) {
     isSubmitting: false,
     uploadSessionId: "",
     attachments: [],
+    mode: keepContext ? (String(previous.mode || "").trim().toLowerCase() === "subissue" ? "subissue" : "standard") : "standard",
+    parentSubjectId: keepContext ? (String(previous.parentSubjectId || "").trim() || null) : null,
+    scopeHost: keepContext ? (String(previous.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main") : "main",
     origin: keepContext ? (previous.origin === "detail" ? "detail" : "table") : "table",
     sourceSubjectId: keepContext ? (String(previous.sourceSubjectId || "").trim() || null) : null
   };
@@ -512,24 +530,32 @@ function openCreateSubjectForm(options = {}) {
   closeSubjectKanbanDropdown();
   ensureViewUiState();
   const previousCreateMore = !!store.situationsView.createSubjectForm?.createMore;
+  const mode = String(options.mode || "").trim().toLowerCase() === "subissue" ? "subissue" : "standard";
   const requestedOrigin = String(options.origin || "").trim().toLowerCase();
-  const origin = requestedOrigin === "detail" ? "detail" : "table";
+  const origin = mode === "subissue" ? "detail" : (requestedOrigin === "detail" ? "detail" : "table");
   const sourceSubjectId = origin === "detail"
     ? (String(options.sourceSubjectId || "").trim() || null)
     : null;
+  const parentSubjectId = mode === "subissue"
+    ? (String(options.parentSubjectId || sourceSubjectId || "").trim() || null)
+    : null;
+  const scopeHost = String(options.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
   store.situationsView.subjectsSubview = "subjects";
-  store.situationsView.showTableOnly = true;
+  if (mode !== "subissue") store.situationsView.showTableOnly = true;
   store.situationsView.createSubjectForm = {
     isOpen: true,
     title: "",
     description: "",
     previewMode: false,
-    createMore: previousCreateMore,
-    meta: buildDefaultDraftSubjectMeta(),
+    createMore: mode === "subissue" ? false : previousCreateMore,
+    meta: mode === "subissue" ? buildSubissueDraftMeta(parentSubjectId) : buildDefaultDraftSubjectMeta(),
     validationError: "",
     isSubmitting: false,
     uploadSessionId: "",
     attachments: [],
+    mode,
+    parentSubjectId,
+    scopeHost,
     origin,
     sourceSubjectId
   };
@@ -652,6 +678,9 @@ async function createSubjectFromDraft() {
         description,
         uploadSessionId
       });
+      if (typeof loadSubjectDescriptionVersionsInSupabase === "function") {
+        await loadSubjectDescriptionVersionsInSupabase(subjectId);
+      }
     }
 
     await reloadSubjectsFromSupabase(getSubjectsCurrentRoot(), {
@@ -1669,6 +1698,31 @@ function getRelationSubjectSuggestions(subject, query = "", options = {}) {
   return candidates.slice(0, 20);
 }
 
+function getExistingSubissueSuggestions(subject, query = "") {
+  const currentSubjectId = String(subject?.id || "");
+  if (!currentSubjectId) return [];
+  const normalizedQuery = String(query || "").trim().toLowerCase();
+  const forbiddenIds = collectDescendantSubjectIds(currentSubjectId);
+  const currentProjectId = String(firstNonEmpty(subject?.project_id, subject?.raw?.project_id, "")).trim();
+  const map = store.projectSubjectsView?.rawSubjectsResult?.subjectsById || {};
+  const candidates = Object.values(map)
+    .filter((item) => {
+      const candidateId = String(item?.id || "");
+      if (!candidateId || forbiddenIds.has(candidateId)) return false;
+      const candidateParentId = String(firstNonEmpty(item?.parent_subject_id, item?.parentSubjectId, item?.raw?.parent_subject_id, "")).trim();
+      if (candidateParentId === currentSubjectId) return false;
+      const candidateProjectId = String(firstNonEmpty(item?.project_id, item?.raw?.project_id, "")).trim();
+      if (currentProjectId && candidateProjectId && candidateProjectId !== currentProjectId) return false;
+      return matchSearch([item?.title, item?.id], normalizedQuery);
+    })
+    .sort((left, right) => {
+      const tsDiff = getSubjectLastActivityTimestamp(right) - getSubjectLastActivityTimestamp(left);
+      if (tsDiff !== 0) return tsDiff;
+      return String(firstNonEmpty(left?.title, left?.id, "")).localeCompare(String(firstNonEmpty(right?.title, right?.id, "")), "fr");
+    });
+  return candidates.slice(0, 20);
+}
+
 function buildRelationSelectItem(candidate, { dropdownState, isSelected = false, dataAttr }) {
   const candidateId = String(candidate?.id || "");
   return {
@@ -1880,6 +1934,22 @@ function buildSubjectMetaMenuItems(subject, field) {
     }
   }
 
+  if (field === "subissue-actions") {
+    const subissueActionsView = String(dropdownState.subissueActionsView || "menu");
+    if (subissueActionsView === "existing-subissue") {
+      const items = getExistingSubissueSuggestions(subject, query).map((candidate) => buildRelationSelectItem(candidate, {
+        dropdownState,
+        isSelected: false,
+        dataAttr: "subject-subissue-existing-entry"
+      }));
+      return {
+        items,
+        emptyHint: query ? "Aucun résultat pour cette recherche." : "Aucun sujet disponible."
+      };
+    }
+    return { items: [], emptyHint: "Aucune action." };
+  }
+
   const emptyHintMap = {
     assignees: "Aucun assigné pour le moment.",
     labels: "Aucun label pour le moment.",
@@ -1984,6 +2054,55 @@ function renderSubjectMetaDropdown(subject, field) {
               <span class="select-menu__item-mainrow">
                 <span class="select-menu__item-content">
                   <span class="select-menu__item-title">Ajouter ou modifier « Est bloquant pour »</span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (field === "subissue-actions") {
+    const subissueActionsView = String(dropdownState.subissueActionsView || "menu");
+    if (subissueActionsView === "existing-subissue") {
+      const { items, emptyHint } = buildSubjectMetaMenuItems(subject, field);
+      return `
+        <div class="subject-meta-dropdown gh-menu gh-menu--open" role="dialog">
+          <button type="button" class="subject-meta-relations-back" data-action="subissue-actions-back">
+            <span class="subject-meta-relations-back__icon">${svgIcon("arrow-left", { className: "octicon octicon-arrow-left" })}</span>
+            <span class="subject-meta-relations-back__label">Ajouter un sujet existant</span>
+          </button>
+          <div class="subject-meta-dropdown__search">
+            <span class="subject-meta-dropdown__search-icon" aria-hidden="true">${svgIcon("search", { className: "octicon octicon-search" })}</span>
+            <input type="search" class="subject-meta-dropdown__search-input" data-subject-meta-search="${escapeHtml(field)}" value="${escapeHtml(query)}" placeholder="Rechercher un sujet" autocomplete="off">
+          </div>
+          <div class="subject-meta-dropdown__body">
+            ${renderSelectMenuSection({
+    items,
+    emptyTitle: "Aucun sujet",
+    emptyHint
+  })}
+          </div>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="subject-meta-dropdown gh-menu gh-menu--open" role="menu">
+        <div class="subject-meta-dropdown__body">
+          <div class="select-menu__section">
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-action="open-create-subissue">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Créer un sous-sujet</span>
+                </span>
+              </span>
+            </button>
+            <button type="button" class="select-menu__item subject-meta-relations-menu__item" role="menuitem" data-action="open-link-existing-subissue">
+              <span class="select-menu__item-mainrow">
+                <span class="select-menu__item-content">
+                  <span class="select-menu__item-title">Ajouter un sujet existant</span>
                 </span>
               </span>
             </button>
@@ -2167,6 +2286,30 @@ function renderSubissueAssigneesCellHtml(subjectId) {
   `;
 }
 
+function renderAddSubissueActionButton(subjectId, options = {}) {
+  const normalizedSubjectId = String(subjectId || "");
+  if (!normalizedSubjectId) return "";
+  const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+  const isOpen = String(dropdown.field || "") === "subissue-actions"
+    && String(dropdown.subissueActionSubjectId || "") === normalizedSubjectId;
+  const placement = String(options.placement || "").trim().toLowerCase() === "subissues" ? "subissues" : "description";
+  return `
+    <div class="subject-add-subissue-action subject-add-subissue-action--${escapeHtml(placement)}">
+      <button
+        type="button"
+        class="gh-btn gh-btn--md subject-add-subissue-action__trigger ${isOpen ? "is-open" : ""}"
+        data-action="open-subissue-action-menu"
+        data-subject-id="${escapeHtml(normalizedSubjectId)}"
+        data-subject-meta-anchor="subissue-actions"
+        aria-expanded="${isOpen ? "true" : "false"}"
+      >
+        <span>Ajouter sous-sujet</span>
+        <span class="subject-add-subissue-action__chevron" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    </div>
+  `;
+}
+
 function renderSubIssuesForSujet(sujet, options = {}) {
   ensureViewUiState();
   const sujetRowClass = options.sujetRowClass || "js-row-sujet";
@@ -2266,7 +2409,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
     title: "Sous-sujets",
     leftMetaHtml: subissuesHeadCountsHtml(childSubjects),
     rightMetaHtml: "",
-    bodyHtml: body,
+    bodyHtml: `${body}${renderAddSubissueActionButton(sujet?.id, { placement: "subissues" })}`,
     isOpen: options.isOpen !== false
   });
 }
@@ -2408,6 +2551,16 @@ function syncSituationsPrimaryScrollSource() {
   refreshProjectShellChrome("situations");
 }
 
+function ensureCreateSubissueModalHost() {
+  let host = document.getElementById("subjectCreateSubissueModalHost");
+  if (!host) {
+    host = document.createElement("div");
+    host.id = "subjectCreateSubissueModalHost";
+    document.body.appendChild(host);
+  }
+  return host;
+}
+
 function rerenderPanels() {
   ensureViewUiState();
   document.body.classList.remove("project-subject-details-top-compact");
@@ -2422,16 +2575,20 @@ function rerenderPanels() {
   if (searchInput) searchInput.value = store.situationsView.search || "";
 
   rerenderSubjectsToolbar();
+  const createForm = store.situationsView.createSubjectForm || {};
+  const isCreateFormOpen = !!createForm.isOpen;
+  const isSubissueCreateMode = isCreateFormOpen && String(createForm.mode || "").trim().toLowerCase() === "subissue";
+  const isStandardCreateMode = isCreateFormOpen && !isSubissueCreateMode;
 
   const shouldDisableProjectCompact = !!panelHost
-    && !store.situationsView.createSubjectForm?.isOpen
+    && !isCreateFormOpen
     && String(store.situationsView.subjectsSubview || "subjects") === "subjects"
     && !store.situationsView.showTableOnly;
   document.body.classList.toggle("project-subject-normal-detail-flow", shouldDisableProjectCompact);
   setProjectCompactEnabled(!shouldDisableProjectCompact);
 
   if (panelHost) {
-    if (store.situationsView.createSubjectForm?.isOpen) {
+    if (isStandardCreateMode) {
       panelHost.innerHTML = `<div id="subjectCreateFormHost" class="project-table-host">${renderCreateSubjectFormHtml()}</div>`;
       const createFormRoot = panelHost.querySelector("[data-create-subject-form]");
       wireDetailsInteractive(createFormRoot);
@@ -2481,6 +2638,15 @@ function rerenderPanels() {
       });
       syncSituationsPrimaryScrollSource();
     }
+  }
+
+  const subissueCreateModalHost = ensureCreateSubissueModalHost();
+  if (isSubissueCreateMode) {
+    subissueCreateModalHost.innerHTML = renderCreateSubissueModalHtml();
+    const modalCreateFormRoot = subissueCreateModalHost.querySelector("[data-create-subject-form]");
+    wireDetailsInteractive(modalCreateFormRoot);
+  } else {
+    subissueCreateModalHost.innerHTML = "";
   }
 
   if (store.situationsView.drilldown?.isOpen) getProjectSubjectDrilldown().updateDrilldownPanel();
@@ -2949,17 +3115,30 @@ function renderCreateSubjectMetaControls() {
 function renderCreateSubjectFormHtml() {
   ensureViewUiState();
   const form = store.situationsView.createSubjectForm || {};
+  const isSubissueMode = String(form.mode || "").trim().toLowerCase() === "subissue";
   const avatar = String(store.user?.avatar || "assets/images/260093543.png");
   const previewHtml = mdToHtml(String(form.description || "").trim());
+  const subissueHeaderTitle = isSubissueMode ? "Créer un sous-sujet" : "Créer un nouveau sujet";
+  const createMoreLabel = isSubissueMode ? "Créer d'autres sous-sujets" : "En ajouter d’autres";
+  const inlineMetaHtml = isSubissueMode
+    ? `<div class="subject-create-inline-meta">${renderCreateSubjectMetaControls()}</div>`
+    : "";
+  const asideHtml = isSubissueMode
+    ? ""
+    : `
+      <aside class="subject-create-aside details-meta-col">
+        ${renderCreateSubjectMetaControls()}
+      </aside>
+    `;
   return `
     <section class="subject-create-shell" data-create-subject-form>
-      <div class="subject-create-layout">
+      <div class="subject-create-layout ${isSubissueMode ? "subject-create-layout--subissue" : ""}">
         <div class="subject-create-main">
           <div class="subject-create-content">
             <img src="${escapeHtml(avatar)}" alt="Auteur" class="subject-create-content__avatar">
             <div class="subject-create-content__fields">
               <div class="subject-create-header">
-                <div class="subject-create-header__title">Créer un nouveau sujet</div>
+                <div class="subject-create-header__title">${escapeHtml(subissueHeaderTitle)}</div>
               </div>
               <label class="subject-create-field">
                 <span class="subject-create-field__label">Ajouter un titre<span class="subject-create-field__required">*</span></span>
@@ -3004,9 +3183,10 @@ function renderCreateSubjectFormHtml() {
 
               <div class="subject-create-footer">
                 <div class="subject-create-footer__left">
+                  ${inlineMetaHtml}
                   <label class="subject-create-checkbox">
                     <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
-                    <span>En ajouter d’autres</span>
+                    <span>${escapeHtml(createMoreLabel)}</span>
                   </label>
                 </div>
                 <div class="subject-create-footer__right">
@@ -3017,12 +3197,22 @@ function renderCreateSubjectFormHtml() {
             </div>
           </div>
         </div>
-        <aside class="subject-create-aside details-meta-col">
-          ${renderCreateSubjectMetaControls()}
-        </aside>
+        ${asideHtml}
       </div>
     </section>
   `;
+}
+
+function renderCreateSubissueModalHtml() {
+  return renderSettingsModal({
+    modalId: "subjectCreateSubissueModal",
+    title: "Create new sub-issue",
+    closeDataAttribute: "data-close-subissue-create-modal",
+    bodyHtml: renderCreateSubjectFormHtml(),
+    variant: "wide",
+    dialogClassName: "subject-create-subissue-modal__dialog",
+    bodyClassName: "subject-create-subissue-modal__body"
+  });
 }
 
 function renderSituationsViewHeaderHtml() {
@@ -3169,6 +3359,8 @@ function getObjectiveById(objectiveId) {
     renderDetailedMetaForSelection,
     renderSubjectMetaControls,
     renderSubjectMetaFieldValue,
+    getChildSubjectList,
+    renderAddSubissueActionButton,
     renderSubIssuesForSujet,
     renderSubIssuesForSituation,
     closeSubjectMetaDropdown,

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -115,6 +115,10 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.query = "";
   dropdown.activeKey = "";
   dropdown.relationsView = "menu";
+  dropdown.subissueActionsView = "menu";
+  dropdown.subissueActionSubjectId = "";
+  dropdown.subissueActionScopeHost = "main";
+  dropdown.subissueActionIntent = "";
 }
 
 export function closeKanbanSelectDropdown(getViewState) {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3159,6 +3159,11 @@ body.is-resizing{
 .subissues-table .issues-table__head{border-bottom:1px solid var(--border2);}
 .subissues-table .issues-table__body{max-height:360px;overflow:auto;}
 .subissue-row--selected{outline:1px solid rgba(88,166,255,.45);background:rgba(56,139,253,.08);}
+.subject-add-subissue-action{width:100%;}
+.subject-add-subissue-action--description{margin-top:8px;margin-bottom:0;}
+.subject-add-subissue-action--subissues{margin:0;padding:10px 12px 12px;border-top:1px solid var(--border2);width:100%;}
+.subject-add-subissue-action__trigger{display:inline-flex;align-items:center;gap:8px;}
+.subject-add-subissue-action__chevron{display:inline-flex;align-items:center;color:var(--muted);}
 
 /* Main table row selection (same visual language as sub-issues selection) */
 .issue-row.selected{
@@ -10691,6 +10696,58 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 
 .subject-create-aside{
   padding-top:36px;
+}
+.subject-create-layout--subissue{
+  grid-template-columns:minmax(0,1fr);
+  gap:0;
+}
+.subject-create-layout--subissue .subject-create-content__avatar{display:none;}
+.subject-create-inline-meta{
+  display:flex;
+  align-items:flex-start;
+}
+.subject-create-layout--subissue .subject-create-footer{
+  align-items:flex-end;
+}
+.subject-create-layout--subissue .subject-meta-controls{
+  margin:0;
+  flex-direction:row;
+  flex-wrap:wrap;
+}
+.subject-create-layout--subissue .subject-meta-controls--create{
+  display:flex;
+  flex-direction:row;
+  gap:8px;
+  flex-wrap:wrap;
+}
+.subject-create-layout--subissue .subject-meta-field{
+  width:auto;
+  margin:0;
+}
+.subject-create-subissue-modal__dialog{
+  width:min(980px, calc(100vw - 48px));
+  position:absolute !important;
+  top:50% !important;
+  left:50% !important;
+  margin:0 !important;
+  transform:translate(-50%, -50%) !important;
+  max-height:calc(100vh - 48px);
+}
+.subject-create-subissue-modal__body{
+  padding:0;
+  overflow:auto;
+}
+.subject-create-subissue-modal__body .subject-create-shell{
+  padding:16px;
+}
+.subject-create-layout--subissue .comment-composer--create-subject{
+  width:min(700px, 100%);
+}
+.subject-create-layout--subissue .comment-composer--create-subject .comment-composer__textarea{
+  width:min(700px, 100%) !important;
+  min-height:326px !important;
+  height:326px !important;
+  max-height:326px !important;
 }
 
 .comment-composer--create-subject{


### PR DESCRIPTION
### Motivation
- Provide a way to create or link sub-issues (sub-sujets) from the subject details and meta dropdown without leaving the current context.
- Allow opening a focused subissue creation flow (modal) with inherited meta and a simplified layout to speed subissue creation.
- Track and render description versions when descriptions are created so the UI can expose history where available.

### Description
- Introduces a dedicated subissue actions dropdown (`subissue-actions`) with two actions: `Créer un sous-sujet` and `Ajouter un sujet existant`, plus the UI for searching and linking existing subjects via `getExistingSubissueSuggestions` and related dropdown rendering logic.
- Adds an `Add subissue` action button (`renderAddSubissueActionButton`) that is injected into the description footer or below the sub-issues panel and toggles the shared dropdown via `data-action="open-subissue-action-menu"`.
- Extends the create-subject flow to support a `mode: "subissue"` with fields `parentSubjectId` and `scopeHost`, a simplified inline/meta layout for subissues, and a modal variant (`renderCreateSubissueModalHtml`) used when creating subissues in a modal.
- Adds state fields to `subjectMetaDropdown` and `createSubjectForm` (`subissueActionsView`, `subissueActionSubjectId`, `subissueActionScopeHost`, `subissueActionIntent`, `mode`, `parentSubjectId`, `scopeHost`) and initializes them in `project-subjects-state.js` and the select-dropdown controller resets.
- Implements event handlers to open the subissue menu, open the create subissue form, link an existing subject as a child (using `setSubjectParent`), and handle create/cancel/submit lifecycle for subissue creation (`handleCreateSubjectSubmit`, `handleCreateSubjectCancel`, `handleCloseSubissueCreateModal`).
- Skip autosize behavior for the create-subject textarea when `mode === "subissue"` to enforce a fixed layout in the modal form.
- After subject creation, load description versions via `loadSubjectDescriptionVersionsInSupabase` when available and set parent-child relation if creating a subissue.
- Update the description renderer to accept a `footerActionsHtml` option so the `Add subissue` action can be injected into the description card (`renderDescriptionCard(selection, { footerActionsHtml })`).
- Adds new and updated unit tests asserting the UI, state, and event wiring for subissue actions and create flows, and updates styles in `style.css` for the subissue button, modal, and subissue create layout.

### Testing
- Updated `project-subjects-create-subject-context.test.mjs` to assert `mode`/`origin`/`parentSubjectId` handling and the presence of the subissue modal hooks; these tests passed.
- Added `project-subjects-subissue-action-menu.test.mjs` to validate the dropdown actions, data attributes, search behavior, and linking flow; this test passed.
- Updated `project-subjects-thread-scope.test.mjs` to ensure `renderDetailsBody` injects the footer via `renderDescriptionCard`; this test passed.
- Ran the project subject view/event unit tests that touch the new code paths and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c42f9efc83299d42993122a5f5b9)