### PR TITLE
Use kanban card lists as scroll sources and sync compact header state

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -276,8 +276,7 @@ export function registerProjectScrollSources(...elements) {
   const onSourceChange = (event) => {
     const sourceEl = event?.currentTarget;
     if (sourceEl) {
-      shellState.activeScrollSourceEl = sourceEl;
-      shellState.activeScrollSourceResolver = null;
+      useProjectScrollSource(sourceEl);
     }
     syncCompactState();
   };
@@ -320,6 +319,15 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
   syncCompactState();
 }
 
+export function useProjectScrollSource(el) {
+  if (!el) return;
+  if (shellState.activeScrollSourceEl === el && !shellState.activeScrollSourceResolver) return;
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+}
+
 export function clearProjectActiveScrollSource(el = null) {
   const activeEl = getActiveScrollSourceEl();
   if (el && activeEl && el !== activeEl) {
@@ -349,6 +357,19 @@ export function refreshProjectShellChrome() {
 
 export function refreshProjectShellCompactState() {
   syncCompactState();
+}
+
+export function syncProjectShellCompactFromScrollSource(el) {
+  if (!el) return;
+
+  refreshProjectShellChromeRefs();
+
+  shellState.compactEnabled = true;
+  shellState.activeScrollSourceEl = el;
+  shellState.activeScrollSourceResolver = null;
+
+  const scrollTop = Number(el.scrollTop || 0);
+  applyCompactState(scrollTop > 12);
 }
 
 export function unmountProjectShellChrome() {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -4,7 +4,7 @@ import {
   PROJECT_SHELL_COMPACT_CHANGE_EVENT,
   setProjectCompactEnabled,
   refreshProjectShellChrome,
-  refreshProjectShellCompactState,
+  syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   setProjectViewHeader
@@ -289,28 +289,41 @@ function rerender(root) {
   const gridScrollBody = root.querySelector(".project-situation-alt-view--grid");
   const roadmapScrollBody = root.querySelector(".project-situation-alt-view--roadmap");
   const kanbanColumns = [...root.querySelectorAll(".situation-kanban__col")];
-  registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody, kanbanColumns);
+  const kanbanCardLists = [...root.querySelectorAll(".situation-kanban__cards")];
+  if (kanbanColumns.length) {
+    registerProjectScrollSources(kanbanColumns, kanbanCardLists, primaryScrollRoot);
+  } else {
+    registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
+  }
 
   const unbindColumnHandlers = [];
-  kanbanColumns.forEach((column) => {
+  const kanbanScrollElements = kanbanColumns.length
+    ? [...new Set([...kanbanColumns, ...kanbanCardLists, primaryScrollRoot].filter(Boolean))]
+    : [];
+  kanbanScrollElements.forEach((source) => {
+    const ownerColumn = source.classList.contains("situation-kanban__col")
+      ? source
+      : source.closest(".situation-kanban__col");
     const activateColumn = () => {
+      if (!ownerColumn) return;
       setProjectCompactEnabled(true);
-      setProjectActiveScrollSource(column);
+      setProjectActiveScrollSource(ownerColumn);
     };
-    const onColumnScroll = () => {
-      setProjectCompactEnabled(true);
-      refreshProjectShellCompactState();
+    const onKanbanScroll = (event) => {
+      const sourceEl = event?.currentTarget;
+      if (!sourceEl) return;
+      syncProjectShellCompactFromScrollSource(sourceEl);
       syncSituationsAvailableHeight(root);
     };
-    column.addEventListener("mouseenter", activateColumn);
-    column.addEventListener("wheel", activateColumn, { passive: true });
-    column.addEventListener("touchstart", activateColumn, { passive: true });
-    column.addEventListener("scroll", onColumnScroll, { passive: true });
+    source.addEventListener("mouseenter", activateColumn);
+    source.addEventListener("wheel", activateColumn, { passive: true });
+    source.addEventListener("touchstart", activateColumn, { passive: true });
+    source.addEventListener("scroll", onKanbanScroll, { passive: true });
     unbindColumnHandlers.push(() => {
-      column.removeEventListener("mouseenter", activateColumn);
-      column.removeEventListener("wheel", activateColumn);
-      column.removeEventListener("touchstart", activateColumn);
-      column.removeEventListener("scroll", onColumnScroll);
+      source.removeEventListener("mouseenter", activateColumn);
+      source.removeEventListener("wheel", activateColumn);
+      source.removeEventListener("touchstart", activateColumn);
+      source.removeEventListener("scroll", onKanbanScroll);
     });
   });
   cleanupSituationsListeners = () => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9959,7 +9959,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:0;
   height:100%;
   align-self:stretch;
-  overflow-y:auto;
+  overflow-y:hidden;
   overflow-x:hidden;
 }
 
@@ -10041,7 +10041,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:0;
   height:100%;
   flex:1 1 auto;
-  overflow-y:visible;
+  overflow-y:auto;
   overflow-x:hidden;
   padding-bottom:8px;
 }


### PR DESCRIPTION
### Motivation
- Ensure the project shell compact header state is driven by the actual scrollable element in kanban views (card lists) rather than the column container so compact/expanded header behavior is accurate when scrolling cards.
- Centralize scroll-source activation and compact-state sync logic to avoid duplicated code paths and race conditions.

### Description
- Added `useProjectScrollSource` to set the active scroll source without attaching extra listeners and to reuse active-source cleanup logic.
- Added `syncProjectShellCompactFromScrollSource` to refresh refs, enable compact mode, set the active source, and apply compact state based on the source's `scrollTop` (`> 12`).
- Updated `registerProjectScrollSources` to call `useProjectScrollSource` when a scroll source is activated via events.
- Updated `project-situations.js` to register kanban column elements and their inner `.situation-kanban__cards` lists as scroll sources when columns exist, to activate the owning column on hover/touch/wheel, and to call `syncProjectShellCompactFromScrollSource` on scroll events.
- Adjusted CSS to move vertical scrolling from `.situation-kanban__col` to `.situation-kanban__cards` by changing `.situation-kanban__col { overflow-y: hidden; }` and `.situation-kanban__cards { overflow-y: auto; }`.

### Testing
- No new automated tests were added to this change and existing test suites were executed; the existing web unit tests and linters completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b5f73988329b74559a5720eaf82)