### PR TITLE
Improve kanban scroll handling and compact header sync; add debug hooks

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -24,6 +24,19 @@ const shellState = {
 };
 export const PROJECT_SHELL_COMPACT_CHANGE_EVENT = "project-shell-compact-change";
 
+function isProjectShellKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugProjectShellKanbanScroll(label, payload) {
+  if (!isProjectShellKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
+
 function getStickyChromeHostEl() {
   return document.getElementById("projectStickyChromeHost");
 }
@@ -148,6 +161,17 @@ function applyCompactState(isCompact) {
   shellState.globalHeaderEl?.classList.toggle("gh-header--compact", shellState.isCompact);
   shellState.projectTabsEl?.classList.toggle("project-tabs--hidden", shellState.isCompact);
   getViewHeaderEl()?.classList.toggle("project-view-header--compact", shellState.isCompact);
+
+  debugProjectShellKanbanScroll("[project-shell:apply-compact-state]", {
+    requested: isCompact,
+    applied: !!(shellState.compactEnabled && isCompact),
+    compactEnabled: shellState.compactEnabled,
+    didChange,
+    bodyHasCompact: document.body.classList.contains("project-shell-compact"),
+    headerClass: shellState.globalHeaderEl?.className,
+    tabsClass: shellState.projectTabsEl?.className,
+    tabsDisplay: shellState.projectTabsEl ? getComputedStyle(shellState.projectTabsEl).display : null
+  });
 
   syncCompactTabLabel();
   if (didChange) {
@@ -276,8 +300,7 @@ export function registerProjectScrollSources(...elements) {
   const onSourceChange = (event) => {
     const sourceEl = event?.currentTarget;
     if (sourceEl) {
-      shellState.activeScrollSourceEl = sourceEl;
-      shellState.activeScrollSourceResolver = null;
+      useProjectScrollSource(sourceEl);
     }
     syncCompactState();
   };
@@ -320,6 +343,15 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
   syncCompactState();
 }
 
+export function useProjectScrollSource(el) {
+  if (!el) return;
+  if (shellState.activeScrollSourceEl === el && !shellState.activeScrollSourceResolver) return;
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+}
+
 export function clearProjectActiveScrollSource(el = null) {
   const activeEl = getActiveScrollSourceEl();
   if (el && activeEl && el !== activeEl) {
@@ -349,6 +381,29 @@ export function refreshProjectShellChrome() {
 
 export function refreshProjectShellCompactState() {
   syncCompactState();
+}
+
+export function syncProjectShellCompactFromScrollSource(el) {
+  if (!el) return;
+
+  refreshProjectShellChromeRefs();
+
+  shellState.compactEnabled = true;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+
+  const scrollTop = Number(el.scrollTop || 0);
+  debugProjectShellKanbanScroll("[project-shell:compact-from-source]", {
+    sourceClass: el.className,
+    sourceDataset: { ...el.dataset },
+    scrollTop: el.scrollTop,
+    shouldCompact: scrollTop > 12,
+    compactEnabled: shellState.compactEnabled,
+    currentIsCompact: shellState.isCompact,
+    globalHeaderFound: !!shellState.globalHeaderEl,
+    projectTabsFound: !!shellState.projectTabsEl
+  });
+  applyCompactState(scrollTop > 12);
 }
 
 export function unmountProjectShellChrome() {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -4,7 +4,7 @@ import {
   PROJECT_SHELL_COMPACT_CHANGE_EVENT,
   setProjectCompactEnabled,
   refreshProjectShellChrome,
-  refreshProjectShellCompactState,
+  syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   setProjectViewHeader
@@ -221,6 +221,19 @@ let currentSituationsRoot = null;
 let cleanupSituationsListeners = null;
 let cleanupSituationsSyncEvents = null;
 
+function isProjectSituationsKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugProjectSituationsKanbanScroll(label, payload) {
+  if (!isProjectSituationsKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
+
 function syncSituationsAvailableHeight(root) {
   if (!root || !root.isConnected) return;
   const shell = root.querySelector(".project-page-shell--situation-view");
@@ -289,28 +302,70 @@ function rerender(root) {
   const gridScrollBody = root.querySelector(".project-situation-alt-view--grid");
   const roadmapScrollBody = root.querySelector(".project-situation-alt-view--roadmap");
   const kanbanColumns = [...root.querySelectorAll(".situation-kanban__col")];
-  registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody, kanbanColumns);
+  const kanbanCardLists = [...root.querySelectorAll(".situation-kanban__cards")];
+  debugProjectSituationsKanbanScroll("[situations:kanban-bind]", {
+    columns: kanbanColumns.length,
+    cardLists: kanbanCardLists.length,
+    columnsMeta: kanbanColumns.map((col) => ({
+      column: col.dataset.situationKanbanColumn,
+      scrollHeight: col.scrollHeight,
+      clientHeight: col.clientHeight,
+      canScroll: col.scrollHeight > col.clientHeight,
+      overflowY: getComputedStyle(col).overflowY
+    })),
+    cardListsMeta: kanbanCardLists.map((list) => ({
+      column: list.closest(".situation-kanban__col")?.dataset?.situationKanbanColumn || null,
+      scrollHeight: list.scrollHeight,
+      clientHeight: list.clientHeight,
+      canScroll: list.scrollHeight > list.clientHeight,
+      overflowY: getComputedStyle(list).overflowY
+    }))
+  });
+  if (kanbanColumns.length) {
+    registerProjectScrollSources(kanbanColumns, kanbanCardLists, primaryScrollRoot);
+  } else {
+    registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
+  }
 
   const unbindColumnHandlers = [];
-  kanbanColumns.forEach((column) => {
+  const kanbanScrollElements = kanbanColumns.length
+    ? [...new Set([...kanbanColumns, ...kanbanCardLists, primaryScrollRoot].filter(Boolean))]
+    : [];
+  kanbanScrollElements.forEach((source) => {
+    const ownerColumn = source.classList.contains("situation-kanban__col")
+      ? source
+      : source.closest(".situation-kanban__col");
     const activateColumn = () => {
+      if (!ownerColumn) return;
       setProjectCompactEnabled(true);
-      setProjectActiveScrollSource(column);
+      setProjectActiveScrollSource(ownerColumn);
     };
-    const onColumnScroll = () => {
-      setProjectCompactEnabled(true);
-      refreshProjectShellCompactState();
+    const onKanbanScroll = (event) => {
+      const sourceEl = event?.currentTarget;
+      if (!sourceEl) return;
+      debugProjectSituationsKanbanScroll("[situations:kanban-column-scroll]", {
+        sourceClass: sourceEl.className,
+        sourceTag: sourceEl.tagName,
+        column: ownerColumn?.dataset?.situationKanbanColumn || null,
+        scrollTop: sourceEl.scrollTop,
+        scrollHeight: sourceEl.scrollHeight,
+        clientHeight: sourceEl.clientHeight,
+        overflowY: getComputedStyle(sourceEl).overflowY,
+        shouldCompact: sourceEl.scrollTop > 12,
+        isConnected: sourceEl.isConnected
+      });
+      syncProjectShellCompactFromScrollSource(sourceEl);
       syncSituationsAvailableHeight(root);
     };
-    column.addEventListener("mouseenter", activateColumn);
-    column.addEventListener("wheel", activateColumn, { passive: true });
-    column.addEventListener("touchstart", activateColumn, { passive: true });
-    column.addEventListener("scroll", onColumnScroll, { passive: true });
+    source.addEventListener("mouseenter", activateColumn);
+    source.addEventListener("wheel", activateColumn, { passive: true });
+    source.addEventListener("touchstart", activateColumn, { passive: true });
+    source.addEventListener("scroll", onKanbanScroll, { passive: true });
     unbindColumnHandlers.push(() => {
-      column.removeEventListener("mouseenter", activateColumn);
-      column.removeEventListener("wheel", activateColumn);
-      column.removeEventListener("touchstart", activateColumn);
-      column.removeEventListener("scroll", onColumnScroll);
+      source.removeEventListener("mouseenter", activateColumn);
+      source.removeEventListener("wheel", activateColumn);
+      source.removeEventListener("touchstart", activateColumn);
+      source.removeEventListener("scroll", onKanbanScroll);
     });
   });
   cleanupSituationsListeners = () => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9959,7 +9959,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:0;
   height:100%;
   align-self:stretch;
-  overflow-y:auto;
+  overflow-y:hidden;
   overflow-x:hidden;
 }
 
@@ -10041,7 +10041,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:0;
   height:100%;
   flex:1 1 auto;
-  overflow-y:visible;
+  overflow-y:auto;
   overflow-x:hidden;
   padding-bottom:8px;
 }


### PR DESCRIPTION
### Motivation
- Fix inconsistent compact header behavior when interacting with the situations kanban by ensuring the correct scroll element is used as the active scroll source.  
- Make kanban column scrolling more predictable by moving vertical scrolling from the column container to the cards list.  
- Add opt-in debug logging to trace scroll-source decisions and compact-state transitions during investigation and troubleshooting.  

### Description
- Added debug helpers `isProjectShellKanbanScrollDebugEnabled` and `debugProjectShellKanbanScroll` to `project-shell-chrome.js` and analogous debug helpers in `project-situations.js`, gated behind `localStorage` flag `debug:situation-kanban-scroll`.  
- Introduced `useProjectScrollSource` and `syncProjectShellCompactFromScrollSource` in `project-shell-chrome.js` and updated scroll-source registration to call `useProjectScrollSource` so the active source is tracked without registering duplicate listeners.  
- Updated compact-state sync to emit richer debug payloads from `applyCompactState` and `syncProjectShellCompactFromScrollSource` so scroll-source, dimensions, and computed compact decisions are logged when enabled.  
- Reworked kanban binding in `project-situations.js` to detect column and `.situation-kanban__cards` elements, register the proper set of scroll sources, and attach unified handlers that call `syncProjectShellCompactFromScrollSource` on scroll while also setting the active scroll source on pointer interactions.  
- Adjusted CSS in `style.css` to stop columns from scrolling (`.situation-kanban__col { overflow-y: hidden }`) and instead enable scrolling on the cards container (`.situation-kanban__cards { overflow-y: auto }`) to keep headers/column layout stable while allowing card lists to scroll.  

### Testing
- Ran linting with `npm run lint` and JS static checks, which completed without errors.  
- Ran the test suite with `npm test`, and all automated tests passed.  
- Verified that kanban column/card scrolling triggers the compact header state transitions and that enabling `localStorage.setItem('debug:situation-kanban-scroll','1')` produces console debug entries for scroll-source events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b5f73988329b74559a5720eaf82)