### PR TITLE
Sync project compact header from kanban column scrolls and add gated debug logging

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -24,6 +24,19 @@ const shellState = {
 };
 export const PROJECT_SHELL_COMPACT_CHANGE_EVENT = "project-shell-compact-change";
 
+function isSituationKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugSituationKanbanScroll(label, payload) {
+  if (!isSituationKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
+
 function getStickyChromeHostEl() {
   return document.getElementById("projectStickyChromeHost");
 }
@@ -148,6 +161,17 @@ function applyCompactState(isCompact) {
   shellState.globalHeaderEl?.classList.toggle("gh-header--compact", shellState.isCompact);
   shellState.projectTabsEl?.classList.toggle("project-tabs--hidden", shellState.isCompact);
   getViewHeaderEl()?.classList.toggle("project-view-header--compact", shellState.isCompact);
+
+  debugSituationKanbanScroll("[project-shell:apply-compact-state]", {
+    requested: isCompact,
+    applied: !!(shellState.compactEnabled && isCompact),
+    compactEnabled: shellState.compactEnabled,
+    didChange,
+    bodyHasCompact: document.body.classList.contains("project-shell-compact"),
+    headerClass: shellState.globalHeaderEl?.className,
+    tabsClass: shellState.projectTabsEl?.className,
+    tabsDisplay: shellState.projectTabsEl ? getComputedStyle(shellState.projectTabsEl).display : null
+  });
 
   syncCompactTabLabel();
   if (didChange) {
@@ -276,8 +300,7 @@ export function registerProjectScrollSources(...elements) {
   const onSourceChange = (event) => {
     const sourceEl = event?.currentTarget;
     if (sourceEl) {
-      shellState.activeScrollSourceEl = sourceEl;
-      shellState.activeScrollSourceResolver = null;
+      useProjectScrollSource(sourceEl);
     }
     syncCompactState();
   };
@@ -320,6 +343,15 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
   syncCompactState();
 }
 
+export function useProjectScrollSource(el) {
+  if (!el) return;
+  if (shellState.activeScrollSourceEl === el && !shellState.activeScrollSourceResolver) return;
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+}
+
 export function clearProjectActiveScrollSource(el = null) {
   const activeEl = getActiveScrollSourceEl();
   if (el && activeEl && el !== activeEl) {
@@ -349,6 +381,29 @@ export function refreshProjectShellChrome() {
 
 export function refreshProjectShellCompactState() {
   syncCompactState();
+}
+
+export function syncProjectShellCompactFromScrollSource(el) {
+  if (!el) return;
+
+  refreshProjectShellChromeRefs();
+
+  shellState.compactEnabled = true;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+
+  const scrollTop = Number(el.scrollTop || 0);
+  debugSituationKanbanScroll("[project-shell:compact-from-source]", {
+    sourceClass: el.className,
+    sourceDataset: { ...el.dataset },
+    scrollTop: el.scrollTop,
+    shouldCompact: scrollTop > 12,
+    compactEnabled: shellState.compactEnabled,
+    currentIsCompact: shellState.isCompact,
+    globalHeaderFound: !!shellState.globalHeaderEl,
+    projectTabsFound: !!shellState.projectTabsEl
+  });
+  applyCompactState(scrollTop > 12);
 }
 
 export function unmountProjectShellChrome() {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -4,7 +4,7 @@ import {
   PROJECT_SHELL_COMPACT_CHANGE_EVENT,
   setProjectCompactEnabled,
   refreshProjectShellChrome,
-  refreshProjectShellCompactState,
+  syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   setProjectViewHeader
@@ -221,6 +221,19 @@ let currentSituationsRoot = null;
 let cleanupSituationsListeners = null;
 let cleanupSituationsSyncEvents = null;
 
+function isSituationKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugSituationKanbanScroll(label, payload) {
+  if (!isSituationKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
+
 function syncSituationsAvailableHeight(root) {
   if (!root || !root.isConnected) return;
   const shell = root.querySelector(".project-page-shell--situation-view");
@@ -289,7 +302,21 @@ function rerender(root) {
   const gridScrollBody = root.querySelector(".project-situation-alt-view--grid");
   const roadmapScrollBody = root.querySelector(".project-situation-alt-view--roadmap");
   const kanbanColumns = [...root.querySelectorAll(".situation-kanban__col")];
-  registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody, kanbanColumns);
+  debugSituationKanbanScroll("[situations:kanban-bind]", {
+    columns: kanbanColumns.length,
+    columnsMeta: kanbanColumns.map((col) => ({
+      column: col.dataset.situationKanbanColumn,
+      scrollHeight: col.scrollHeight,
+      clientHeight: col.clientHeight,
+      canScroll: col.scrollHeight > col.clientHeight,
+      overflowY: getComputedStyle(col).overflowY
+    }))
+  });
+  if (kanbanColumns.length) {
+    registerProjectScrollSources(kanbanColumns);
+  } else {
+    registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
+  }
 
   const unbindColumnHandlers = [];
   kanbanColumns.forEach((column) => {
@@ -297,9 +324,19 @@ function rerender(root) {
       setProjectCompactEnabled(true);
       setProjectActiveScrollSource(column);
     };
-    const onColumnScroll = () => {
-      setProjectCompactEnabled(true);
-      refreshProjectShellCompactState();
+    const onColumnScroll = (event) => {
+      const columnEl = event?.currentTarget;
+      if (!columnEl) return;
+      debugSituationKanbanScroll("[situations:kanban-column-scroll]", {
+        column: columnEl.dataset.situationKanbanColumn,
+        scrollTop: columnEl.scrollTop,
+        scrollHeight: columnEl.scrollHeight,
+        clientHeight: columnEl.clientHeight,
+        overflowY: getComputedStyle(columnEl).overflowY,
+        shouldCompact: columnEl.scrollTop > 12,
+        isConnected: columnEl.isConnected
+      });
+      syncProjectShellCompactFromScrollSource(columnEl);
       syncSituationsAvailableHeight(root);
     };
     column.addEventListener("mouseenter", activateColumn);


### PR DESCRIPTION
### Motivation
- Ensure the project header/compact state is driven reliably by the active scroll source when viewing kanban columns and make it easier to diagnose scroll-related compact toggles.
- Add optional, low-noise debug logging for situation/kanban scroll behavior that can be enabled via localStorage.

### Description
- Added gated debug helpers `isSituationKanbanScrollDebugEnabled()` and `debugSituationKanbanScroll()` and sprinkled debug output in `applyCompactState`, kanban binding, and column scroll handlers; the debug is enabled by setting `localStorage['debug:situation-kanban-scroll'] = '1'`.
- Introduced `useProjectScrollSource()` to centralize switching the active scroll source and refactored `registerProjectScrollSources()` to call it when a source becomes active.
- Added `syncProjectShellCompactFromScrollSource(el)` which refreshes shell refs, marks the provided element as the active scroll source, and applies compact state based on `el.scrollTop > 12` (with debug payloads).
- Updated situations view kanban binding to register kanban columns as scroll sources as a group when present, and changed per-column scroll handlers to call `syncProjectShellCompactFromScrollSource(columnEl)` and emit richer debug info.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b5f73988329b74559a5720eaf82)