### PR TITLE
Fix empty subissue textarea height on mount autosize passes

### DIFF
--- a/apps/web/js/utils/textarea-autosize.js
+++ b/apps/web/js/utils/textarea-autosize.js
@@ -72,12 +72,20 @@ export function autosizeTextarea(textarea, options = {}) {
     };
   }
   const baseFloor = Math.max(minHeight, manualFloor);
-  const isFirstMountPass = !!preferMinHeightOnFirstMount
-    && String(cause || "").startsWith("mount")
-    && !previousAutosizeHeight
+  const causeLabel = String(cause || "");
+  const isMountLikeCause = causeLabel.startsWith("mount");
+  const isEmptyValue = !String(textarea?.value || "").trim();
+  const wasUserInteracted = textarea?.dataset?.autosizeUserInteracted === "1";
+  const shouldMarkUserInteracted = !isMountLikeCause || !isEmptyValue || manualFloor > 0;
+  if (textarea?.dataset && shouldMarkUserInteracted) {
+    textarea.dataset.autosizeUserInteracted = "1";
+  }
+  const keepMinHeightDuringMount = !!preferMinHeightOnFirstMount
+    && isMountLikeCause
     && !manualFloor
-    && !String(textarea?.value || "").trim();
-  const targetHeight = isFirstMountPass
+    && isEmptyValue
+    && !wasUserInteracted;
+  const targetHeight = keepMinHeightDuringMount
     ? baseFloor
     : Math.max(baseFloor, Math.round(measuredScrollHeight + comfortHeight));
   textarea.style.height = `${targetHeight}px`;

--- a/apps/web/js/utils/textarea-autosize.test.mjs
+++ b/apps/web/js/utils/textarea-autosize.test.mjs
@@ -139,6 +139,76 @@ test("autosizeTextarea peut forcer la hauteur minimale au premier mount", () => 
   assert.equal(textarea.style.height, "326px");
 });
 
+test("autosizeTextarea conserve le minHeight sur mount puis mount-after-visible quand la textarea est vide", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "0px" };
+    }
+  };
+
+  const textarea = {
+    isConnected: true,
+    value: "",
+    style: { height: "", overflowY: "auto" },
+    dataset: {},
+    scrollHeight: 420,
+    offsetHeight: 0,
+    offsetParent: {}
+  };
+
+  const first = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount",
+    preferMinHeightOnFirstMount: true
+  });
+  const second = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount-after-visible",
+    preferMinHeightOnFirstMount: true
+  });
+
+  assert.equal(first?.nextHeight, 326);
+  assert.equal(second?.nextHeight, 326);
+  assert.equal(textarea.style.height, "326px");
+});
+
+test("autosizeTextarea peut dépasser le minHeight après saisie utilisateur", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "0px" };
+    }
+  };
+
+  const textarea = {
+    isConnected: true,
+    value: "",
+    style: { height: "", overflowY: "auto" },
+    dataset: {},
+    scrollHeight: 420,
+    offsetHeight: 0,
+    offsetParent: {}
+  };
+
+  autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount",
+    preferMinHeightOnFirstMount: true
+  });
+  textarea.value = "Du contenu saisi";
+  const inputResult = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "input",
+    preferMinHeightOnFirstMount: true
+  });
+
+  assert.equal(inputResult?.nextHeight, 480);
+  assert.equal(textarea.style.height, "480px");
+});
+
 test("autosizeTextarea retourne null si textarea invalide (sans style)", () => {
   const textarea = { isConnected: false };
   const result = autosizeTextarea(textarea);


### PR DESCRIPTION
### Motivation
- The subissue creation textarea should stay at the CSS min-height (326px) when empty across mount-like autosize passes (e.g. `mount` then `mount-after-visible`), but a later autosize pass recalculates `scrollHeight + comfortHeight` and wrongly grows it.
- The existing `preferMinHeightOnFirstMount` logic only protected the very first pass (`!previousAutosizeHeight`) and did not survive subsequent mount-phase passes while the textarea remained empty.

### Description
- Modify `autosizeTextarea` (`apps/web/js/utils/textarea-autosize.js`) to detect mount-like causes (`cause.startsWith("mount")`), the empty value state, and whether the user has previously interacted, and keep the min-height floor during all mount-like passes while the textarea is empty and not user-interacted.
- Add a dataset flag `autosizeUserInteracted` to mark when autosize should stop preserving the mount-floor (set when leaving mount-like cause, when there is content, or when manualFloor > 0) so normal autosize resumes after user typing or manual resize.
- Preserve existing manual-resize behavior via `manualResizeFloor` and keep comfort lines behavior intact during user input.
- Update tests in `apps/web/js/utils/textarea-autosize.test.mjs` to add a regression test for `mount` -> `mount-after-visible` stability and a test that verifies growth after `input` cause; files modified: `apps/web/js/utils/textarea-autosize.js` and `apps/web/js/utils/textarea-autosize.test.mjs`.

### Testing
- Ran the unit suite with `node --test apps/web/js/utils/textarea-autosize.test.mjs` and all tests passed (`10` tests, `0` failures).
- New tests cover the mount then mount-after-visible case keeping `326px` and the case where an `input` cause allows autosize to exceed `326px`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e7a8a1708329ad081d3e9ed2ff89)