### PR TITLE
Add debug logging for subissue flow and normalize final selection after create/link

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs
@@ -24,6 +24,13 @@ test("le flux subissue conserve setSubjectParent avec skipRerender true", () => 
   assert.match(eventsSource, /await setSubjectParent\(result\.subjectId, parentSubjectId, \{ root: interactionRoot, skipRerender: true \}\);/);
 });
 
+test("le flux subissue revient au sujet parent après succès dans le bon scope", () => {
+  assert.match(eventsSource, /const finalSubjectId = String\(parentSubjectId \|\| result\.subjectId \|\| ""\);/);
+  assert.match(eventsSource, /\(openDrilldownFromSubjectPanel \|\| openDrilldownFromSujetPanel\)\(finalSubjectId\);/);
+  assert.match(eventsSource, /selectSubject\(finalSubjectId\) \|\| selectSujet\(finalSubjectId\);/);
+  assert.match(eventsSource, /debugSubissueFlow\("final-selection", \{/);
+});
+
 test("createSubjectFromDraft ne force plus le chargement des versions de description juste après update", () => {
   assert.match(viewSource, /await updateSubjectDescriptionInSupabase\(\{\s*subjectId,\s*description,\s*uploadSessionId\s*\}\);/);
   assert.doesNotMatch(viewSource, /loadSubjectDescriptionVersionsInSupabase\(subjectId\)/);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -172,6 +172,10 @@ export function createProjectSubjectsEvents(config) {
     console.log("[subissues-dnd]", eventName, payload);
   }
 
+  function debugSubissueFlow(eventName, payload = {}) {
+    console.debug("[subissue-flow]", eventName, payload);
+  }
+
   function dropdownController() {
     return getDropdownController();
   }
@@ -609,6 +613,10 @@ export function createProjectSubjectsEvents(config) {
         dropdownController().closeMeta();
         dropdown.subissueActionIntent = "create";
         if (parentSubjectId && getNestedSujet(parentSubjectId)) {
+          debugSubissueFlow("create-modal-open", {
+            parentSubjectId,
+            scopeHost
+          });
           openCreateSubjectForm({
             mode: "subissue",
             parentSubjectId,
@@ -628,6 +636,10 @@ export function createProjectSubjectsEvents(config) {
         event.preventDefault();
         event.stopPropagation();
         const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        debugSubissueFlow("menu-open-existing-view", {
+          parentSubjectId: String(dropdown.subissueActionSubjectId || ""),
+          scopeHost: String(dropdown.subissueActionScopeHost || "main")
+        });
         dropdown.subissueActionsView = "existing-subissue";
         dropdown.query = "";
         dropdown.subissueActionIntent = "link-existing";
@@ -660,7 +672,17 @@ export function createProjectSubjectsEvents(config) {
         if (selectedChildParentId === parentSubjectId) return;
         const applied = await setSubjectParent(childSubjectId, parentSubjectId, { root, skipRerender: true });
         if (!applied) return;
+        debugSubissueFlow("parent-linked", {
+          parentSubjectId,
+          childSubjectId,
+          source: "link-existing"
+        });
         dropdownController().closeMeta();
+        debugSubissueFlow("final-selection", {
+          subjectId: parentSubjectId,
+          scopeHost: String(dropdown.subissueActionScopeHost || "main"),
+          source: "link-existing"
+        });
         rerenderScope(root);
       };
     });
@@ -853,6 +875,13 @@ export function createProjectSubjectsEvents(config) {
       descriptionLength,
       didCallUpdateSubjectDescription: descriptionLength > 0 || (Array.isArray(formContext.attachments) && formContext.attachments.length > 0)
     });
+    if (formMode === "subissue") {
+      debugSubissueFlow("create-submit", {
+        parentSubjectId,
+        scopeHost,
+        descriptionLength
+      });
+    }
     const rerenderSubmitScope = () => {
       if (interactionRoot && interactionRoot.isConnected) {
         rerenderScope(interactionRoot);
@@ -884,24 +913,24 @@ export function createProjectSubjectsEvents(config) {
             rerenderSubmitScope();
             return;
           }
+          debugSubissueFlow("parent-linked", {
+            parentSubjectId,
+            childSubjectId: String(result.subjectId || ""),
+            source: "create"
+          });
         }
         resetCreateSubjectForm({ keepCreateMore: true });
-        const shouldReopenParent = !!parentSubjectId;
-        console.debug("[create-subissue-flow] reopen parent after create", {
-          mode: formMode,
-          subjectId: String(result.subjectId || ""),
-          parentSubjectId,
-          shouldReopenParent
-        });
+        const finalSubjectId = String(parentSubjectId || result.subjectId || "");
         if (scopeHost === "drilldown") {
-          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(shouldReopenParent ? parentSubjectId : result.subjectId);
+          (openDrilldownFromSubjectPanel || openDrilldownFromSujetPanel)(finalSubjectId);
         } else {
-          if (shouldReopenParent) {
-            selectSubject(parentSubjectId) || selectSujet(parentSubjectId);
-          } else {
-            selectSubject(result.subjectId) || selectSujet(result.subjectId);
-          }
+          selectSubject(finalSubjectId) || selectSujet(finalSubjectId);
         }
+        debugSubissueFlow("final-selection", {
+          subjectId: finalSubjectId,
+          scopeHost,
+          source: "create"
+        });
         rerenderPanels();
         return;
       }
@@ -1053,6 +1082,10 @@ export function createProjectSubjectsEvents(config) {
         if (isAlreadyOpen) {
           dropdownController().closeMeta();
         } else {
+          debugSubissueFlow("menu-open", {
+            subjectId: targetSubjectId,
+            scopeHost: isDrilldownScope ? "drilldown" : "main"
+          });
           dropdownController().closeKanban();
           dropdownController().openMeta({ field: "subissue-actions" });
           dropdown.subissueActionsView = "menu";
@@ -1080,6 +1113,10 @@ export function createProjectSubjectsEvents(config) {
         dropdownController().closeMeta();
         dropdown.subissueActionIntent = "create";
         if (parentSubjectId && getNestedSujet(parentSubjectId)) {
+          debugSubissueFlow("create-modal-open", {
+            parentSubjectId,
+            scopeHost
+          });
           openCreateSubjectForm({
             mode: "subissue",
             parentSubjectId,
@@ -1100,6 +1137,10 @@ export function createProjectSubjectsEvents(config) {
         event.preventDefault();
         event.stopPropagation();
         const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+        debugSubissueFlow("menu-open-existing-view", {
+          parentSubjectId: String(dropdown.subissueActionSubjectId || ""),
+          scopeHost: String(dropdown.subissueActionScopeHost || "main")
+        });
         dropdown.subissueActionsView = "existing-subissue";
         dropdown.query = "";
         dropdown.subissueActionIntent = "link-existing";

--- a/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
@@ -41,6 +41,7 @@ test("le dropdown Ajouter sous-sujet expose exactement les deux actions attendue
 
 test("l'événement d'ouverture du menu sous-sujet utilise le dropdown mutualisé", () => {
   assert.match(eventsSource, /\[data-action='open-subissue-action-menu'\]/);
+  assert.match(eventsSource, /debugSubissueFlow\("menu-open", \{/);
   assert.match(eventsSource, /dropdownController\(\)\.openMeta\(\{ field: "subissue-actions" \}\)/);
   assert.match(eventsSource, /dropdownController\(\)\.closeKanban\(\);/);
   assert.match(eventsSource, /dropdown\.subissueActionsView = "menu";/);
@@ -51,6 +52,7 @@ test("l'événement d'ouverture du menu sous-sujet utilise le dropdown mutualis�
 test("l'action Ajouter un sujet existant ouvre une sous-vue latérale sans fermer le dropdown", () => {
   assert.match(eventsSource, /\[data-action='open-link-existing-subissue'\]/);
   assert.match(eventsSource, /dropdownHost\.querySelectorAll\("\[data-action='open-link-existing-subissue'\]"\)/);
+  assert.match(eventsSource, /debugSubissueFlow\("menu-open-existing-view", \{/);
   assert.match(eventsSource, /dropdown\.subissueActionsView = "existing-subissue";/);
   assert.match(eventsSource, /dropdownController\(\)\.focusSearch\(\{ field: "subissue-actions" \}\);/);
   assert.match(eventsSource, /\[data-action='open-link-existing-subissue'\][\s\S]{0,600}refreshSubjectMetaDropdownUi\(root, \{ preserveScroll: true, preserveFocus: false \}\);/);
@@ -59,6 +61,8 @@ test("l'action Ajouter un sujet existant ouvre une sous-vue latérale sans ferme
 test("la sélection d'un sujet existant utilise setSubjectParent puis referme le dropdown", () => {
   assert.match(eventsSource, /\[data-subject-subissue-existing-entry\]/);
   assert.match(eventsSource, /await setSubjectParent\(childSubjectId, parentSubjectId, \{ root, skipRerender: true \}\);/);
+  assert.match(eventsSource, /debugSubissueFlow\("parent-linked", \{/);
+  assert.match(eventsSource, /debugSubissueFlow\("final-selection", \{/);
   assert.match(eventsSource, /dropdownController\(\)\.closeMeta\(\);/);
 });
 


### PR DESCRIPTION
### Motivation

- Improve observability of the subissue create/link UI flow to ease debugging of user interactions. 
- Ensure the post-create behavior selects or opens the correct subject (either the parent or the created child) consistently across scopes. 

### Description

- Introduces a `debugSubissueFlow` helper for structured `console.debug` logs and adds calls at key points including `menu-open`, `menu-open-existing-view`, `create-modal-open`, `create-submit`, `parent-linked`, and `final-selection`.
- Consolidates the final selection logic in the create-subissue flow by computing `finalSubjectId = String(parentSubjectId || result.subjectId || "")` and using it for both drilldown opening and selection calls.
- Adds debug calls when linking an existing child and after a successful create/link before rerendering panels.
- Updates unit tests to assert the new debug calls and the normalized final-selection behavior in `project-subjects-create-subissue-submit-flow.test.mjs` and `project-subjects-subissue-action-menu.test.mjs`.

### Testing

- Ran the `node:test` unit tests including `project-subjects-create-subissue-submit-flow.test.mjs` and `project-subjects-subissue-action-menu.test.mjs` which verify the added debug calls and final selection behavior, and they passed.
- Existing view/service related assertions were preserved and continued to pass in the updated test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ecf1a6348329952b7a9201830304)