### PR TITLE
Fix vibration of Kanban header by using actual scrollable card lists and idempotent compact state

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -153,6 +153,17 @@ function applyCompactState(isCompact) {
   refreshProjectShellChromeRefs();
   const nextCompact = !!(shellState.compactEnabled && isCompact);
   const didChange = shellState.isCompact !== nextCompact;
+  if (!didChange) {
+    debugProjectShellKanbanScroll("[project-shell:apply-compact-state]", {
+      requested: isCompact,
+      applied: nextCompact,
+      compactEnabled: shellState.compactEnabled,
+      didChange,
+      skipped: true
+    });
+    return;
+  }
+
   shellState.isCompact = nextCompact;
 
   document.body.classList.add("route--project");
@@ -174,11 +185,9 @@ function applyCompactState(isCompact) {
   });
 
   syncCompactTabLabel();
-  if (didChange) {
-    window.dispatchEvent(new CustomEvent(PROJECT_SHELL_COMPACT_CHANGE_EVENT, {
-      detail: { isCompact: shellState.isCompact }
-    }));
-  }
+  window.dispatchEvent(new CustomEvent(PROJECT_SHELL_COMPACT_CHANGE_EVENT, {
+    detail: { isCompact: shellState.isCompact }
+  }));
 }
 
 function syncCompactState() {

--- a/apps/web/js/views/project-situations-scroll-source.js
+++ b/apps/web/js/views/project-situations-scroll-source.js
@@ -1,0 +1,12 @@
+export function resolveKanbanScrollableSource(target) {
+  if (!target || typeof target.closest !== "function") return null;
+
+  const cards = target.closest(".situation-kanban__cards");
+  if (cards) return cards;
+
+  const column = target.closest(".situation-kanban__col");
+  if (!column) return null;
+
+  return column.querySelector(".situation-kanban__cards") || null;
+}
+

--- a/apps/web/js/views/project-situations-scroll-source.test.mjs
+++ b/apps/web/js/views/project-situations-scroll-source.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveKanbanScrollableSource } from "./project-situations-scroll-source.js";
+
+function createMockNode({ classes = [], parent = null, cards = null } = {}) {
+  const classSet = new Set(classes);
+  const node = {
+    parent,
+    cards,
+    matches(selector) {
+      if (selector === ".situation-kanban__cards") return classSet.has("situation-kanban__cards");
+      if (selector === ".situation-kanban__col") return classSet.has("situation-kanban__col");
+      return false;
+    },
+    closest(selector) {
+      let cursor = this;
+      while (cursor) {
+        if (typeof cursor.matches === "function" && cursor.matches(selector)) {
+          return cursor;
+        }
+        cursor = cursor.parent || null;
+      }
+      return null;
+    },
+    querySelector(selector) {
+      if (selector === ".situation-kanban__cards") return this.cards || null;
+      return null;
+    }
+  };
+  return node;
+}
+
+test("resolveKanbanScrollableSource returns cards when target is inside cards", () => {
+  const column = createMockNode({ classes: ["situation-kanban__col"] });
+  const cards = createMockNode({ classes: ["situation-kanban__cards"], parent: column });
+  column.cards = cards;
+  const card = createMockNode({ parent: cards });
+
+  assert.equal(resolveKanbanScrollableSource(card), cards);
+});
+
+test("resolveKanbanScrollableSource returns column cards when target is inside column", () => {
+  const column = createMockNode({ classes: ["situation-kanban__col"] });
+  const cards = createMockNode({ classes: ["situation-kanban__cards"], parent: column });
+  column.cards = cards;
+  const head = createMockNode({ parent: column });
+
+  assert.equal(resolveKanbanScrollableSource(head), cards);
+});
+
+test("resolveKanbanScrollableSource returns null outside kanban column", () => {
+  const node = createMockNode({});
+  assert.equal(resolveKanbanScrollableSource(node), null);
+});
+

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -7,7 +7,6 @@ import {
   syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
-  useProjectScrollSource,
   setProjectViewHeader
 } from "./project-shell-chrome.js";
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
@@ -30,6 +29,7 @@ import { createProjectSituationsEvents } from "./project-situations/project-situ
 import { createProjectSituationsReviewState } from "./project-situations/project-situations-review-state.js";
 import { createProjectSituationsThread } from "./project-situations/project-situations-thread.js";
 import { createProjectSituationsKanbanView } from "./project-situations/project-situations-view-kanban.js";
+import { resolveKanbanScrollableSource } from "./project-situations-scroll-source.js";
 import { renderGlobalHeader } from "./global-header.js";
 
 export { getEffectiveSujetStatus, getEffectiveSituationStatus } from "./project-subjects.js";
@@ -220,6 +220,19 @@ function syncProjectHeader(root) {
 let situationsTabResetBound = false;
 let currentSituationsRoot = null;
 let cleanupSituationsListeners = null;
+
+function isKanbanScrollDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:situation-kanban-scroll") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function debugKanbanScroll(label, payload) {
+  if (!isKanbanScrollDebugEnabled()) return;
+  console.info(label, payload);
+}
 let cleanupSituationsSyncEvents = null;
 
 function syncSituationsAvailableHeight(root) {
@@ -292,28 +305,56 @@ function rerender(root) {
   const kanbanColumns = [...root.querySelectorAll(".situation-kanban__col")];
   const kanbanCardLists = [...root.querySelectorAll(".situation-kanban__cards")];
   if (kanbanColumns.length) {
-    registerProjectScrollSources(kanbanColumns, kanbanCardLists, primaryScrollRoot);
+    registerProjectScrollSources(kanbanCardLists);
   } else {
     registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
   }
 
   const unbindColumnHandlers = [];
   const kanbanScrollElements = kanbanColumns.length
-    ? [...new Set([...kanbanColumns, ...kanbanCardLists, primaryScrollRoot].filter(Boolean))]
+    ? [...new Set([...kanbanColumns, ...kanbanCardLists].filter(Boolean))]
     : [];
+
+  const resolveAndActivateKanbanScrollableSource = (target, eventType = null) => {
+    const sourceEl = resolveKanbanScrollableSource(target);
+    if (!sourceEl) return;
+
+    setProjectCompactEnabled(true);
+    setProjectActiveScrollSource(sourceEl);
+
+    const scrollTop = Number(sourceEl.scrollTop || 0);
+    const nextCompact = scrollTop > 12;
+    const didChange = document.body.classList.contains("project-shell-compact") !== nextCompact;
+    debugKanbanScroll("[situations:kanban-scroll-source]", {
+      eventType,
+      sourceTag: sourceEl.tagName || null,
+      sourceClass: sourceEl.className || null,
+      scrollTop,
+      nextCompact,
+      didChange
+    });
+  };
+
   kanbanScrollElements.forEach((source) => {
-    const ownerColumn = source.classList.contains("situation-kanban__col")
-      ? source
-      : source.closest(".situation-kanban__col");
-    const activateColumn = () => {
-      if (!ownerColumn) return;
-      setProjectCompactEnabled(true);
-      setProjectActiveScrollSource(ownerColumn);
+    const activateColumn = (event) => {
+      resolveAndActivateKanbanScrollableSource(event?.target || source, event?.type || null);
     };
     const onKanbanScroll = (event) => {
       const sourceEl = event?.currentTarget;
       if (!sourceEl) return;
       syncProjectShellCompactFromScrollSource(sourceEl);
+
+      const scrollTop = Number(sourceEl.scrollTop || 0);
+      const nextCompact = scrollTop > 12;
+      const didChange = document.body.classList.contains("project-shell-compact") !== nextCompact;
+      debugKanbanScroll("[situations:kanban-scroll]", {
+        eventType: event?.type || null,
+        sourceTag: sourceEl.tagName || null,
+        sourceClass: sourceEl.className || null,
+        scrollTop,
+        nextCompact,
+        didChange
+      });
       syncSituationsAvailableHeight(root);
     };
     source.addEventListener("mouseenter", activateColumn);


### PR DESCRIPTION
### Motivation
- Corriger le clignotement du header en vue Situations > Kanban causé par un ping-pong entre `.situation-kanban__col` (overflow-y:hidden) et `.situation-kanban__cards` (vraiment scrollable).
- Empêcher des écritures DOM / dispatchs d'événements inutiles lors d'un scroll quand l'état compact n'a pas changé.

### Description
- Ajout d'un resolver `resolveKanbanScrollableSource()` dans `apps/web/js/views/project-situations-scroll-source.js` qui retourne systématiquement le conteneur `.situation-kanban__cards` le plus proche ou `null` hors Kanban. 
- Dans `apps/web/js/views/project-situations.js` on n'enregistre plus les colonnes comme sources verticales de compactage et on résout/active désormais uniquement les vrais conteneurs scrollables (`.situation-kanban__cards`) sur `mouseenter`/`wheel`/`touchstart`/`scroll`.
- Instrumentation debug ajoutée, activable via `localStorage['debug:situation-kanban-scroll'] === '1'`, qui logge la source utilisée, son tag/class, `scrollTop`, `nextCompact` et `didChange` sans polluer la console hors debug. 
- `applyCompactState()` dans `apps/web/js/views/project-shell-chrome.js` devient idempotente et quitte immédiatement si l'état compact ne change pas, et ne provoque donc ni retoggle de classes ni dispatch superflu; l'événement `PROJECT_SHELL_COMPACT_CHANGE_EVENT` n'est émis que lorsqu'un changement effectif est appliqué.
- Ajout d'un test unitaire ciblé `apps/web/js/views/project-situations-scroll-source.test.mjs` pour valider la résolution de la source scrollable (dans la carte, dans la colonne, hors Kanban).

### Testing
- Exécution du test unitaire ciblé avec `node --test apps/web/js/views/project-situations-scroll-source.test.mjs` qui a passé les 3 cas (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3b15bd1483299f20ac5361d7254d)