### PR TITLE
Fix compact header sync for Situations Kanban internal scroll

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -28,6 +28,16 @@ function getStickyChromeHostEl() {
   return document.getElementById("projectStickyChromeHost");
 }
 
+function refreshProjectShellChromeRefs() {
+  shellState.globalHeaderEl = document.querySelector("#globalHeaderHost .gh-header");
+  shellState.projectTabsEl = document.querySelector(".project-tabs");
+  shellState.viewHeaderHostEl = document.getElementById("projectViewHeaderHost");
+  shellState.compactTabHostEl = document.getElementById("projectCompactTab");
+  shellState.compactTabLabelEl = document.getElementById("projectCompactTabLabel");
+  shellState.compactTabLabelPrimaryEl = document.getElementById("projectCompactTabLabelPrimary");
+  shellState.compactTabLabelSuffixEl = document.getElementById("projectCompactTabLabelSuffix");
+}
+
 export function setProjectStickyChrome(html = "") {
   const host = getStickyChromeHostEl();
   if (!host) return;
@@ -102,6 +112,7 @@ function syncCompactPrimaryAction() {
 }
 
 function syncCompactTabLabel() {
+  refreshProjectShellChromeRefs();
   const primaryLabel = String(shellState.compactTabCustomLabel || getTabLabel(shellState.tab) || "").trim();
   const suffixLabel = String(shellState.compactTabCustomSuffix || "").trim();
   const hasStructuredLabel = !!(shellState.compactTabLabelPrimaryEl || shellState.compactTabLabelSuffixEl);
@@ -126,6 +137,7 @@ function syncCompactTabLabel() {
 }
 
 function applyCompactState(isCompact) {
+  refreshProjectShellChromeRefs();
   const nextCompact = !!(shellState.compactEnabled && isCompact);
   const didChange = shellState.isCompact !== nextCompact;
   shellState.isCompact = nextCompact;
@@ -201,13 +213,7 @@ export function mountProjectShellChrome({ projectId, tab }) {
 
   shellState.projectId = projectId || null;
   shellState.tab = tab || "dashboard";
-  shellState.globalHeaderEl = document.querySelector("#globalHeaderHost .gh-header");
-  shellState.projectTabsEl = document.querySelector(".project-tabs");
-  shellState.viewHeaderHostEl = document.getElementById("projectViewHeaderHost");
-  shellState.compactTabHostEl = document.getElementById("projectCompactTab");
-  shellState.compactTabLabelEl = document.getElementById("projectCompactTabLabel");
-  shellState.compactTabLabelPrimaryEl = document.getElementById("projectCompactTabLabelPrimary");
-  shellState.compactTabLabelSuffixEl = document.getElementById("projectCompactTabLabelSuffix");
+  refreshProjectShellChromeRefs();
 
   if (shellState.viewHeaderHostEl) {
     shellState.viewHeaderHostEl.innerHTML = "";
@@ -337,6 +343,11 @@ export function setProjectCompactEnabled(enabled = true) {
 }
 
 export function refreshProjectShellChrome() {
+  refreshProjectShellChromeRefs();
+  syncCompactState();
+}
+
+export function refreshProjectShellCompactState() {
   syncCompactState();
 }
 

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -3,6 +3,8 @@ import { PROJECT_TAB_RESELECTED_EVENT } from "./project-header.js";
 import {
   PROJECT_SHELL_COMPACT_CHANGE_EVENT,
   setProjectCompactEnabled,
+  refreshProjectShellChrome,
+  refreshProjectShellCompactState,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   setProjectViewHeader
@@ -275,8 +277,9 @@ function rerender(root) {
   cleanupSituationsListeners = null;
   const hasSelectedSituation = !!String(store.situationsView?.selectedSituationId || "").trim();
   root.className = `project-shell__content${hasSelectedSituation ? " project-shell__content--situation-kanban" : ""}`;
-  syncProjectHeader(root);
   renderGlobalHeader();
+  syncProjectHeader(root);
+  refreshProjectShellChrome();
   root.innerHTML = renderPage();
   bindSituationsSyncEvents(root);
   syncSituationsAvailableHeight(root);
@@ -296,7 +299,7 @@ function rerender(root) {
     };
     const onColumnScroll = () => {
       setProjectCompactEnabled(true);
-      setProjectActiveScrollSource(column);
+      refreshProjectShellCompactState();
       syncSituationsAvailableHeight(root);
     };
     column.addEventListener("mouseenter", activateColumn);


### PR DESCRIPTION
### Motivation
- Corriger le problème où le compactage visuel du header n’était pas appliqué après que `renderGlobalHeader()` réécrive le DOM du header, laissant des références obsolètes dans le code de chrome projet. 
- Rendre le compactage fiable pour la vue Situations en s’assurant que les références DOM du header sont rafraîchies après chaque reconstruction et en stabilisant la logique de scroll des colonnes Kanban.

### Description
- Ajout de `refreshProjectShellChromeRefs()` dans `apps/web/js/views/project-shell-chrome.js` pour rafraîchir centralement les références DOM (`globalHeaderEl`, `projectTabsEl`, `viewHeaderHostEl`, `compactTab*`).
- Appel de `refreshProjectShellChromeRefs()` depuis `mountProjectShellChrome()`, `syncCompactTabLabel()`, `applyCompactState()` et `refreshProjectShellChrome()` pour garantir que les toggles de classes s’appliquent sur des éléments DOM frais.
- Exposition de `refreshProjectShellCompactState()` (wrapper léger de `syncCompactState()`) pour recalculer l’état compact sans rebinder d’écoutes de scroll actives.
- Dans `apps/web/js/views/project-situations.js`, inversion de l’ordre de rerender pour exécuter `renderGlobalHeader()` avant `syncProjectHeader(root)` puis appel de `refreshProjectShellChrome()` pour resynchroniser immédiatement le chrome après reconstruction du header global.
- Simplification des handlers Kanban : `mouseenter`, `wheel` et `touchstart` définissent la colonne active via `setProjectActiveScrollSource()`, tandis que le handler `scroll` n’appelle plus `setProjectActiveScrollSource()` mais utilise `refreshProjectShellCompactState()` pour rafraîchir uniquement l’état compact et recalculer la hauteur disponible.

### Testing
- Exécution des vérifications de syntaxe avec `node --check apps/web/js/views/project-shell-chrome.js` et `node --check apps/web/js/views/project-situations.js`, les deux commandes ont terminé sans erreur.
- Aucune suite de tests automatisés supplémentaire disponible dans cet environnement : la validation manuelle attendue inclut le scénario « Situations > vue Tableau > scroll colonne kanban » décrit dans la demande initiale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb294b26a88329a8bc552a3cbb3657)