### PR TITLE
Isolate subject metadata dropdown sessions by unique anchor instance

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-dropdown-anchor-isolation.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-dropdown-anchor-isolation.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const viewSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-view.js"), "utf8");
+const eventsSource = fs.readFileSync(path.resolve(__dirname, "./project-subjects-events.js"), "utf8");
+const controllerSource = fs.readFileSync(path.resolve(__dirname, "../ui/select-dropdown-controller.js"), "utf8");
+
+test("les ancres meta utilisent une clé unique scope + host + subjectId + field + instance", () => {
+  assert.match(controllerSource, /export function buildSubjectMetaAnchorKey\(/);
+  assert.match(controllerSource, /\[normalizedScope, normalizedScopeHost, normalizedSubjectId, normalizedField, normalizedInstance\]\.join\(":"\)/);
+  assert.match(viewSource, /data-subject-meta-anchor="\$\{escapeHtml\(anchorKey\)\}"/);
+});
+
+test("l'état visuel ouvert compare le contexte complet et la clé d'ancre", () => {
+  assert.match(controllerSource, /export function isMetaDropdownOpenForAnchor\(/);
+  assert.match(controllerSource, /String\(dropdown\.anchorKey \|\| ""\) === expectedAnchorKey/);
+  assert.match(viewSource, /const isOpen = isMetaDropdownOpenForAnchor\(dropdown, \{ field, subjectId, scope, scopeHost, anchorKey \}\);/);
+});
+
+test("le contrôleur positionne via anchorKey sans fallback ambigu basé sur field", () => {
+  assert.match(controllerSource, /const anchorKey = String\(viewState\.subjectMetaDropdown\?\.anchorKey \|\| ""\)\.trim\(\);/);
+  assert.match(controllerSource, /anchorSelector = `\[data-subject-meta-anchor="\$\{CSS\.escape\(anchorKey\)\}"\]`;/);
+  assert.doesNotMatch(controllerSource, /data-subject-meta-anchor="\$\{field\}"/);
+});
+
+test("la modale subissue bloque les triggers de l'aside sous-jacent", () => {
+  assert.match(eventsSource, /function isBlockedBySubissueModal\(root, trigger = null\)/);
+  assert.match(eventsSource, /if \(isBlockedBySubissueModal\(root, btn\)\) return;/);
+});
+
+test("fermeture dropdown nettoie la session d'ancre", () => {
+  assert.match(controllerSource, /dropdown\.anchorKey = "";/);
+  assert.match(controllerSource, /dropdown\.instanceKey = "";/);
+  assert.match(controllerSource, /dropdown\.openedFrom = "";/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs
@@ -16,11 +16,13 @@ test("subjectMetaDropdown stocke un contexte explicite (scope + subjectId)", () 
   assert.match(stateSource, /scope:\s*""/);
   assert.match(stateSource, /scopeHost:\s*"main"/);
   assert.match(stateSource, /subjectId:\s*""/);
+  assert.match(stateSource, /anchorKey:\s*""/);
+  assert.match(stateSource, /instanceKey:\s*""/);
 });
 
 test("les ouvertures de dropdown méta fournissent scope et subjectId explicites", () => {
-  assert.match(eventsSource, /openMeta\(\{\s*field,\s*scope,\s*scopeHost:\s*scope === "drilldown" \? "drilldown" : "main",\s*subjectId:\s*targetSubjectId/s);
-  assert.match(eventsSource, /openMeta\(\{\s*field:\s*"subissue-actions",\s*scope,\s*scopeHost:\s*scope === "drilldown" \? "drilldown" : "main",\s*subjectId:\s*targetSubjectId/s);
+  assert.match(eventsSource, /openMeta\(\{\s*field,\s*scope,\s*scopeHost,\s*subjectId:\s*targetSubjectId,[\s\S]*anchorKey,[\s\S]*instanceKey/s);
+  assert.match(eventsSource, /openMeta\(\{\s*field:\s*"subissue-actions",\s*scope,\s*scopeHost,\s*subjectId:\s*targetSubjectId,[\s\S]*anchorKey,[\s\S]*instanceKey/s);
 });
 
 test("les actions dropdown utilisent le sujet du contexte explicite", () => {
@@ -35,6 +37,8 @@ test("les actions dropdown utilisent le sujet du contexte explicite", () => {
 test("le contrôleur dropdown conserve le subjectId explicite pendant la session", () => {
   assert.match(dropdownControllerSource, /dropdown\.subjectId = String\(subjectId \|\| ""\);/);
   assert.match(dropdownControllerSource, /dropdown\.subjectId = "";/);
+  assert.match(dropdownControllerSource, /dropdown\.anchorKey = String\(anchorKey \|\| ""\)\.trim\(\)/);
+  assert.match(dropdownControllerSource, /dropdown\.anchorKey = "";/);
   assert.match(dropdownControllerSource, /const explicitSubjectId = String\(viewState\.subjectMetaDropdown\?\.subjectId \|\| ""\)\.trim\(\);/);
 });
 

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -17,6 +17,7 @@ import { searchSubjectRefs } from "../../utils/subject-ref-index.js";
 import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js";
 import { autosizeTextarea } from "../../utils/textarea-autosize.js";
 import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
+import { isMetaDropdownOpenForAnchor } from "../ui/select-dropdown-controller.js";
 
 export function createProjectSubjectsEvents(config) {
   const EMOJI_GRID_COLUMNS = 6;
@@ -203,6 +204,17 @@ export function createProjectSubjectsEvents(config) {
     if (root?.closest?.("[data-create-subject-form]")) return "draft";
     if (root?.closest?.("#drilldownPanel")) return "drilldown";
     return "main";
+  }
+
+  function isSubissueCreateModalOpen() {
+    const form = getSubjectsViewState()?.createSubjectForm || {};
+    return !!form.isOpen && String(form.mode || "").trim().toLowerCase() === "subissue";
+  }
+
+  function isBlockedBySubissueModal(root, trigger = null) {
+    if (!isSubissueCreateModalOpen()) return false;
+    if (trigger?.closest?.("#subjectCreateSubissueModal")) return false;
+    return !root?.closest?.("#subjectCreateSubissueModal");
   }
 
   function resolveMetaDropdownContext(root, fallbackSelection = null) {
@@ -757,7 +769,11 @@ export function createProjectSubjectsEvents(config) {
     if (!root) return null;
     const subject = getDropdownContextSubject(root, { selection: getScopedSelection(root) });
     if (subject?.id && field && typeof renderSubjectMetaFieldValue === "function") {
-      const fieldSection = root.querySelector(`[data-subject-meta-trigger="${field}"]`)?.closest?.(".subject-meta-field") || null;
+      const anchorKey = String(dropdown.anchorKey || "");
+      const fieldSelector = anchorKey
+        ? `[data-subject-meta-trigger="${field}"][data-subject-meta-anchor="${CSS.escape(anchorKey)}"]`
+        : `[data-subject-meta-trigger="${field}"]`;
+      const fieldSection = root.querySelector(fieldSelector)?.closest?.(".subject-meta-field") || null;
       const fieldValue = fieldSection?.querySelector?.(".subject-meta-field__value") || null;
       if (fieldValue) {
         fieldValue.innerHTML = renderSubjectMetaFieldValue(subject, field);
@@ -1067,24 +1083,40 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = async (event) => {
         event.preventDefault();
         event.stopPropagation();
+        if (isBlockedBySubissueModal(root, btn)) return;
         const field = String(btn.dataset.subjectMetaTrigger || "");
         const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
-        const isAlreadyOpen = dropdown.field === field;
+        const scope = String(btn.dataset.subjectMetaScope || resolveDropdownScopeFromRoot(root));
+        const scopeHost = String(btn.dataset.subjectMetaScopeHost || (scope === "drilldown" ? "drilldown" : "main"));
+        const currentSelection = getScopedSelection(root);
+        const targetSubjectId = String(
+          btn.dataset.subjectMetaSubjectId
+          || (currentSelection?.type === "sujet" ? currentSelection.item?.id || "" : "")
+        );
+        const anchorKey = String(btn.dataset.subjectMetaAnchor || "");
+        const instanceKey = String(btn.dataset.subjectMetaInstance || "");
+        const isAlreadyOpen = isMetaDropdownOpenForAnchor(dropdown, {
+          field,
+          scope,
+          scopeHost,
+          subjectId: targetSubjectId,
+          anchorKey
+        });
         if (isAlreadyOpen) {
           dropdownController().closeMeta();
         } else {
-          const currentSelection = getScopedSelection(root);
-          const scope = resolveDropdownScopeFromRoot(root);
-          const targetSubjectId = String(currentSelection?.type === "sujet" ? currentSelection.item?.id || "" : "");
           if (!targetSubjectId) return;
           dropdownController().closeKanban();
           dropdownController().openMeta({
             field,
             scope,
-            scopeHost: scope === "drilldown" ? "drilldown" : "main",
+            scopeHost,
             subjectId: targetSubjectId,
             showClosedSituations: false,
-            anchor: btn
+            anchor: btn,
+            anchorKey,
+            instanceKey,
+            openedFrom: "subject-meta-trigger"
           });
           dropdown.relationsView = field === "relations" ? "menu" : "";
           const entries = currentSelection?.type === "sujet" ? getSubjectMetaMenuEntries(currentSelection.item, field) : [];
@@ -1109,11 +1141,18 @@ export function createProjectSubjectsEvents(config) {
 
     const syncSubissueActionTriggerUi = () => {
       const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
-      const openedSubjectId = String(dropdown.subissueActionSubjectId || "");
-      const isMenuOpen = String(dropdown.field || "") === "subissue-actions";
       root.querySelectorAll("[data-action='open-subissue-action-menu'][data-subject-id]").forEach((trigger) => {
-        const subjectId = String(trigger.dataset.subjectId || "");
-        const isOpen = isMenuOpen && subjectId && subjectId === openedSubjectId;
+        const subjectId = String(trigger.dataset.subjectMetaSubjectId || trigger.dataset.subjectId || "");
+        const scope = String(trigger.dataset.subjectMetaScope || resolveDropdownScopeFromRoot(root));
+        const scopeHost = String(trigger.dataset.subjectMetaScopeHost || (scope === "drilldown" ? "drilldown" : "main"));
+        const anchorKey = String(trigger.dataset.subjectMetaAnchor || "");
+        const isOpen = isMetaDropdownOpenForAnchor(dropdown, {
+          field: "subissue-actions",
+          scope,
+          scopeHost,
+          subjectId,
+          anchorKey
+        });
         trigger.setAttribute("aria-expanded", isOpen ? "true" : "false");
         trigger.classList.toggle("is-open", isOpen);
       });
@@ -1123,31 +1162,45 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = (event) => {
         event.preventDefault();
         event.stopPropagation();
+        if (isBlockedBySubissueModal(root, btn)) return;
         const currentSelection = getScopedSelection(root);
-        const targetSubjectId = String(btn.dataset.subjectId || currentSelection?.item?.id || "");
+        const targetSubjectId = String(btn.dataset.subjectMetaSubjectId || btn.dataset.subjectId || currentSelection?.item?.id || "");
         if (!targetSubjectId) return;
-        const scope = resolveDropdownScopeFromRoot(root);
+        const scope = String(btn.dataset.subjectMetaScope || resolveDropdownScopeFromRoot(root));
+        const scopeHost = String(btn.dataset.subjectMetaScopeHost || (scope === "drilldown" ? "drilldown" : "main"));
+        const anchorKey = String(btn.dataset.subjectMetaAnchor || "");
+        const instanceKey = String(btn.dataset.subjectMetaInstance || "");
         const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
-        const isAlreadyOpen = dropdown.field === "subissue-actions" && String(dropdown.subissueActionSubjectId || "") === targetSubjectId;
+        const isAlreadyOpen = isMetaDropdownOpenForAnchor(dropdown, {
+          field: "subissue-actions",
+          scope,
+          scopeHost,
+          subjectId: targetSubjectId,
+          anchorKey
+        });
         if (isAlreadyOpen) {
           dropdownController().closeMeta();
         } else {
           debugSubissueFlow("menu-open", {
             subjectId: targetSubjectId,
-            scopeHost: isDrilldownScope ? "drilldown" : "main"
+            scopeHost
           });
           dropdownController().closeKanban();
           dropdownController().openMeta({
             field: "subissue-actions",
             scope,
-            scopeHost: scope === "drilldown" ? "drilldown" : "main",
-            subjectId: targetSubjectId
+            scopeHost,
+            subjectId: targetSubjectId,
+            anchor: btn,
+            anchorKey,
+            instanceKey,
+            openedFrom: "subissue-actions-trigger"
           });
           dropdown.subissueActionsView = "menu";
           dropdown.query = "";
           dropdown.activeKey = "";
           dropdown.subissueActionSubjectId = targetSubjectId;
-          dropdown.subissueActionScopeHost = isDrilldownScope ? "drilldown" : "main";
+          dropdown.subissueActionScopeHost = scopeHost;
           dropdown.subissueActionIntent = "";
         }
         refreshSubjectMetaDropdownUi(root, { preserveScroll: true, preserveFocus: false });

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -198,6 +198,9 @@ export function createProjectSubjectsState({ store }) {
         scope: "",
         scopeHost: "main",
         subjectId: "",
+        anchorKey: "",
+        instanceKey: "",
+        openedFrom: "",
         query: "",
         activeKey: "",
         showClosedSituations: false,
@@ -211,6 +214,9 @@ export function createProjectSubjectsState({ store }) {
     if (typeof v.subjectMetaDropdown.scope !== "string") v.subjectMetaDropdown.scope = "";
     if (typeof v.subjectMetaDropdown.scopeHost !== "string") v.subjectMetaDropdown.scopeHost = "main";
     if (typeof v.subjectMetaDropdown.subjectId !== "string") v.subjectMetaDropdown.subjectId = "";
+    if (typeof v.subjectMetaDropdown.anchorKey !== "string") v.subjectMetaDropdown.anchorKey = "";
+    if (typeof v.subjectMetaDropdown.instanceKey !== "string") v.subjectMetaDropdown.instanceKey = "";
+    if (typeof v.subjectMetaDropdown.openedFrom !== "string") v.subjectMetaDropdown.openedFrom = "";
     if (typeof v.subjectMetaDropdown.showClosedSituations !== "boolean") v.subjectMetaDropdown.showClosedSituations = false;
     if (typeof v.subjectMetaDropdown.relationsView !== "string") v.subjectMetaDropdown.relationsView = "menu";
     if (typeof v.subjectMetaDropdown.subissueActionsView !== "string") v.subjectMetaDropdown.subissueActionsView = "menu";
@@ -291,6 +297,9 @@ export function createProjectSubjectsState({ store }) {
       scope: "",
       scopeHost: "main",
       subjectId: "",
+      anchorKey: "",
+      instanceKey: "",
+      openedFrom: "",
       query: "",
       activeKey: "",
       showClosedSituations: false,

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -7,9 +7,11 @@ import {
   resolveSubjectAssigneeIds
 } from "../../services/subject-assignees-service.js";
 import {
+  buildSubjectMetaAnchorKey,
   createSelectDropdownController,
   ensureSelectDropdownHost,
   getSubjectSelectDropdownScopeRoot,
+  isMetaDropdownOpenForAnchor,
   renderSelectDropdownHost,
   syncSelectDropdownPosition
 } from "../ui/select-dropdown-controller.js";
@@ -1200,9 +1202,19 @@ function summarizeSubjectMetaValue(items, emptyLabel = "Aucun") {
   return `${items[0]} +${items.length - 1}`;
 }
 
-function renderSubjectMetaField({ field, label, valueHtml, emptyState = null }) {
+function renderSubjectMetaField({
+  field,
+  label,
+  valueHtml,
+  emptyState = null,
+  subjectId = "",
+  scope = "main",
+  scopeHost = "main",
+  instance = "aside"
+}) {
   const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
-  const isOpen = dropdown.field === field;
+  const anchorKey = buildSubjectMetaAnchorKey({ field, subjectId, scope, scopeHost, instance });
+  const isOpen = isMetaDropdownOpenForAnchor(dropdown, { field, subjectId, scope, scopeHost, anchorKey });
   const isEmpty = !!(emptyState && emptyState.isEmpty);
   return `
     <section class="subject-meta-field ${isOpen ? "is-open" : ""}">
@@ -1210,7 +1222,11 @@ function renderSubjectMetaField({ field, label, valueHtml, emptyState = null }) 
         type="button"
         class="subject-meta-field__trigger ${isEmpty ? "subject-meta-field__trigger--empty" : ""}"
         data-subject-meta-trigger="${escapeHtml(field)}"
-        data-subject-meta-anchor="${escapeHtml(field)}"
+        data-subject-meta-anchor="${escapeHtml(anchorKey)}"
+        data-subject-meta-instance="${escapeHtml(instance)}"
+        data-subject-meta-scope="${escapeHtml(scope)}"
+        data-subject-meta-scope-host="${escapeHtml(scopeHost)}"
+        data-subject-meta-subject-id="${escapeHtml(subjectId)}"
         aria-expanded="${isOpen ? "true" : "false"}"
       >
         ${isEmpty ? `
@@ -2240,32 +2256,53 @@ function renderSubjectKanbanDropdown(subjectId, situationId) {
 function renderSubjectMetaControls(subject) {
   const meta = getSubjectSidebarMeta(subject.id);
   const selectedObjectives = meta.objectiveIds.map((objectiveId) => getObjectiveById(objectiveId)).filter(Boolean);
+  const subjectId = String(subject?.id || "");
   return `
     <div class="subject-meta-controls">
       ${renderSubjectMetaField({
         field: "assignees",
         label: "Assigné à",
-        valueHtml: renderSubjectAssigneesValue(subject.id)
+        valueHtml: renderSubjectAssigneesValue(subject.id),
+        subjectId,
+        scope: "main",
+        scopeHost: "main",
+        instance: "detail-aside"
       })}
       ${renderSubjectMetaField({
         field: "labels",
         label: "Labels",
-        valueHtml: renderSubjectLabelsValue(subject.id)
+        valueHtml: renderSubjectLabelsValue(subject.id),
+        subjectId,
+        scope: "main",
+        scopeHost: "main",
+        instance: "detail-aside"
       })}
       ${renderSubjectMetaField({
         field: "situations",
         label: "Situation",
-        valueHtml: renderSubjectSituationsValue(subject.id)
+        valueHtml: renderSubjectSituationsValue(subject.id),
+        subjectId,
+        scope: "main",
+        scopeHost: "main",
+        instance: "detail-aside"
       })}
       ${renderSubjectMetaField({
         field: "objectives",
         label: "Objectifs",
-        valueHtml: renderSubjectObjectivesValue(subject.id)
+        valueHtml: renderSubjectObjectivesValue(subject.id),
+        subjectId,
+        scope: "main",
+        scopeHost: "main",
+        instance: "detail-aside"
       })}
       ${renderSubjectMetaField({
         field: "relations",
         label: "Relations",
-        valueHtml: renderSubjectRelationsCards(subject.id)
+        valueHtml: renderSubjectRelationsCards(subject.id),
+        subjectId,
+        scope: "main",
+        scopeHost: "main",
+        instance: "detail-aside"
       })}
     </div>
   `;
@@ -2314,9 +2351,24 @@ function renderAddSubissueActionButton(subjectId, options = {}) {
   const normalizedSubjectId = String(subjectId || "");
   if (!normalizedSubjectId) return "";
   const dropdown = getSubjectsViewState().subjectMetaDropdown || {};
-  const isOpen = String(dropdown.field || "") === "subissue-actions"
-    && String(dropdown.subissueActionSubjectId || "") === normalizedSubjectId;
+  const scopeHost = String(options.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+  const scope = String(options.scope || (scopeHost === "drilldown" ? "drilldown" : "main")).trim().toLowerCase() || "main";
   const placement = String(options.placement || "").trim().toLowerCase() === "subissues" ? "subissues" : "description";
+  const instance = placement === "subissues" ? "subissue-actions-subtable" : "subissue-actions-detail";
+  const anchorKey = buildSubjectMetaAnchorKey({
+    field: "subissue-actions",
+    scope,
+    scopeHost,
+    subjectId: normalizedSubjectId,
+    instance
+  });
+  const isOpen = isMetaDropdownOpenForAnchor(dropdown, {
+    field: "subissue-actions",
+    scope,
+    scopeHost,
+    subjectId: normalizedSubjectId,
+    anchorKey
+  });
   return `
     <div class="subject-add-subissue-action subject-add-subissue-action--${escapeHtml(placement)}">
       <button
@@ -2324,7 +2376,11 @@ function renderAddSubissueActionButton(subjectId, options = {}) {
         class="gh-btn gh-btn--md subject-add-subissue-action__trigger ${isOpen ? "is-open" : ""}"
         data-action="open-subissue-action-menu"
         data-subject-id="${escapeHtml(normalizedSubjectId)}"
-        data-subject-meta-anchor="subissue-actions"
+        data-subject-meta-anchor="${escapeHtml(anchorKey)}"
+        data-subject-meta-instance="${escapeHtml(instance)}"
+        data-subject-meta-scope="${escapeHtml(scope)}"
+        data-subject-meta-scope-host="${escapeHtml(scopeHost)}"
+        data-subject-meta-subject-id="${escapeHtml(normalizedSubjectId)}"
         aria-expanded="${isOpen ? "true" : "false"}"
       >
         <span>Ajouter sous-sujet</span>
@@ -3278,6 +3334,10 @@ function renderCreateSubjectMetaControls() {
   const objectivesValueHtml = isSubissueMode
     ? renderCreateSubissueObjectiveValue(subject.id)
     : (objective ? renderSubjectObjectivesValue(subject.id) : renderSubjectMetaButtonValue("Aucun objectif"));
+  const scope = "draft";
+  const scopeHost = "main";
+  const instance = isSubissueMode ? "create-subissue-modal" : "create-subject-standard";
+  const subjectId = String(subject?.id || "");
 
   return `
     <div class="subject-meta-controls subject-meta-controls--create">
@@ -3285,25 +3345,41 @@ function renderCreateSubjectMetaControls() {
         field: "assignees",
         label: "Assignee",
         valueHtml: assigneesValueHtml,
-        emptyState: isSubissueMode ? { isEmpty: !assigneesValueHtml, icon: "people", text: "Assigné à" } : null
+        emptyState: isSubissueMode ? { isEmpty: !assigneesValueHtml, icon: "people", text: "Assigné à" } : null,
+        subjectId,
+        scope,
+        scopeHost,
+        instance
       })}
       ${renderSubjectMetaField({
         field: "labels",
         label: "Labels",
         valueHtml: labelsValueHtml,
-        emptyState: isSubissueMode ? { isEmpty: !labelsValueHtml, icon: "tag", text: "Label" } : null
+        emptyState: isSubissueMode ? { isEmpty: !labelsValueHtml, icon: "tag", text: "Label" } : null,
+        subjectId,
+        scope,
+        scopeHost,
+        instance
       })}
       ${renderSubjectMetaField({
         field: "situations",
         label: "Project",
         valueHtml: situationsValueHtml,
-        emptyState: isSubissueMode ? { isEmpty: !situationsValueHtml, icon: "table", text: "Situation" } : null
+        emptyState: isSubissueMode ? { isEmpty: !situationsValueHtml, icon: "table", text: "Situation" } : null,
+        subjectId,
+        scope,
+        scopeHost,
+        instance
       })}
       ${renderSubjectMetaField({
         field: "objectives",
         label: "Milestone",
         valueHtml: objectivesValueHtml,
-        emptyState: isSubissueMode ? { isEmpty: !objectivesValueHtml, icon: "milestone", text: "Objectif" } : null
+        emptyState: isSubissueMode ? { isEmpty: !objectivesValueHtml, icon: "milestone", text: "Objectif" } : null,
+        subjectId,
+        scope,
+        scopeHost,
+        instance
       })}
     </div>
   `;

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -6,6 +6,42 @@ function getViewStateFromGetter(getViewState) {
   return typeof getViewState === "function" ? getViewState() : getViewState;
 }
 
+function normalizeMetaScope(scope = "") {
+  const normalized = String(scope || "").trim().toLowerCase();
+  return normalized || "main";
+}
+
+function normalizeMetaScopeHost(scopeHost = "") {
+  return String(scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+}
+
+export function buildSubjectMetaAnchorKey({
+  field = "",
+  scope = "",
+  scopeHost = "main",
+  subjectId = "",
+  instance = ""
+} = {}) {
+  const normalizedField = String(field || "").trim().toLowerCase();
+  const normalizedScope = normalizeMetaScope(scope);
+  const normalizedScopeHost = normalizeMetaScopeHost(scopeHost);
+  const normalizedSubjectId = String(subjectId || "").trim() || "none";
+  const normalizedInstance = String(instance || "").trim().toLowerCase() || "default";
+  return [normalizedScope, normalizedScopeHost, normalizedSubjectId, normalizedField, normalizedInstance].join(":");
+}
+
+export function isMetaDropdownOpenForAnchor(dropdown = {}, context = {}) {
+  if (!dropdown || !context) return false;
+  const expectedAnchorKey = String(context.anchorKey || "").trim()
+    || buildSubjectMetaAnchorKey(context);
+  if (!expectedAnchorKey) return false;
+  return String(dropdown.field || "") === String(context.field || "")
+    && String(dropdown.scope || "") === String(context.scope || "")
+    && normalizeMetaScopeHost(dropdown.scopeHost || "main") === normalizeMetaScopeHost(context.scopeHost || "main")
+    && String(dropdown.subjectId || "") === String(context.subjectId || "")
+    && String(dropdown.anchorKey || "") === expectedAnchorKey;
+}
+
 function isSelectDropdownOpenFromState(state) {
   return !!state?.subjectMetaDropdown?.field
     || (!!state?.subjectKanbanDropdown?.subjectId && !!state?.subjectKanbanDropdown?.situationId);
@@ -118,6 +154,9 @@ export function closeMetaSelectDropdown(getViewState) {
   dropdown.scope = "";
   dropdown.scopeHost = "main";
   dropdown.subjectId = "";
+  dropdown.anchorKey = "";
+  dropdown.instanceKey = "";
+  dropdown.openedFrom = "";
   dropdown.query = "";
   dropdown.activeKey = "";
   dropdown.relationsView = "menu";
@@ -149,16 +188,23 @@ export function openMetaSelectDropdown(
     activeKey = "",
     query = "",
     showClosedSituations = false,
-    anchor = null
+    anchor = null,
+    anchorKey = "",
+    instanceKey = "",
+    openedFrom = ""
   } = {}
 ) {
   const viewState = getViewStateFromGetter(getViewState);
   const dropdown = viewState?.subjectMetaDropdown;
   if (!dropdown) return;
   dropdown.field = String(field || "") || null;
-  dropdown.scope = String(scope || "");
-  dropdown.scopeHost = String(scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+  dropdown.scope = normalizeMetaScope(scope);
+  dropdown.scopeHost = normalizeMetaScopeHost(scopeHost);
   dropdown.subjectId = String(subjectId || "");
+  dropdown.anchorKey = String(anchorKey || "").trim()
+    || buildSubjectMetaAnchorKey({ field, scope: dropdown.scope, scopeHost: dropdown.scopeHost, subjectId, instance: instanceKey });
+  dropdown.instanceKey = String(instanceKey || "").trim();
+  dropdown.openedFrom = String(openedFrom || "").trim().toLowerCase();
   dropdown.query = String(query || "");
   dropdown.activeKey = String(activeKey || "");
   dropdown.showClosedSituations = !!showClosedSituations;
@@ -293,7 +339,12 @@ export function syncSelectDropdownPosition({
   const host = ensureHost();
   let anchorSelector = "";
   if (field) {
-    anchorSelector = `[data-subject-meta-anchor="${field}"]`;
+    const anchorKey = String(viewState.subjectMetaDropdown?.anchorKey || "").trim();
+    if (!anchorKey) {
+      hideSelectDropdownHost(host);
+      return;
+    }
+    anchorSelector = `[data-subject-meta-anchor="${CSS.escape(anchorKey)}"]`;
   } else if (String(kanbanDropdown.subjectId || "") && String(kanbanDropdown.situationId || "")) {
     anchorSelector = `[data-subject-kanban-anchor="${CSS.escape(String(kanbanDropdown.subjectId || ""))}::${CSS.escape(String(kanbanDropdown.situationId || ""))}"]`;
   } else {
@@ -316,10 +367,12 @@ export function syncSelectDropdownPosition({
     ].filter(Boolean);
     const stateAnchor = viewState?.subjectMetaDropdown?.anchorElement;
     const stateAnchorField = String(viewState?.subjectMetaDropdown?.anchorField || "");
+    const stateAnchorKey = String(viewState?.subjectMetaDropdown?.anchorKey || "");
     const anchorFromState = stateAnchor
       && stateAnchorField === field
       && stateAnchor.isConnected
       && stateAnchor.matches?.(anchorSelector)
+      && String(stateAnchor?.dataset?.subjectMetaAnchor || "") === stateAnchorKey
       ? stateAnchor
       : null;
     const anchor = anchorFromState || roots
@@ -472,7 +525,12 @@ export function bindSelectDropdownDocumentEvents({
   const handleDocumentClick = (event) => {
     if (!isOpen()) return;
     if (event.target.closest("#subjectMetaDropdownHost .subject-meta-dropdown")) return;
-    if (event.target.closest("[data-subject-meta-trigger]")) return;
+    const activeAnchorKey = String(getViewStateFromGetter(getViewState)?.subjectMetaDropdown?.anchorKey || "");
+    const trigger = event.target.closest("[data-subject-meta-trigger]");
+    if (trigger) {
+      const triggerAnchorKey = String(trigger.dataset.subjectMetaAnchor || "");
+      if (activeAnchorKey && triggerAnchorKey === activeAnchorKey) return;
+    }
     if (event.target.closest("[data-subject-kanban-trigger]")) return;
     onRequestClose?.();
     onRerender?.(getScopeRoot?.() || event.target);


### PR DESCRIPTION
### Motivation
- Dropdown open-state was globalized by `field` causing visual/structural collisions between same-field triggers (main detail vs create-subject subissue modal). 
- When the subissue creation modal is open, underlying aside triggers could still be considered anchors or activated, breaking isolation and UX.

### Description
- Added explicit session fields to dropdown state: `anchorKey`, `instanceKey`, and `openedFrom`, and initialized/cleared them on reset/close. (`project-subjects-state.js`)
- Introduced shared helpers `buildSubjectMetaAnchorKey` and `isMetaDropdownOpenForAnchor` and scope-normalizers to compute and compare a unique anchor key from `(scope, scopeHost, subjectId, field, instance)`. (`select-dropdown-controller.js`)
- `openMeta(...)` now accepts and stores `anchorKey`, `instanceKey`, and `openedFrom`; `closeMeta()` clears them; `syncPosition()` resolves anchor by `anchorKey` (no more fallback by `field` only). (`select-dropdown-controller.js`)
- Renderers emit instance-scoped anchor attributes (`data-subject-meta-anchor`, `data-subject-meta-instance`, `data-subject-meta-scope*`, `data-subject-meta-subject-id`) and use `isMetaDropdownOpenForAnchor` to compute `is-open`/`aria-expanded`. (`project-subjects-view.js`)
- Event handlers were updated to compute scope/subject/anchor context from trigger attributes, to store the anchor session on open, and to block underlying triggers when the subissue creation modal is open. UI sync for subissue-action triggers now uses anchor identity. (`project-subjects-events.js`)
- Localized refresh now targets the current anchor instance when updating field values. Added/updated tests to assert anchor uniqueness, session cleanup and subissue-modal blocking. (new and updated test files)

### Testing
- Ran the updated contextual tests: `node --test apps/web/js/views/project-subjects/project-subjects-dropdown-context.test.mjs apps/web/js/views/project-subjects/project-subjects-dropdown-anchor-isolation.test.mjs` and they passed.
- Ran related subject tests: `node --test apps/web/js/views/project-subjects/project-subjects-subissue-action-menu.test.mjs apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs` and they passed.
- All added/modified automated tests succeeded (no failing tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea015b95288329824147ac8295f448)