### PR TITLE
feat(situations): add dedicated project situation drilldown component

### DIFF
--- a/apps/web/js/views/project-situation-drilldown.js
+++ b/apps/web/js/views/project-situation-drilldown.js
@@ -1,0 +1,48 @@
+import { escapeHtml } from "../utils/escape-html.js";
+
+function normalizeSituation(situation) {
+  if (!situation || typeof situation !== "object") {
+    return { title: "Situation", description: "" };
+  }
+  return {
+    title: String(situation.title || "Situation"),
+    description: String(situation.description || "")
+  };
+}
+
+export function renderProjectSituationDrilldown(situation, options = {}) {
+  const normalizedSituation = normalizeSituation(situation);
+  const closeButtonId = String(options.closeButtonId || "drilldownClose");
+  const closeButtonLabel = String(options.closeButtonLabel || "Fermer");
+  const editActionLabel = String(options.editActionLabel || "Modifier");
+  const shortDescriptionLabel = String(options.shortDescriptionLabel || "Description courte");
+
+  return `
+    <div class="project-situation-drilldown" data-project-situation-drilldown="true">
+      <div class="project-situation-drilldown__header">
+        <div class="project-situation-drilldown__title">${escapeHtml(normalizedSituation.title)}</div>
+        <button
+          type="button"
+          id="${escapeHtml(closeButtonId)}"
+          class="project-situation-drilldown__close"
+          aria-label="${escapeHtml(closeButtonLabel)}"
+          title="${escapeHtml(closeButtonLabel)}"
+        >✕</button>
+      </div>
+
+      <div class="project-situation-drilldown__section">
+        <div class="project-situation-drilldown__section-head">
+          <span class="project-situation-drilldown__section-title">
+            <svg class="icon" aria-hidden="true" focusable="false">
+              <use href="#situation-description"></use>
+            </svg>
+            ${escapeHtml(shortDescriptionLabel)}
+          </span>
+          <button type="button" class="project-situation-drilldown__section-action">${escapeHtml(editActionLabel)}</button>
+        </div>
+
+        <div class="project-situation-drilldown__section-content">${escapeHtml(normalizedSituation.description)}</div>
+      </div>
+    </div>
+  `;
+}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13301,6 +13301,87 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   max-width:860px;
 }
 
+
+.project-situation-drilldown{
+  width:580px;
+  max-width:100%;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.project-situation-drilldown__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.project-situation-drilldown__title{
+  margin:0;
+  font-size:24px;
+  line-height:1.25;
+  font-weight:600;
+}
+
+.project-situation-drilldown__close{
+  border:0;
+  background:transparent;
+  color:var(--muted);
+  width:32px;
+  height:32px;
+  border-radius:8px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.project-situation-drilldown__close:hover,
+.project-situation-drilldown__close:focus-visible{
+  color:var(--text);
+  background:rgba(110,118,129,.18);
+}
+
+.project-situation-drilldown__section{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+
+.project-situation-drilldown__section-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+}
+
+.project-situation-drilldown__section-title{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  font-size:24px;
+  line-height:1.2;
+  font-weight:600;
+}
+
+.project-situation-drilldown__section-action{
+  border:0;
+  background:transparent;
+  color:var(--muted);
+  font-weight:500;
+}
+
+.project-situation-drilldown__section-action:hover,
+.project-situation-drilldown__section-action:focus-visible{
+  color:var(--accent-fg);
+  text-decoration:underline;
+}
+
+.project-situation-drilldown__section-content{
+  color:var(--text);
+  line-height:1.5;
+}
+
 .project-situation-layout-tabs{
   margin:6px 0 0;
 }


### PR DESCRIPTION
### Motivation
- Introduire un drilldown spécifique pour les "situations" avec une structure DOM et des classes dédiées tout en évitant toute modification du drilldown générique existant.

### Description
- Ajout de `apps/web/js/views/project-situation-drilldown.js` qui exporte `renderProjectSituationDrilldown(situation, options)` et attend la prop `situation` pour rendre la structure DOM demandée (titre, bouton close, section « Description courte » avec icône `#situation-description`).
- Ajout des styles dédiés dans `apps/web/style.css` pour les classes `project-situation-drilldown*` avec largeur fixe `580px` et styles pour `__header`, `__title`, `__close`, `__section`, `__section-head`, `__section-title`, `__section-action` et `__section-content`.
- Aucun changement au contrôleur drilldown générique, aucun `fetch` ajouté et aucun nouveau state global introduit.

### Testing
- Exécution de `node --check apps/web/js/views/project-situation-drilldown.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb51335b4c83298d5ee2682f2d720e)