### PR TITLE
Fix Kanban column scroll source selection for compact header

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -276,8 +276,7 @@ export function registerProjectScrollSources(...elements) {
   const onSourceChange = (event) => {
     const sourceEl = event?.currentTarget;
     if (sourceEl) {
-      shellState.activeScrollSourceEl = sourceEl;
-      shellState.activeScrollSourceResolver = null;
+      useProjectScrollSource(sourceEl);
     }
     syncCompactState();
   };
@@ -318,6 +317,15 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
   }
 
   syncCompactState();
+}
+
+export function useProjectScrollSource(el) {
+  if (!el) return;
+  if (shellState.activeScrollSourceEl === el && !shellState.activeScrollSourceResolver) return;
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
 }
 
 export function clearProjectActiveScrollSource(el = null) {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -7,6 +7,7 @@ import {
   refreshProjectShellCompactState,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
+  useProjectScrollSource,
   setProjectViewHeader
 } from "./project-shell-chrome.js";
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
@@ -297,8 +298,11 @@ function rerender(root) {
       setProjectCompactEnabled(true);
       setProjectActiveScrollSource(column);
     };
-    const onColumnScroll = () => {
+    const onColumnScroll = (event) => {
+      const columnEl = event?.currentTarget;
+      if (!columnEl) return;
       setProjectCompactEnabled(true);
+      useProjectScrollSource(columnEl);
       refreshProjectShellCompactState();
       syncSituationsAvailableHeight(root);
     };


### PR DESCRIPTION
### Motivation

- Kanban column scrolling did not always compact the global header because `refreshProjectShellCompactState()` read a stale active scroll source when `scroll` events occurred without a preceding `mouseenter`/`wheel`/`touchstart` (native scrollbar, trackpad inertia, programmatic scrolls). 

### Description

- Add a lightweight `useProjectScrollSource(el)` helper in `apps/web/js/views/project-shell-chrome.js` that switches the active scroll source without attaching new `scroll` listeners.
- Update `registerProjectScrollSources()` to call `useProjectScrollSource(sourceEl)` in its `onSourceChange` handler so the active source is set reliably before `syncCompactState()`.
- Update the Situations Kanban column `scroll` handler in `apps/web/js/views/project-situations.js` to accept the `event`, guard `event.currentTarget`, and call `useProjectScrollSource(columnEl)` before calling `refreshProjectShellCompactState()` and `syncSituationsAvailableHeight(root)`.
- Import `useProjectScrollSource` in `project-situations.js` and avoid reattaching listeners on each scroll to prevent listener rebinding loops.

### Testing

- Ran syntax/type checks with `node --check apps/web/js/views/project-shell-chrome.js` and `node --check apps/web/js/views/project-situations.js`, and both checks succeeded. 
- No automated browser/UI tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b5f73988329b74559a5720eaf82)