### PR TITLE
Dropdown méta : session contextualisée (scope + subjectId)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -480,7 +480,21 @@ export function createProjectSubjectsActions(config) {
   function setSubjectLabels(subjectId, labels) {
     const subjectKey = String(subjectId || "");
     const nextLabels = normalizeSubjectLabels(labels);
-    if (subjectKey !== DRAFT_SUBJECT_ID) return;
+    if (!subjectKey) return;
+    if (subjectKey !== DRAFT_SUBJECT_ID) {
+      persistRunBucket((bucket) => {
+        bucket.subjectMeta = bucket.subjectMeta && typeof bucket.subjectMeta === "object" ? bucket.subjectMeta : {};
+        bucket.subjectMeta.sujet = bucket.subjectMeta.sujet && typeof bucket.subjectMeta.sujet === "object" ? bucket.subjectMeta.sujet : {};
+        const current = bucket.subjectMeta.sujet[subjectKey] && typeof bucket.subjectMeta.sujet[subjectKey] === "object"
+          ? bucket.subjectMeta.sujet[subjectKey]
+          : {};
+        bucket.subjectMeta.sujet[subjectKey] = {
+          ...current,
+          labels: nextLabels
+        };
+      });
+      return;
+    }
 
     ensureViewUiState();
     store.situationsView.createSubjectForm.meta = {

--- a/apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const eventsSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-events.js"), "utf8");
+const stateSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-state.js"), "utf8");
+const dropdownControllerSource = fs.readFileSync(path.resolve(__dirname, "../ui/select-dropdown-controller.js"), "utf8");
+const actionsSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-actions.js"), "utf8");
+
+test("subjectMetaDropdown stocke un contexte explicite (scope + subjectId)", () => {
+  assert.match(stateSource, /scope:\s*""/);
+  assert.match(stateSource, /scopeHost:\s*"main"/);
+  assert.match(stateSource, /subjectId:\s*""/);
+});
+
+test("les ouvertures de dropdown méta fournissent scope et subjectId explicites", () => {
+  assert.match(eventsSource, /openMeta\(\{\s*field,\s*scope,\s*scopeHost:\s*scope === "drilldown" \? "drilldown" : "main",\s*subjectId:\s*targetSubjectId/s);
+  assert.match(eventsSource, /openMeta\(\{\s*field:\s*"subissue-actions",\s*scope,\s*scopeHost:\s*scope === "drilldown" \? "drilldown" : "main",\s*subjectId:\s*targetSubjectId/s);
+});
+
+test("les actions dropdown utilisent le sujet du contexte explicite", () => {
+  assert.match(eventsSource, /function getDropdownContextSubject\(root, options = \{\}\)/);
+  assert.match(eventsSource, /const targetSubject = getDropdownContextSubject\(root\);/);
+  assert.doesNotMatch(eventsSource, /toggleSubjectObjective\(subjectSelection\.item\.id/);
+  assert.doesNotMatch(eventsSource, /toggleSubjectSituation\(subjectSelection\.item\.id/);
+  assert.doesNotMatch(eventsSource, /toggleSubjectLabel\(subjectSelection\.item\.id/);
+  assert.doesNotMatch(eventsSource, /toggleSubjectAssignee\(subjectSelection\.item\.id/);
+});
+
+test("le contrôleur dropdown conserve le subjectId explicite pendant la session", () => {
+  assert.match(dropdownControllerSource, /dropdown\.subjectId = String\(subjectId \|\| ""\);/);
+  assert.match(dropdownControllerSource, /dropdown\.subjectId = "";/);
+  assert.match(dropdownControllerSource, /const explicitSubjectId = String\(viewState\.subjectMetaDropdown\?\.subjectId \|\| ""\)\.trim\(\);/);
+});
+
+test("setSubjectLabels écrit aussi pour un sujet persistant", () => {
+  assert.match(actionsSource, /if \(subjectKey !== DRAFT_SUBJECT_ID\) \{/);
+  assert.match(actionsSource, /bucket\.subjectMeta\.sujet\[subjectKey\] = \{/);
+  assert.match(actionsSource, /labels:\s*nextLabels/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -199,6 +199,39 @@ export function createProjectSubjectsEvents(config) {
     detachDropdownDocumentEvents = null;
   }
 
+  function resolveDropdownScopeFromRoot(root) {
+    if (root?.closest?.("[data-create-subject-form]")) return "draft";
+    if (root?.closest?.("#drilldownPanel")) return "drilldown";
+    return "main";
+  }
+
+  function resolveMetaDropdownContext(root, fallbackSelection = null) {
+    const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
+    const scope = String(dropdown.scope || "").trim().toLowerCase();
+    const scopeHost = String(dropdown.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+    const subjectId = String(dropdown.subjectId || "").trim();
+    if (scope && subjectId) {
+      return { scope, scopeHost, subjectId, field: String(dropdown.field || "") };
+    }
+    const selection = fallbackSelection || getScopedSelection(root);
+    const resolvedScope = resolveDropdownScopeFromRoot(root);
+    return {
+      scope: resolvedScope,
+      scopeHost: resolvedScope === "drilldown" ? "drilldown" : "main",
+      subjectId: String(selection?.type === "sujet" ? selection.item?.id || "" : ""),
+      field: String(dropdown.field || "")
+    };
+  }
+
+  function getDropdownContextSubject(root, options = {}) {
+    const context = resolveMetaDropdownContext(root, options.selection || null);
+    const subjectId = String(context.subjectId || "");
+    if (!subjectId) return null;
+    const selection = getScopedSelection(root);
+    if (selection?.type === "sujet" && String(selection.item?.id || "") === subjectId) return selection.item;
+    return getNestedSujet(subjectId) || null;
+  }
+
   async function resolveSelfCollaboratorAssigneeId() {
     const currentUserId = String(store.user?.id || "").trim();
     const currentEmail = String(store.user?.email || "").trim().toLowerCase();
@@ -351,8 +384,7 @@ export function createProjectSubjectsEvents(config) {
       input.oninput = () => {
         const field = String(input.dataset.subjectMetaSearch || "");
         dropdownController().setMetaQuery(input.value || "");
-        const selection = getScopedSelection(root);
-        const subject = selection?.type === "sujet" ? selection.item : null;
+        const subject = getDropdownContextSubject(root);
         const entries = subject ? getSubjectMetaMenuEntries(subject, field) : [];
         const currentKey = String(getSubjectsViewState().subjectMetaDropdown.activeKey || "");
         getSubjectsViewState().subjectMetaDropdown.activeKey = entries.some((entry) => String(entry?.key || "") === currentKey)
@@ -363,11 +395,11 @@ export function createProjectSubjectsEvents(config) {
 
       input.onkeydown = async (event) => {
         const field = String(input.dataset.subjectMetaSearch || "");
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         if (event.key === "ArrowDown" || event.key === "ArrowUp") {
           event.preventDefault();
-          setSubjectMetaActiveEntry(subjectSelection.item, field, event.key === "ArrowDown" ? 1 : -1);
+          setSubjectMetaActiveEntry(targetSubject, field, event.key === "ArrowDown" ? 1 : -1);
           refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field } });
           return;
         }
@@ -386,7 +418,7 @@ export function createProjectSubjectsEvents(config) {
             const subissueActionsView = String(dropdown.subissueActionsView || "menu");
             if (subissueActionsView === "existing-subissue") {
               if (typeof setSubjectParent !== "function") return;
-              const parentSubjectId = String(dropdown.subissueActionSubjectId || subjectSelection.item.id || "");
+              const parentSubjectId = String(dropdown.subissueActionSubjectId || targetSubject.id || "");
               if (!parentSubjectId || activeKey === parentSubjectId) return;
               const selectedChild = getNestedSujet(activeKey);
               const selectedChildParentId = String(
@@ -407,34 +439,34 @@ export function createProjectSubjectsEvents(config) {
             const relationsView = String(getSubjectsViewState().subjectMetaDropdown?.relationsView || "");
             if (relationsView === "parent") {
               if (typeof setSubjectParent !== "function") return;
-              await applyNonDestructiveMetaToggle(root, field, () => setSubjectParent(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+              await applyNonDestructiveMetaToggle(root, field, () => setSubjectParent(targetSubject.id, activeKey, { root, skipRerender: true }));
               return;
             }
             if (relationsView === "blocked_by") {
               if (typeof toggleSubjectBlockedByRelation !== "function") return;
-              await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectBlockedByRelation(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+              await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectBlockedByRelation(targetSubject.id, activeKey, { root, skipRerender: true }));
               return;
             }
             if (relationsView === "blocking_for") {
               if (typeof toggleSubjectBlockingForRelation !== "function") return;
-              await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectBlockingForRelation(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+              await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectBlockingForRelation(targetSubject.id, activeKey, { root, skipRerender: true }));
               return;
             }
           }
           if (field === "objectives") {
-            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectObjective(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectObjective(targetSubject.id, activeKey, { root, skipRerender: true }));
             return;
           }
           if (field === "situations") {
-            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectSituation(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectSituation(targetSubject.id, activeKey, { root, skipRerender: true }));
             return;
           }
           if (field === "labels") {
-            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectLabel(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectLabel(targetSubject.id, activeKey, { root, skipRerender: true }));
             return;
           }
           if (field === "assignees") {
-            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectAssignee(subjectSelection.item.id, activeKey, { root, skipRerender: true }));
+            await applyNonDestructiveMetaToggle(root, field, () => toggleSubjectAssignee(targetSubject.id, activeKey, { root, skipRerender: true }));
           }
         }
       };
@@ -444,10 +476,10 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         const objectiveId = String(btn.dataset.objectiveSelect || "");
-        await applyNonDestructiveMetaToggle(root, "objectives", () => toggleSubjectObjective(subjectSelection.item.id, objectiveId, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "objectives", () => toggleSubjectObjective(targetSubject.id, objectiveId, { root, skipRerender: true }));
       };
     });
 
@@ -455,10 +487,10 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         const situationId = String(btn.dataset.situationToggle || "");
-        await applyNonDestructiveMetaToggle(root, "situations", () => toggleSubjectSituation(subjectSelection.item.id, situationId, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "situations", () => toggleSubjectSituation(targetSubject.id, situationId, { root, skipRerender: true }));
       };
     });
 
@@ -466,10 +498,10 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         const labelKey = String(btn.dataset.subjectLabelToggle || "");
-        await applyNonDestructiveMetaToggle(root, "labels", () => toggleSubjectLabel(subjectSelection.item.id, labelKey, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "labels", () => toggleSubjectLabel(targetSubject.id, labelKey, { root, skipRerender: true }));
       };
     });
 
@@ -477,10 +509,10 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         const assigneeId = String(btn.dataset.subjectAssigneeToggle || "");
-        await applyNonDestructiveMetaToggle(root, "assignees", () => toggleSubjectAssignee(subjectSelection.item.id, assigneeId, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "assignees", () => toggleSubjectAssignee(targetSubject.id, assigneeId, { root, skipRerender: true }));
       };
     });
 
@@ -488,11 +520,11 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         if (typeof setSubjectParent !== "function") return;
         const parentSubjectId = String(btn.dataset.subjectRelationsParentEntry || "");
-        await applyNonDestructiveMetaToggle(root, "relations", () => setSubjectParent(subjectSelection.item.id, parentSubjectId, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "relations", () => setSubjectParent(targetSubject.id, parentSubjectId, { root, skipRerender: true }));
       };
     });
 
@@ -500,10 +532,10 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         if (typeof setSubjectParent !== "function") return;
-        await applyNonDestructiveMetaToggle(root, "relations", () => setSubjectParent(subjectSelection.item.id, "", { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "relations", () => setSubjectParent(targetSubject.id, "", { root, skipRerender: true }));
       };
     });
 
@@ -515,9 +547,9 @@ export function createProjectSubjectsEvents(config) {
         dropdown.relationsView = "parent";
         dropdown.query = "";
         dropdown.activeKey = "";
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type === "sujet") {
-          const entries = getSubjectMetaMenuEntries(subjectSelection.item, "relations");
+        const targetSubject = getDropdownContextSubject(root);
+        if (targetSubject?.id) {
+          const entries = getSubjectMetaMenuEntries(targetSubject, "relations");
           dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
         }
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
@@ -532,9 +564,9 @@ export function createProjectSubjectsEvents(config) {
         dropdown.relationsView = "blocked_by";
         dropdown.query = "";
         dropdown.activeKey = "";
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type === "sujet") {
-          const entries = getSubjectMetaMenuEntries(subjectSelection.item, "relations");
+        const targetSubject = getDropdownContextSubject(root);
+        if (targetSubject?.id) {
+          const entries = getSubjectMetaMenuEntries(targetSubject, "relations");
           dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
         }
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
@@ -549,9 +581,9 @@ export function createProjectSubjectsEvents(config) {
         dropdown.relationsView = "blocking_for";
         dropdown.query = "";
         dropdown.activeKey = "";
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type === "sujet") {
-          const entries = getSubjectMetaMenuEntries(subjectSelection.item, "relations");
+        const targetSubject = getDropdownContextSubject(root);
+        if (targetSubject?.id) {
+          const entries = getSubjectMetaMenuEntries(targetSubject, "relations");
           dropdown.activeKey = String((entries.find((entry) => entry.isSelected) || entries[0] || {}).key || "");
         }
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: true, focusArgs: { field: "relations" } });
@@ -562,11 +594,11 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         if (typeof toggleSubjectBlockedByRelation !== "function") return;
         const relationSubjectId = String(btn.dataset.subjectRelationsBlockedByEntry || "");
-        await applyNonDestructiveMetaToggle(root, "relations", () => toggleSubjectBlockedByRelation(subjectSelection.item.id, relationSubjectId, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "relations", () => toggleSubjectBlockedByRelation(targetSubject.id, relationSubjectId, { root, skipRerender: true }));
       };
     });
 
@@ -574,11 +606,11 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const subjectSelection = getScopedSelection(root);
-        if (subjectSelection?.type !== "sujet") return;
+        const targetSubject = getDropdownContextSubject(root);
+        if (!targetSubject?.id) return;
         if (typeof toggleSubjectBlockingForRelation !== "function") return;
         const relationSubjectId = String(btn.dataset.subjectRelationsBlockingForEntry || "");
-        await applyNonDestructiveMetaToggle(root, "relations", () => toggleSubjectBlockingForRelation(subjectSelection.item.id, relationSubjectId, { root, skipRerender: true }));
+        await applyNonDestructiveMetaToggle(root, "relations", () => toggleSubjectBlockingForRelation(targetSubject.id, relationSubjectId, { root, skipRerender: true }));
       };
     });
 
@@ -647,8 +679,7 @@ export function createProjectSubjectsEvents(config) {
         dropdown.query = "";
         dropdown.subissueActionIntent = "link-existing";
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
-        const selection = getScopedSelection(root);
-        const subject = selection?.type === "sujet" ? selection.item : null;
+        const subject = getDropdownContextSubject(root);
         const entries = subject ? getSubjectMetaMenuEntries(subject, "subissue-actions") : [];
         dropdown.activeKey = String(entries[0]?.key || "");
         dropdownController().focusSearch({ field: "subissue-actions" });
@@ -724,12 +755,12 @@ export function createProjectSubjectsEvents(config) {
 
   function refreshSubjectMetaDropdownUi(root, { field = "", preserveScroll = false, preserveFocus = false, focusArgs = null } = {}) {
     if (!root) return null;
-    const selection = getScopedSelection(root);
-    if (selection?.type === "sujet" && field && typeof renderSubjectMetaFieldValue === "function") {
+    const subject = getDropdownContextSubject(root, { selection: getScopedSelection(root) });
+    if (subject?.id && field && typeof renderSubjectMetaFieldValue === "function") {
       const fieldSection = root.querySelector(`[data-subject-meta-trigger="${field}"]`)?.closest?.(".subject-meta-field") || null;
       const fieldValue = fieldSection?.querySelector?.(".subject-meta-field__value") || null;
       if (fieldValue) {
-        fieldValue.innerHTML = renderSubjectMetaFieldValue(selection.item, field);
+        fieldValue.innerHTML = renderSubjectMetaFieldValue(subject, field);
         if (field === "situations") bindSubjectSituationFieldInteractions(root, fieldSection);
       }
     }
@@ -1042,15 +1073,26 @@ export function createProjectSubjectsEvents(config) {
         if (isAlreadyOpen) {
           dropdownController().closeMeta();
         } else {
+          const currentSelection = getScopedSelection(root);
+          const scope = resolveDropdownScopeFromRoot(root);
+          const targetSubjectId = String(currentSelection?.type === "sujet" ? currentSelection.item?.id || "" : "");
+          if (!targetSubjectId) return;
           dropdownController().closeKanban();
-          dropdownController().openMeta({ field, showClosedSituations: false, anchor: btn });
+          dropdownController().openMeta({
+            field,
+            scope,
+            scopeHost: scope === "drilldown" ? "drilldown" : "main",
+            subjectId: targetSubjectId,
+            showClosedSituations: false,
+            anchor: btn
+          });
           dropdown.relationsView = field === "relations" ? "menu" : "";
-          const entries = scopedSelection?.type === "sujet" ? getSubjectMetaMenuEntries(scopedSelection.item, field) : [];
-          const selectedObjectiveKey = field === "objectives" && scopedSelection?.type === "sujet"
-            ? String(getSubjectSidebarMeta(scopedSelection.item.id).objectiveIds[0] || "")
+          const entries = currentSelection?.type === "sujet" ? getSubjectMetaMenuEntries(currentSelection.item, field) : [];
+          const selectedObjectiveKey = field === "objectives" && currentSelection?.type === "sujet"
+            ? String(getSubjectSidebarMeta(currentSelection.item.id).objectiveIds[0] || "")
             : "";
-          const selectedLabelKey = field === "labels" && scopedSelection?.type === "sujet"
-            ? String((getSubjectSidebarMeta(scopedSelection.item.id).labels[0] || "")).trim().toLowerCase()
+          const selectedLabelKey = field === "labels" && currentSelection?.type === "sujet"
+            ? String((getSubjectSidebarMeta(currentSelection.item.id).labels[0] || "")).trim().toLowerCase()
             : "";
           const preferredKey = selectedObjectiveKey || selectedLabelKey;
           dropdown.activeKey = preferredKey && entries.some((entry) => String(entry?.key || "") === preferredKey)
@@ -1081,8 +1123,10 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
-        const targetSubjectId = String(btn.dataset.subjectId || scopedSelection?.item?.id || "");
+        const currentSelection = getScopedSelection(root);
+        const targetSubjectId = String(btn.dataset.subjectId || currentSelection?.item?.id || "");
         if (!targetSubjectId) return;
+        const scope = resolveDropdownScopeFromRoot(root);
         const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
         const isAlreadyOpen = dropdown.field === "subissue-actions" && String(dropdown.subissueActionSubjectId || "") === targetSubjectId;
         if (isAlreadyOpen) {
@@ -1093,7 +1137,12 @@ export function createProjectSubjectsEvents(config) {
             scopeHost: isDrilldownScope ? "drilldown" : "main"
           });
           dropdownController().closeKanban();
-          dropdownController().openMeta({ field: "subissue-actions" });
+          dropdownController().openMeta({
+            field: "subissue-actions",
+            scope,
+            scopeHost: scope === "drilldown" ? "drilldown" : "main",
+            subjectId: targetSubjectId
+          });
           dropdown.subissueActionsView = "menu";
           dropdown.query = "";
           dropdown.activeKey = "";
@@ -1151,8 +1200,7 @@ export function createProjectSubjectsEvents(config) {
         dropdown.query = "";
         dropdown.subissueActionIntent = "link-existing";
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });
-        const selection = getScopedSelection(root);
-        const subject = selection?.type === "sujet" ? selection.item : null;
+        const subject = getDropdownContextSubject(root);
         const entries = subject ? getSubjectMetaMenuEntries(subject, "subissue-actions") : [];
         dropdown.activeKey = String(entries[0]?.key || "");
         dropdownController().focusSearch({ field: "subissue-actions" });

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -195,6 +195,9 @@ export function createProjectSubjectsState({ store }) {
     if (!v.subjectMetaDropdown || typeof v.subjectMetaDropdown !== "object") {
       v.subjectMetaDropdown = {
         field: null,
+        scope: "",
+        scopeHost: "main",
+        subjectId: "",
         query: "",
         activeKey: "",
         showClosedSituations: false,
@@ -205,6 +208,9 @@ export function createProjectSubjectsState({ store }) {
         subissueActionIntent: ""
       };
     }
+    if (typeof v.subjectMetaDropdown.scope !== "string") v.subjectMetaDropdown.scope = "";
+    if (typeof v.subjectMetaDropdown.scopeHost !== "string") v.subjectMetaDropdown.scopeHost = "main";
+    if (typeof v.subjectMetaDropdown.subjectId !== "string") v.subjectMetaDropdown.subjectId = "";
     if (typeof v.subjectMetaDropdown.showClosedSituations !== "boolean") v.subjectMetaDropdown.showClosedSituations = false;
     if (typeof v.subjectMetaDropdown.relationsView !== "string") v.subjectMetaDropdown.relationsView = "menu";
     if (typeof v.subjectMetaDropdown.subissueActionsView !== "string") v.subjectMetaDropdown.subissueActionsView = "menu";
@@ -282,6 +288,9 @@ export function createProjectSubjectsState({ store }) {
     };
     v.subjectMetaDropdown = {
       field: null,
+      scope: "",
+      scopeHost: "main",
+      subjectId: "",
       query: "",
       activeKey: "",
       showClosedSituations: false,

--- a/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs
@@ -42,7 +42,7 @@ test("le dropdown Ajouter sous-sujet expose exactement les deux actions attendue
 test("l'événement d'ouverture du menu sous-sujet utilise le dropdown mutualisé", () => {
   assert.match(eventsSource, /\[data-action='open-subissue-action-menu'\]/);
   assert.match(eventsSource, /debugSubissueFlow\("menu-open", \{/);
-  assert.match(eventsSource, /dropdownController\(\)\.openMeta\(\{ field: "subissue-actions" \}\)/);
+  assert.match(eventsSource, /dropdownController\(\)\.openMeta\(\{\s*field: "subissue-actions",[\s\S]*subjectId: targetSubjectId/);
   assert.match(eventsSource, /dropdownController\(\)\.closeKanban\(\);/);
   assert.match(eventsSource, /dropdown\.subissueActionsView = "menu";/);
   assert.match(eventsSource, /const syncSubissueActionTriggerUi = \(\) => \{/);

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -3088,6 +3088,10 @@ const subjectSelectDropdown = createSelectDropdownController({
     getViewState: getSubjectsViewState,
     root,
     getScopedSelection,
+    resolveSubjectById: (subjectId) => {
+      if (String(subjectId || "") === DRAFT_SUBJECT_ID) return getDraftSubjectSelection()?.item || null;
+      return getNestedSujet(subjectId);
+    },
     renderMetaDropdown: renderSubjectMetaDropdown,
     renderKanbanDropdown: renderSubjectKanbanDropdown,
     ensureHost: ensureSelectDropdownHost

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -115,6 +115,9 @@ export function closeMetaSelectDropdown(getViewState) {
   const dropdown = viewState?.subjectMetaDropdown;
   if (!dropdown) return;
   dropdown.field = null;
+  dropdown.scope = "";
+  dropdown.scopeHost = "main";
+  dropdown.subjectId = "";
   dropdown.query = "";
   dropdown.activeKey = "";
   dropdown.relationsView = "menu";
@@ -136,11 +139,26 @@ export function closeKanbanSelectDropdown(getViewState) {
   dropdown.activeKey = "";
 }
 
-export function openMetaSelectDropdown(getViewState, { field = "", activeKey = "", query = "", showClosedSituations = false, anchor = null } = {}) {
+export function openMetaSelectDropdown(
+  getViewState,
+  {
+    field = "",
+    scope = "",
+    scopeHost = "main",
+    subjectId = "",
+    activeKey = "",
+    query = "",
+    showClosedSituations = false,
+    anchor = null
+  } = {}
+) {
   const viewState = getViewStateFromGetter(getViewState);
   const dropdown = viewState?.subjectMetaDropdown;
   if (!dropdown) return;
   dropdown.field = String(field || "") || null;
+  dropdown.scope = String(scope || "");
+  dropdown.scopeHost = String(scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+  dropdown.subjectId = String(subjectId || "");
   dropdown.query = String(query || "");
   dropdown.activeKey = String(activeKey || "");
   dropdown.showClosedSituations = !!showClosedSituations;
@@ -197,6 +215,7 @@ export function renderSelectDropdownHost({
   getViewState,
   root,
   getScopedSelection,
+  resolveSubjectById,
   renderMetaDropdown,
   renderKanbanDropdown,
   ensureHost = ensureSelectDropdownHost
@@ -205,12 +224,18 @@ export function renderSelectDropdownHost({
   const viewState = getViewStateFromGetter(getViewState) || {};
   const field = String(viewState.subjectMetaDropdown?.field || "");
   const kanbanDropdown = viewState.subjectKanbanDropdown || {};
-  const selection = getScopedSelection?.(root);
-  if (selection?.type !== "sujet") {
-    hideSelectDropdownHost(host);
-    return host;
-  }
+  const explicitSubjectId = String(viewState.subjectMetaDropdown?.subjectId || "").trim();
+  const explicitSubject = explicitSubjectId && typeof resolveSubjectById === "function"
+    ? resolveSubjectById(explicitSubjectId)
+    : null;
+  const selection = explicitSubject
+    ? { type: "sujet", item: explicitSubject }
+    : getScopedSelection?.(root);
   if (field) {
+    if (selection?.type !== "sujet") {
+      hideSelectDropdownHost(host);
+      return host;
+    }
     host.innerHTML = renderMetaDropdown(selection.item, field);
     host.setAttribute("aria-hidden", "false");
     return host;


### PR DESCRIPTION
### Motivation
- Corriger les collisions entre plusieurs UI contexts causées par un état global de dropdown et une résolution implicite de la sélection courante qui faisait muter le mauvais sujet.
- Introduire une session dropdown explicitement ciblée pour garantir que chaque ouverture/toggle/use agit toujours sur la cible métier attendue (main | drilldown | draft).

### Description
- Ajout d’un contexte explicite dans l’état UI `subjectMetaDropdown` (`scope`, `scopeHost`, `subjectId`) et reset cohérent à la fermeture, dans `project-subjects-state.js` et usages connexes.
- Enrichissement du contrôleur mutualisé `openMetaSelectDropdown`/`closeMetaSelectDropdown` dans `select-dropdown-controller.js` pour transporter et restaurer ce contexte, et préférence à la résolution explicite du sujet lors du rendu du host via `resolveSubjectById`.
- Refactor des handlers d’événements dropdown dans `project-subjects-events.js` pour toujours résoudre la cible depuis le contexte du dropdown (`getDropdownContextSubject`) et pour ouvrir les dropdowns en enregistrant `scope` + `subjectId` depuis le bouton cliqué (y compris `subissue-actions`).
- Correction métier : `setSubjectLabels` dans `project-subjects-actions.js` écrit maintenant aussi les labels pour les sujets persistants dans le run bucket (le draft reste isolé dans `createSubjectForm.meta`).
- Ajout d’un test d’architecture `project-subjects-dropdown-context.test.mjs` et adaptation d’un test existant `project-subjects-subissue-action-menu.test.mjs` pour valider le nouveau contrat `openMeta({... subjectId ...})`.
- Conservé la mutualisation du contrôleur dropdown (host partagé, positionnement, focus, escape / click outside) afin d’éviter de dupliquer la logique métier.

### Testing
- Tests unitaires ajoutés/édités et exécutés avec : `node --test apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs apps/web/js/views/project-subjects/project-subjects-selection-scope.test.mjs apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs`.
- Résultat : tous les sous-tests ciblés sont passés (suite complète passée), incluant la nouvelle vérification de contexte explicite et l’adaptation du test `subissue-action-menu`.
- Fichier de test ajouté : `apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs`.
- Les changements visent uniquement l’étape 1 (contextualisation / ciblage); comportement de focus, positionnement et fermeture par Escape / click outside a été conservé et vérifié par les tests existants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f9e107ac8329a3f90f81972e4e07)