### PR TITLE
Fix metadata dropdown placement in subissue creation modal

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -3064,10 +3064,25 @@ function syncCommentPreview(root) {
 }
 
 
+function resolveSubjectDropdownPlacement({ anchor, field, viewState }) {
+  const isMetaField = ["assignees", "labels", "objectives", "situations"].includes(String(field || ""));
+  const isSubissueCreateMode = String(viewState?.createSubjectForm?.mode || "").trim().toLowerCase() === "subissue";
+  const isInsideCreateForm = !!anchor?.closest?.("[data-create-subject-form]");
+  if (isMetaField && isSubissueCreateMode && isInsideCreateForm) {
+    return {
+      horizontal: "anchor-start",
+      vertical: "above-preferred",
+      spacing: 8
+    };
+  }
+  return null;
+}
+
 const subjectSelectDropdown = createSelectDropdownController({
   getViewState: getSubjectsViewState,
   bindingKey: "project-subjects-dropdown",
   getScopeRoot: () => getSubjectSelectDropdownScopeRoot(getSubjectsViewState),
+  resolvePlacement: resolveSubjectDropdownPlacement,
   ensureHost: ensureSelectDropdownHost,
   renderHost: (root) => renderSelectDropdownHost({
     getViewState: getSubjectsViewState,
@@ -3081,7 +3096,8 @@ const subjectSelectDropdown = createSelectDropdownController({
     getViewState: getSubjectsViewState,
     root: scopeRoot,
     getScopeRoot: () => getSubjectSelectDropdownScopeRoot(getSubjectsViewState),
-    ensureHost: ensureSelectDropdownHost
+    ensureHost: ensureSelectDropdownHost,
+    resolvePlacement: resolveSubjectDropdownPlacement
   })
 });
 

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -35,6 +35,7 @@ export function createSelectDropdownController(config = {}) {
   const {
     getViewState,
     getScopeRoot,
+    resolvePlacement,
     renderHost,
     ensureHost = ensureSelectDropdownHost,
     bindingKey = "select-dropdown",
@@ -63,7 +64,8 @@ export function createSelectDropdownController(config = {}) {
         getViewState,
         root: root || (typeof getScopeRoot === "function" ? getScopeRoot() : undefined),
         getScopeRoot,
-        ensureHost
+        ensureHost,
+        resolvePlacement
       });
     },
     captureScrollState: () => captureSelectDropdownScrollState({ host: ensureHost() }),
@@ -84,7 +86,8 @@ export function createSelectDropdownController(config = {}) {
           getViewState,
           root: scopeRoot,
           getScopeRoot,
-          ensureHost
+          ensureHost,
+          resolvePlacement
         });
       }),
       getScopeRoot: overrides.getScopeRoot || getScopeRoot,
@@ -244,6 +247,7 @@ export function syncSelectDropdownPosition({
   root,
   getScopeRoot = () => getSubjectSelectDropdownScopeRoot(getViewState),
   ensureHost = ensureSelectDropdownHost,
+  resolvePlacement,
   candidateRoots = []
 }) {
   const viewState = getViewStateFromGetter(getViewState) || {};
@@ -287,7 +291,15 @@ export function syncSelectDropdownPosition({
     const dropdownWidth = 320;
     const gutter = 12;
     const spacing = 8;
-    const left = Math.max(gutter, Math.min(rect.right - dropdownWidth, viewportWidth - dropdownWidth - gutter));
+    const placement = typeof resolvePlacement === "function"
+      ? (resolvePlacement({ anchor, field, viewState, root: scopeRoot }) || {})
+      : {};
+    const horizontalAlign = placement.horizontal === "anchor-start" ? "anchor-start" : "anchor-end";
+    const verticalMode = placement.vertical === "above-preferred" ? "above-preferred" : "auto";
+    const requestedSpacing = Number(placement.spacing);
+    const resolvedSpacing = Number.isFinite(requestedSpacing) ? Math.max(0, requestedSpacing) : spacing;
+    const anchorLeft = horizontalAlign === "anchor-start" ? rect.left : (rect.right - dropdownWidth);
+    const left = Math.max(gutter, Math.min(anchorLeft, viewportWidth - dropdownWidth - gutter));
     const spaceBelow = Math.max(0, viewportHeight - rect.bottom - gutter);
     const spaceAbove = Math.max(0, rect.top - gutter);
     const preferredHeight = Math.min(420, Math.max(240, Math.max(spaceBelow, spaceAbove)));
@@ -297,10 +309,17 @@ export function syncSelectDropdownPosition({
     dropdown.style.maxHeight = `${maxHeight}px`;
 
     const measuredHeight = Math.min(dropdown.offsetHeight || maxHeight, maxHeight);
-    const shouldOpenAbove = spaceBelow < Math.min(240, measuredHeight) && spaceAbove > spaceBelow;
-    const top = shouldOpenAbove
-      ? Math.max(gutter, rect.top - measuredHeight - spacing)
-      : Math.max(gutter, rect.bottom - 4);
+    const minVisibleHeight = Math.min(240, measuredHeight);
+    const shouldOpenAbove = verticalMode === "above-preferred"
+      ? (spaceAbove >= minVisibleHeight || (spaceAbove >= spaceBelow && spaceAbove >= 120))
+      : (spaceBelow < minVisibleHeight && spaceAbove > spaceBelow);
+    const aboveTop = rect.top - measuredHeight - resolvedSpacing;
+    const belowTop = verticalMode === "above-preferred"
+      ? rect.bottom + resolvedSpacing
+      : rect.bottom - 4;
+    const rawTop = shouldOpenAbove ? aboveTop : belowTop;
+    const maxTop = Math.max(gutter, viewportHeight - measuredHeight - gutter);
+    const top = Math.max(gutter, Math.min(rawTop, maxTop));
 
     dropdown.style.left = `${left}px`;
     dropdown.style.top = `${top}px`;


### PR DESCRIPTION
### Motivation
- Les dropdowns de métadonnées dans la modale «Créer un sous‑sujet» s’ouvraient alignés à droite comme dans l’aside, cachant le trigger au lieu d’apparaître en popover au‑dessus du bouton.  
- La racine du problème était le calcul horizontal global qui utilisait `rect.right - dropdownWidth` au lieu d’un alignement sur le bord gauche du bouton dans ce contexte.  
- Il fallait une correction JS (pas un hack CSS) ciblée sur le contexte de la modale subissue sans impacter les autres usages existants des dropdowns.

### Description
- Ajout d’un hook optionnel `resolvePlacement` à `createSelectDropdownController` pour permettre une stratégie de placement contextuelle sans casser le cycle de vie global des dropdowns.  
- Modification de `syncSelectDropdownPosition` pour prendre en charge `resolvePlacement` et pour calculer la position horizontale en fonction de `anchor-start` (aligner `left = rect.left` avec clamp viewport) ou fallback à l’alignement par défaut.  
- Introduction d’un mode vertical `above-preferred` qui priorise l’ouverture au‑dessus du trigger (avec fallback dessous si l’espace est insuffisant), en conservant le `maxHeight`, les clamps haut/bas et la visibilité du bouton.  
- Implantation de `resolveSubjectDropdownPlacement` dans `project-subjects-view.js` et branchement de ce resolver uniquement quand le champ est `assignees`, `labels`, `objectives` ou `situations`, que la `createSubjectForm.mode === "subissue"` et que le trigger est à l’intérieur de `[data-create-subject-form]` (modification limitée à `apps/web/js/views/ui/select-dropdown-controller.js` et `apps/web/js/views/project-subjects/project-subjects-view.js`).

### Testing
- Exécution de la vérification de syntaxe JS avec `node --check apps/web/js/views/ui/select-dropdown-controller.js && node --check apps/web/js/views/project-subjects/project-subjects-view.js` qui a réussi.  
- Inspection des fichiers modifiés et commit (`git status` / commit) pour valider l’étendue minimale des changements.  
- Aucune suite de tests automatisés existante trouvée pour ce périmètre, donc aucun test unitaire ajusté dans ce PR (recommandation : ajout d’un test d’intégration DOM si une infra de test UI existe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f06b9b788329bf00fea60d082c56)