### PR TITLE
Render linked subjects as safe inline entity links and add styles; include child/blocked_by event handling

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread-business-events.js
@@ -79,7 +79,7 @@ export const BUSINESS_ACTIVITY_CONFIG = {
   },
   subject_parent_added: { icon: "issue-tracked-by", tone: "business-rel", verb: "a ajouté un parent" },
   subject_parent_removed: { icon: "arrow-up", tone: "business-rel", verb: "a retiré un parent" },
-  subject_child_added: { icon: "arrow-down", tone: "business-rel", verb: "a ajouté un sous-sujet" },
+  subject_child_added: { icon: "issue-tracks", tone: "business-rel", verb: "a ajouté un sous-sujet" },
   subject_child_removed: { icon: "arrow-down", tone: "business-rel", verb: "a retiré un sous-sujet" },
   subject_blocked_by_added: { icon: "blocked", tone: "business-alert", verb: "a ajouté un blocage entrant" },
   subject_blocked_by_removed: { icon: "blocked", tone: "business-alert", verb: "a retiré un blocage entrant" },

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1306,11 +1306,17 @@ priority=${firstNonEmpty(subject.priority, "")}`
       ? svgIcon("check-circle", { style: "color: var(--fgColor-done)" })
       : svgIcon("issue-opened", { style: "color: var(--fgColor-open)" });
     const title = firstNonEmpty(subject?.title, fallbackTitle, "");
-    const linkedSubject = entityDisplayLinkHtml("sujet", counterpartId);
+    const linkedSubjectRef = entityDisplayLinkHtml("sujet", counterpartId);
+    const linkedSubjectRefLabel = firstNonEmpty(String(linkedSubjectRef).match(/>([^<]*)<\/a>/)?.[1], "#?");
+    const safeType = escapeHtml("sujet");
+    const safeId = escapeHtml(counterpartId);
     return `
       <span class="tl-note-inline-link">
         <span class="tl-note-inline-subject-status" aria-hidden="true">${iconSvg}</span>
-        ${title ? `${escapeHtml(title)} ` : ""}${linkedSubject}
+        <a href="#" class="entity-link tl-note-inline-subject-link" data-nav-type="${safeType}" data-nav-id="${safeId}">
+          ${title ? `<span class="tl-note-inline-subject-title">${escapeHtml(title)}</span>` : ""}
+          <span class="tl-note-inline-subject-ref">${escapeHtml(linkedSubjectRefLabel)}</span>
+        </a>
       </span>
     `;
   }
@@ -1387,7 +1393,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
       return `${renderSituationInline(situation?.id, situation?.label)}`;
     }
 
-    if (eventType === "subject_blocked_by_added" && counterpartId) {
+    if ((eventType === "subject_blocked_by_added" || eventType === "subject_blocked_by_removed") && counterpartId) {
       return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
@@ -1396,6 +1402,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
     }
 
     if (eventType === "subject_parent_added" && counterpartId) {
+      return renderLinkedSubjectInline(counterpartId, counterpartTitle);
+    }
+
+    if (eventType === "subject_child_added" && counterpartId) {
       return renderLinkedSubjectInline(counterpartId, counterpartTitle);
     }
 
@@ -1494,7 +1504,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
             && (action === "added" || action === "removed")
           ) || isSubjectTitleUpdated;
           const shouldRenderInlineBelow = (
-            (eventType === "subject_parent_added")
+            (
+              eventType === "subject_parent_added"
+              || eventType === "subject_child_added"
+              || eventType === "subject_blocked_by_added"
+              || eventType === "subject_blocked_by_removed"
+            )
             || (eventType === "subject_assignees_changed" && (action === "added" || action === "removed"))
           );
           const secondLineInlineHtml = shouldRenderInlineBelow && inlineDetailHtml
@@ -1503,7 +1518,12 @@ priority=${firstNonEmpty(subject.priority, "")}`
           const inlineClassName = isSubjectTitleUpdated
             ? "tl-note-inline tl-note-inline--title-updated"
             : "tl-note-inline";
-          const defaultInlineHtml = eventType === "subject_parent_added"
+          const defaultInlineHtml = (
+            eventType === "subject_parent_added"
+            || eventType === "subject_child_added"
+            || eventType === "subject_blocked_by_added"
+            || eventType === "subject_blocked_by_removed"
+          )
             ? ""
             : (inlineDetailHtml ? `<span class="${inlineClassName}">${inlineDetailHtml}</span>` : "");
           const inlineBeforeTimestampHtml = shouldRenderInlineBeforeTimestamp ? defaultInlineHtml : "";
@@ -1545,16 +1565,28 @@ priority=${firstNonEmpty(subject.priority, "")}`
           iconHtml = `<span class="tl-ico-wrap tl-ico-closed" aria-hidden="true">${SVG_TL_CLOSED}</span>`;
           const sujetId = e?.meta?.problem_id;
           const sujet = sujetId ? getNestedSujet(sujetId) : null;
-          const sujetTitle = sujet?.title ? `${escapeHtml(sujet.title)} ` : "";
+          const sujetTitle = firstNonEmpty(sujet?.title, "");
+          const safeSujetId = escapeHtml(sujetId || "");
+          const safeSujetTitle = escapeHtml(sujetTitle);
+          const sujetRefLink = entityDisplayLinkHtml("sujet", sujetId);
+          const sujetRefLabel = firstNonEmpty(String(sujetRefLink).match(/>([^<]*)<\/a>/)?.[1], "#?");
           verb = "closed";
-          targetHtml = sujetId ? `sujet ${sujetTitle}${entityDisplayLinkHtml("sujet", sujetId)}` : "this";
+          targetHtml = sujetId
+            ? `sujet <a href="#" class="entity-link tl-note-inline-subject-link" data-nav-type="sujet" data-nav-id="${safeSujetId}">${safeSujetTitle ? `<span class="tl-note-inline-subject-title">${safeSujetTitle}</span>` : ""}<span class="tl-note-inline-subject-ref">${escapeHtml(sujetRefLabel)}</span></a>`
+            : "this";
         } else if (kind === "issue_reopened") {
           iconHtml = `<span class="tl-ico-wrap tl-ico-reopened" aria-hidden="true">${SVG_TL_REOPENED}</span>`;
           const sujetId = e?.meta?.problem_id;
           const sujet = sujetId ? getNestedSujet(sujetId) : null;
-          const sujetTitle = sujet?.title ? `${escapeHtml(sujet.title)} ` : "";
+          const sujetTitle = firstNonEmpty(sujet?.title, "");
+          const safeSujetId = escapeHtml(sujetId || "");
+          const safeSujetTitle = escapeHtml(sujetTitle);
+          const sujetRefLink = entityDisplayLinkHtml("sujet", sujetId);
+          const sujetRefLabel = firstNonEmpty(String(sujetRefLink).match(/>([^<]*)<\/a>/)?.[1], "#?");
           verb = "reopened";
-          targetHtml = sujetId ? `sujet ${sujetTitle}${entityDisplayLinkHtml("sujet", sujetId)}` : "this";
+          targetHtml = sujetId
+            ? `sujet <a href="#" class="entity-link tl-note-inline-subject-link" data-nav-type="sujet" data-nav-id="${safeSujetId}">${safeSujetTitle ? `<span class="tl-note-inline-subject-title">${safeSujetTitle}</span>` : ""}<span class="tl-note-inline-subject-ref">${escapeHtml(sujetRefLabel)}</span></a>`
+            : "this";
         } else if (kind === "review_validated" || kind === "review_rejected" || kind === "review_dismissed" || kind === "review_restored") {
           const entityType = String(e?.entity_type || "").toLowerCase();
           const entityId = String(e?.entity_id || "");

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3962,6 +3962,24 @@ body.drilldown-open .drilldown__inner,
 .tl-note-inline--title-updated{display:inline;}
 .tl-note-inline--parent-added{display:flex;margin-top:4px;margin-right:0;}
 .tl-note-inline-link{display:inline-flex;align-items:center;gap:6px;}
+.tl-note-inline-subject-link{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  color:#fff;
+  text-decoration:underline;
+  text-decoration-color:#fff;
+  text-decoration-thickness:1px;
+}
+.tl-note-inline-subject-link:hover,
+.tl-note-inline-subject-link:focus-visible{
+  color:#fff;
+  text-decoration:underline;
+  text-decoration-color:#fff;
+  outline:none;
+}
+.tl-note-inline-subject-title{color:#fff;}
+.tl-note-inline-subject-ref{color:var(--muted);}
 .tl-note-inline-subject-status{display:inline-flex;align-items:center;}
 .tl-note-inline-text{display:inline;}
 .tl-note-inline-text--quote{padding-inline:1px;}


### PR DESCRIPTION
### Motivation

- Improve how linked subjects are rendered inside business activity notes so the link is a proper inline anchor with consistent metadata and safer escaping. 
- Ensure additional business events (child added and blocked_by removed) render inline linked subject previews like other relation events. 
- Add styling to match the new inline anchor markup and keep visual consistency.

### Description

- Update `renderLinkedSubjectInline` to build an anchor element using `entityDisplayLinkHtml` output as a label, extract the link label, and render a structured anchor with `data-nav-type` and `data-nav-id`, plus safer escaping of title and id. 
- Add handling to include `subject_child_added` and `subject_blocked_by_removed` in the inline rendering logic and update the inline rendering rules to treat these events like other relation events. 
- Change the `subject_child_added` icon in `BUSINESS_ACTIVITY_CONFIG` from `arrow-down` to `issue-tracks`. 
- Update issue close/reopen rendering to use the same inline anchor pattern (safe id/title escaping and extracted ref label). 
- Add CSS rules in `style.css` for `.tl-note-inline-subject-link`, `.tl-note-inline-subject-title`, and `.tl-note-inline-subject-ref` to style the new inline anchor and its pieces.

### Testing

- Ran the frontend unit test suite with `yarn test` and all tests passed. 
- Ran the CSS linter with `stylelint` and no issues were reported. 
- Performed a production build with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2637d0f08329acfb7390c475ed57)