### PR TITLE
Customize empty-state meta buttons in subissue creation modal

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1200,22 +1200,30 @@ function summarizeSubjectMetaValue(items, emptyLabel = "Aucun") {
   return `${items[0]} +${items.length - 1}`;
 }
 
-function renderSubjectMetaField({ field, label, valueHtml }) {
+function renderSubjectMetaField({ field, label, valueHtml, emptyState = null }) {
   const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
   const isOpen = dropdown.field === field;
+  const isEmpty = !!(emptyState && emptyState.isEmpty);
   return `
     <section class="subject-meta-field ${isOpen ? "is-open" : ""}">
       <button
         type="button"
-        class="subject-meta-field__trigger"
+        class="subject-meta-field__trigger ${isEmpty ? "subject-meta-field__trigger--empty" : ""}"
         data-subject-meta-trigger="${escapeHtml(field)}"
         data-subject-meta-anchor="${escapeHtml(field)}"
         aria-expanded="${isOpen ? "true" : "false"}"
       >
-        <span class="subject-meta-field__label-row">
-          <span class="subject-meta-field__label">${escapeHtml(label)}</span>
-          <span class="subject-meta-field__gear" aria-hidden="true">${svgIcon("gear", { className: "octicon octicon-gear" })}</span>
-        </span>
+        ${isEmpty ? `
+          <span class="subject-meta-field__empty-content">
+            <span class="subject-meta-field__empty-icon" aria-hidden="true">${svgIcon(emptyState.icon || "dot", { className: `octicon octicon-${escapeHtml(emptyState.icon || "dot")}` })}</span>
+            <span class="subject-meta-field__empty-text">${escapeHtml(emptyState.text || label)}</span>
+          </span>
+        ` : `
+          <span class="subject-meta-field__label-row">
+            <span class="subject-meta-field__label">${escapeHtml(label)}</span>
+            <span class="subject-meta-field__gear" aria-hidden="true">${svgIcon("gear", { className: "octicon octicon-gear" })}</span>
+          </span>
+        `}
       </button>
       <div class="subject-meta-field__value">${valueHtml}</div>
     </section>
@@ -3160,33 +3168,43 @@ function renderCreateSubjectMetaControls() {
   const meta = getSubjectSidebarMeta(subject.id);
   const objective = meta.objectiveIds.map((objectiveId) => getObjectiveById(objectiveId)).filter(Boolean)[0] || null;
   const isSubissueMode = String(store.situationsView.createSubjectForm?.mode || "").trim().toLowerCase() === "subissue";
+  const assigneesValueHtml = isSubissueMode ? renderCreateSubissueAssigneesValue(subject.id) : renderSubjectAssigneesValue(subject.id);
+  const labelsValueHtml = isSubissueMode ? renderCreateSubissueLabelsValue(subject.id) : renderSubjectLabelsValue(subject.id);
+  const situationsValueHtml = isSubissueMode ? renderCreateSubissueSituationValue(subject.id) : renderSubjectSituationsValue(subject.id);
+  const objectivesValueHtml = isSubissueMode
+    ? renderCreateSubissueObjectiveValue(subject.id)
+    : (objective ? renderSubjectObjectivesValue(subject.id) : renderSubjectMetaButtonValue("Aucun objectif"));
+
   return `
     <div class="subject-meta-controls subject-meta-controls--create">
       ${renderSubjectMetaField({
         field: "assignees",
         label: "Assignee",
-        valueHtml: isSubissueMode ? renderCreateSubissueAssigneesValue(subject.id) : renderSubjectAssigneesValue(subject.id)
+        valueHtml: assigneesValueHtml,
+        emptyState: isSubissueMode ? { isEmpty: !assigneesValueHtml, icon: "people", text: "Assigné à" } : null
       })}
       ${renderSubjectMetaField({
         field: "labels",
         label: "Labels",
-        valueHtml: isSubissueMode ? renderCreateSubissueLabelsValue(subject.id) : renderSubjectLabelsValue(subject.id)
+        valueHtml: labelsValueHtml,
+        emptyState: isSubissueMode ? { isEmpty: !labelsValueHtml, icon: "tag", text: "Label" } : null
       })}
       ${renderSubjectMetaField({
         field: "situations",
         label: "Project",
-        valueHtml: isSubissueMode ? renderCreateSubissueSituationValue(subject.id) : renderSubjectSituationsValue(subject.id)
+        valueHtml: situationsValueHtml,
+        emptyState: isSubissueMode ? { isEmpty: !situationsValueHtml, icon: "table", text: "Situation" } : null
       })}
       ${renderSubjectMetaField({
         field: "objectives",
         label: "Milestone",
-        valueHtml: isSubissueMode
-          ? renderCreateSubissueObjectiveValue(subject.id)
-          : (objective ? renderSubjectObjectivesValue(subject.id) : renderSubjectMetaButtonValue("Aucun objectif"))
+        valueHtml: objectivesValueHtml,
+        emptyState: isSubissueMode ? { isEmpty: !objectivesValueHtml, icon: "milestone", text: "Objectif" } : null
       })}
     </div>
   `;
 }
+
 
 function renderCreateSubjectFormHtml() {
   ensureViewUiState();

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10745,6 +10745,33 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   align-items:center;
   gap:6px;
 }
+.subject-create-layout--subissue .subject-meta-field__trigger--empty{
+  background-color:rgb(33, 40, 48);
+  color:rgb(145, 152, 161);
+  border-style:dashed;
+  border-color:rgb(61, 68, 77);
+  border-width:1px;
+}
+.subject-create-layout--subissue .subject-meta-field__empty-content{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.subject-create-layout--subissue .subject-meta-field__empty-icon{
+  display:inline-flex;
+  width:14px;
+  height:14px;
+  color:inherit;
+}
+.subject-create-layout--subissue .subject-meta-field__empty-icon .octicon{
+  width:14px;
+  height:14px;
+}
+.subject-create-layout--subissue .subject-meta-field__empty-text{
+  font-size:12px;
+  font-weight:500;
+  color:inherit;
+}
 .subject-create-layout--subissue .subject-meta-field__label-row{
   display:inline-flex;
   align-items:center;


### PR DESCRIPTION
### Motivation
- Provide a specific empty-state appearance for the four meta buttons shown in the subissue creation modal so empty controls display icon + label and a distinct visual style.
- Use existing SVG icons and a dashed, muted background treatment to make empty fields clearer and consistent in subissue creation mode.

### Description
- Extended `renderSubjectMetaField` to accept an `emptyState` parameter and render a dedicated empty trigger layout when `emptyState.isEmpty` is true via the `subject-meta-field__trigger--empty` modifier.
- Updated `renderCreateSubjectMetaControls` to compute `valueHtml` for each meta field and pass per-field `emptyState` objects in subissue mode with icons and texts: `people` → "Assigné à", `tag` → "Label", `table` → "Situation", and `milestone` → "Objectif".
- Added CSS rules in `apps/web/style.css` to style `.subject-meta-field__trigger--empty` and the empty-content children to implement the requested background color, text color, dashed border and layout for icon + text.
- This change targets only the empty-state layout for the subissue creation modal; non-empty/custom styling for populated buttons is left for follow-up work.

### Testing
- Ran `node --check apps/web/js/views/project-subjects/project-subjects-view.js` to validate JavaScript syntax, which succeeded.
- Ran `git diff --check` to ensure no diff-check issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c1fdacb08329a50273c46b7597be)