### PR TITLE
Fix duplicate kanban debug declarations in project-situations.js

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -221,46 +221,6 @@ let situationsTabResetBound = false;
 let currentSituationsRoot = null;
 let cleanupSituationsListeners = null;
 let cleanupSituationsSyncEvents = null;
-const DEBUG_SITUATION_KANBAN_SCROLL = window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-
-function isSituationKanbanScrollDebugEnabled() {
-  try {
-    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-  } catch (_) {
-    return false;
-  }
-}
-
-function debugSituationKanbanScroll(label, payload) {
-  if (!isSituationKanbanScrollDebugEnabled()) return;
-  console.info(label, payload);
-}
-
-function isSituationKanbanScrollDebugEnabled() {
-  try {
-    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-  } catch (_) {
-    return false;
-  }
-}
-
-function debugSituationKanbanScroll(label, payload) {
-  if (!isSituationKanbanScrollDebugEnabled()) return;
-  console.info(label, payload);
-}
-
-function isProjectSituationsKanbanScrollDebugEnabled() {
-  try {
-    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
-  } catch (_) {
-    return false;
-  }
-}
-
-function debugProjectSituationsKanbanScroll(label, payload) {
-  if (!isProjectSituationsKanbanScrollDebugEnabled()) return;
-  console.info(label, payload);
-}
 
 function syncSituationsAvailableHeight(root) {
   if (!root || !root.isConnected) return;


### PR DESCRIPTION
### Motivation
- Fix runtime syntax error `Uncaught SyntaxError: Identifier 'isSituationKanbanScrollDebugEnabled' has already been declared` caused by duplicated debug helper declarations in `apps/web/js/views/project-situations.js`.

### Description
- Remove duplicated and unused kanban debug helpers and constant (`DEBUG_SITUATION_KANBAN_SCROLL`, `isSituationKanbanScrollDebugEnabled`, `debugSituationKanbanScroll`, `isProjectSituationsKanbanScrollDebugEnabled`, `debugProjectSituationsKanbanScroll`) from `apps/web/js/views/project-situations.js` to eliminate conflicting declarations.

### Testing
- Ran `node --check apps/web/js/views/project-situations.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb380e43d48329a209ba83f8b307cf)