### PR TITLE
Refactor subissue indentation to single dynamic spacer

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2416,8 +2416,8 @@ function renderSubIssuesForSujet(sujet, options = {}) {
     const isExpanded = hasChildren && expandedIds.has(subjectId);
     const canDrag = depth === 0;
     const isRowMenuOpen = openMenuId === subjectId;
-    const nestedSpacerCells = depth > 0
-      ? new Array(depth).fill('<div class="cell cell-subissue-drag-spacer" aria-hidden="true"></div>').join("")
+    const nestedSpacerCell = depth > 0
+      ? `<div class="cell cell-subissue-drag-spacer" style="width:${depth * 24}px" aria-hidden="true"></div>`
       : "";
 
     rows.push(`
@@ -2438,7 +2438,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
               </button>`
             : ""}
         </div>
-        ${nestedSpacerCells}
+        ${nestedSpacerCell}
         <div class="cell cell-subissue-drag-spacer">
           ${hasChildren
             ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">


### PR DESCRIPTION
### Motivation
- Reduce DOM bloat and simplify indentation logic by replacing multiple repeated spacer elements with a single spacer whose width is computed from the node depth (`depth * 24px`).

### Description
- Update `renderSubIssuesForSujet` in `apps/web/js/views/project-subjects/project-subjects-view.js` to render one `div.cell.cell-subissue-drag-spacer` with an inline `style="width:${depth * 24}px"` instead of creating `depth` duplicated spacer `div`s.

### Testing
- Ran `node --check apps/web/js/views/project-subjects/project-subjects-view.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafa7a94288329a7e91136ff80d3ec)