### PR TITLE
Améliore le kanban de situation (hauteur colonne, header compact au scroll, tabs de vue)

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -1,6 +1,6 @@
 import { store } from "../store.js";
 import { PROJECT_TAB_RESELECTED_EVENT } from "./project-header.js";
-import { registerProjectScrollSources, setProjectViewHeader } from "./project-shell-chrome.js";
+import { registerProjectScrollSources, setProjectActiveScrollSource, setProjectViewHeader } from "./project-shell-chrome.js";
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
 import { loadFlatSubjectsForCurrentProject } from "../services/project-subjects-supabase.js";
 import {
@@ -252,6 +252,17 @@ function rerender(root) {
   const tableScrollBody = root.querySelector(".issues-table .data-table-shell__body");
   const kanbanColumnBodies = [...root.querySelectorAll(".situation-kanban__cards")];
   registerProjectScrollSources(primaryScrollRoot, tableScrollBody, kanbanColumnBodies);
+  root.querySelectorAll(".situation-kanban__col").forEach((column) => {
+    column.addEventListener("mouseenter", () => {
+      setProjectActiveScrollSource(column);
+    });
+    column.addEventListener("wheel", () => {
+      setProjectActiveScrollSource(column);
+    }, { passive: true });
+    column.addEventListener("touchstart", () => {
+      setProjectActiveScrollSource(column);
+    }, { passive: true });
+  });
   bindEvents(root);
   bindViewEvents(root);
   kanbanView.bindKanbanEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1,3 +1,5 @@
+import { bindLightTabs } from "../ui/light-tabs.js";
+
 function syncSubmitButtonState(button, { submitting = false, title = "" } = {}) {
   if (!button) return;
   button.disabled = submitting || !String(title || "").trim();
@@ -279,6 +281,18 @@ export function createProjectSituationsEvents({
         store.situationsView.filters.status = value;
         rerender(root);
       });
+    });
+
+    bindLightTabs(root, {
+      selector: ".project-situation-layout-tabs [data-light-tab-target]",
+      onChange: (nextTabId) => {
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        const normalizedTabId = String(nextTabId || "").trim().toLowerCase();
+        const nextLayout = ["grille", "tableau", "planning"].includes(normalizedTabId) ? normalizedTabId : "tableau";
+        if (store.situationsView.selectedSituationLayout === nextLayout) return;
+        store.situationsView.selectedSituationLayout = nextLayout;
+        rerender(root);
+      }
     });
 
     bindCreateModalEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-state.js
+++ b/apps/web/js/views/project-situations/project-situations-state.js
@@ -87,6 +87,13 @@ export function createProjectSituationsState({ store }) {
     if (!view.kanbanStatusBySituationId || typeof view.kanbanStatusBySituationId !== "object" || Array.isArray(view.kanbanStatusBySituationId)) {
       view.kanbanStatusBySituationId = {};
     }
+    if (typeof view.selectedSituationLayout !== "string") {
+      view.selectedSituationLayout = "tableau";
+    }
+    view.selectedSituationLayout = String(view.selectedSituationLayout || "").trim().toLowerCase();
+    if (!["grille", "tableau", "planning"].includes(view.selectedSituationLayout)) {
+      view.selectedSituationLayout = "tableau";
+    }
     if (!view.pagination || typeof view.pagination !== "object") {
       view.pagination = {
         mode: "full",

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -3,6 +3,7 @@ import { svgIcon } from "../../ui/icons.js";
 import { renderSettingsModal } from "../ui/settings-modal.js";
 import { renderStatusBadge } from "../ui/status-badges.js";
 import { renderSideNavLayout, renderSideNavGroup, renderSideNavItem } from "../ui/side-nav-layout.js";
+import { renderLightTabs } from "../ui/light-tabs.js";
 import { renderSituationForm } from "./project-situations-form.js";
 
 export function createProjectSituationsView({
@@ -15,6 +16,35 @@ export function createProjectSituationsView({
   getSituationById,
   renderSituationKanban
 }) {
+  function getSelectedSituationLayout() {
+    const layout = String(store.situationsView?.selectedSituationLayout || "").trim().toLowerCase();
+    return ["grille", "tableau", "planning"].includes(layout) ? layout : "tableau";
+  }
+
+  function renderSituationLayoutTabs() {
+    return renderLightTabs({
+      tabs: [
+        { id: "grille", label: "Grille" },
+        { id: "tableau", label: "Tableau" },
+        { id: "planning", label: "Planning" }
+      ],
+      activeTabId: getSelectedSituationLayout(),
+      ariaLabel: "Modes d'affichage de la situation",
+      className: "settings-lots-tabs project-situation-layout-tabs"
+    });
+  }
+
+  function renderSelectedSituationLayoutBody(selectedSituation) {
+    const selectedLayout = getSelectedSituationLayout();
+    if (selectedLayout === "tableau") {
+      return renderSituationKanban(selectedSituation, uiState.selectedSituationSubjects, { loading: uiState.selectedSituationLoading });
+    }
+    if (selectedLayout === "grille") {
+      return `<div class="settings-empty-state">Vue grille disponible prochainement.</div>`;
+    }
+    return `<div class="settings-empty-state">Vue planning disponible prochainement.</div>`;
+  }
+
   function renderCreateSituationModal() {
     if (!uiState.createModalOpen) return "";
 
@@ -86,7 +116,10 @@ export function createProjectSituationsView({
           ${uiState.selectedSituationError ? `<div class="settings-inline-error">${escapeHtml(uiState.selectedSituationError)}</div>` : ""}
           ${uiState.selectedSituationLoading
             ? `<div class="settings-empty-state">Chargement des sujets de la situation…</div>`
-            : renderSituationKanban(selectedSituation, uiState.selectedSituationSubjects, { loading: uiState.selectedSituationLoading })}
+            : `
+              ${renderSituationLayoutTabs()}
+              ${renderSelectedSituationLayoutBody(selectedSituation)}
+            `}
         </div>
       </section>
     `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9914,7 +9914,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   flex:1 1 auto;
   width:max-content;
   min-width:100%;
-  min-height:100%;
+  min-height:calc(100vh - 180px);
   gap:12px;
   padding:8px 16px 16px;
 }
@@ -9925,14 +9925,15 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   background:var(--bgAssistPanel);
   border:none;
   border-radius:12px;
-  padding:8px;
+  padding:8px 8px 12px;
   display:flex;
   flex-direction:column;
   gap:12px;
   min-height:100%;
-  height:auto;
+  height:100%;
   align-self:stretch;
-  overflow:hidden;
+  overflow-y:auto;
+  overflow-x:hidden;
 }
 
 @media (max-width: 1480px){
@@ -10013,7 +10014,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   min-height:220px;
   height:100%;
   flex:1 1 auto;
-  overflow-y:auto;
+  overflow-y:visible;
   overflow-x:hidden;
   padding-bottom:8px;
 }
@@ -13222,6 +13223,10 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-detail-head__description{
   max-width:860px;
+}
+
+.project-situation-layout-tabs{
+  margin:0 16px 12px;
 }
 
 .project-situations-table__title-inline{


### PR DESCRIPTION
### Motivation
- Permettre aux colonnes du kanban de situation d’occuper toute la hauteur disponible et de gérer le scroll au niveau de la colonne pour une meilleure lisibilité et ergonomie. 
- Activer le mode header compact lorsque l’utilisateur scroll/interagit dans une colonne pour gagner de l’espace à l’écran. 
- Ajouter un jeu d’onglets de présentation sous le titre de la situation pour permettre de basculer entre plusieurs vues (Grille / Tableau / Planning), avec `Tableau` comme valeur par défaut.

### Description
- Ajout d’un état de vue `store.situationsView.selectedSituationLayout` géré/fallback via `createProjectSituationsState` et normalisé à `grille|tableau|planning` (fallback `tableau`).
- Rendu des tabs sous le titre via le composant partagé `renderLightTabs` et binding des actions avec `bindLightTabs` pour rerenderer la vue selon l’onglet (`Grille`, `Tableau`, `Planning`) ; l’onglet `Tableau` affiche le kanban et les autres affichent des placeholders pour l’instant.
- Ajustements CSS pour que `.situation-kanban__col` monte jusqu’en bas du viewport, ait `padding-bottom: 12px`, soit scrollable (`overflow-y:auto`) et que le conteneur `.situation-kanban` ait une `min-height` cohérente avec le viewport.
- Activation du mode header compact lors d’interactions/scroll sur une colonne en enregistrant la colonne comme source active de scroll via `setProjectActiveScrollSource` sur `mouseenter`, `wheel` et `touchstart`.

### Testing
- Vérification de syntaxe JavaScript exécutée avec `node --check` sur les fichiers modifiés (`apps/web/js/views/project-situations.js`, `apps/web/js/views/project-situations/project-situations-view.js`, `apps/web/js/views/project-situations/project-situations-events.js`) — réussite.
- Aucune erreur de parsing JS détectée durant les contrôles automatiques lancés dans l’environnement (syntaxe OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb004a73d48329bb896f4b599ceec1)