### PR TITLE
Avoid redundant empty description-version fetches and warnings; improve subissue create flow and logging

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs
@@ -534,3 +534,113 @@ test("description card: précharge les versions et affiche un spinner auteur en 
 
   cleanupFakeDom();
 });
+
+test("description versions: un sujet sans description persistée (titre seul) ne spamme pas warning ni reload vide", async () => {
+  installFakeDom({
+    "sujet::subject-no-description": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) }
+  });
+  const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
+  let loadCalls = 0;
+  const warnCalls = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnCalls.push(args);
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: { descriptions: { sujet: {}, situation: {} } } }),
+    persistRunBucket: () => {},
+    getSelectionEntityType: (type) => type,
+    getEntityByType: () => ({ id: "subject-no-description", title: "Titre sans description", raw: {} }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-no-description", item: { id: "subject-no-description" } }),
+    rerenderScope: () => {},
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async () => {
+      loadCalls += 1;
+      return [];
+    }
+  });
+
+  api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-no-description", title: "Titre sans description", raw: {} }
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-no-description", title: "Titre sans description", raw: {} }
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(loadCalls, 1);
+  assert.equal(warnCalls.length, 0);
+
+  console.warn = originalWarn;
+  cleanupFakeDom();
+});
+
+test("description versions: description persistée + versions vides log une seule alerte et ne boucle pas", async () => {
+  installFakeDom({
+    "sujet::subject-empty-versions": { getBoundingClientRect: () => ({ top: 100, right: 320, bottom: 140, left: 260, width: 60, height: 40 }) }
+  });
+  const store = { user: { id: "u1" }, projectForm: { collaborators: [] }, projectSubjectsView: {}, situationsView: {} };
+  let loadCalls = 0;
+  const warnCalls = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnCalls.push(args);
+  const api = createProjectSubjectsDescription({
+    store,
+    ensureViewUiState: () => { store.projectSubjectsView ||= {}; },
+    firstNonEmpty: (...values) => values.find((value) => String(value ?? "").trim()) || "",
+    escapeHtml: (value) => String(value ?? ""),
+    svgIcon: () => "",
+    mdToHtml: (value) => String(value || ""),
+    fmtTs: () => "20/04/2026",
+    nowIso: () => new Date().toISOString(),
+    setOverlayChromeOpenState: () => {},
+    SVG_AVATAR_HUMAN: "",
+    renderCommentComposer: () => "",
+    getRunBucket: () => ({ bucket: { descriptions: { sujet: {}, situation: {} } } }),
+    persistRunBucket: () => {},
+    getSelectionEntityType: (type) => type,
+    getEntityByType: () => ({ id: "subject-empty-versions", title: "Sujet", raw: { description: "Description persistée" } }),
+    getEntityReviewMeta: () => ({}),
+    setEntityReviewMeta: () => {},
+    currentDecisionTarget: () => ({ type: "sujet", id: "subject-empty-versions", item: { id: "subject-empty-versions" } }),
+    rerenderScope: () => {},
+    markEntityValidated: () => {},
+    updateSubjectDescription: async () => ({}),
+    loadSubjectDescriptionVersions: async () => {
+      loadCalls += 1;
+      return [];
+    }
+  });
+
+  api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-empty-versions", title: "Sujet", raw: { description: "Description persistée" } }
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  api.renderDescriptionCard({
+    type: "sujet",
+    item: { id: "subject-empty-versions", title: "Sujet", raw: { description: "Description persistée" } }
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(loadCalls, 1);
+  assert.equal(warnCalls.length, 1);
+
+  console.warn = originalWarn;
+  cleanupFakeDom();
+});

--- a/apps/web/js/views/project-subjects/project-subjects-description.js
+++ b/apps/web/js/views/project-subjects/project-subjects-description.js
@@ -84,7 +84,10 @@ export function createProjectSubjectsDescription(config = {}) {
       versions: [],
       selectedVersionId: "",
       modalOpen: false,
-      loadToken: 0
+      loadToken: 0,
+      lastLoadedEntityKey: "",
+      lastLoadReturnedEmpty: false,
+      warnedMissingHistoryByEntity: {}
     };
     if (!Array.isArray(view.descriptionVersionsUi.versions)) view.descriptionVersionsUi.versions = [];
     if (typeof view.descriptionVersionsUi.error !== "string") view.descriptionVersionsUi.error = "";
@@ -93,6 +96,11 @@ export function createProjectSubjectsDescription(config = {}) {
     if (typeof view.descriptionVersionsUi.selectedVersionId !== "string") view.descriptionVersionsUi.selectedVersionId = "";
     if (typeof view.descriptionVersionsUi.modalOpen !== "boolean") view.descriptionVersionsUi.modalOpen = false;
     if (!Number.isFinite(Number(view.descriptionVersionsUi.loadToken))) view.descriptionVersionsUi.loadToken = 0;
+    if (typeof view.descriptionVersionsUi.lastLoadedEntityKey !== "string") view.descriptionVersionsUi.lastLoadedEntityKey = "";
+    if (typeof view.descriptionVersionsUi.lastLoadReturnedEmpty !== "boolean") view.descriptionVersionsUi.lastLoadReturnedEmpty = false;
+    if (!view.descriptionVersionsUi.warnedMissingHistoryByEntity || typeof view.descriptionVersionsUi.warnedMissingHistoryByEntity !== "object") {
+      view.descriptionVersionsUi.warnedMissingHistoryByEntity = {};
+    }
     return view.descriptionVersionsUi;
   }
 
@@ -364,7 +372,21 @@ export function createProjectSubjectsDescription(config = {}) {
     ui.selectedVersionId = "";
     ui.versions = [];
     ui.error = "";
+    ui.lastLoadedEntityKey = "";
+    ui.lastLoadReturnedEmpty = false;
     if (options.resetLoading !== false) ui.isLoading = false;
+  }
+
+  function getPersistedDescriptionInfo(entityType, entityId) {
+    const entity = getEntityByType(entityType, entityId);
+    const raw = entity?.raw && typeof entity.raw === "object" ? entity.raw : {};
+    const persistedBody = firstNonEmpty(raw.description, entity?.description, "");
+    const hasPersistedDescription = !!String(persistedBody || "").trim();
+    const hasDisplayFallbackOnly = !hasPersistedDescription && !!String(entity?.title || "").trim();
+    return {
+      hasPersistedDescription,
+      hasDisplayFallbackOnly
+    };
   }
 
   function syncDescriptionVersionsTarget(root) {
@@ -407,8 +429,31 @@ export function createProjectSubjectsDescription(config = {}) {
     const ui = ensureDescriptionVersionsUiState();
     const forceReload = !!options.forceReload;
     const sameTarget = ui.entityType === entityType && ui.entityId === entityId;
+    const currentEntityKey = `${entityType}::${entityId}`;
     const versionsInMemory = Array.isArray(ui.versions) ? ui.versions.length : 0;
     const previousLoading = !!ui.isLoading;
+    if (!forceReload && previousLoading && sameTarget) {
+      console.debug(`${VERSIONS_LOG_PREFIX} skip fetch`, {
+        entityType,
+        entityId,
+        skipReason: "already-loading",
+        lastLoadToken: Number(ui.loadToken || 0)
+      });
+      return;
+    }
+    if (!forceReload && sameTarget && ui.lastLoadedEntityKey === currentEntityKey && ui.lastLoadReturnedEmpty && !ui.error) {
+      const persistedInfo = getPersistedDescriptionInfo(entityType, entityId);
+      console.debug(`${VERSIONS_LOG_PREFIX} skip fetch`, {
+        entityType,
+        entityId,
+        skipReason: "empty-result-already-acknowledged",
+        hasPersistedDescription: persistedInfo.hasPersistedDescription,
+        hasDisplayFallbackOnly: persistedInfo.hasDisplayFallbackOnly,
+        versionsCount: versionsInMemory,
+        lastLoadToken: Number(ui.loadToken || 0)
+      });
+      return;
+    }
     logDescriptionVersions("ensure start", {
       entityType,
       entityId,
@@ -474,26 +519,39 @@ export function createProjectSubjectsDescription(config = {}) {
         return;
       }
       currentUi.versions = normalizedVersions;
+      currentUi.lastLoadedEntityKey = currentEntityKey;
+      currentUi.lastLoadReturnedEmpty = normalizedVersions.length === 0;
       if (!currentUi.selectedVersionId && currentUi.versions.length) {
         currentUi.selectedVersionId = String(currentUi.versions[0]?.id || "");
       }
       syncDescriptionCurrentAuthorFromVersions(entityType, entityId, currentUi.versions);
       if (!currentUi.versions.length) {
+        const persistedInfo = getPersistedDescriptionInfo(entityType, entityId);
         logDescriptionVersions("ensure loaded with empty result set", {
           entityType,
-          entityId
+          entityId,
+          hasPersistedDescription: persistedInfo.hasPersistedDescription,
+          hasDisplayFallbackOnly: persistedInfo.hasDisplayFallbackOnly,
+          versionsCount: 0,
+          lastLoadToken: loadToken
         });
-        const descriptionState = getEntityDescriptionState(entityType, entityId);
-        const hasCurrentDescription = !!String(descriptionState?.body || "").trim();
-        if (hasCurrentDescription) {
-          console.warn(
-            `${VERSIONS_LOG_PREFIX} subject has current description but no historical version rows; check backfill / RPC deployment`,
-            {
-              timestamp: new Date().toISOString(),
-              entityType,
-              entityId
-            }
-          );
+        if (persistedInfo.hasPersistedDescription) {
+          const warningKey = `${entityType}::${entityId}`;
+          if (!currentUi.warnedMissingHistoryByEntity?.[warningKey]) {
+            currentUi.warnedMissingHistoryByEntity[warningKey] = true;
+            console.warn(
+              `${VERSIONS_LOG_PREFIX} subject has current description but no historical version rows; check backfill / RPC deployment`,
+              {
+                timestamp: new Date().toISOString(),
+                entityType,
+                entityId,
+                hasPersistedDescription: true,
+                hasDisplayFallbackOnly: persistedInfo.hasDisplayFallbackOnly,
+                versionsCount: 0,
+                lastLoadToken: loadToken
+              }
+            );
+          }
         }
       }
     } catch (error) {
@@ -850,7 +908,13 @@ export function createProjectSubjectsDescription(config = {}) {
     }
     host.innerHTML = renderDescriptionVersionsDropdownContent(entityType, entityId);
     host.setAttribute("aria-hidden", "false");
-    if (!ui.isLoading && !ui.error && (!Array.isArray(ui.versions) || ui.versions.length === 0) && entityType === "sujet") {
+    if (
+      !ui.isLoading
+      && !ui.error
+      && (!Array.isArray(ui.versions) || ui.versions.length === 0)
+      && entityType === "sujet"
+      && !(ui.lastLoadedEntityKey === `${entityType}::${entityId}` && ui.lastLoadReturnedEmpty)
+    ) {
       void ensureDescriptionVersionsLoaded(root, entityType, entityId);
     }
     syncDescriptionVersionsDropdownPosition(root);
@@ -869,6 +933,7 @@ export function createProjectSubjectsDescription(config = {}) {
       && typeof loadSubjectDescriptionVersions === "function"
       && !versionsUi.isLoading
       && !hasVersionsLoaded
+      && !(versionsUi.lastLoadedEntityKey === `${entityType}::${entityId}` && versionsUi.lastLoadReturnedEmpty && !versionsUi.error)
     ) {
       void ensureDescriptionVersionsLoaded(null, entityType, entityId);
     }

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -845,6 +845,14 @@ export function createProjectSubjectsEvents(config) {
     const parentSubjectId = String(formContext.parentSubjectId || "").trim() || null;
     const scopeHost = String(formContext.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
     const setSubjectParent = getSetSubjectParent?.();
+    const descriptionLength = String(formContext.description || "").trim().length;
+    console.debug("[create-subissue-flow] submit", {
+      mode: formMode,
+      subjectId: null,
+      parentSubjectId,
+      descriptionLength,
+      didCallUpdateSubjectDescription: descriptionLength > 0 || (Array.isArray(formContext.attachments) && formContext.attachments.length > 0)
+    });
 
     (async () => {
       const submitPromise = createSubjectFromDraft();
@@ -854,6 +862,13 @@ export function createProjectSubjectsEvents(config) {
         rerenderPanels();
         return;
       }
+      console.debug("[create-subissue-flow] submit result", {
+        mode: formMode,
+        subjectId: String(result.subjectId || ""),
+        parentSubjectId,
+        descriptionLength,
+        didCallUpdateSubjectDescription: descriptionLength > 0 || (Array.isArray(formContext.attachments) && formContext.attachments.length > 0)
+      });
 
       if (formMode === "subissue") {
         if (parentSubjectId && typeof setSubjectParent === "function") {
@@ -864,10 +879,21 @@ export function createProjectSubjectsEvents(config) {
           }
         }
         resetCreateSubjectForm({ keepCreateMore: true });
+        const shouldReopenParent = !!parentSubjectId;
+        console.debug("[create-subissue-flow] reopen parent after create", {
+          mode: formMode,
+          subjectId: String(result.subjectId || ""),
+          parentSubjectId,
+          shouldReopenParent
+        });
         if (scopeHost === "drilldown") {
-          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(result.subjectId);
+          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(shouldReopenParent ? parentSubjectId : result.subjectId);
         } else {
-          selectSubject(result.subjectId) || selectSujet(result.subjectId);
+          if (shouldReopenParent) {
+            selectSubject(parentSubjectId) || selectSujet(parentSubjectId);
+          } else {
+            selectSubject(result.subjectId) || selectSujet(result.subjectId);
+          }
         }
         rerenderPanels();
         return;

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -620,6 +620,10 @@ async function createSubjectFromDraft() {
 
   const description = String(formState.description || "").trim();
   const draftAttachments = normalizeCreateSubjectDraftAttachments(formState.attachments);
+  const mode = String(formState.mode || "").trim().toLowerCase() === "subissue" ? "subissue" : "standard";
+  const parentSubjectId = mode === "subissue" ? String(formState.parentSubjectId || "").trim() : "";
+  const descriptionLength = description.length;
+  const shouldCallUpdateSubjectDescription = Boolean(description || draftAttachments.length > 0);
 
   store.situationsView.createSubjectForm.validationError = "";
   store.situationsView.createSubjectForm.isSubmitting = true;
@@ -634,6 +638,13 @@ async function createSubjectFromDraft() {
     if (!subjectId) {
       throw new Error("Le backend n'a pas renvoyé d'identifiant de sujet.");
     }
+    console.debug("[create-subissue-flow] createSubjectFromDraft created subject", {
+      mode,
+      subjectId,
+      parentSubjectId: parentSubjectId || null,
+      descriptionLength,
+      didCallUpdateSubjectDescription: false
+    });
 
     if (nextMeta.assignees.length) {
       await replaceSubjectAssigneesInSupabase(subjectId, nextMeta.assignees);
@@ -673,6 +684,13 @@ async function createSubjectFromDraft() {
     }
 
     if (description || uploadSessionId) {
+      console.debug("[create-subissue-flow] createSubjectFromDraft description update", {
+        mode,
+        subjectId,
+        parentSubjectId: parentSubjectId || null,
+        descriptionLength,
+        didCallUpdateSubjectDescription: shouldCallUpdateSubjectDescription
+      });
       await updateSubjectDescriptionInSupabase({
         subjectId,
         description,


### PR DESCRIPTION
### Motivation
- Prevent repeated network calls and console warnings when description versions API returns empty results for entities without meaningful persisted description.
- Make subissue creation flow more robust about which subject to reopen/select after creation and add debug logs to aid troubleshooting.

### Description
- Add UI state fields `lastLoadedEntityKey`, `lastLoadReturnedEmpty`, and `warnedMissingHistoryByEntity` to `descriptionVersionsUi` to track previous empty loads and issued warnings.
- Add helper `getPersistedDescriptionInfo` to determine whether an entity has a persisted description or only a title fallback.
- Update `ensureDescriptionVersionsLoaded`, `renderDescriptionVersionsDropdownHost` and `renderDescriptionCard` to skip redundant fetches when the last load for the same entity returned an empty set, and to only warn once per-entity when a persisted description exists but no history rows are returned.
- Improve subissue creation logic by computing `mode`, `parentSubjectId`, `descriptionLength` and `shouldCallUpdateSubjectDescription`, adding `console.debug` traces in `handleCreateSubjectSubmit` and `createSubjectFromDraft`, and ensuring the parent subject is reopened/selected when appropriate after creating a subissue.

### Testing
- Added unit tests in `project-subjects-description-versions.test.mjs` to assert that an entity without persisted description does not emit warnings or repeat loads, and that an entity with a persisted description but empty versions logs a single warning and does not loop; both tests passed.
- Existing description-version related tests were exercised and remained green during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e449893c8329ac2ca03c58f65d66)