### PR TITLE
Ajuste l'alignement des lignes d'activité dans la timeline

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -3874,7 +3874,7 @@ body.drilldown-open .drilldown__inner,
 .thread-item--activity::before{display:block;height:auto;}
 .tl-activity{
   display:flex;
-  align-items:center;
+  align-items:flex-start;
   gap:10px;
   padding:4px 12px 8px 57px;
 }
@@ -3891,11 +3891,20 @@ body.drilldown-open .drilldown__inner,
   justify-content:center;
   flex:0 0 auto;
   overflow:hidden;
+  margin-top:7px;
 }
 .tl-author--human svg{width:14px;height:14px;}
 .tl-author--agent{font-size:11px;color:var(--text);line-height:1;}
 
-.tl-activity__text{min-width:0;white-space:normal;overflow:visible;text-overflow:clip;word-break:break-word;}
+.tl-activity__text{
+  min-width:0;
+  white-space:normal;
+  overflow:visible;
+  text-overflow:clip;
+  word-break:break-word;
+  line-height:20px;
+  padding-top:6px;
+}
 .tl-author-name{font-weight:600;color:var(--text);font-size:14px;margin-right:2px;}
 .tl-note{
   margin:0 12px 8px 127px; /* align with .tl-activity__text */


### PR DESCRIPTION
### Motivation
- Corriger l'alignement vertical pour que l'icône de timeline, l'icône de l'auteur et la première ligne de texte soient alignés et que toute deuxième ligne se place naturellement en dessous alignée à gauche.

### Description
- Modifie `apps/web/style.css` en passant ` .tl-activity { align-items: flex-start; }`, en ajoutant `margin-top: 7px` à `.tl-author` et en définissant `line-height: 20px` et `padding-top: 6px` sur `.tl-activity__text` pour centrer visuellement la première ligne par rapport aux icônes.

### Testing
- L'exécution de la vérification automatique `git diff --check` a réussi et la vérification d'état a confirmé la modification unique de `apps/web/style.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea43f0128883299f472365f58b0205)