### PR TITLE
Stabiliser le flux de création de sous-sujet et atténuer les logs de versions de description

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1382,6 +1382,7 @@ export async function updateSubjectTitle({ subjectId, title } = {}) {
 
 export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
   const logPrefix = "[subject-description-versions]";
+  const debugEnabled = isSubjectDescriptionDebugEnabled();
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");
   const limit = Math.min(100, Math.max(1, Number(options?.limit || 50)));
@@ -1425,8 +1426,8 @@ export async function loadSubjectDescriptionVersions(subjectId, options = {}) {
   }
   const versionRows = await versionsResponse.json().catch(() => []);
   const rows = Array.isArray(versionRows) ? versionRows : [];
-  if (!rows.length) {
-    console.warn(`${logPrefix} fetch succeeded but returned no version rows`, {
+  if (!rows.length && debugEnabled) {
+    console.debug(`${logPrefix} fetch succeeded but returned no version rows`, {
       timestamp: new Date().toISOString(),
       subjectId: normalizedSubjectId
     });

--- a/apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+const viewPath = path.resolve(__dirname, "./project-subjects-view.js");
+const viewSource = fs.readFileSync(viewPath, "utf8");
+const servicePath = path.resolve(__dirname, "../../services/project-subjects-supabase.js");
+const serviceSource = fs.readFileSync(servicePath, "utf8");
+const migrationPath = path.resolve(__dirname, "../../../../../supabase/migrations/202606150026_subject_history_title_description_close_reopen.sql");
+const migrationSource = fs.readFileSync(migrationPath, "utf8");
+
+test("le submit de création de sous-sujet n'appelle plus rerenderPanels immédiatement après createSubjectFromDraft", () => {
+  assert.match(eventsSource, /const submitPromise = createSubjectFromDraft\(\);\s*rerenderSubmitScope\(\);\s*const result = await submitPromise;/);
+  assert.doesNotMatch(eventsSource, /const submitPromise = createSubjectFromDraft\(\);\s*rerenderPanels\(\);/);
+});
+
+test("le flux subissue conserve setSubjectParent avec skipRerender true", () => {
+  assert.match(eventsSource, /await setSubjectParent\(result\.subjectId, parentSubjectId, \{ root: interactionRoot, skipRerender: true \}\);/);
+});
+
+test("createSubjectFromDraft ne force plus le chargement des versions de description juste après update", () => {
+  assert.match(viewSource, /await updateSubjectDescriptionInSupabase\(\{\s*subjectId,\s*description,\s*uploadSessionId\s*\}\);/);
+  assert.doesNotMatch(viewSource, /loadSubjectDescriptionVersionsInSupabase\(subjectId\)/);
+});
+
+test("loadSubjectDescriptionVersions ne console.warn plus quand aucun historique n'est renvoyé", () => {
+  assert.doesNotMatch(serviceSource, /console\.warn\(`\$\{logPrefix\} fetch succeeded but returned no version rows`/);
+  assert.match(serviceSource, /if \(!rows\.length && debugEnabled\) \{\s*console\.debug\(`\$\{logPrefix\} fetch succeeded but returned no version rows`/);
+});
+
+test("le RPC update_subject_description attendu par le front est celui qui insère dans subject_description_versions", () => {
+  assert.match(serviceSource, /payload = await rpcCall\("update_subject_description", rpcPayload\);/);
+  assert.match(migrationSource, /insert into public\.subject_description_versions \(/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -853,13 +853,20 @@ export function createProjectSubjectsEvents(config) {
       descriptionLength,
       didCallUpdateSubjectDescription: descriptionLength > 0 || (Array.isArray(formContext.attachments) && formContext.attachments.length > 0)
     });
+    const rerenderSubmitScope = () => {
+      if (interactionRoot && interactionRoot.isConnected) {
+        rerenderScope(interactionRoot);
+        return;
+      }
+      rerenderPanels();
+    };
 
     (async () => {
       const submitPromise = createSubjectFromDraft();
-      rerenderPanels();
+      rerenderSubmitScope();
       const result = await submitPromise;
       if (!result.ok) {
-        rerenderPanels();
+        rerenderSubmitScope();
         return;
       }
       console.debug("[create-subissue-flow] submit result", {
@@ -874,7 +881,7 @@ export function createProjectSubjectsEvents(config) {
         if (parentSubjectId && typeof setSubjectParent === "function") {
           const linked = await setSubjectParent(result.subjectId, parentSubjectId, { root: interactionRoot, skipRerender: true });
           if (!linked) {
-            rerenderPanels();
+            rerenderSubmitScope();
             return;
           }
         }
@@ -914,7 +921,7 @@ export function createProjectSubjectsEvents(config) {
       rerenderPanels();
     })().catch((error) => {
       showError(`Création du sujet impossible : ${String(error?.message || error || "Erreur inconnue")}`);
-      rerenderPanels();
+      rerenderSubmitScope();
     }).finally(() => {
       isCreateSubjectSubmitHandling = false;
     });

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -98,7 +98,6 @@ export function createProjectSubjectsView(deps) {
     replaceSubjectSituationsInSupabase,
     replaceSubjectObjectivesInSupabase,
     updateSubjectDescriptionInSupabase,
-    loadSubjectDescriptionVersionsInSupabase,
     uploadAttachmentFile
   } = deps;
 
@@ -696,9 +695,6 @@ async function createSubjectFromDraft() {
         description,
         uploadSessionId
       });
-      if (typeof loadSubjectDescriptionVersionsInSupabase === "function") {
-        await loadSubjectDescriptionVersionsInSupabase(subjectId);
-      }
     }
 
     await reloadSubjectsFromSupabase(getSubjectsCurrentRoot(), {


### PR DESCRIPTION
### Motivation
- La création d’un sous‑sujet depuis la modale provoquait des rerenders globaux prématurés (scintillement) et un rendu désordonné pendant l’envoi. 
- Le flux effectuait un fetch immédiat des versions de description après l’update, générant un warning console inutile lorsque 0 lignes étaient retournées.
- Besoin d’une correction minimale qui réduise les rerenders au scope local, conserve le contrat de linkage parent et évite des fetchs/logs superflus.

### Description
- Réduit les rerenders pendant la soumission en introduisant `rerenderSubmitScope()` dans `project-subjects-events.js` qui privilégie `rerenderScope(interactionRoot)` et ne retombe sur `rerenderPanels()` que si nécessaire, remplaçant l’appel immédiat à `rerenderPanels()` pendant l’in-flight submit.
- Stabilise la séquence de création : `createSubjectFromDraft()` crée + applique description/attachments, `setSubjectParent(..., { skipRerender: true })` est conservé pour le lien parent, puis un seul refresh final est effectué (pas de reloads/rerenders globaux intermédiaires).
- Supprime l’appel eager à `loadSubjectDescriptionVersionsInSupabase(subjectId)` après `updateSubjectDescriptionInSupabase(...)` dans `project-subjects-view.js` pour rendre le chargement des versions lazy.
- Assainit le service bas niveau `loadSubjectDescriptionVersions()` dans `project-subjects-supabase.js` en remplaçant `console.warn` (lorsque 0 lignes) par `console.debug` conditionnel si le debug description est activé, évitant le bruit console parasite.
- Ajoute un test ciblé `project-subjects-create-subissue-submit-flow.test.mjs` qui vérifie les contrats modifiés (pas de `rerenderPanels()` immédiat, conservation de `skipRerender`, pas de fetch forcé de versions, et plus de warn sur 0 lignes).
- Fichiers modifiés :
  - apps/web/js/views/project-subjects/project-subjects-events.js
  - apps/web/js/views/project-subjects/project-subjects-view.js
  - apps/web/js/services/project-subjects-supabase.js
  - apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs (nouveau)

### Testing
- Exécution du test ajouté : `node --test apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs` — réussi (5 assertions OK).
- Exécution de suites existantes impactées : `node --test apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs` — toutes réussies (tests existants OK).
- Tous les tests automatiques lancés dans cette validation sont passés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8eb12c28483299d113e4273a52e7d)