### PR TITLE
Make subject meta dropdown anchor-aware and add customizable placement for create-subject forms

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -1043,7 +1043,7 @@ export function createProjectSubjectsEvents(config) {
           dropdownController().closeMeta();
         } else {
           dropdownController().closeKanban();
-          dropdownController().openMeta({ field, showClosedSituations: false });
+          dropdownController().openMeta({ field, showClosedSituations: false, anchor: btn });
           dropdown.relationsView = field === "relations" ? "menu" : "";
           const entries = scopedSelection?.type === "sujet" ? getSubjectMetaMenuEntries(scopedSelection.item, field) : [];
           const selectedObjectiveKey = field === "objectives" && scopedSelection?.type === "sujet"

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -3064,10 +3064,25 @@ function syncCommentPreview(root) {
 }
 
 
+function resolveSubjectDropdownPlacement({ anchor, field, viewState }) {
+  const isMetaField = ["assignees", "labels", "objectives", "situations"].includes(String(field || ""));
+  const isSubissueCreateMode = String(viewState?.createSubjectForm?.mode || "").trim().toLowerCase() === "subissue";
+  const isInsideCreateForm = !!anchor?.closest?.("[data-create-subject-form]");
+  if (isMetaField && isSubissueCreateMode && isInsideCreateForm) {
+    return {
+      horizontal: "anchor-start",
+      vertical: "above-preferred",
+      spacing: 8
+    };
+  }
+  return null;
+}
+
 const subjectSelectDropdown = createSelectDropdownController({
   getViewState: getSubjectsViewState,
   bindingKey: "project-subjects-dropdown",
   getScopeRoot: () => getSubjectSelectDropdownScopeRoot(getSubjectsViewState),
+  resolvePlacement: resolveSubjectDropdownPlacement,
   ensureHost: ensureSelectDropdownHost,
   renderHost: (root) => renderSelectDropdownHost({
     getViewState: getSubjectsViewState,
@@ -3081,7 +3096,8 @@ const subjectSelectDropdown = createSelectDropdownController({
     getViewState: getSubjectsViewState,
     root: scopeRoot,
     getScopeRoot: () => getSubjectSelectDropdownScopeRoot(getSubjectsViewState),
-    ensureHost: ensureSelectDropdownHost
+    ensureHost: ensureSelectDropdownHost,
+    resolvePlacement: resolveSubjectDropdownPlacement
   })
 });
 

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -35,6 +35,7 @@ export function createSelectDropdownController(config = {}) {
   const {
     getViewState,
     getScopeRoot,
+    resolvePlacement,
     renderHost,
     ensureHost = ensureSelectDropdownHost,
     bindingKey = "select-dropdown",
@@ -63,7 +64,8 @@ export function createSelectDropdownController(config = {}) {
         getViewState,
         root: root || (typeof getScopeRoot === "function" ? getScopeRoot() : undefined),
         getScopeRoot,
-        ensureHost
+        ensureHost,
+        resolvePlacement
       });
     },
     captureScrollState: () => captureSelectDropdownScrollState({ host: ensureHost() }),
@@ -84,7 +86,8 @@ export function createSelectDropdownController(config = {}) {
           getViewState,
           root: scopeRoot,
           getScopeRoot,
-          ensureHost
+          ensureHost,
+          resolvePlacement
         });
       }),
       getScopeRoot: overrides.getScopeRoot || getScopeRoot,
@@ -119,6 +122,8 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.subissueActionSubjectId = "";
   dropdown.subissueActionScopeHost = "main";
   dropdown.subissueActionIntent = "";
+  dropdown.anchorElement = null;
+  dropdown.anchorField = "";
 }
 
 export function closeKanbanSelectDropdown(getViewState) {
@@ -131,7 +136,7 @@ export function closeKanbanSelectDropdown(getViewState) {
   dropdown.activeKey = "";
 }
 
-export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "", query = "", showClosedSituations = false } = {}) {
+export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "", query = "", showClosedSituations = false, anchor = null } = {}) {
   const viewState = getViewStateFromGetter(getViewState);
   const dropdown = viewState?.subjectMetaDropdown;
   if (!dropdown) return;
@@ -140,6 +145,8 @@ export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "
   dropdown.activeKey = String(activeKey || "");
   dropdown.showClosedSituations = !!showClosedSituations;
   dropdown.relationsView = field === "relations" ? "menu" : "";
+  dropdown.anchorElement = anchor instanceof Element ? anchor : null;
+  dropdown.anchorField = dropdown.anchorElement ? String(field || "") : "";
 }
 
 export function openKanbanSelectDropdown(getViewState, { subjectId = "", situationId = "", activeKey = "", query = "" } = {}) {
@@ -166,8 +173,16 @@ export function setKanbanSelectDropdownQuery(getViewState, query = "") {
 
 export function getSubjectSelectDropdownScopeRoot(getViewState) {
   const viewState = getViewStateFromGetter(getViewState) || {};
-  const createSubjectFormRoot = document.querySelector("[data-create-subject-form]");
-  if (viewState.createSubjectForm?.isOpen && createSubjectFormRoot) return createSubjectFormRoot;
+  if (viewState.createSubjectForm?.isOpen) {
+    const createMode = String(viewState.createSubjectForm?.mode || "").trim().toLowerCase();
+    if (createMode === "subissue") {
+      const subissueModal = document.getElementById("subjectCreateSubissueModal");
+      const modalCreateFormRoot = subissueModal?.querySelector?.("[data-create-subject-form]");
+      if (modalCreateFormRoot) return modalCreateFormRoot;
+    }
+    const createSubjectFormRoots = [...document.querySelectorAll("[data-create-subject-form]")];
+    if (createSubjectFormRoots.length) return createSubjectFormRoots[createSubjectFormRoots.length - 1];
+  }
 
   const drilldownBody = document.getElementById("drilldownBody");
   if (viewState.drilldown?.isOpen && drilldownBody) return drilldownBody;
@@ -244,6 +259,7 @@ export function syncSelectDropdownPosition({
   root,
   getScopeRoot = () => getSubjectSelectDropdownScopeRoot(getViewState),
   ensureHost = ensureSelectDropdownHost,
+  resolvePlacement,
   candidateRoots = []
 }) {
   const viewState = getViewStateFromGetter(getViewState) || {};
@@ -270,10 +286,18 @@ export function syncSelectDropdownPosition({
       ...candidateRoots,
       document.getElementById("detailsBodyModal"),
       document.getElementById("drilldownBody"),
-      document.querySelector("[data-create-subject-form]"),
+      ...document.querySelectorAll("[data-create-subject-form]"),
       document.getElementById("situationsDetailsHost")
     ].filter(Boolean);
-    const anchor = roots
+    const stateAnchor = viewState?.subjectMetaDropdown?.anchorElement;
+    const stateAnchorField = String(viewState?.subjectMetaDropdown?.anchorField || "");
+    const anchorFromState = stateAnchor
+      && stateAnchorField === field
+      && stateAnchor.isConnected
+      && stateAnchor.matches?.(anchorSelector)
+      ? stateAnchor
+      : null;
+    const anchor = anchorFromState || roots
       .map((candidateRoot) => candidateRoot?.querySelector?.(anchorSelector))
       .find(Boolean);
     if (!anchor || !dropdown) {
@@ -287,7 +311,15 @@ export function syncSelectDropdownPosition({
     const dropdownWidth = 320;
     const gutter = 12;
     const spacing = 8;
-    const left = Math.max(gutter, Math.min(rect.right - dropdownWidth, viewportWidth - dropdownWidth - gutter));
+    const placement = typeof resolvePlacement === "function"
+      ? (resolvePlacement({ anchor, field, viewState, root: scopeRoot }) || {})
+      : {};
+    const horizontalAlign = placement.horizontal === "anchor-start" ? "anchor-start" : "anchor-end";
+    const verticalMode = placement.vertical === "above-preferred" ? "above-preferred" : "auto";
+    const requestedSpacing = Number(placement.spacing);
+    const resolvedSpacing = Number.isFinite(requestedSpacing) ? Math.max(0, requestedSpacing) : spacing;
+    const anchorLeft = horizontalAlign === "anchor-start" ? rect.left : (rect.right - dropdownWidth);
+    const left = Math.max(gutter, Math.min(anchorLeft, viewportWidth - dropdownWidth - gutter));
     const spaceBelow = Math.max(0, viewportHeight - rect.bottom - gutter);
     const spaceAbove = Math.max(0, rect.top - gutter);
     const preferredHeight = Math.min(420, Math.max(240, Math.max(spaceBelow, spaceAbove)));
@@ -297,10 +329,17 @@ export function syncSelectDropdownPosition({
     dropdown.style.maxHeight = `${maxHeight}px`;
 
     const measuredHeight = Math.min(dropdown.offsetHeight || maxHeight, maxHeight);
-    const shouldOpenAbove = spaceBelow < Math.min(240, measuredHeight) && spaceAbove > spaceBelow;
-    const top = shouldOpenAbove
-      ? Math.max(gutter, rect.top - measuredHeight - spacing)
-      : Math.max(gutter, rect.bottom - 4);
+    const minVisibleHeight = Math.min(240, measuredHeight);
+    const shouldOpenAbove = verticalMode === "above-preferred"
+      ? (spaceAbove >= minVisibleHeight || (spaceAbove >= spaceBelow && spaceAbove >= 120))
+      : (spaceBelow < minVisibleHeight && spaceAbove > spaceBelow);
+    const aboveTop = rect.top - measuredHeight - resolvedSpacing;
+    const belowTop = verticalMode === "above-preferred"
+      ? rect.bottom + resolvedSpacing
+      : rect.bottom - 4;
+    const rawTop = shouldOpenAbove ? aboveTop : belowTop;
+    const maxTop = Math.max(gutter, viewportHeight - measuredHeight - gutter);
+    const top = Math.max(gutter, Math.min(rawTop, maxTop));
 
     dropdown.style.left = `${left}px`;
     dropdown.style.top = `${top}px`;


### PR DESCRIPTION
### Motivation

- Improve dropdown placement and anchoring when opening subject meta menus from dynamic contexts such as nested create-subject forms and modals.
- Ensure dropdown stays attached to the original trigger element when the DOM has multiple possible anchors or when the trigger is inside a subissue create modal.

### Description

- Add an `anchor` argument to `openMetaSelectDropdown` and persist `anchorElement` and `anchorField` on the `subjectMetaDropdown` view state, and clear them on close.
- Prefer the stored `anchorElement` when computing the dropdown anchor (if still connected and matching the expected selector), falling back to searching candidate roots; include all `[data-create-subject-form]` nodes when resolving scope roots.
- Introduce `resolveSubjectDropdownPlacement` and wire a `resolvePlacement` hook into the `createSelectDropdownController` and `syncSelectDropdownPosition` so callers can request `horizontal`, `vertical`, and `spacing` placement hints (used for subissue create form to prefer opening above and aligning to anchor start).
- Update the positioning math to honor the `resolvePlacement` results (anchor-start vs anchor-end, `above-preferred`, and custom `spacing`) and compute safe `left`/`top` coordinates accordingly.
- Pass the trigger element as `anchor` when opening the meta dropdown in `project-subjects-events.js`.

### Testing

- Ran frontend unit tests with `yarn test:unit`, and all tests passed.
- Ran the linter with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f06b9b788329bf00fea60d082c56)