### PR TITLE
Add localized subissues panel rerender and optimize nested spacer markup

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -394,6 +394,7 @@ const projectSubjectsEvents = createProjectSubjectsEvents({
   getSubjectMetaMenuEntries: (...args) => projectSubjectsView.getSubjectMetaMenuEntries(...args),
   getSubjectSidebarMeta: (...args) => projectSubjectsView.getSubjectSidebarMeta(...args),
   rerenderScope: (...args) => projectSubjectsView.rerenderScope(...args),
+  rerenderSubissuesPanelScope: (...args) => projectSubjectsView.rerenderSubissuesPanelScope(...args),
   syncSubjectMetaDropdownPosition: (...args) => projectSubjectsView.syncSubjectMetaDropdownPosition(...args),
   getSubjectMetaScopeRoot: (...args) => projectSubjectsView.getSubjectMetaScopeRoot(...args),
   getSubjectKanbanMenuEntries: (...args) => projectSubjectsView.getSubjectKanbanMenuEntries(...args),

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -34,6 +34,7 @@ export function createProjectSubjectsEvents(config) {
     getSubjectMetaMenuEntries,
     getSubjectSidebarMeta,
     rerenderScope,
+    rerenderSubissuesPanelScope,
     getInlineReplyUiState,
     syncSubjectMetaDropdownPosition,
     getSubjectMetaScopeRoot,
@@ -2796,7 +2797,8 @@ export function createProjectSubjectsEvents(config) {
     root.querySelectorAll("[data-action='toggle-subissues']").forEach((btn) => {
       btn.onclick = () => {
         scopedUiState.rightSubissuesOpen = !scopedUiState.rightSubissuesOpen;
-        rerenderDetailsScope();
+        if (typeof rerenderSubissuesPanelScope === "function" && rerenderSubissuesPanelScope(btn)) return;
+        rerenderScope(btn);
       };
     });
 
@@ -2811,7 +2813,8 @@ export function createProjectSubjectsEvents(config) {
         if (!subjectId) return;
         if (subissuesExpandedSet.has(subjectId)) subissuesExpandedSet.delete(subjectId);
         else subissuesExpandedSet.add(subjectId);
-        rerenderDetailsScope();
+        if (typeof rerenderSubissuesPanelScope === "function" && rerenderSubissuesPanelScope(btn)) return;
+        rerenderScope(btn);
       };
     });
 
@@ -2821,7 +2824,8 @@ export function createProjectSubjectsEvents(config) {
         event.stopPropagation();
         const subjectId = String(btn.dataset.subissueActionsTrigger || "");
         scopedUiState.rightSubissueMenuOpenId = String(scopedUiState.rightSubissueMenuOpenId || "") === subjectId ? "" : subjectId;
-        rerenderDetailsScope();
+        if (typeof rerenderSubissuesPanelScope === "function" && rerenderSubissuesPanelScope(btn)) return;
+        rerenderScope(btn);
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2416,8 +2416,8 @@ function renderSubIssuesForSujet(sujet, options = {}) {
     const isExpanded = hasChildren && expandedIds.has(subjectId);
     const canDrag = depth === 0;
     const isRowMenuOpen = openMenuId === subjectId;
-    const nestedSpacerCells = depth > 0
-      ? new Array(depth).fill('<div class="cell cell-subissue-drag-spacer" aria-hidden="true"></div>').join("")
+    const nestedSpacerCell = depth > 0
+      ? `<div class="cell cell-subissue-drag-spacer" style="width:${depth * 24}px" aria-hidden="true"></div>`
       : "";
 
     rows.push(`
@@ -2438,7 +2438,7 @@ function renderSubIssuesForSujet(sujet, options = {}) {
               </button>`
             : ""}
         </div>
-        ${nestedSpacerCells}
+        ${nestedSpacerCell}
         <div class="cell cell-subissue-drag-spacer">
           ${hasChildren
             ? `<button type="button" class="subissue-tree-toggle js-subissue-tree-toggle" data-subissue-tree-toggle="${escapeHtml(subjectId)}" aria-label="${isExpanded ? "Replier" : "Déplier"} le sous-sujet">
@@ -2723,6 +2723,73 @@ function rerenderCreateSubissueModal() {
   const modalScopeRoot = bumpInteractiveEpoch(modalHost);
   wireDetailsInteractive(modalScopeRoot);
   return modalScopeRoot;
+}
+
+function rerenderSubissuesPanelScope(root, options = {}) {
+  if (!root || !root.isConnected) return false;
+  ensureViewUiState();
+  const targetPanel = root.closest?.(".details-subissues");
+  if (!targetPanel) return false;
+
+  const isDrilldownScope = !!targetPanel.closest?.("#drilldownPanel");
+  const isModalScope = !!targetPanel.closest?.("#detailsBodyModal");
+  const uiState = getSubjectsViewState();
+  const scopedUiState = (() => {
+    if (isModalScope) {
+      if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") {
+        store.projectSubjectsView = {};
+      }
+      return store.projectSubjectsView;
+    }
+    if (!isDrilldownScope) return uiState;
+    if (!uiState.drilldown || typeof uiState.drilldown !== "object") {
+      uiState.drilldown = {};
+    }
+    return uiState.drilldown;
+  })();
+  const scopeHost = isDrilldownScope ? "drilldown" : "main";
+  const scopedSelection = options.selectionOverride || getSelectionForScope(scopeHost);
+  if (!scopedSelection?.item) return false;
+
+  if (typeof scopedUiState.rightSubissuesOpen !== "boolean") scopedUiState.rightSubissuesOpen = true;
+  if (!(scopedUiState.rightSubissuesExpandedSubjectIds instanceof Set)) {
+    scopedUiState.rightSubissuesExpandedSubjectIds = new Set(
+      Array.isArray(scopedUiState.rightSubissuesExpandedSubjectIds) ? scopedUiState.rightSubissuesExpandedSubjectIds : []
+    );
+  }
+  if (!(scopedUiState.rightExpandedSujets instanceof Set)) {
+    scopedUiState.rightExpandedSujets = new Set(
+      Array.isArray(scopedUiState.rightExpandedSujets) ? scopedUiState.rightExpandedSujets : []
+    );
+  }
+  if (typeof scopedUiState.rightSubissueMenuOpenId !== "string") scopedUiState.rightSubissueMenuOpenId = "";
+
+  const subissuesOptions = {
+    sujetRowClass: "js-modal-drilldown-sujet",
+    sujetToggleClass: "js-modal-toggle-sujet",
+    avisRowClass: "js-modal-drilldown-avis",
+    expandedSujets: scopedUiState.rightExpandedSujets,
+    expandedSubjectIds: scopedUiState.rightSubissuesExpandedSubjectIds,
+    openMenuId: scopedUiState.rightSubissueMenuOpenId,
+    isOpen: scopedUiState.rightSubissuesOpen
+  };
+
+  const nextPanelHtml = scopedSelection.type === "sujet"
+    ? renderSubIssuesForSujet(scopedSelection.item, subissuesOptions)
+    : renderSubIssuesForSituation(scopedSelection.item, subissuesOptions);
+  if (!nextPanelHtml) return false;
+  const template = document.createElement("template");
+  template.innerHTML = String(nextPanelHtml || "").trim();
+  const nextPanel = template.content.firstElementChild;
+  if (!nextPanel) return false;
+
+  targetPanel.replaceWith(nextPanel);
+  wireDetailsInteractive(bumpInteractiveEpoch(nextPanel));
+  debugRenderScope("details-subissues", {
+    mode: "local-subissues-rerender",
+    host: isDrilldownScope ? "drilldown" : "main"
+  });
+  return true;
 }
 
 function rerenderPanels() {
@@ -3662,6 +3729,7 @@ function getObjectiveById(objectiveId) {
     renderCreateSubjectFormHtml,
     rerenderSubjectsToolbar,
     syncSituationsPrimaryScrollSource,
+    rerenderSubissuesPanelScope,
     rerenderPanels,
     rerenderScope,
     scheduleScopedRerender,


### PR DESCRIPTION
### Motivation
- Improve rendering performance and UX by allowing the subissues panel to be rerendered locally without re-rendering the entire details scope. 
- Reduce DOM complexity for nested subissue indentation by replacing multiple spacer cells with a single width-controlled spacer element.

### Description
- Added a new `rerenderSubissuesPanelScope` function in `project-subjects-view.js` that locally re-renders the `.details-subissues` panel and wires interactive behavior when possible. 
- Plumbed `rerenderSubissuesPanelScope` through to the events layer by adding it to the `createProjectSubjectsEvents` config in `project-subjects.js` and `project-subjects-events.js`. 
- Updated subissues interaction handlers in `project-subjects-events.js` to call `rerenderSubissuesPanelScope` first and fall back to `rerenderScope` only when local rerendering is not applicable. 
- Simplified subissue nesting markup in `renderSubIssuesForSujet` by replacing the `nestedSpacerCells` array with a single `div` whose inline `width` is computed from `depth`.

### Testing
- Ran the frontend unit test suite and integration tests; all tests completed successfully. 
- Ran the project's linter/format checks (`eslint`); no new lint errors were introduced. 
- Performed localized UI smoke checks for subissue toggles, tree expand/collapse and action menu interactions to confirm the local rerender behavior and spacing adjustments work as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafa7a94288329a7e91136ff80d3ec)