### PR TITLE
Améliore l’activité “a ajouté un sous-sujet” dans le fil de discussion

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -79,7 +79,7 @@ export const BUSINESS_ACTIVITY_CONFIG = {
   },
   subject_parent_added: { icon: "issue-tracked-by", tone: "business-rel", verb: "a ajouté un parent" },
   subject_parent_removed: { icon: "arrow-up", tone: "business-rel", verb: "a retiré un parent" },
-  subject_child_added: { icon: "arrow-down", tone: "business-rel", verb: "a ajouté un sous-sujet" },
+  subject_child_added: { icon: "issue-tracks", tone: "business-rel", verb: "a ajouté un sous-sujet" },
   subject_child_removed: { icon: "arrow-down", tone: "business-rel", verb: "a retiré un sous-sujet" },
   subject_blocked_by_added: { icon: "blocked", tone: "business-alert", verb: "a ajouté un blocage entrant" },
   subject_blocked_by_removed: { icon: "blocked", tone: "business-alert", verb: "a retiré un blocage entrant" },

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1399,6 +1399,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
+    if (eventType === "subject_child_added" && counterpartId) {
+      return renderLinkedSubjectInline(counterpartId, counterpartTitle);
+    }
+
     return "";
   }
 
@@ -1494,7 +1498,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
             && (action === "added" || action === "removed")
           ) || isSubjectTitleUpdated;
           const shouldRenderInlineBelow = (
-            (eventType === "subject_parent_added")
+            (eventType === "subject_parent_added" || eventType === "subject_child_added")
             || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))
           );
           const secondLineInlineHtml = shouldRenderInlineBelow && inlineDetailHtml
@@ -1503,7 +1507,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const inlineClassName = isSubjectTitleUpdated
             ? "tl-note-inline tl-note-inline--title-updated"
             : "tl-note-inline";
-          const defaultInlineHtml = eventType === "subject_parent_added"
+          const defaultInlineHtml = (eventType === "subject_parent_added" || eventType === "subject_child_added")
             ? ""
             : (inlineDetailHtml ? `<span class="${inlineClassName}">${inlineDetailHtml}</span>` : "");
           const inlineBeforeTimestampHtml = shouldRenderInlineBeforeTimestamp ? defaultInlineHtml : "";


### PR DESCRIPTION
### Motivation
- Rendre l’activité "a ajouté un sous-sujet" visuellement cohérente avec "a ajouté le sujet parent" en affichant l’icône spécifique fournie, l’état ouvert/fermé du sous‑sujet et un lien cliquable `#numéro` au lieu du texte générique "... comme sous-sujet".

### Description
- Remplace l’icône de `subject_child_added` par `issue-tracks` dans `BUSINESS_ACTIVITY_CONFIG` pour utiliser l’icône SVG existante et la même `tone: "business-rel"` que les autres activités de ce groupe (couleur partagée via CSS). 
- Ajoute le rendu riche pour `subject_child_added` en réutilisant `renderLinkedSubjectInline(counterpartId, counterpartTitle)` afin d’afficher l’icône état ouvert/fermé + titre + lien `#numéro` de la même manière que pour `subject_parent_added`.
- Ajuste la logique d’affichage inline pour traiter `subject_child_added` comme `subject_parent_added` (s’affiche sur la 2e ligne et supprime le texte inline par défaut).

### Testing
- Exécution des tests unitaires : `node --test apps/web/js/views/project-subjects/project-subjects-thread-business-events.test.mjs` — succès (4 tests passés, 0 échoués).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2637d0f08329acfb7390c475ed57)