### PR TITLE
Track user interaction to preserve minHeight on initial mounts and adjust autosize behavior

### DIFF
--- a/apps/web/js/utils/textarea-autosize.js
+++ b/apps/web/js/utils/textarea-autosize.js
@@ -72,12 +72,28 @@ export function autosizeTextarea(textarea, options = {}) {
     };
   }
   const baseFloor = Math.max(minHeight, manualFloor);
-  const isFirstMountPass = !!preferMinHeightOnFirstMount
-    && String(cause || "").startsWith("mount")
-    && !previousAutosizeHeight
+  const causeLabel = String(cause || "");
+  const normalizedCause = causeLabel.toLowerCase();
+  const isLikelyUserInteractionCause = normalizedCause === "manual"
+    || normalizedCause.includes("input")
+    || normalizedCause.includes("paste")
+    || normalizedCause.includes("cut")
+    || normalizedCause.includes("drop")
+    || normalizedCause.includes("emoji")
+    || normalizedCause.includes("mention")
+    || normalizedCause.includes("subject-ref");
+  const isEmptyValue = !String(textarea?.value || "").trim();
+  const wasUserInteracted = textarea?.dataset?.autosizeUserInteracted === "1";
+  const shouldMarkUserInteracted = isLikelyUserInteractionCause || !isEmptyValue || manualFloor > 0;
+  if (textarea?.dataset && shouldMarkUserInteracted) {
+    textarea.dataset.autosizeUserInteracted = "1";
+  }
+  const keepMinHeightDuringMount = !!preferMinHeightOnFirstMount
     && !manualFloor
-    && !String(textarea?.value || "").trim();
-  const targetHeight = isFirstMountPass
+    && isEmptyValue
+    && !wasUserInteracted
+    && !isLikelyUserInteractionCause;
+  const targetHeight = keepMinHeightDuringMount
     ? baseFloor
     : Math.max(baseFloor, Math.round(measuredScrollHeight + comfortHeight));
   textarea.style.height = `${targetHeight}px`;

--- a/apps/web/js/utils/textarea-autosize.test.mjs
+++ b/apps/web/js/utils/textarea-autosize.test.mjs
@@ -139,6 +139,110 @@ test("autosizeTextarea peut forcer la hauteur minimale au premier mount", () => 
   assert.equal(textarea.style.height, "326px");
 });
 
+test("autosizeTextarea conserve le minHeight sur mount puis mount-after-visible quand la textarea est vide", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "0px" };
+    }
+  };
+
+  const textarea = {
+    isConnected: true,
+    value: "",
+    style: { height: "", overflowY: "auto" },
+    dataset: {},
+    scrollHeight: 420,
+    offsetHeight: 0,
+    offsetParent: {}
+  };
+
+  const first = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount",
+    preferMinHeightOnFirstMount: true
+  });
+  const second = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount-after-visible",
+    preferMinHeightOnFirstMount: true
+  });
+
+  assert.equal(first?.nextHeight, 326);
+  assert.equal(second?.nextHeight, 326);
+  assert.equal(textarea.style.height, "326px");
+});
+
+test("autosizeTextarea conserve le minHeight pendant une passe de bind de montage", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "0px" };
+    }
+  };
+
+  const textarea = {
+    isConnected: true,
+    value: "",
+    style: { height: "", overflowY: "auto" },
+    dataset: {},
+    scrollHeight: 420,
+    offsetHeight: 0,
+    offsetParent: {}
+  };
+
+  autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount",
+    preferMinHeightOnFirstMount: true
+  });
+  const bindPass = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "create-subject-bind",
+    preferMinHeightOnFirstMount: true
+  });
+
+  assert.equal(bindPass?.nextHeight, 326);
+  assert.equal(textarea.style.height, "326px");
+});
+
+test("autosizeTextarea peut dépasser le minHeight après saisie utilisateur", () => {
+  global.window = {
+    getComputedStyle() {
+      return { lineHeight: "20px", minHeight: "0px" };
+    }
+  };
+
+  const textarea = {
+    isConnected: true,
+    value: "",
+    style: { height: "", overflowY: "auto" },
+    dataset: {},
+    scrollHeight: 420,
+    offsetHeight: 0,
+    offsetParent: {}
+  };
+
+  autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "mount",
+    preferMinHeightOnFirstMount: true
+  });
+  textarea.value = "Du contenu saisi";
+  const inputResult = autosizeTextarea(textarea, {
+    minHeightFallback: 326,
+    comfortLines: 3,
+    cause: "input",
+    preferMinHeightOnFirstMount: true
+  });
+
+  assert.equal(inputResult?.nextHeight, 480);
+  assert.equal(textarea.style.height, "480px");
+});
+
 test("autosizeTextarea retourne null si textarea invalide (sans style)", () => {
   const textarea = { isConnected: false };
   const result = autosizeTextarea(textarea);


### PR DESCRIPTION
### Motivation

- Prevent the autosizer from forcing the minHeight on first mount when the textarea has been or is likely to be user-interacted, and make mount-related heuristics more robust to different cause labels.

### Description

- Normalize the `cause` and detect likely user interactions (e.g. `manual`, `input`, `paste`, `cut`, `drop`, `emoji`, `mention`, `subject-ref`) and set a dataset flag `autosizeUserInteracted` when appropriate.
- Change the first-mount/min-height logic to consider `dataset.autosizeUserInteracted`, whether the textarea value is empty, and `manualFloor` to decide when to keep the minHeight during mount passes (`keepMinHeightDuringMount`).
- Persist the computed height to `dataset.autosizeLastHeight` as before and retain existing logging behavior.
- Add several unit tests exercising mount, mount-after-visible, bind-mount passes and the transition after user input to ensure minHeight is preserved or exceeded appropriately.

### Testing

- Ran unit tests in `apps/web/js/utils/textarea-autosize.test.mjs`, including `autosizeTextarea conserve le minHeight sur mount puis mount-after-visible quand la textarea est vide`, `autosizeTextarea conserve le minHeight pendant une passe de bind de montage`, and `autosizeTextarea peut dépasser le minHeight après saisie utilisateur`, and they passed.
- Existing autosize tests (including invalid textarea and `bindAutosizeTextarea` behavior) were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e7a8a1708329ad081d3e9ed2ff89)