### PR TITLE
Isolate draft metadata mutations from persistent subject maps

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -133,6 +133,10 @@ export function createProjectSubjectsActions(config) {
     return normalizeAssigneeIds(assigneeIds);
   }
 
+  function isDraftMetaTarget(subjectId) {
+    return String(subjectId || "") === DRAFT_SUBJECT_ID;
+  }
+
   function setSubjectAssigneeIds(subjectId, assigneeIds) {
     const subjectKey = String(subjectId || "");
     const nextIds = normalizeSubjectAssigneeIds(assigneeIds);
@@ -181,15 +185,18 @@ export function createProjectSubjectsActions(config) {
       ? currentIds.filter((id) => id !== assigneeKey)
       : [...currentIds, assigneeKey];
     setSubjectAssigneeIds(subjectKey, nextIds);
+    if (isDraftMetaTarget(subjectKey)) {
+      if (!options.skipRerender) {
+        if (options.root) rerenderScope(options.root);
+        else rerenderPanels();
+      }
+      return true;
+    }
     syncSubjectAssigneeMap(subjectKey, nextIds);
 
     if (!options.skipRerender) {
       if (options.root) rerenderScope(options.root);
       else rerenderPanels();
-    }
-
-    if (subjectKey === DRAFT_SUBJECT_ID) {
-      return true;
     }
 
     try {
@@ -451,13 +458,15 @@ export function createProjectSubjectsActions(config) {
       : [...meta.situationIds, situationKey];
 
     setSubjectSituationIds(subjectKey, nextIds);
-    syncSubjectSituationMaps(subjectKey, situationKey, !wasLinked);
+    if (!isDraftMetaTarget(subjectKey)) {
+      syncSubjectSituationMaps(subjectKey, situationKey, !wasLinked);
+    }
 
     if (!options.skipRerender) {
       if (options.root) rerenderScope(options.root);
     }
 
-    if (subjectKey === DRAFT_SUBJECT_ID) {
+    if (isDraftMetaTarget(subjectKey)) {
       return true;
     }
 
@@ -661,15 +670,17 @@ export function createProjectSubjectsActions(config) {
     const addedObjectiveIds = nextIds.filter((id) => !previousIds.includes(id));
 
     setSubjectObjectiveIds(subjectKey, nextIds);
-    removedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, false));
-    addedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, true));
+    if (!isDraftMetaTarget(subjectKey)) {
+      removedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, false));
+      addedObjectiveIds.forEach((id) => syncSubjectObjectiveMaps(subjectKey, id, true));
+    }
 
     if (!options.skipRerender) {
       if (options.root) rerenderScope(options.root);
       else rerenderPanels();
     }
 
-    if (subjectKey === DRAFT_SUBJECT_ID) {
+    if (isDraftMetaTarget(subjectKey)) {
       return true;
     }
 

--- a/apps/web/js/views/project-subjects/project-subjects-meta-mutations-scope.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-meta-mutations-scope.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const actionsSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-actions.js"), "utf8");
+
+test("les toggles méta utilisent une garde centralisée pour la cible draft", () => {
+  assert.match(actionsSource, /function isDraftMetaTarget\(subjectId\) \{/);
+  assert.match(actionsSource, /if \(isDraftMetaTarget\(subjectKey\)\) \{/);
+});
+
+test("toggleSubjectAssignee n'écrit pas dans les maps persistantes pour un draft", () => {
+  assert.match(
+    actionsSource,
+    /setSubjectAssigneeIds\(subjectKey, nextIds\);\s*if \(isDraftMetaTarget\(subjectKey\)\) \{[\s\S]*?return true;\s*\}\s*syncSubjectAssigneeMap\(subjectKey, nextIds\);/
+  );
+});
+
+test("toggleSubjectSituation n'écrit pas dans les maps persistantes pour un draft", () => {
+  assert.match(
+    actionsSource,
+    /setSubjectSituationIds\(subjectKey, nextIds\);\s*if \(!isDraftMetaTarget\(subjectKey\)\) \{\s*syncSubjectSituationMaps\(subjectKey, situationKey, !wasLinked\);\s*\}/
+  );
+  assert.match(actionsSource, /if \(isDraftMetaTarget\(subjectKey\)\) \{\s*return true;\s*\}/);
+});
+
+test("toggleSubjectObjective n'écrit pas dans les maps persistantes pour un draft", () => {
+  assert.match(
+    actionsSource,
+    /setSubjectObjectiveIds\(subjectKey, nextIds\);\s*if \(!isDraftMetaTarget\(subjectKey\)\) \{\s*removedObjectiveIds\.forEach\(\(id\) => syncSubjectObjectiveMaps\(subjectKey, id, false\)\);\s*addedObjectiveIds\.forEach\(\(id\) => syncSubjectObjectiveMaps\(subjectKey, id, true\)\);\s*\}/
+  );
+  assert.match(actionsSource, /if \(isDraftMetaTarget\(subjectKey\)\) \{\s*return true;\s*\}/);
+});


### PR DESCRIPTION
### Motivation
- Corriger les fuites de mutation entre le draft de création de sous-sujet et l’état persistant en mémoire qui provoquaient des contaminations de labels/assignés/objectifs entre scopes (main, drilldown, draft). 
- Rendre explicite et centralisée la détection de la cible draft pour que les handlers métier n’écrivent jamais dans les projections persistantes quand l’intention est de modifier uniquement le draft.

### Description
- Ajout d’un helper `isDraftMetaTarget(subjectId)` dans `apps/web/js/views/project-subjects/project-subjects-actions.js` pour centraliser la détection du draft. 
- Protection des chemins métier dans `toggleSubjectAssignee`, `toggleSubjectSituation` et `toggleSubjectObjective` pour empêcher l’écriture dans les maps persistantes (`rawSubjectsResult` / `objectivesById` / etc.) quand la cible est un draft, tout en conservant le rerender local attendu pour l’UX draft. 
- Les synchronisations de maps (`syncSubjectAssigneeMap`, `syncSubjectSituationMaps`, `syncSubjectObjectiveMaps`) sont exécutées uniquement pour des sujets persistants. 
- Ajout d’un test de non-régression `apps/web/js/views/project-subjects/project-subjects-meta-mutations-scope.test.mjs` qui verrouille l’invariant draft vs persistant pour ces toggles.

### Testing
- Exécution des tests ciblés via `node --test apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs apps/web/js/views/project-subjects/project-subjects-meta-mutations-scope.test.mjs`.
- Résultat: tous les tests définis pour ces scénarios sont passés (TAP output OK, 9 tests, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fc024eac8329ac48668c613a8c9d)