### PR TITLE
Fix compact header sync for Kanban columns and add debug logging

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -23,6 +23,7 @@ const shellState = {
   activeScrollSourceResolver: null
 };
 export const PROJECT_SHELL_COMPACT_CHANGE_EVENT = "project-shell-compact-change";
+const DEBUG_SITUATION_KANBAN_SCROLL = window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
 
 function getStickyChromeHostEl() {
   return document.getElementById("projectStickyChromeHost");
@@ -148,6 +149,19 @@ function applyCompactState(isCompact) {
   shellState.globalHeaderEl?.classList.toggle("gh-header--compact", shellState.isCompact);
   shellState.projectTabsEl?.classList.toggle("project-tabs--hidden", shellState.isCompact);
   getViewHeaderEl()?.classList.toggle("project-view-header--compact", shellState.isCompact);
+
+  if (DEBUG_SITUATION_KANBAN_SCROLL) {
+    console.debug("[project-shell:apply-compact-state]", {
+      requested: isCompact,
+      applied: !!(shellState.compactEnabled && isCompact),
+      compactEnabled: shellState.compactEnabled,
+      didChange,
+      bodyHasCompact: document.body.classList.contains("project-shell-compact"),
+      headerClass: shellState.globalHeaderEl?.className,
+      tabsClass: shellState.projectTabsEl?.className,
+      tabsDisplay: shellState.projectTabsEl ? getComputedStyle(shellState.projectTabsEl).display : null
+    });
+  }
 
   syncCompactTabLabel();
   if (didChange) {
@@ -276,8 +290,7 @@ export function registerProjectScrollSources(...elements) {
   const onSourceChange = (event) => {
     const sourceEl = event?.currentTarget;
     if (sourceEl) {
-      shellState.activeScrollSourceEl = sourceEl;
-      shellState.activeScrollSourceResolver = null;
+      useProjectScrollSource(sourceEl);
     }
     syncCompactState();
   };
@@ -320,6 +333,15 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
   syncCompactState();
 }
 
+export function useProjectScrollSource(el) {
+  if (!el) return;
+  if (shellState.activeScrollSourceEl === el && !shellState.activeScrollSourceResolver) return;
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+}
+
 export function clearProjectActiveScrollSource(el = null) {
   const activeEl = getActiveScrollSourceEl();
   if (el && activeEl && el !== activeEl) {
@@ -349,6 +371,31 @@ export function refreshProjectShellChrome() {
 
 export function refreshProjectShellCompactState() {
   syncCompactState();
+}
+
+export function syncProjectShellCompactFromScrollSource(el) {
+  if (!el) return;
+
+  refreshProjectShellChromeRefs();
+
+  shellState.compactEnabled = true;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+
+  const scrollTop = Number(el.scrollTop || 0);
+  if (DEBUG_SITUATION_KANBAN_SCROLL) {
+    console.debug("[project-shell:compact-from-source]", {
+      sourceClass: el.className,
+      sourceDataset: { ...el.dataset },
+      scrollTop: el.scrollTop,
+      shouldCompact: scrollTop > 12,
+      compactEnabled: shellState.compactEnabled,
+      currentIsCompact: shellState.isCompact,
+      globalHeaderFound: !!shellState.globalHeaderEl,
+      projectTabsFound: !!shellState.projectTabsEl
+    });
+  }
+  applyCompactState(scrollTop > 12);
 }
 
 export function unmountProjectShellChrome() {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -4,7 +4,7 @@ import {
   PROJECT_SHELL_COMPACT_CHANGE_EVENT,
   setProjectCompactEnabled,
   refreshProjectShellChrome,
-  refreshProjectShellCompactState,
+  syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   setProjectViewHeader
@@ -220,6 +220,7 @@ let situationsTabResetBound = false;
 let currentSituationsRoot = null;
 let cleanupSituationsListeners = null;
 let cleanupSituationsSyncEvents = null;
+const DEBUG_SITUATION_KANBAN_SCROLL = window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
 
 function syncSituationsAvailableHeight(root) {
   if (!root || !root.isConnected) return;
@@ -289,7 +290,23 @@ function rerender(root) {
   const gridScrollBody = root.querySelector(".project-situation-alt-view--grid");
   const roadmapScrollBody = root.querySelector(".project-situation-alt-view--roadmap");
   const kanbanColumns = [...root.querySelectorAll(".situation-kanban__col")];
-  registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody, kanbanColumns);
+  if (DEBUG_SITUATION_KANBAN_SCROLL) {
+    console.debug("[situations:kanban-bind]", {
+      columns: kanbanColumns.length,
+      columnsMeta: kanbanColumns.map((col) => ({
+        column: col.dataset.situationKanbanColumn,
+        scrollHeight: col.scrollHeight,
+        clientHeight: col.clientHeight,
+        canScroll: col.scrollHeight > col.clientHeight,
+        overflowY: getComputedStyle(col).overflowY
+      }))
+    });
+  }
+  if (kanbanColumns.length) {
+    registerProjectScrollSources(kanbanColumns);
+  } else {
+    registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
+  }
 
   const unbindColumnHandlers = [];
   kanbanColumns.forEach((column) => {
@@ -297,9 +314,21 @@ function rerender(root) {
       setProjectCompactEnabled(true);
       setProjectActiveScrollSource(column);
     };
-    const onColumnScroll = () => {
-      setProjectCompactEnabled(true);
-      refreshProjectShellCompactState();
+    const onColumnScroll = (event) => {
+      const columnEl = event?.currentTarget;
+      if (!columnEl) return;
+      if (DEBUG_SITUATION_KANBAN_SCROLL) {
+        console.debug("[situations:kanban-column-scroll]", {
+          column: columnEl.dataset.situationKanbanColumn,
+          scrollTop: columnEl.scrollTop,
+          scrollHeight: columnEl.scrollHeight,
+          clientHeight: columnEl.clientHeight,
+          overflowY: getComputedStyle(columnEl).overflowY,
+          shouldCompact: columnEl.scrollTop > 12,
+          isConnected: columnEl.isConnected
+        });
+      }
+      syncProjectShellCompactFromScrollSource(columnEl);
       syncSituationsAvailableHeight(root);
     };
     column.addEventListener("mouseenter", activateColumn);


### PR DESCRIPTION
### Motivation
- Ensure the project header compact state correctly tracks scroll source changes in Kanban columns and make the behavior easier to debug.
- Avoid stale active-scroll-source state when switching scroll sources and provide visibility into why compact state is applied.

### Description
- Add a debug toggle `debug:situation-kanban-scroll` (localStorage) and emit diagnostic `console.debug` messages from `applyCompactState` and during Kanban column binding/scroll handling.
- Introduce `useProjectScrollSource` to centralize setting the active scroll source and clean up previous bindings, and update `registerProjectScrollSources` to call it on source change events.
- Add `syncProjectShellCompactFromScrollSource(el)` to compute compact state directly from a given scroll element and call `applyCompactState` accordingly, and use it in Kanban column scroll handlers.
- Update the situations view to register Kanban columns specially (register columns if present) and wire per-column handlers that activate the column and call the new sync function, with additional debug logging of column metrics.

### Testing
- Ran the frontend unit test suite with `npm test`, which completed successfully. 
- Ran the linter with `npm run lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b5f73988329b74559a5720eaf82)