### PR TITLE
Fix duplicate kanban debug declarations in project shell

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -23,33 +23,6 @@ const shellState = {
   activeScrollSourceResolver: null
 };
 export const PROJECT_SHELL_COMPACT_CHANGE_EVENT = "project-shell-compact-change";
-const DEBUG_SITUATION_KANBAN_SCROLL = window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-
-function isSituationKanbanScrollDebugEnabled() {
-  try {
-    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-  } catch (_) {
-    return false;
-  }
-}
-
-function debugSituationKanbanScroll(label, payload) {
-  if (!isSituationKanbanScrollDebugEnabled()) return;
-  console.info(label, payload);
-}
-
-function isSituationKanbanScrollDebugEnabled() {
-  try {
-    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-  } catch (_) {
-    return false;
-  }
-}
-
-function debugSituationKanbanScroll(label, payload) {
-  if (!isSituationKanbanScrollDebugEnabled()) return;
-  console.info(label, payload);
-}
 
 function isProjectShellKanbanScrollDebugEnabled() {
   try {


### PR DESCRIPTION
### Motivation
- Corriger l'erreur runtime `Uncaught SyntaxError: Identifier 'isSituationKanbanScrollDebugEnabled' has already been declared` causée par des déclarations dupliquées de helpers de debug dans le fichier de chrome du projet.

### Description
- Supprimé les déclarations en double de `DEBUG_SITUATION_KANBAN_SCROLL`, `isSituationKanbanScrollDebugEnabled` et `debugSituationKanbanScroll` dans `apps/web/js/views/project-shell-chrome.js` et conservé les helpers `isProjectShellKanbanScrollDebugEnabled` et `debugProjectShellKanbanScroll` utilisés pour le logging.

### Testing
- Exécuté `node --check apps/web/js/views/project-shell-chrome.js` avec succès (aucune erreur de syntaxe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb372bb5948329ad16a21cb931bdfb)