### PR TITLE
Fix kanban scroll handling and compact-header sync; add debug hooks

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -24,6 +24,19 @@ const shellState = {
 };
 export const PROJECT_SHELL_COMPACT_CHANGE_EVENT = "project-shell-compact-change";
 
+function isSituationKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugSituationKanbanScroll(label, payload) {
+  if (!isSituationKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
+
 function getStickyChromeHostEl() {
   return document.getElementById("projectStickyChromeHost");
 }
@@ -148,6 +161,17 @@ function applyCompactState(isCompact) {
   shellState.globalHeaderEl?.classList.toggle("gh-header--compact", shellState.isCompact);
   shellState.projectTabsEl?.classList.toggle("project-tabs--hidden", shellState.isCompact);
   getViewHeaderEl()?.classList.toggle("project-view-header--compact", shellState.isCompact);
+
+  debugSituationKanbanScroll("[project-shell:apply-compact-state]", {
+    requested: isCompact,
+    applied: !!(shellState.compactEnabled && isCompact),
+    compactEnabled: shellState.compactEnabled,
+    didChange,
+    bodyHasCompact: document.body.classList.contains("project-shell-compact"),
+    headerClass: shellState.globalHeaderEl?.className,
+    tabsClass: shellState.projectTabsEl?.className,
+    tabsDisplay: shellState.projectTabsEl ? getComputedStyle(shellState.projectTabsEl).display : null
+  });
 
   syncCompactTabLabel();
   if (didChange) {
@@ -276,8 +300,7 @@ export function registerProjectScrollSources(...elements) {
   const onSourceChange = (event) => {
     const sourceEl = event?.currentTarget;
     if (sourceEl) {
-      shellState.activeScrollSourceEl = sourceEl;
-      shellState.activeScrollSourceResolver = null;
+      useProjectScrollSource(sourceEl);
     }
     syncCompactState();
   };
@@ -320,6 +343,15 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
   syncCompactState();
 }
 
+export function useProjectScrollSource(el) {
+  if (!el) return;
+  if (shellState.activeScrollSourceEl === el && !shellState.activeScrollSourceResolver) return;
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+}
+
 export function clearProjectActiveScrollSource(el = null) {
   const activeEl = getActiveScrollSourceEl();
   if (el && activeEl && el !== activeEl) {
@@ -349,6 +381,29 @@ export function refreshProjectShellChrome() {
 
 export function refreshProjectShellCompactState() {
   syncCompactState();
+}
+
+export function syncProjectShellCompactFromScrollSource(el) {
+  if (!el) return;
+
+  refreshProjectShellChromeRefs();
+
+  shellState.compactEnabled = true;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+
+  const scrollTop = Number(el.scrollTop || 0);
+  debugSituationKanbanScroll("[project-shell:compact-from-source]", {
+    sourceClass: el.className,
+    sourceDataset: { ...el.dataset },
+    scrollTop: el.scrollTop,
+    shouldCompact: scrollTop > 12,
+    compactEnabled: shellState.compactEnabled,
+    currentIsCompact: shellState.isCompact,
+    globalHeaderFound: !!shellState.globalHeaderEl,
+    projectTabsFound: !!shellState.projectTabsEl
+  });
+  applyCompactState(scrollTop > 12);
 }
 
 export function unmountProjectShellChrome() {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -4,7 +4,7 @@ import {
   PROJECT_SHELL_COMPACT_CHANGE_EVENT,
   setProjectCompactEnabled,
   refreshProjectShellChrome,
-  refreshProjectShellCompactState,
+  syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   setProjectViewHeader
@@ -221,6 +221,19 @@ let currentSituationsRoot = null;
 let cleanupSituationsListeners = null;
 let cleanupSituationsSyncEvents = null;
 
+function isSituationKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugSituationKanbanScroll(label, payload) {
+  if (!isSituationKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
+
 function syncSituationsAvailableHeight(root) {
   if (!root || !root.isConnected) return;
   const shell = root.querySelector(".project-page-shell--situation-view");
@@ -289,28 +302,70 @@ function rerender(root) {
   const gridScrollBody = root.querySelector(".project-situation-alt-view--grid");
   const roadmapScrollBody = root.querySelector(".project-situation-alt-view--roadmap");
   const kanbanColumns = [...root.querySelectorAll(".situation-kanban__col")];
-  registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody, kanbanColumns);
+  const kanbanCardLists = [...root.querySelectorAll(".situation-kanban__cards")];
+  debugSituationKanbanScroll("[situations:kanban-bind]", {
+    columns: kanbanColumns.length,
+    cardLists: kanbanCardLists.length,
+    columnsMeta: kanbanColumns.map((col) => ({
+      column: col.dataset.situationKanbanColumn,
+      scrollHeight: col.scrollHeight,
+      clientHeight: col.clientHeight,
+      canScroll: col.scrollHeight > col.clientHeight,
+      overflowY: getComputedStyle(col).overflowY
+    })),
+    cardListsMeta: kanbanCardLists.map((list) => ({
+      column: list.closest(".situation-kanban__col")?.dataset?.situationKanbanColumn || null,
+      scrollHeight: list.scrollHeight,
+      clientHeight: list.clientHeight,
+      canScroll: list.scrollHeight > list.clientHeight,
+      overflowY: getComputedStyle(list).overflowY
+    }))
+  });
+  if (kanbanColumns.length) {
+    registerProjectScrollSources(kanbanColumns, kanbanCardLists, primaryScrollRoot);
+  } else {
+    registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
+  }
 
   const unbindColumnHandlers = [];
-  kanbanColumns.forEach((column) => {
+  const kanbanScrollElements = kanbanColumns.length
+    ? [...new Set([...kanbanColumns, ...kanbanCardLists, primaryScrollRoot].filter(Boolean))]
+    : [];
+  kanbanScrollElements.forEach((source) => {
+    const ownerColumn = source.classList.contains("situation-kanban__col")
+      ? source
+      : source.closest(".situation-kanban__col");
     const activateColumn = () => {
+      if (!ownerColumn) return;
       setProjectCompactEnabled(true);
-      setProjectActiveScrollSource(column);
+      setProjectActiveScrollSource(ownerColumn);
     };
-    const onColumnScroll = () => {
-      setProjectCompactEnabled(true);
-      refreshProjectShellCompactState();
+    const onKanbanScroll = (event) => {
+      const sourceEl = event?.currentTarget;
+      if (!sourceEl) return;
+      debugSituationKanbanScroll("[situations:kanban-column-scroll]", {
+        sourceClass: sourceEl.className,
+        sourceTag: sourceEl.tagName,
+        column: ownerColumn?.dataset?.situationKanbanColumn || null,
+        scrollTop: sourceEl.scrollTop,
+        scrollHeight: sourceEl.scrollHeight,
+        clientHeight: sourceEl.clientHeight,
+        overflowY: getComputedStyle(sourceEl).overflowY,
+        shouldCompact: sourceEl.scrollTop > 12,
+        isConnected: sourceEl.isConnected
+      });
+      syncProjectShellCompactFromScrollSource(sourceEl);
       syncSituationsAvailableHeight(root);
     };
-    column.addEventListener("mouseenter", activateColumn);
-    column.addEventListener("wheel", activateColumn, { passive: true });
-    column.addEventListener("touchstart", activateColumn, { passive: true });
-    column.addEventListener("scroll", onColumnScroll, { passive: true });
+    source.addEventListener("mouseenter", activateColumn);
+    source.addEventListener("wheel", activateColumn, { passive: true });
+    source.addEventListener("touchstart", activateColumn, { passive: true });
+    source.addEventListener("scroll", onKanbanScroll, { passive: true });
     unbindColumnHandlers.push(() => {
-      column.removeEventListener("mouseenter", activateColumn);
-      column.removeEventListener("wheel", activateColumn);
-      column.removeEventListener("touchstart", activateColumn);
-      column.removeEventListener("scroll", onColumnScroll);
+      source.removeEventListener("mouseenter", activateColumn);
+      source.removeEventListener("wheel", activateColumn);
+      source.removeEventListener("touchstart", activateColumn);
+      source.removeEventListener("scroll", onKanbanScroll);
     });
   });
   cleanupSituationsListeners = () => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9959,7 +9959,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:0;
   height:100%;
   align-self:stretch;
-  overflow-y:auto;
+  overflow-y:hidden;
   overflow-x:hidden;
 }
 
@@ -10041,7 +10041,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:0;
   height:100%;
   flex:1 1 auto;
-  overflow-y:visible;
+  overflow-y:auto;
   overflow-x:hidden;
   padding-bottom:8px;
 }


### PR DESCRIPTION
### Motivation
- Address incorrect compact-header toggling and scroll-source detection in the Situations kanban view when inner card lists scroll instead of column containers.
- Make it easier to debug scroll/compact interactions by providing optional logging controlled by localStorage.

### Description
- Change kanban layout scrolling so columns use `overflow-y:hidden` and the card lists use `overflow-y:auto` by updating `.situation-kanban__col` and `.situation-kanban__cards` in `style.css`.
- Register scroll sources from the kanban view using both column containers and their inner card lists and prefer those as active sources when scrolling by updating `project-situations.js` to collect `kanbanCardLists` and conditionally register them with `registerProjectScrollSources`.
- Add debug helpers `isSituationKanbanScrollDebugEnabled` and `debugSituationKanbanScroll` and sprinkle informative debug calls around binding and scroll handlers to log environment and scroll metrics when `localStorage.debug:situation-kanban-scroll` is set to `1`.
- Refactor scroll-source management in `project-shell-chrome.js` by introducing `useProjectScrollSource` and `syncProjectShellCompactFromScrollSource`, calling `useProjectScrollSource` from `registerProjectScrollSources`, and using `syncProjectShellCompactFromScrollSource` from kanban scroll handlers to compute and apply compact state from the actual scroll source.

### Testing
- Ran lint and the frontend build with `npm run lint` and `npm run build`, and both completed successfully.
- Ran the frontend unit test suite with `npm test` and all tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b5f73988329b74559a5720eaf82)