### PR TITLE
Prevent global rerenders from subissue create modal; idempotent interactive bindings

### DIFF
--- a/apps/web/js/views/project-subjects/project-subject-detail.js
+++ b/apps/web/js/views/project-subjects/project-subject-detail.js
@@ -11,6 +11,13 @@ function restoreScrollableElementScrollState(element, state) {
   element.scrollTop = Math.max(0, Math.min(Number(state.scrollTop || 0), maxScrollTop));
 }
 
+function bumpInteractiveEpoch(root) {
+  if (!root) return root;
+  const currentEpoch = Number(root.dataset.detailsInteractiveEpoch || 0);
+  root.dataset.detailsInteractiveEpoch = String(currentEpoch + 1);
+  return root;
+}
+
 export function createProjectSubjectDetailController(config) {
   const {
     store,
@@ -79,7 +86,7 @@ export function createProjectSubjectDetailController(config) {
 
     ensureDrilldownDom();
 
-    wireDetailsInteractive(body);
+    wireDetailsInteractive(bumpInteractiveEpoch(body));
     bindDetailsScroll(document);
     restoreScrollableElementScrollState(body, bodyScrollState);
     body.__syncCondensedTitle?.();

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -28,6 +28,13 @@ function restoreScrollableElementScrollState(element, state) {
   element.scrollTop = Math.max(0, Math.min(Number(state.scrollTop || 0), maxScrollTop));
 }
 
+function bumpInteractiveEpoch(root) {
+  if (!root) return root;
+  const currentEpoch = Number(root.dataset.detailsInteractiveEpoch || 0);
+  root.dataset.detailsInteractiveEpoch = String(currentEpoch + 1);
+  return root;
+}
+
 export function createProjectSubjectDrilldownController(config) {
   const {
     store,
@@ -187,7 +194,7 @@ export function createProjectSubjectDrilldownController(config) {
       };
     });
 
-    wireDetailsInteractive(body);
+    wireDetailsInteractive(bumpInteractiveEpoch(body));
     ensureTimelineLoadedForSelection?.(selection, { scopeHost: "drilldown" });
     bindDetailsScroll(panel);
     applyNormalDetailsCompactSnapshot(viewState.drilldown?.normalDetailsCompactSnapshot);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -113,6 +113,7 @@ export function createProjectSubjectsEvents(config) {
   let subjectsTabResetBound = false;
   let descriptionVersionsPositionBound = false;
   let isCreateSubjectSubmitHandling = false;
+  const interactiveBindingEpochByRoot = new WeakMap();
 
   function getTextareaAutosizeMeta(textarea) {
     const type = textarea?.matches?.("#humanCommentBox")
@@ -183,7 +184,7 @@ export function createProjectSubjectsEvents(config) {
   function bindSubjectMetaDropdownDocumentEvents() {
     if (typeof detachDropdownDocumentEvents === "function") return detachDropdownDocumentEvents;
     detachDropdownDocumentEvents = dropdownController().bindDocumentEvents({
-      onRerender: () => rerenderScope(),
+      onRerender: (scopeRoot) => rerenderScope(scopeRoot || getSubjectMetaScopeRoot?.() || document),
       onSyncPosition: (scopeRoot) => syncSubjectMetaDropdownPosition(scopeRoot),
       getScopeRoot: getSubjectMetaScopeRoot
     });
@@ -304,16 +305,16 @@ export function createProjectSubjectsEvents(config) {
     const reorderSubjectChildren = getReorderSubjectChildren?.();
 
     dropdownHost.querySelectorAll("[data-subject-kanban-search]").forEach((input) => {
-      input.addEventListener("input", () => {
+      input.oninput = () => {
         const subjectId = String(input.dataset.subjectKanbanSearch || "");
         const situationId = String(input.dataset.subjectKanbanSearchSituationId || "");
         dropdownController().setKanbanQuery(input.value || "");
         const entries = getSubjectKanbanMenuEntries(subjectId, situationId, input.value || "");
         getSubjectsViewState().subjectKanbanDropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { subjectId, situationId } });
-      });
+      };
 
-      input.addEventListener("keydown", (event) => {
+      input.onkeydown = (event) => {
         const subjectId = String(input.dataset.subjectKanbanSearch || "");
         const situationId = String(input.dataset.subjectKanbanSearchSituationId || "");
         const entries = getSubjectKanbanMenuEntries(subjectId, situationId, getSubjectsViewState().subjectKanbanDropdown.query || "");
@@ -341,11 +342,11 @@ export function createProjectSubjectsEvents(config) {
           dropdownController().closeKanban();
           rerenderScope(root);
         }
-      });
+      };
     });
 
     dropdownHost.querySelectorAll("[data-subject-meta-search]").forEach((input) => {
-      input.addEventListener("input", () => {
+      input.oninput = () => {
         const field = String(input.dataset.subjectMetaSearch || "");
         dropdownController().setMetaQuery(input.value || "");
         const selection = getScopedSelection(root);
@@ -356,9 +357,9 @@ export function createProjectSubjectsEvents(config) {
           ? currentKey
           : String(entries[0]?.key || "");
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field } });
-      });
+      };
 
-      input.addEventListener("keydown", async (event) => {
+      input.onkeydown = async (event) => {
         const field = String(input.dataset.subjectMetaSearch || "");
         const subjectSelection = getScopedSelection(root);
         if (subjectSelection?.type !== "sujet") return;
@@ -434,7 +435,7 @@ export function createProjectSubjectsEvents(config) {
             await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectAssignee(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
           }
         }
-      });
+      };
     });
 
     dropdownHost.querySelectorAll("[data-objective-select]").forEach((btn) => {
@@ -960,6 +961,9 @@ export function createProjectSubjectsEvents(config) {
 
   function wireDetailsInteractive(root) {
     if (!root) return;
+    const bindingEpoch = String(root.dataset.detailsInteractiveEpoch || "0");
+    if (interactiveBindingEpochByRoot.get(root) === bindingEpoch) return;
+    interactiveBindingEpochByRoot.set(root, bindingEpoch);
     const isAutosizeDebugEnabled = () => typeof window !== "undefined" && window?.__MDALL_DEBUG_TEXTAREA_AUTOSIZE__ === true;
     const isElementMeasurable = (element) => {
       if (!element || element.isConnected === false) return false;
@@ -1188,7 +1192,7 @@ export function createProjectSubjectsEvents(config) {
         const explicitTab = String(btn.dataset.createSubjectTab || "").trim();
         const isPreview = explicitTab === "preview" || action === "create-subject-tab-preview";
         store.situationsView.createSubjectForm.previewMode = isPreview;
-        rerenderPanels();
+        rerenderScope(root);
       };
     });
     root.querySelectorAll("[data-create-subject-title]").forEach((input) => {
@@ -1201,7 +1205,7 @@ export function createProjectSubjectsEvents(config) {
       textarea.oninput = () => {
         store.situationsView.createSubjectForm.description = String(textarea.value || "");
         runAutosize(textarea, "create-subject-input");
-        if (store.situationsView.createSubjectForm.previewMode) rerenderPanels();
+        if (store.situationsView.createSubjectForm.previewMode) rerenderScope(root);
       };
     });
     root.querySelectorAll("[data-create-subject-create-more]").forEach((checkbox) => {

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2585,6 +2585,37 @@ function ensureCreateSubissueModalHost() {
   return host;
 }
 
+function bumpInteractiveEpoch(root) {
+  if (!root) return root;
+  const currentEpoch = Number(root.dataset.detailsInteractiveEpoch || 0);
+  root.dataset.detailsInteractiveEpoch = String(currentEpoch + 1);
+  return root;
+}
+
+function isSubissueCreateFormOpen() {
+  const createForm = store.situationsView.createSubjectForm || {};
+  return !!createForm.isOpen && String(createForm.mode || "").trim().toLowerCase() === "subissue";
+}
+
+function isCreateSubissueModalScopeRoot(root) {
+  if (!root || !isSubissueCreateFormOpen()) return false;
+  const modalHost = document.getElementById("subjectCreateSubissueModalHost");
+  if (!modalHost || !modalHost.isConnected) return false;
+  return root === modalHost || !!root.closest?.("#subjectCreateSubissueModalHost");
+}
+
+function rerenderCreateSubissueModal() {
+  const modalHost = ensureCreateSubissueModalHost();
+  if (!isSubissueCreateFormOpen()) {
+    modalHost.innerHTML = "";
+    return null;
+  }
+  modalHost.innerHTML = renderCreateSubissueModalHtml();
+  const modalCreateFormRoot = bumpInteractiveEpoch(modalHost.querySelector("[data-create-subject-form]"));
+  wireDetailsInteractive(modalCreateFormRoot);
+  return modalCreateFormRoot;
+}
+
 function rerenderPanels() {
   ensureViewUiState();
   document.body.classList.remove("project-subject-details-top-compact");
@@ -2615,7 +2646,7 @@ function rerenderPanels() {
   if (panelHost) {
     if (isStandardCreateMode) {
       panelHost.innerHTML = `<div id="subjectCreateFormHost" class="project-table-host">${renderCreateSubjectFormHtml()}</div>`;
-      const createFormRoot = panelHost.querySelector("[data-create-subject-form]");
+      const createFormRoot = bumpInteractiveEpoch(panelHost.querySelector("[data-create-subject-form]"));
       wireDetailsInteractive(createFormRoot);
       syncSituationsPrimaryScrollSource();
     } else if (String(store.situationsView.subjectsSubview || "subjects") === "labels") {
@@ -2653,7 +2684,7 @@ function rerenderPanels() {
       `;
       const detailsHost = document.getElementById("situationsDetailsHost");
       renderDetailsDiscussionScopes(detailsHost);
-      wireDetailsInteractive(detailsHost);
+      wireDetailsInteractive(bumpInteractiveEpoch(detailsHost));
       bindDetailsScroll(document);
       restoreDocumentScrollState(detailsScrollState);
       requestAnimationFrame(() => {
@@ -2665,14 +2696,7 @@ function rerenderPanels() {
     }
   }
 
-  const subissueCreateModalHost = ensureCreateSubissueModalHost();
-  if (isSubissueCreateMode) {
-    subissueCreateModalHost.innerHTML = renderCreateSubissueModalHtml();
-    const modalCreateFormRoot = subissueCreateModalHost.querySelector("[data-create-subject-form]");
-    wireDetailsInteractive(modalCreateFormRoot);
-  } else {
-    subissueCreateModalHost.innerHTML = "";
-  }
+  rerenderCreateSubissueModal();
 
   if (store.situationsView.drilldown?.isOpen) getProjectSubjectDrilldown().updateDrilldownPanel();
   refreshProjectShellChrome("situations");
@@ -2703,6 +2727,12 @@ function rerenderScope(root) {
   const isComposerScopeRoot = !!root?.closest?.("[data-details-composer-host]");
   const drilldownBody = document.getElementById("drilldownBody");
   const isDrilldownScopeRoot = !!root?.closest?.("#drilldownPanel");
+
+  if (isCreateSubissueModalScopeRoot(root)) {
+    debugRenderScope("create-subissue-modal", { mode: "modal-only-rerender" });
+    rerenderCreateSubissueModal();
+    return;
+  }
 
   if (shouldRerenderDetailsModal) {
     debugRenderScope("details-modal", { mode: "full-modal-rerender" });
@@ -2737,7 +2767,7 @@ function rerenderScope(root) {
     });
     detailsHost.innerHTML = details.bodyHtml;
     renderDetailsDiscussionScopes(detailsHost);
-    wireDetailsInteractive(detailsHost);
+    wireDetailsInteractive(bumpInteractiveEpoch(detailsHost));
     bindDetailsScroll(document);
     restoreScrollableElementScrollState(detailsHost, detailsScrollState);
     requestAnimationFrame(() => {
@@ -2873,7 +2903,7 @@ function renderDetailsDiscussionScopes(detailsHost, options = {}) {
     const threadHost = detailsHost.querySelector("[data-details-thread-host]");
     if (threadHost) {
       threadHost.innerHTML = discussion.threadHtml;
-      wireDetailsInteractive(threadHost);
+      wireDetailsInteractive(bumpInteractiveEpoch(threadHost));
     }
   }
   if (renderComposer) {
@@ -2886,7 +2916,7 @@ function renderDetailsDiscussionScopes(detailsHost, options = {}) {
     const composerHost = detailsHost.querySelector("[data-details-composer-host]");
     if (composerHost) {
       composerHost.innerHTML = discussion.composerHtml;
-      wireDetailsInteractive(composerHost);
+      wireDetailsInteractive(bumpInteractiveEpoch(composerHost));
     }
   }
 }

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -411,7 +411,7 @@ export function bindSelectDropdownDocumentEvents({
     if (event.target.closest("[data-subject-meta-trigger]")) return;
     if (event.target.closest("[data-subject-kanban-trigger]")) return;
     onRequestClose?.();
-    onRerender?.();
+    onRerender?.(getScopeRoot?.() || event.target);
   };
 
   const handleWindowResize = () => {


### PR DESCRIPTION
### Motivation
- Root cause: the subissue creation modal had no dedicated render scope so interactions inside the modal fell back to `rerenderPanels()` and caused unwanted rerenders of the parent detail view. 
- Secondary issues observed were duplicated event listeners on persistent hosts and autosize/textarea instability due to those global rerenders.

### Description
- Added a dedicated modal render scope and mini-renderer: `isCreateSubissueModalScopeRoot`, `rerenderCreateSubissueModal()` and used it from `rerenderPanels()` and `rerenderScope(root)` so modal interactions only rerender the modal host (`apps/web/js/views/project-subjects/project-subjects-view.js`).
- Made interactive wiring idempotent by tracking a per-root binding epoch with `data-details-interactive-epoch` and a `WeakMap` to avoid stacking listeners while still rebinding on real remounts; bumped the epoch at remount points (`project-subjects-view`, `project-subject-drilldown`, `project-subject-detail`) (`apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/project-subjects/project-subjects-view.js`, `apps/web/js/views/project-subjects/project-subject-drilldown.js`, `apps/web/js/views/project-subjects/project-subject-detail.js`).
- Scoped dropdown close rerender callbacks to the active scope root by passing the scope into `onRerender`, avoiding global detail rerenders when meta dropdowns are closed from within the modal (`apps/web/js/views/ui/select-dropdown-controller.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`).
- Replaced repeated `addEventListener` usage in dropdown host inputs with idempotent `oninput` / `onkeydown` assignments to avoid listener stacking on persistent hosts (`apps/web/js/views/project-subjects/project-subjects-events.js`).
- Adjusted create-subject UI interactions (tab switch / preview-mode typing / autosize) to call `rerenderScope(root)` instead of `rerenderPanels()` when rooted inside the modal so textarea resize, buttons and preview are stable and local to the modal (`apps/web/js/views/project-subjects/project-subjects-events.js`).

### Testing
- Ran syntax checks on modified files with `node --check`: `apps/web/js/views/project-subjects/project-subjects-view.js`, `apps/web/js/views/project-subjects/project-subjects-events.js`, `apps/web/js/views/ui/select-dropdown-controller.js`, `apps/web/js/views/project-subjects/project-subject-drilldown.js`, `apps/web/js/views/project-subjects/project-subject-detail.js`; all checks succeeded.
- Verified code paths for: modal open/close, local modal rerendering (write/preview), dropdown close from modal, and creation submit flow to ensure the global detail rerender only occurs at the final, intended step; automated runtime tests not present, manual control-flow validation performed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d77c21c88329904e534ac19be0be)