### PR TITLE
Fix Kanban header compact mode to react only to real scroll

### DIFF
--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -331,7 +331,7 @@ export function registerProjectPrimaryScrollSource(el) {
   registerProjectScrollSources(el);
 }
 
-export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
+export function setProjectActiveScrollSource(el, { resolve = null, syncImmediately = true } = {}) {
   shellState.cleanupActiveScrollSource?.();
   shellState.cleanupActiveScrollSource = null;
   shellState.activeScrollSourceEl = el || null;
@@ -349,7 +349,9 @@ export function setProjectActiveScrollSource(el, { resolve = null } = {}) {
     };
   }
 
-  syncCompactState();
+  if (syncImmediately !== false) {
+    syncCompactState();
+  }
 }
 
 export function useProjectScrollSource(el) {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -315,12 +315,12 @@ function rerender(root) {
     ? [...new Set([...kanbanColumns, ...kanbanCardLists].filter(Boolean))]
     : [];
 
-  const resolveAndActivateKanbanScrollableSource = (target, eventType = null) => {
+  const resolveAndActivateKanbanScrollableSource = (target, eventType = null, { syncImmediately = false } = {}) => {
     const sourceEl = resolveKanbanScrollableSource(target);
     if (!sourceEl) return;
 
     setProjectCompactEnabled(true);
-    setProjectActiveScrollSource(sourceEl);
+    setProjectActiveScrollSource(sourceEl, { syncImmediately });
 
     const scrollTop = Number(sourceEl.scrollTop || 0);
     const nextCompact = scrollTop > 12;
@@ -331,13 +331,27 @@ function rerender(root) {
       sourceClass: sourceEl.className || null,
       scrollTop,
       nextCompact,
-      didChange
+      didChange,
+      syncImmediately
     });
   };
 
   kanbanScrollElements.forEach((source) => {
-    const activateColumn = (event) => {
-      resolveAndActivateKanbanScrollableSource(event?.target || source, event?.type || null);
+    const onKanbanMouseEnter = (event) => {
+      const sourceEl = resolveKanbanScrollableSource(event?.target || source);
+      if (!sourceEl) return;
+      debugKanbanScroll("[situations:kanban-hover-ignored]", {
+        eventType: event?.type || null,
+        sourceTag: sourceEl.tagName || null,
+        sourceClass: sourceEl.className || null,
+        scrollTop: Number(sourceEl.scrollTop || 0),
+        ignoredHover: true
+      });
+    };
+    const prepareScrollSource = (event) => {
+      resolveAndActivateKanbanScrollableSource(event?.target || source, event?.type || null, {
+        syncImmediately: false
+      });
     };
     const onKanbanScroll = (event) => {
       const sourceEl = event?.currentTarget;
@@ -357,14 +371,14 @@ function rerender(root) {
       });
       syncSituationsAvailableHeight(root);
     };
-    source.addEventListener("mouseenter", activateColumn);
-    source.addEventListener("wheel", activateColumn, { passive: true });
-    source.addEventListener("touchstart", activateColumn, { passive: true });
+    source.addEventListener("mouseenter", onKanbanMouseEnter);
+    source.addEventListener("wheel", prepareScrollSource, { passive: true });
+    source.addEventListener("touchstart", prepareScrollSource, { passive: true });
     source.addEventListener("scroll", onKanbanScroll, { passive: true });
     unbindColumnHandlers.push(() => {
-      source.removeEventListener("mouseenter", activateColumn);
-      source.removeEventListener("wheel", activateColumn);
-      source.removeEventListener("touchstart", activateColumn);
+      source.removeEventListener("mouseenter", onKanbanMouseEnter);
+      source.removeEventListener("wheel", prepareScrollSource);
+      source.removeEventListener("touchstart", prepareScrollSource);
       source.removeEventListener("scroll", onKanbanScroll);
     });
   });


### PR DESCRIPTION
### Motivation
- Prevent the project header from toggling compact/expanded when simply hovering between Kanban columns, since hover could trigger activation of a column that happened to have `scrollTop === 0` and wrongly expand the header. 
- Ensure the header state is driven only by real vertical scrolling of a column, while preserving existing behavior for other views.

### Description
- Added an option `syncImmediately` to `setProjectActiveScrollSource(el, { syncImmediately })` with default `true` so callers can opt out of an immediate compact-state sync; implemented in `apps/web/js/views/project-shell-chrome.js`.
- In `apps/web/js/views/project-situations.js`, removed the previous `mouseenter`-driven activation that immediately changed the header state and replaced it with a hover-ignored debug handler that does not call the shell activation logic.
- Made `wheel` and `touchstart` handlers only prepare the Kanban column as a candidate scroll source by calling `setProjectActiveScrollSource(..., { syncImmediately:false })` instead of forcing immediate `syncCompactState` changes.
- Kept the real `scroll` handler calling `syncProjectShellCompactFromScrollSource(sourceEl)` so the header actually updates only on true scroll events; added/extended debug payloads (`ignoredHover`, `syncImmediately`) to aid diagnosis.

### Testing
- Ran `git -C /workspace/Mdall diff --check` which produced no issues and exited successfully. 
- Verified working tree status with `git -C /workspace/Mdall status --short` and committed the change successfully. 
- Confirmed through code inspection that existing non-Kanban callers of `setProjectActiveScrollSource` keep the previous immediate-sync behavior because `syncImmediately` defaults to `true`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3f35cdd083299dd7f68cb6fdf729)