### PR TITLE
Enhance subject linkification, activity rendering for kanban status changes, and human actor labeling

### DIFF
--- a/apps/web/js/utils/subject-links.js
+++ b/apps/web/js/utils/subject-links.js
@@ -141,5 +141,21 @@ export function linkifySubjectRefsInHtml(html = "", { resolveSubjectByNumber } =
     textNode.parentNode?.replaceChild(fragment, textNode);
   });
 
+  const anchoredLinks = template.content.querySelectorAll("a[href]");
+  anchoredLinks.forEach((link) => {
+    if (!(link instanceof HTMLAnchorElement)) return;
+    if (String(link.dataset.subjectId || "").trim()) return;
+    const href = String(link.getAttribute("href") || "").trim();
+    const match = href.match(/^#(\d{1,7})$/);
+    if (!match) return;
+    const number = normalizeNumber(match[1]);
+    const subject = number ? resolveSubjectByNumber(number) : null;
+    if (!subject?.id) return;
+    link.setAttribute("href", "#");
+    link.classList.add("md-subject-link");
+    link.dataset.subjectId = String(subject.id || "");
+    link.dataset.subjectNumber = String(number);
+  });
+
   return template.innerHTML;
 }

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -47,6 +47,18 @@ export function createProjectSubjectsActions(config) {
     rerenderPanels
   } = config;
 
+  function resolveDefaultHumanActorLabel() {
+    const user = store?.user && typeof store.user === "object" ? store.user : {};
+    const firstName = String(user.firstName || "").trim();
+    const lastName = String(user.lastName || "").trim();
+    const fullName = `${firstName} ${lastName}`.trim();
+    return fullName
+      || String(user.fullName || "").trim()
+      || String(user.name || "").trim()
+      || String(user.email || "").trim()
+      || "Human";
+  }
+
   function setSujetKanbanStatus(sujetId, nextStatus, options = {}) {
     const normalized = normalizeSujetKanbanStatus(nextStatus);
     const situationId = String(options.situationId || "");
@@ -67,7 +79,7 @@ export function createProjectSubjectsActions(config) {
         entity_id: situationId,
         type: "ACTIVITY",
         kind: "sujet_kanban_status_changed",
-        actor: options.actor || "Human",
+        actor: options.actor || resolveDefaultHumanActorLabel(),
         agent: options.agent || "human",
         message: "",
         meta: {

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1298,6 +1298,16 @@ priority=${firstNonEmpty(subject.priority, "")}`
     `;
   }
 
+  function getSituationKanbanStatusLabel(statusKey = "") {
+    const normalized = String(statusKey || "").trim().toLowerCase();
+    if (normalized === "non_active") return "Non activé";
+    if (normalized === "to_activate") return "À activer";
+    if (normalized === "in_progress") return "En cours";
+    if (normalized === "in_arbitration") return "En arbitrage";
+    if (normalized === "resolved") return "Résolu";
+    return "—";
+  }
+
   function renderLinkedSubjectInline(counterpartId = "", fallbackTitle = "") {
     const subject = counterpartId ? getNestedSujet(counterpartId) : null;
     const status = String(getEffectiveSujetStatus(counterpartId) || subject?.status || "open").toLowerCase();
@@ -1446,7 +1456,7 @@ priority=${firstNonEmpty(subject.priority, "")}`
 
       if (type === "ACTIVITY") {
         const kind = String(e?.kind || "").toLowerCase();
-        if (kind === "message_deleted" || kind === "issue_closed" || kind === "issue_reopened") return "";
+        if (kind === "message_deleted" || kind === "issue_closed" || kind === "issue_reopened" || kind === "message_frozen") return "";
         if (String(e?.meta?.source || "") === "subject_history") {
           const activityIdentity = getAuthorIdentity({
             author: e?.actor,
@@ -1557,6 +1567,27 @@ priority=${firstNonEmpty(subject.priority, "")}`
         });
         const displayName = activityIdentity.displayName;
         const ts = fmtTs(e?.ts || "");
+        if (kind === "sujet_kanban_status_changed") {
+          const fromStatus = getSituationKanbanStatusLabel(e?.meta?.from);
+          const toStatus = getSituationKanbanStatusLabel(e?.meta?.to);
+          const situationId = normalizeId(e?.meta?.situation_id || e?.entity_id);
+          const inlineSituationHtml = renderSituationInline(situationId, "Situation");
+          return renderMessageThreadActivity({
+            idx,
+            className: "thread-item--business thread-item--business-rel thread-item--event-subject-situation-status-changed",
+            iconHtml: `<span class="tl-ico tl-ico--business tl-ico--business-rel" aria-hidden="true">${svgIcon("table")}</span>`,
+            authorIconHtml: activityIdentity.avatarHtml
+              ? `<span class="tl-author tl-author--custom" aria-hidden="true">${activityIdentity.avatarHtml}</span>`
+              : miniAuthorIconHtml("human"),
+            textHtml: `
+              <span class="tl-author-name">${escapeHtml(displayName)}</span>
+              <span class="mono-small"> a modifié de l'état </span>
+              <span class="tl-note-inline"><span class="tl-note-inline-text">${escapeHtml(fromStatus)}</span><span class="mono-small"> à </span><span class="tl-note-inline-text">${escapeHtml(toStatus)}</span><span class="mono-small"> dans la situation </span>${inlineSituationHtml}</span>
+              <span class="mono-small tl-time-inline"><span aria-hidden="true">·</span><span>${escapeHtml(ts)}</span></span>
+            `,
+            noteHtml: ""
+          });
+        }
         let iconHtml = `<span class="tl-ico tl-ico--muted" aria-hidden="true"></span>`;
         let verb = "updated";
         let targetHtml = "";
@@ -1648,7 +1679,29 @@ priority=${firstNonEmpty(subject.priority, "")}`
         }
 
         const note = String(e?.message || "").trim();
+        const hasKnownLegacyKind = [
+          "review_validated",
+          "review_rejected",
+          "review_dismissed",
+          "review_restored",
+          "description_version_initial",
+          "description_version_saved",
+          "subject_description_updated",
+          "message_posted",
+          "message_edited",
+          "message_frozen",
+          "conversation_locked",
+          "conversation_unlocked",
+          "attachments_linked"
+        ].includes(kind);
+        const isLegacyHistoryFallback = !hasKnownLegacyKind;
+        const historySource = firstNonEmpty(e?.meta?.source, e?.kind, "legacy");
+        const resolvedTargetHtml = isLegacyHistoryFallback ? "#history" : (targetHtml || "");
+        const legacyReason = isLegacyHistoryFallback
+          ? `Activité #history générée quand un événement historique n'est pas encore mappé (source: ${historySource}).`
+          : "";
         const noteHtml = note ? `<div class="tl-note">${mdToHtml(note)}</div>` : "";
+        const fallbackNoteHtml = !note && legacyReason ? `<div class="tl-note">${escapeHtml(legacyReason)}</div>` : "";
 
         return renderMessageThreadActivity({
           idx,
@@ -1658,10 +1711,10 @@ priority=${firstNonEmpty(subject.priority, "")}`
             : miniAuthorIconHtml(agent),
           textHtml: `
             <span class="tl-author-name">${escapeHtml(displayName)}</span>
-            <span class="mono-small"> ${escapeHtml(verb)} ${targetHtml || ""} </span>
+            <span class="mono-small"> ${escapeHtml(verb)} ${resolvedTargetHtml} </span>
             <span class="mono-small">at ${escapeHtml(ts)}</span>
           `,
-          noteHtml
+          noteHtml: noteHtml || fallbackNoteHtml
         });
       }
 


### PR DESCRIPTION
### Motivation
- Convert existing anchor references like `#123` into interactive subject links when possible to improve link behavior and metadata availability.
- Provide a sensible default display name for human actors in activity records instead of a generic `Human` label.
- Render and surface kanban status change activities for subjects in the thread view and provide clearer fallback handling for legacy history events.

### Description
- In `utils/subject-links.js` added post-processing that scans existing `a[href]` anchors and converts `href="#<number>"` anchors into subject links by setting `href` to `#`, adding the `md-subject-link` class, and populating `data-subject-id` and `data-subject-number` using `resolveSubjectByNumber` and `normalizeNumber`.
- In `project-subjects-actions.js` introduced `resolveDefaultHumanActorLabel()` to build a readable actor label from `store.user` fields and used it as the default `actor` when persisting `sujet_kanban_status_changed` activities.
- In `project-subjects-thread.js` added `getSituationKanbanStatusLabel()` to localize status keys to French labels, implemented rendering for `sujet_kanban_status_changed` activities to show from/to statuses and the situation inline, extended filtering to treat `message_frozen` appropriately, and added legacy-activity detection with a fallback explanatory note when an event kind is not explicitly mapped.

### Testing
- Ran the JavaScript unit test suite with `yarn test` and the tests covering thread rendering and subject link utilities passed.
- Ran the linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea38c64d9c8329a48af93b2febc45a)