### PR TITLE
Add footer support to settings modal and improve subissue create modal layout/styles

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs
@@ -68,6 +68,11 @@ test("Créer un sous-sujet ouvre le create form en mode subissue (modale)", () =
   assert.match(viewSource, /function renderCreateSubissueModalHtml\(\)/);
   assert.match(viewSource, /subjectCreateSubissueModal/);
   assert.match(viewSource, /title: "Créer un sous-sujet"/);
+  assert.match(viewSource, /footerHtml: renderCreateSubjectFooterHtml\(\{ form, isSubissueMode: true \}\)/);
+  assert.match(viewSource, /footerClassName: "subject-create-subissue-modal__footer"/);
+  assert.match(viewSource, /\$\{isSubissueMode \? `<div class="subject-create-inline-meta">\$\{renderCreateSubjectMetaControls\(\)\}<\/div>` : ""\}/);
+  assert.match(viewSource, /\$\{isSubissueMode \? "" : renderCreateSubjectFooterHtml\(\{ form, isSubissueMode \}\)\}/);
+  assert.match(viewSource, /document\.body\.classList\.toggle\("subject-create-subissue-modal-open", isSubissueCreateMode\);/);
   assert.match(viewSource, /\$\{isSubissueMode \? "" : `[\s\S]*subject-create-header__title/);
   assert.match(viewSource, /function renderCreateSubissueAssigneesValue\(subjectId\)/);
   assert.match(viewSource, /function renderCreateSubissueLabelsValue\(subjectId\)/);
@@ -76,6 +81,12 @@ test("Créer un sous-sujet ouvre le create form en mode subissue (modale)", () =
   assert.match(styleSource, /\.settings-modal__dialog\.subject-create-subissue-modal__dialog\{[\s\S]*width:800px;[\s\S]*height:673px;/);
   assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__title\{[\s\S]*font-size:14px;/);
   assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__close\{[\s\S]*background:transparent;/);
+  assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__head\{[\s\S]*height:49px;[\s\S]*padding:8px;/);
+  assert.match(styleSource, /\.subject-create-subissue-modal__body\{[\s\S]*height:560px;[\s\S]*padding:16px;[\s\S]*overflow-y:auto;/);
+  assert.match(styleSource, /\.subject-create-subissue-modal__dialog \.settings-modal__footer\.subject-create-subissue-modal__footer\{[\s\S]*height:64px;[\s\S]*border-top:solid 1px var\(--border\);/);
+  assert.match(styleSource, /body\.subject-create-subissue-modal-open \.details-body,[\s\S]*overflow: hidden !important;/);
+  assert.match(styleSource, /\.subject-create-layout--subissue \.comment-composer--create-subject \.comment-composer__textarea\{[\s\S]*width:min\(766px, 100%\) !important;[\s\S]*resize:vertical !important;/);
+  assert.match(styleSource, /\.subject-create-layout--subissue \.subject-create-inline-meta\{[\s\S]*margin-top:12px;/);
   assert.match(styleSource, /\.settings-modal__head,[\s\S]*border-bottom:solid 1px var\(--border\);/);
   assert.match(styleSource, /\.subject-create-layout--subissue \.subject-meta-field__trigger\{[\s\S]*border:1px dashed var\(--border2\);/);
   assert.match(styleSource, /\.subject-create-subissue-inline-label__dot\{/);

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2603,6 +2603,7 @@ function rerenderPanels() {
   const isCreateFormOpen = !!createForm.isOpen;
   const isSubissueCreateMode = isCreateFormOpen && String(createForm.mode || "").trim().toLowerCase() === "subissue";
   const isStandardCreateMode = isCreateFormOpen && !isSubissueCreateMode;
+  document.body.classList.toggle("subject-create-subissue-modal-open", isSubissueCreateMode);
 
   const shouldDisableProjectCompact = !!panelHost
     && !isCreateFormOpen
@@ -3213,10 +3214,6 @@ function renderCreateSubjectFormHtml() {
   const avatar = String(store.user?.avatar || "assets/images/260093543.png");
   const previewHtml = mdToHtml(String(form.description || "").trim());
   const subissueHeaderTitle = isSubissueMode ? "Créer un sous-sujet" : "Créer un nouveau sujet";
-  const createMoreLabel = isSubissueMode ? "Créer d'autres sous-sujets" : "En ajouter d’autres";
-  const inlineMetaHtml = isSubissueMode
-    ? `<div class="subject-create-inline-meta">${renderCreateSubjectMetaControls()}</div>`
-    : "";
   const asideHtml = isSubissueMode
     ? ""
     : `
@@ -3277,19 +3274,8 @@ function renderCreateSubjectFormHtml() {
                 ${form.validationError ? `<div class="subject-create-form__error">${escapeHtml(form.validationError)}</div>` : ""}
               </div>
 
-              <div class="subject-create-footer">
-                <div class="subject-create-footer__left">
-                  ${inlineMetaHtml}
-                  <label class="subject-create-checkbox">
-                    <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
-                    <span>${escapeHtml(createMoreLabel)}</span>
-                  </label>
-                </div>
-                <div class="subject-create-footer__right">
-                  <button type="button" class="gh-btn" data-create-subject-cancel>Annuler</button>
-                  <button type="button" class="gh-btn gh-btn--primary" data-create-subject-submit ${form.isSubmitting ? "disabled" : ""}>${form.isSubmitting ? "Création..." : "Ajouter"}</button>
-                </div>
-              </div>
+              ${isSubissueMode ? `<div class="subject-create-inline-meta">${renderCreateSubjectMetaControls()}</div>` : ""}
+              ${isSubissueMode ? "" : renderCreateSubjectFooterHtml({ form, isSubissueMode })}
             </div>
           </div>
         </div>
@@ -3299,15 +3285,36 @@ function renderCreateSubjectFormHtml() {
   `;
 }
 
+function renderCreateSubjectFooterHtml({ form = {}, isSubissueMode = false } = {}) {
+  const createMoreLabel = isSubissueMode ? "Créer d'autres sous-sujets" : "En ajouter d’autres";
+  return `
+    <div class="subject-create-footer">
+      <div class="subject-create-footer__left">
+        <label class="subject-create-checkbox">
+          <input type="checkbox" data-create-subject-create-more ${form.createMore ? "checked" : ""}>
+          <span>${escapeHtml(createMoreLabel)}</span>
+        </label>
+      </div>
+      <div class="subject-create-footer__right">
+        <button type="button" class="gh-btn" data-create-subject-cancel>Annuler</button>
+        <button type="button" class="gh-btn gh-btn--primary" data-create-subject-submit ${form.isSubmitting ? "disabled" : ""}>${form.isSubmitting ? "Création..." : "Ajouter"}</button>
+      </div>
+    </div>
+  `;
+}
+
 function renderCreateSubissueModalHtml() {
+  const form = store.situationsView.createSubjectForm || {};
   return renderSettingsModal({
     modalId: "subjectCreateSubissueModal",
     title: "Créer un sous-sujet",
     closeDataAttribute: "data-close-subissue-create-modal",
     bodyHtml: renderCreateSubjectFormHtml(),
+    footerHtml: renderCreateSubjectFooterHtml({ form, isSubissueMode: true }),
     variant: "wide",
     dialogClassName: "subject-create-subissue-modal__dialog",
-    bodyClassName: "subject-create-subissue-modal__body"
+    bodyClassName: "subject-create-subissue-modal__body",
+    footerClassName: "subject-create-subissue-modal__footer"
   });
 }
 

--- a/apps/web/js/views/ui/settings-modal.js
+++ b/apps/web/js/views/ui/settings-modal.js
@@ -10,11 +10,13 @@ export function renderSettingsModal({
   title = "",
   subtitle = "",
   bodyHtml = "",
+  footerHtml = "",
   closeDataAttribute = "data-close-settings-modal",
   variant = "default",
   rootClassName = "",
   dialogClassName = "",
-  bodyClassName = ""
+  bodyClassName = "",
+  footerClassName = ""
 } = {}) {
   const safeModalId = escapeHtml(modalId);
   const safeTitleId = escapeHtml(`${modalId}Title`);
@@ -30,6 +32,7 @@ export function renderSettingsModal({
 
   const dialogClasses = ["settings-modal__dialog", normalizeClassName(dialogClassName)].filter(Boolean).join(" ");
   const bodyClasses = ["settings-modal__body", normalizeClassName(bodyClassName)].filter(Boolean).join(" ");
+  const footerClasses = ["settings-modal__footer", normalizeClassName(footerClassName)].filter(Boolean).join(" ");
 
   return `
     <div class="${rootClasses}" id="${safeModalId}">
@@ -49,6 +52,11 @@ export function renderSettingsModal({
         <div class="${bodyClasses}">
           ${bodyHtml}
         </div>
+        ${footerHtml ? `
+          <div class="${footerClasses}">
+            ${footerHtml}
+          </div>
+        ` : ""}
       </div>
     </div>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -1323,6 +1323,12 @@ body.modal-open {
   overflow: hidden;
 }
 
+body.subject-create-subissue-modal-open .details-body,
+body.subject-create-subissue-modal-open .subject-details-body,
+body.subject-create-subissue-modal-open #situationsDetailsHost{
+  overflow: hidden !important;
+}
+
 /* ===== Details head state classes (for clean CSS cascade) =====
    JS toggles these classes on .gh-panel__head--tight and .modal__head.
    You can override/extend these rules as needed. */
@@ -10863,11 +10869,31 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   transform:translate(-50%, -50%) !important;
 }
 .subject-create-subissue-modal__body{
-  padding:0;
-  overflow:auto;
+  height:560px;
+  padding:16px;
+  box-sizing:border-box;
+  overflow-y:auto;
+  overflow-x:hidden;
 }
 .subject-create-subissue-modal__body .subject-create-shell{
+  padding:0;
+}
+.subject-create-subissue-modal__dialog .settings-modal__head{
+  height:49px;
+  padding:8px;
+  box-sizing:border-box;
+}
+.subject-create-subissue-modal__dialog .settings-modal__footer.subject-create-subissue-modal__footer{
+  height:64px;
   padding:16px;
+  border-top:solid 1px var(--border);
+  box-sizing:border-box;
+  overflow:visible;
+}
+.subject-create-subissue-modal__footer .subject-create-footer{
+  margin-top:0;
+  align-items:center;
+  overflow:visible;
 }
 .subject-create-subissue-modal__dialog .settings-modal__title{
   font-size:14px;
@@ -10876,13 +10902,17 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   background:transparent;
 }
 .subject-create-layout--subissue .comment-composer--create-subject{
-  width:min(700px, 100%);
+  width:min(766px, 100%);
 }
 .subject-create-layout--subissue .comment-composer--create-subject .comment-composer__textarea{
-  width:min(700px, 100%) !important;
+  width:min(766px, 100%) !important;
   min-height:326px !important;
-  height:326px !important;
-  max-height:326px !important;
+  height:auto !important;
+  max-height:none !important;
+  resize:vertical !important;
+}
+.subject-create-layout--subissue .subject-create-inline-meta{
+  margin-top:12px;
 }
 
 .comment-composer--create-subject{
@@ -12100,6 +12130,10 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 .settings-modal__body,
 .personal-settings-delete-modal__body{
   padding:0 16px 16px;
+}
+
+.settings-modal__footer{
+  padding:16px;
 }
 
 .settings-modal__alert,


### PR DESCRIPTION
### Motivation
- Introduce a footer slot for generic settings modals so complex modal dialogs can render custom actions and layout classes via the modal renderer.
- Extract and reuse the create-subject footer to keep markup consistent between inline create forms and the subissue modal dialog.
- Ensure the subissue create modal disables background scrolling and uses dedicated layout/spacing rules to accommodate the inline meta controls and larger editor.

### Description
- Added `footerHtml` and `footerClassName` options to `renderSettingsModal` and render a footer wrapper only when `footerHtml` is provided.
- Added `renderCreateSubjectFooterHtml` helper and refactored `renderCreateSubjectFormHtml` to use it and to render inline meta controls for subissue mode. 
- Updated `renderCreateSubissueModalHtml` to pass `footerHtml` and `footerClassName` into `renderSettingsModal` and pass the current `form` into the footer helper. 
- Toggle the `subject-create-subissue-modal-open` body class from `rerenderPanels` so JS-driven open state and CSS no-scroll rules are synchronized. 
- Adjusted CSS in `style.css` to size the subissue dialog, body, head and footer, to prevent background scroll when the modal is open, and to improve editor sizing and inline-meta spacing.
- Updated `project-subjects-create-subject-context.test.mjs` expectations to assert the new footer rendering, classes, body class toggle and related markup/CSS changes.

### Testing
- Ran the updated unit test file `apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs` which asserts modal/footer/rendering rules and it passed.
- Ran the full test suite for the views module with the modified tests and no regressions were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c46c391483298d4b7da15e566700)