### PR TITLE
Restructuration de la modale de création de sous-sujet avec footer fixe

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
@@ -68,6 +68,9 @@ test("Créer un sous-sujet ouvre le create form en mode subissue (modale)", () =
   assert.match(viewSource, /function renderCreateSubissueModalHtml\(\)/);
   assert.match(viewSource, /subjectCreateSubissueModal/);
   assert.match(viewSource, /title: "Créer un sous-sujet"/);
+  assert.match(viewSource, /footerHtml: renderCreateSubjectFooterHtml\(\{ form, isSubissueMode: true \}\)/);
+  assert.match(viewSource, /footerClassName: "subject-create-subissue-modal__footer"/);
+  assert.match(viewSource, /\$\{isSubissueMode \? "" : renderCreateSubjectFooterHtml\(\{ form, isSubissueMode \}\)\}/);
   assert.match(viewSource, /\$\{isSubissueMode \? "" : `[\s\S]*subject-create-header__title/);
   assert.match(viewSource, /function renderCreateSubissueAssigneesValue\(subjectId\)/);
   assert.match(viewSource, /function renderCreateSubissueLabelsValue\(subjectId\)/);
@@ -76,6 +79,9 @@ test("Créer un sous-sujet ouvre le create form en mode subissue (modale)", () =
   assert.match(styleSource, /\.settings-modal__dialog\.subject-create-subissue-modal__dialog\{[\s\S]*width:800px;[\s\S]*height:673px;/);
   assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__title\{[\s\S]*font-size:14px;/);
   assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__close\{[\s\S]*background:transparent;/);
+  assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__head\{[\s\S]*height:49px;[\s\S]*padding:8px;/);
+  assert.match(styleSource, /\.subject-create-subissue-modal__body\{[\s\S]*height:560px;[\s\S]*padding:16px;[\s\S]*overflow-y:auto;/);
+  assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__footer\.subject-create-subissue-modal__footer\{[\s\S]*height:64px;[\s\S]*border-top:solid 1px var\(--border\);/);
   assert.match(styleSource, /\.settings-modal__head,[\s\S]*border-bottom:solid 1px var\(--border\);/);
   assert.match(styleSource, /\.subject-create-layout--subissue \.subject-meta-field__trigger\{[\s\S]*border:1px dashed var\(--border2\);/);
   assert.match(styleSource, /\.subject-create-subissue-inline-label__dot\{/);

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -3213,10 +3213,6 @@ function renderCreateSubjectFormHtml() {
   const avatar = String(store.user?.avatar || "assets/images/260093543.png");
   const previewHtml = mdToHtml(String(form.description || "").trim());
   const subissueHeaderTitle = isSubissueMode ? "Créer un sous-sujet" : "Créer un nouveau sujet";
-  const createMoreLabel = isSubissueMode ? "Créer d'autres sous-sujets" : "En ajouter d’autres";
-  const inlineMetaHtml = isSubissueMode
-    ? `<div class="subject-create-inline-meta">${renderCreateSubjectMetaControls()}</div>`
-    : "";
   const asideHtml = isSubissueMode
     ? ""
     : `
@@ -3277,19 +3273,7 @@ function renderCreateSubjectFormHtml() {
                 ${form.validationError ? `<div class="subject-create-form__error">${escapeHtml(form.validationError)}</div>` : ""}
               </div>
 
-              <div class="subject-create-footer">
-                <div class="subject-create-footer__left">
-                  ${inlineMetaHtml}
-                  <label class="subject-create-checkbox">
-                    <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
-                    <span>${escapeHtml(createMoreLabel)}</span>
-                  </label>
-                </div>
-                <div class="subject-create-footer__right">
-                  <button type="button" class="gh-btn" data-create-subject-cancel>Annuler</button>
-                  <button type="button" class="gh-btn gh-btn--primary" data-create-subject-submit ${form.isSubmitting ? "disabled" : ""}>${form.isSubmitting ? "Création..." : "Ajouter"}</button>
-                </div>
-              </div>
+              ${isSubissueMode ? "" : renderCreateSubjectFooterHtml({ form, isSubissueMode })}
             </div>
           </div>
         </div>
@@ -3299,15 +3283,40 @@ function renderCreateSubjectFormHtml() {
   `;
 }
 
+function renderCreateSubjectFooterHtml({ form = {}, isSubissueMode = false } = {}) {
+  const createMoreLabel = isSubissueMode ? "Créer d'autres sous-sujets" : "En ajouter d’autres";
+  const inlineMetaHtml = isSubissueMode
+    ? `<div class="subject-create-inline-meta">${renderCreateSubjectMetaControls()}</div>`
+    : "";
+  return `
+    <div class="subject-create-footer">
+      <div class="subject-create-footer__left">
+        ${inlineMetaHtml}
+        <label class="subject-create-checkbox">
+          <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
+          <span>${escapeHtml(createMoreLabel)}</span>
+        </label>
+      </div>
+      <div class="subject-create-footer__right">
+        <button type="button" class="gh-btn" data-create-subject-cancel>Annuler</button>
+        <button type="button" class="gh-btn gh-btn--primary" data-create-subject-submit ${form.isSubmitting ? "disabled" : ""}>${form.isSubmitting ? "Création..." : "Ajouter"}</button>
+      </div>
+    </div>
+  `;
+}
+
 function renderCreateSubissueModalHtml() {
+  const form = store.situationsView.createSubjectForm || {};
   return renderSettingsModal({
     modalId: "subjectCreateSubissueModal",
     title: "Créer un sous-sujet",
     closeDataAttribute: "data-close-subissue-create-modal",
     bodyHtml: renderCreateSubjectFormHtml(),
+    footerHtml: renderCreateSubjectFooterHtml({ form, isSubissueMode: true }),
     variant: "wide",
     dialogClassName: "subject-create-subissue-modal__dialog",
-    bodyClassName: "subject-create-subissue-modal__body"
+    bodyClassName: "subject-create-subissue-modal__body",
+    footerClassName: "subject-create-subissue-modal__footer"
   });
 }
 

--- a/apps/web/js/views/ui/settings-modal.js
+++ b/apps/web/js/views/ui/settings-modal.js
@@ -10,11 +10,13 @@ export function renderSettingsModal({
   title = "",
   subtitle = "",
   bodyHtml = "",
+  footerHtml = "",
   closeDataAttribute = "data-close-settings-modal",
   variant = "default",
   rootClassName = "",
   dialogClassName = "",
-  bodyClassName = ""
+  bodyClassName = "",
+  footerClassName = ""
 } = {}) {
   const safeModalId = escapeHtml(modalId);
   const safeTitleId = escapeHtml(`${modalId}Title`);
@@ -30,6 +32,7 @@ export function renderSettingsModal({
 
   const dialogClasses = ["settings-modal__dialog", normalizeClassName(dialogClassName)].filter(Boolean).join(" ");
   const bodyClasses = ["settings-modal__body", normalizeClassName(bodyClassName)].filter(Boolean).join(" ");
+  const footerClasses = ["settings-modal__footer", normalizeClassName(footerClassName)].filter(Boolean).join(" ");
 
   return `
     <div class="${rootClasses}" id="${safeModalId}">
@@ -49,6 +52,11 @@ export function renderSettingsModal({
         <div class="${bodyClasses}">
           ${bodyHtml}
         </div>
+        ${footerHtml ? `
+          <div class="${footerClasses}">
+            ${footerHtml}
+          </div>
+        ` : ""}
       </div>
     </div>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10863,11 +10863,28 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   transform:translate(-50%, -50%) !important;
 }
 .subject-create-subissue-modal__body{
-  padding:0;
-  overflow:auto;
+  height:560px;
+  padding:16px;
+  box-sizing:border-box;
+  overflow-y:auto;
+  overflow-x:hidden;
 }
 .subject-create-subissue-modal__body .subject-create-shell{
+  padding:0;
+}
+.subject-create-subissue-modal__dialog .settings-modal__head{
+  height:49px;
+  padding:8px;
+  box-sizing:border-box;
+}
+.subject-create-subissue-modal__dialog .settings-modal__footer.subject-create-subissue-modal__footer{
+  height:64px;
   padding:16px;
+  border-top:solid 1px var(--border);
+  box-sizing:border-box;
+}
+.subject-create-subissue-modal__footer .subject-create-footer{
+  margin-top:0;
 }
 .subject-create-subissue-modal__dialog .settings-modal__title{
   font-size:14px;
@@ -12100,6 +12117,10 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 .settings-modal__body,
 .personal-settings-delete-modal__body{
   padding:0 16px 16px;
+}
+
+.settings-modal__footer{
+  padding:16px;
 }
 
 .settings-modal__alert,


### PR DESCRIPTION
### Motivation
- Restructurer le DOM de la modale de création de sous-sujet pour séparer proprement `head / body / footer` et déplacer les contrôles d’action vers un footer fixe. 
- Appliquer des dimensions et paddings spécifiques (head 800×49 px, body 800×560 px scrollable, footer 800×64 px) pour garantir un rendu cohérent en mode subissue.

### Description
- Ajout d’un support optionnel de footer dans le helper partagé `renderSettingsModal` via les paramètres `footerHtml` et `footerClassName` dans `apps/web/js/views/ui/settings-modal.js`. 
- Création de `renderCreateSubjectFooterHtml` et déplacement des contrôles (checkbox `data-create-subject-create-more`, bouton `data-create-subject-cancel`, bouton `data-create-subject-submit`) du body vers le footer pour la modale subissue dans `apps/web/js/views/project-subjects/project-subjects-view.js`, sans duplication DOM. 
- Ajout de styles CSS dédiés dans `apps/web/style.css` pour la modale subissue : header (`height:49px; padding:8px;`), body (`height:560px; padding:16px; overflow-y:auto;`), footer (`height:64px; padding:16px; border-top:solid 1px var(--border);`) et règle de base `.settings-modal__footer`. 
- Mise à jour des assertions de régression dans `apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs` pour vérifier le câblage du footer et les règles CSS.

### Testing
- Exécution du test ciblé avec `node --test apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs` qui a réussi (`7 passed, 0 failed`).
- Aucune erreur automatique ajoutée par les tests unitaires à la suite des modifications (tests de rendu et assertions CSS mis à jour).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c46c391483298d4b7da15e566700)