### PR TITLE
Adjust child/blocked event icon and inline rendering in project subject threads

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -79,7 +79,7 @@ export const BUSINESS_ACTIVITY_CONFIG = {
   },
   subject_parent_added: { icon: "issue-tracked-by", tone: "business-rel", verb: "a ajouté un parent" },
   subject_parent_removed: { icon: "arrow-up", tone: "business-rel", verb: "a retiré un parent" },
-  subject_child_added: { icon: "arrow-down", tone: "business-rel", verb: "a ajouté un sous-sujet" },
+  subject_child_added: { icon: "issue-tracks", tone: "business-rel", verb: "a ajouté un sous-sujet" },
   subject_child_removed: { icon: "arrow-down", tone: "business-rel", verb: "a retiré un sous-sujet" },
   subject_blocked_by_added: { icon: "blocked", tone: "business-alert", verb: "a ajouté un blocage entrant" },
   subject_blocked_by_removed: { icon: "blocked", tone: "business-alert", verb: "a retiré un blocage entrant" },

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1387,7 +1387,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return `${renderSituationInline(situation?.id, situation?.label)}`;
     }
 
-    if (eventType === "subject_blocked_by_added" && counterpartId) {
+    if ((eventType === "subject_blocked_by_added" || eventType === "subject_blocked_by_removed") && counterpartId) {
       return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
@@ -1396,6 +1396,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
     }
 
     if (eventType === "subject_parent_added" && counterpartId) {
+      return renderLinkedSubjectInline(counterpartId, counterpartTitle);
+    }
+
+    if (eventType === "subject_child_added" && counterpartId) {
       return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
@@ -1494,7 +1498,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
             && (action === "added" || action === "removed")
           ) || isSubjectTitleUpdated;
           const shouldRenderInlineBelow = (
-            (eventType === "subject_parent_added")
+            (
+              eventType === "subject_parent_added"
+              || eventType === "subject_child_added"
+              || eventType === "subject_blocked_by_added"
+              || eventType === "subject_blocked_by_removed"
+            )
             || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))
           );
           const secondLineInlineHtml = shouldRenderInlineBelow && inlineDetailHtml
@@ -1503,7 +1512,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const inlineClassName = isSubjectTitleUpdated
             ? "tl-note-inline tl-note-inline--title-updated"
             : "tl-note-inline";
-          const defaultInlineHtml = eventType === "subject_parent_added"
+          const defaultInlineHtml = (
+            eventType === "subject_parent_added"
+            || eventType === "subject_child_added"
+            || eventType === "subject_blocked_by_added"
+            || eventType === "subject_blocked_by_removed"
+          )
             ? ""
             : (inlineDetailHtml ? `<span class="${inlineClassName}">${inlineDetailHtml}</span>` : "");
           const inlineBeforeTimestampHtml = shouldRenderInlineBeforeTimestamp ? defaultInlineHtml : "";


### PR DESCRIPTION
### Motivation
- Fix incorrect icon and inconsistent inline rendering for subject relationship events so linked-subjects display correctly and avoid duplicate inline text.
- Ensure both adding and removing blocked relationships render the linked subject inline when applicable.
- Prevent certain relationship events from redundantly showing default inline text to match UX expectations.

### Description
- Change the `subject_child_added` icon from `arrow-down` to `issue-tracks` in `BUSINESS_ACTIVITY_CONFIG`.
- Extend the counterpart-linked rendering condition to include `subject_blocked_by_removed` so removed incoming blocks also render the linked subject inline when `counterpartId` is present.
- Add rendering for `subject_child_added` with `renderLinkedSubjectInline(counterpartId, counterpartTitle)` when `counterpartId` exists.
- Treat `subject_child_added`, `subject_blocked_by_added`, and `subject_blocked_by_removed` as events that suppress the default inline text by updating `shouldRenderInlineBelow` and `defaultInlineHtml` conditions.

### Testing
- Ran `yarn lint` and the linter completed without errors.
- Ran the JavaScript test suite with `yarn test` and all tests passed.
- Performed a production build with `yarn build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2637d0f08329acfb7390c475ed57)