### PR TITLE
Fix subject drilldown links and legacy #history activity fallback

### DIFF
--- a/apps/web/js/utils/subject-links.js
+++ b/apps/web/js/utils/subject-links.js
@@ -141,5 +141,21 @@ export function linkifySubjectRefsInHtml(html = "", { resolveSubjectByNumber } =
     textNode.parentNode?.replaceChild(fragment, textNode);
   });
 
+  const anchoredLinks = template.content.querySelectorAll("a[href]");
+  anchoredLinks.forEach((link) => {
+    if (!(link instanceof HTMLAnchorElement)) return;
+    if (String(link.dataset.subjectId || "").trim()) return;
+    const href = String(link.getAttribute("href") || "").trim();
+    const match = href.match(/^#(\d{1,7})$/);
+    if (!match) return;
+    const number = normalizeNumber(match[1]);
+    const subject = number ? resolveSubjectByNumber(number) : null;
+    if (!subject?.id) return;
+    link.setAttribute("href", "#");
+    link.classList.add("md-subject-link");
+    link.dataset.subjectId = String(subject.id || "");
+    link.dataset.subjectNumber = String(number);
+  });
+
   return template.innerHTML;
 }

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1648,7 +1648,29 @@ priority=${firstNonEmpty(subject.priority, "")}`
         }
 
         const note = String(e?.message || "").trim();
+        const hasKnownLegacyKind = [
+          "review_validated",
+          "review_rejected",
+          "review_dismissed",
+          "review_restored",
+          "description_version_initial",
+          "description_version_saved",
+          "subject_description_updated",
+          "message_posted",
+          "message_edited",
+          "message_frozen",
+          "conversation_locked",
+          "conversation_unlocked",
+          "attachments_linked"
+        ].includes(kind);
+        const isLegacyHistoryFallback = !hasKnownLegacyKind;
+        const historySource = firstNonEmpty(e?.meta?.source, e?.kind, "legacy");
+        const resolvedTargetHtml = isLegacyHistoryFallback ? "#history" : (targetHtml || "");
+        const legacyReason = isLegacyHistoryFallback
+          ? `Activité #history générée quand un événement historique n'est pas encore mappé (source: ${historySource}).`
+          : "";
         const noteHtml = note ? `<div class="tl-note">${mdToHtml(note)}</div>` : "";
+        const fallbackNoteHtml = !note && legacyReason ? `<div class="tl-note">${escapeHtml(legacyReason)}</div>` : "";
 
         return renderMessageThreadActivity({
           idx,
@@ -1658,10 +1680,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
             : miniAuthorIconHtml(agent),
           textHtml: `
             <span class="tl-author-name">${escapeHtml(displayName)}</span>
-            <span class="mono-small"> ${escapeHtml(verb)} ${targetHtml || ""} </span>
+            <span class="mono-small"> ${escapeHtml(verb)} ${resolvedTargetHtml} </span>
             <span class="mono-small">at ${escapeHtml(ts)}</span>
           `,
-          noteHtml
+          noteHtml: noteHtml || fallbackNoteHtml
         });
       }
 


### PR DESCRIPTION
### Motivation
- Prevent Markdown anchors like `[Sujet](#123)` from navigating to the page hash and instead open the in-app subject drilldown when the referenced subject exists.
- Make ambiguous legacy timeline entries (e.g. “Human update at …”) explicit and explain when a fallback `#history` activity is generated so users can distinguish unmapped historical events.

### Description
- Convert anchor nodes with `href="#<num>"` into internal subject links by adding `class="md-subject-link"` and `data-subject-id`/`data-subject-number` when `resolveSubjectByNumber` finds a subject (change in `apps/web/js/utils/subject-links.js`).
- Add a legacy-activity fallback in the thread renderer that detects unmapped/unknown business-event kinds, renders their target as `#history`, and inserts an explanatory note when no message is present (changes in `apps/web/js/views/project-subjects/project-subjects-thread.js`).
- Use the existing `.md-subject-link` handling so clicks on converted anchors reuse the drilldown opening behavior already wired in the subject UI.
- Modified files: `apps/web/js/utils/subject-links.js`, `apps/web/js/views/project-subjects/project-subjects-thread.js`.

### Testing
- Ran unit tests with `node --test apps/web/js/utils/markdown-renderer.test.mjs apps/web/js/services/subject-timeline-merge.test.mjs` and all tests passed (6/6).
- No browser-end-to-end tests were run in this environment; changes rely on existing DOM click handlers for `.md-subject-link` to open drilldowns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea38c64d9c8329a48af93b2febc45a)