### PR TITLE
Add selectable situation layouts (grid/tableau/roadmap) and improve kanban scrolling behavior

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -1,6 +1,6 @@
 import { store } from "../store.js";
 import { PROJECT_TAB_RESELECTED_EVENT } from "./project-header.js";
-import { registerProjectScrollSources, setProjectViewHeader } from "./project-shell-chrome.js";
+import { registerProjectScrollSources, setProjectActiveScrollSource, setProjectViewHeader } from "./project-shell-chrome.js";
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
 import { loadFlatSubjectsForCurrentProject } from "../services/project-subjects-supabase.js";
 import {
@@ -252,6 +252,17 @@ function rerender(root) {
   const tableScrollBody = root.querySelector(".issues-table .data-table-shell__body");
   const kanbanColumnBodies = [...root.querySelectorAll(".situation-kanban__cards")];
   registerProjectScrollSources(primaryScrollRoot, tableScrollBody, kanbanColumnBodies);
+  root.querySelectorAll(".situation-kanban__col").forEach((column) => {
+    column.addEventListener("mouseenter", () => {
+      setProjectActiveScrollSource(column);
+    });
+    column.addEventListener("wheel", () => {
+      setProjectActiveScrollSource(column);
+    }, { passive: true });
+    column.addEventListener("touchstart", () => {
+      setProjectActiveScrollSource(column);
+    }, { passive: true });
+  });
   bindEvents(root);
   bindViewEvents(root);
   kanbanView.bindKanbanEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1,3 +1,5 @@
+import { bindLightTabs } from "../ui/light-tabs.js";
+
 function syncSubmitButtonState(button, { submitting = false, title = "" } = {}) {
   if (!button) return;
   button.disabled = submitting || !String(title || "").trim();
@@ -279,6 +281,19 @@ export function createProjectSituationsEvents({
         store.situationsView.filters.status = value;
         rerender(root);
       });
+    });
+
+    bindLightTabs(root, {
+      selector: ".project-situation-layout-tabs [data-light-tab-target]",
+      onChange: (nextTabId) => {
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        const normalizedTabId = String(nextTabId || "").trim().toLowerCase();
+        const resolvedTabId = normalizedTabId === "planning" ? "roadmap" : normalizedTabId;
+        const nextLayout = ["grille", "tableau", "roadmap"].includes(resolvedTabId) ? resolvedTabId : "tableau";
+        if (store.situationsView.selectedSituationLayout === nextLayout) return;
+        store.situationsView.selectedSituationLayout = nextLayout;
+        rerender(root);
+      }
     });
 
     bindCreateModalEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-state.js
+++ b/apps/web/js/views/project-situations/project-situations-state.js
@@ -87,6 +87,16 @@ export function createProjectSituationsState({ store }) {
     if (!view.kanbanStatusBySituationId || typeof view.kanbanStatusBySituationId !== "object" || Array.isArray(view.kanbanStatusBySituationId)) {
       view.kanbanStatusBySituationId = {};
     }
+    if (typeof view.selectedSituationLayout !== "string") {
+      view.selectedSituationLayout = "tableau";
+    }
+    view.selectedSituationLayout = String(view.selectedSituationLayout || "").trim().toLowerCase();
+    if (view.selectedSituationLayout === "planning") {
+      view.selectedSituationLayout = "roadmap";
+    }
+    if (!["grille", "tableau", "roadmap"].includes(view.selectedSituationLayout)) {
+      view.selectedSituationLayout = "tableau";
+    }
     if (!view.pagination || typeof view.pagination !== "object") {
       view.pagination = {
         mode: "full",

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -1,0 +1,14 @@
+import { escapeHtml } from "../../utils/escape-html.js";
+
+export function renderSituationGridView(situation, subjects = []) {
+  const subjectCount = Array.isArray(subjects) ? subjects.length : 0;
+  const title = String(situation?.title || "Situation");
+
+  return `
+    <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
+      <div class="settings-empty-state">
+        La vue grille de <strong>${escapeHtml(title)}</strong> sera affichée ici (${subjectCount} sujet(s)).
+      </div>
+    </section>
+  `;
+}

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -1,0 +1,14 @@
+import { escapeHtml } from "../../utils/escape-html.js";
+
+export function renderSituationRoadmapView(situation, subjects = []) {
+  const subjectCount = Array.isArray(subjects) ? subjects.length : 0;
+  const title = String(situation?.title || "Situation");
+
+  return `
+    <section class="project-situation-alt-view project-situation-alt-view--roadmap" aria-label="Vue trajectoire">
+      <div class="settings-empty-state">
+        La vue trajectoire de <strong>${escapeHtml(title)}</strong> sera affichée ici (${subjectCount} sujet(s)).
+      </div>
+    </section>
+  `;
+}

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -3,7 +3,10 @@ import { svgIcon } from "../../ui/icons.js";
 import { renderSettingsModal } from "../ui/settings-modal.js";
 import { renderStatusBadge } from "../ui/status-badges.js";
 import { renderSideNavLayout, renderSideNavGroup, renderSideNavItem } from "../ui/side-nav-layout.js";
+import { renderLightTabs } from "../ui/light-tabs.js";
 import { renderSituationForm } from "./project-situations-form.js";
+import { renderSituationGridView } from "./project-situations-view-grid.js";
+import { renderSituationRoadmapView } from "./project-situations-view-roadmap.js";
 
 export function createProjectSituationsView({
   store,
@@ -15,6 +18,36 @@ export function createProjectSituationsView({
   getSituationById,
   renderSituationKanban
 }) {
+  function getSelectedSituationLayout() {
+    const layout = String(store.situationsView?.selectedSituationLayout || "").trim().toLowerCase();
+    if (layout === "planning") return "roadmap";
+    return ["grille", "tableau", "roadmap"].includes(layout) ? layout : "tableau";
+  }
+
+  function renderSituationLayoutTabs() {
+    return renderLightTabs({
+      tabs: [
+        { id: "grille", label: "Grille" },
+        { id: "tableau", label: "Tableau" },
+        { id: "roadmap", label: "Trajectoire" }
+      ],
+      activeTabId: getSelectedSituationLayout(),
+      ariaLabel: "Modes d'affichage de la situation",
+      className: "settings-lots-tabs project-situation-layout-tabs"
+    });
+  }
+
+  function renderSelectedSituationLayoutBody(selectedSituation) {
+    const selectedLayout = getSelectedSituationLayout();
+    if (selectedLayout === "tableau") {
+      return renderSituationKanban(selectedSituation, uiState.selectedSituationSubjects, { loading: uiState.selectedSituationLoading });
+    }
+    if (selectedLayout === "grille") {
+      return renderSituationGridView(selectedSituation, uiState.selectedSituationSubjects);
+    }
+    return renderSituationRoadmapView(selectedSituation, uiState.selectedSituationSubjects);
+  }
+
   function renderCreateSituationModal() {
     if (!uiState.createModalOpen) return "";
 
@@ -79,6 +112,7 @@ export function createProjectSituationsView({
                 <div class="project-situation-detail-head__meta">${statusBadge}${modeBadge}<span class="mono-small">${uiState.selectedSituationSubjects.length} sujet(s)</span></div>
               </div>
               ${selectedSituation.description ? `<div class="issue-row-meta-text project-situation-detail-head__description">${escapeHtml(selectedSituation.description)}</div>` : ""}
+              ${renderSituationLayoutTabs()}
             </div>
           </div>
         </div>
@@ -86,7 +120,7 @@ export function createProjectSituationsView({
           ${uiState.selectedSituationError ? `<div class="settings-inline-error">${escapeHtml(uiState.selectedSituationError)}</div>` : ""}
           ${uiState.selectedSituationLoading
             ? `<div class="settings-empty-state">Chargement des sujets de la situation…</div>`
-            : renderSituationKanban(selectedSituation, uiState.selectedSituationSubjects, { loading: uiState.selectedSituationLoading })}
+            : renderSelectedSituationLayoutBody(selectedSituation)}
         </div>
       </section>
     `;
@@ -161,7 +195,7 @@ export function createProjectSituationsView({
 
     return `
       <section class="project-simple-page project-simple-page--settings">
-        <div class="project-simple-scroll" id="projectSituationsScroll">
+        <div class="project-simple-scroll${hasSelectedSituation ? " project-simple-scroll--situation-kanban" : ""}" id="projectSituationsScroll">
           <div class="settings-content project-page-shell project-page-shell--content${hasSelectedSituation ? " project-page-shell--situation-kanban" : ""}">
             ${hasSelectedSituation
               ? `${uiState.editPanelOpen ? renderEditSituationPanel() : renderSelectedSituationDetails()}`

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9874,8 +9874,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
     
 .project-shell__content--situation-kanban{
   padding-inline:0;
-  overflow-x:auto;
-  overflow-y:hidden;
+  overflow:hidden;
 }
 
 .project-page-shell--situation-kanban{
@@ -9884,6 +9883,12 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   padding-inline:0;
   display:flex;
   flex-direction:column;
+  height:calc(100dvh - 150px);
+  min-height:calc(100dvh - 150px);
+}
+
+body.route--project .project-simple-scroll.project-simple-scroll--situation-kanban{
+  overflow:hidden;
 }
 
 .gh-panel--details-situation-kanban{
@@ -9892,7 +9897,8 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   box-shadow:none;
   display:flex;
   flex-direction:column;
-  min-height:calc(100vh - 180px);
+  min-height:0;
+  height:100%;
 }
 
 .gh-panel--details-situation-kanban > .gh-panel__head{
@@ -9925,14 +9931,15 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   background:var(--bgAssistPanel);
   border:none;
   border-radius:12px;
-  padding:8px;
+  padding:8px 8px 12px;
   display:flex;
   flex-direction:column;
   gap:12px;
   min-height:100%;
-  height:auto;
+  height:100%;
   align-self:stretch;
-  overflow:hidden;
+  overflow-y:auto;
+  overflow-x:hidden;
 }
 
 @media (max-width: 1480px){
@@ -10013,7 +10020,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   min-height:220px;
   height:100%;
   flex:1 1 auto;
-  overflow-y:auto;
+  overflow-y:visible;
   overflow-x:hidden;
   padding-bottom:8px;
 }
@@ -13222,6 +13229,10 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-detail-head__description{
   max-width:860px;
+}
+
+.project-situation-layout-tabs{
+  margin:6px 0 0;
 }
 
 .project-situations-table__title-inline{


### PR DESCRIPTION
### Motivation

- Provide multiple display modes for a selected situation (grid, kanban/tableau, roadmap) and persist the chosen layout in `store.situationsView`.
- Improve scrolling behavior and active-scroll-source detection for kanban columns to prevent scroll-jank and support touch/wheel interactions.

### Description

- Added layout UI: introduced light tabs for layouts and hooked them into the view via `renderLightTabs` and `bindLightTabs`, storing the selection in `store.situationsView.selectedSituationLayout` and normalizing legacy `planning` to `roadmap`.
- Implemented two placeholder layout renderers `renderSituationGridView` and `renderSituationRoadmapView` and updated `createProjectSituationsView` to render the chosen layout via `renderSelectedSituationLayoutBody` while keeping the existing kanban renderer for `tableau`.
- Persisted and normalized layout state in `createProjectSituationsState.ensureSituationsViewState` with defaulting and allowed-values enforcement for `grille`, `tableau`, and `roadmap`.
- Improved scrolling/UX: updated CSS to change overflow/height rules for kanban and detail panels, registered kanban column mouse/touch/wheel handlers that call `setProjectActiveScrollSource`, and adjusted the `project-shell-chrome` import to include `setProjectActiveScrollSource`.

### Testing

- Ran frontend static checks and unit test suite via `npm run lint` and `npm test`, both completed successfully.
- Verified the frontend build via `npm run build` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb004a73d48329bb896f4b599ceec1)