### PR TITLE
Anchor-aware subject meta dropdown + configurable placement for subissue create form

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1043,7 +1043,7 @@ export function createProjectSubjectsEvents(config) {
           dropdownController().closeMeta();
         } else {
           dropdownController().closeKanban();
-          dropdownController().openMeta({ field, showClosedSituations: false });
+          dropdownController().openMeta({ field, showClosedSituations: false, anchor: btn });
           dropdown.relationsView = field === "relations" ? "menu" : "";
           const entries = scopedSelection?.type === "sujet" ? getSubjectMetaMenuEntries(scopedSelection.item, field) : [];
           const selectedObjectiveKey = field === "objectives" && scopedSelection?.type === "sujet"

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -3064,10 +3064,25 @@ function syncCommentPreview(root) {
 }
 
 
+function resolveSubjectDropdownPlacement({ anchor, field, viewState }) {
+  const isMetaField = ["assignees", "labels", "objectives", "situations"].includes(String(field || ""));
+  const isSubissueCreateMode = String(viewState?.createSubjectForm?.mode || "").trim().toLowerCase() === "subissue";
+  const isInsideCreateForm = !!anchor?.closest?.("[data-create-subject-form]");
+  if (isMetaField && isSubissueCreateMode && isInsideCreateForm) {
+    return {
+      horizontal: "anchor-start",
+      vertical: "above-preferred",
+      spacing: 8
+    };
+  }
+  return null;
+}
+
 const subjectSelectDropdown = createSelectDropdownController({
   getViewState: getSubjectsViewState,
   bindingKey: "project-subjects-dropdown",
   getScopeRoot: () => getSubjectSelectDropdownScopeRoot(getSubjectsViewState),
+  resolvePlacement: resolveSubjectDropdownPlacement,
   ensureHost: ensureSelectDropdownHost,
   renderHost: (root) => renderSelectDropdownHost({
     getViewState: getSubjectsViewState,
@@ -3081,7 +3096,8 @@ const subjectSelectDropdown = createSelectDropdownController({
     getViewState: getSubjectsViewState,
     root: scopeRoot,
     getScopeRoot: () => getSubjectSelectDropdownScopeRoot(getSubjectsViewState),
-    ensureHost: ensureSelectDropdownHost
+    ensureHost: ensureSelectDropdownHost,
+    resolvePlacement: resolveSubjectDropdownPlacement
   })
 });
 

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -35,6 +35,7 @@ export function createSelectDropdownController(config = {}) {
   const {
     getViewState,
     getScopeRoot,
+    resolvePlacement,
     renderHost,
     ensureHost = ensureSelectDropdownHost,
     bindingKey = "select-dropdown",
@@ -63,7 +64,8 @@ export function createSelectDropdownController(config = {}) {
         getViewState,
         root: root || (typeof getScopeRoot === "function" ? getScopeRoot() : undefined),
         getScopeRoot,
-        ensureHost
+        ensureHost,
+        resolvePlacement
       });
     },
     captureScrollState: () => captureSelectDropdownScrollState({ host: ensureHost() }),
@@ -84,7 +86,8 @@ export function createSelectDropdownController(config = {}) {
           getViewState,
           root: scopeRoot,
           getScopeRoot,
-          ensureHost
+          ensureHost,
+          resolvePlacement
         });
       }),
       getScopeRoot: overrides.getScopeRoot || getScopeRoot,
@@ -119,6 +122,8 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.subissueActionSubjectId = "";
   dropdown.subissueActionScopeHost = "main";
   dropdown.subissueActionIntent = "";
+  dropdown.anchorElement = null;
+  dropdown.anchorField = "";
 }
 
 export function closeKanbanSelectDropdown(getViewState) {
@@ -131,7 +136,7 @@ export function closeKanbanSelectDropdown(getViewState) {
   dropdown.activeKey = "";
 }
 
-export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "", query = "", showClosedSituations = false } = {}) {
+export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "", query = "", showClosedSituations = false, anchor = null } = {}) {
   const viewState = getViewStateFromGetter(getViewState);
   const dropdown = viewState?.subjectMetaDropdown;
   if (!dropdown) return;
@@ -140,6 +145,8 @@ export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "
   dropdown.activeKey = String(activeKey || "");
   dropdown.showClosedSituations = !!showClosedSituations;
   dropdown.relationsView = field === "relations" ? "menu" : "";
+  dropdown.anchorElement = anchor instanceof Element ? anchor : null;
+  dropdown.anchorField = dropdown.anchorElement ? String(field || "") : "";
 }
 
 export function openKanbanSelectDropdown(getViewState, { subjectId = "", situationId = "", activeKey = "", query = "" } = {}) {
@@ -244,6 +251,7 @@ export function syncSelectDropdownPosition({
   root,
   getScopeRoot = () => getSubjectSelectDropdownScopeRoot(getViewState),
   ensureHost = ensureSelectDropdownHost,
+  resolvePlacement,
   candidateRoots = []
 }) {
   const viewState = getViewStateFromGetter(getViewState) || {};
@@ -273,7 +281,15 @@ export function syncSelectDropdownPosition({
       document.querySelector("[data-create-subject-form]"),
       document.getElementById("situationsDetailsHost")
     ].filter(Boolean);
-    const anchor = roots
+    const stateAnchor = viewState?.subjectMetaDropdown?.anchorElement;
+    const stateAnchorField = String(viewState?.subjectMetaDropdown?.anchorField || "");
+    const anchorFromState = stateAnchor
+      && stateAnchorField === field
+      && stateAnchor.isConnected
+      && stateAnchor.matches?.(anchorSelector)
+      ? stateAnchor
+      : null;
+    const anchor = anchorFromState || roots
       .map((candidateRoot) => candidateRoot?.querySelector?.(anchorSelector))
       .find(Boolean);
     if (!anchor || !dropdown) {
@@ -287,7 +303,15 @@ export function syncSelectDropdownPosition({
     const dropdownWidth = 320;
     const gutter = 12;
     const spacing = 8;
-    const left = Math.max(gutter, Math.min(rect.right - dropdownWidth, viewportWidth - dropdownWidth - gutter));
+    const placement = typeof resolvePlacement === "function"
+      ? (resolvePlacement({ anchor, field, viewState, root: scopeRoot }) || {})
+      : {};
+    const horizontalAlign = placement.horizontal === "anchor-start" ? "anchor-start" : "anchor-end";
+    const verticalMode = placement.vertical === "above-preferred" ? "above-preferred" : "auto";
+    const requestedSpacing = Number(placement.spacing);
+    const resolvedSpacing = Number.isFinite(requestedSpacing) ? Math.max(0, requestedSpacing) : spacing;
+    const anchorLeft = horizontalAlign === "anchor-start" ? rect.left : (rect.right - dropdownWidth);
+    const left = Math.max(gutter, Math.min(anchorLeft, viewportWidth - dropdownWidth - gutter));
     const spaceBelow = Math.max(0, viewportHeight - rect.bottom - gutter);
     const spaceAbove = Math.max(0, rect.top - gutter);
     const preferredHeight = Math.min(420, Math.max(240, Math.max(spaceBelow, spaceAbove)));
@@ -297,10 +321,17 @@ export function syncSelectDropdownPosition({
     dropdown.style.maxHeight = `${maxHeight}px`;
 
     const measuredHeight = Math.min(dropdown.offsetHeight || maxHeight, maxHeight);
-    const shouldOpenAbove = spaceBelow < Math.min(240, measuredHeight) && spaceAbove > spaceBelow;
-    const top = shouldOpenAbove
-      ? Math.max(gutter, rect.top - measuredHeight - spacing)
-      : Math.max(gutter, rect.bottom - 4);
+    const minVisibleHeight = Math.min(240, measuredHeight);
+    const shouldOpenAbove = verticalMode === "above-preferred"
+      ? (spaceAbove >= minVisibleHeight || (spaceAbove >= spaceBelow && spaceAbove >= 120))
+      : (spaceBelow < minVisibleHeight && spaceAbove > spaceBelow);
+    const aboveTop = rect.top - measuredHeight - resolvedSpacing;
+    const belowTop = verticalMode === "above-preferred"
+      ? rect.bottom + resolvedSpacing
+      : rect.bottom - 4;
+    const rawTop = shouldOpenAbove ? aboveTop : belowTop;
+    const maxTop = Math.max(gutter, viewportHeight - measuredHeight - gutter);
+    const top = Math.max(gutter, Math.min(rawTop, maxTop));
 
     dropdown.style.left = `${left}px`;
     dropdown.style.top = `${top}px`;


### PR DESCRIPTION
### Motivation
- Ensure subject meta dropdowns can be anchored to the originating button/element so the popup stays attached to the correct host even when rendered into a global host element. 
- Allow specialized placement behavior for meta fields when creating a subissue (prefer opening above and aligned to anchor start) to avoid clipping inside the create form. 
- Provide a hook to customize dropdown placement resolution for different dropdown contexts.

### Description
- Added an `anchor` option to `openMetaSelectDropdown` and persist `anchorElement`/`anchorField` on the view state, and clear them in `closeMetaSelectDropdown`.
- Updated `syncSelectDropdownPosition` to prefer an anchored element from view state (if connected and matching the selector) before falling back to querying scope roots, and to accept a `resolvePlacement` hook to change horizontal/vertical alignment and spacing.
- Exposed `resolvePlacement` through `createSelectDropdownController` and passed it into `syncPosition` and controller creation sites.
- Implemented `resolveSubjectDropdownPlacement` which returns a placement of `{ horizontal: 'anchor-start', vertical: 'above-preferred', spacing: 8 }` for meta fields when inside a `data-create-subject-form` while in subissue create mode, and wired callers to pass `anchor: btn` when opening the dropdown.
- Adjusted the dropdown positioning math to respect the requested horizontal alignment, vertical mode, and spacing when computing `left` and `top` positions.

### Testing
- Ran frontend unit tests with `yarn test` and they completed successfully. 
- Ran linter with `yarn lint` and the changes passed linting. 
- Built the web assets with `yarn build` to validate runtime bundling and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f06b9b788329bf00fea60d082c56)