### PR TITLE
Brancher le bouton « Étendre la barre latérale » (Situations) au drilldown spécifique

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -36,7 +36,8 @@ export { getEffectiveSujetStatus, getEffectiveSituationStatus } from "./project-
 import {
   getSujetKanbanStatusForSituation,
   setSujetKanbanStatusForSituation,
-  openSubjectDrilldownFromSituation
+  openSubjectDrilldownFromSituation,
+  openSituationDrilldownFromSelection
 } from "./project-subjects.js";
 
 const { uiState, ensureSituationsViewState } = createProjectSituationsState({ store });
@@ -419,8 +420,8 @@ const { bindEvents } = createProjectSituationsEvents({
   updateSituationRecord,
   setSelectedSituationId,
   getSituationById,
-  getSituationEditForm,
-  loadSituationSelection
+  loadSituationSelection,
+  openSituationDrilldownFromSelection
 });
 
 export function renderProjectSituations(root) {

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1,4 +1,5 @@
 import { bindLightTabs } from "../ui/light-tabs.js";
+import { renderProjectSituationDrilldown } from "../project-situation-drilldown.js";
 
 function syncSubmitButtonState(button, { submitting = false, title = "" } = {}) {
   if (!button) return;
@@ -25,7 +26,8 @@ export function createProjectSituationsEvents({
   updateSituationRecord,
   setSelectedSituationId,
   getSituationById,
-  loadSituationSelection
+  loadSituationSelection,
+  openSituationDrilldownFromSelection
 }) {
   function buildEditSituationPayload() {
     const form = uiState.editForm || getDefaultCreateForm();
@@ -255,6 +257,35 @@ export function createProjectSituationsEvents({
     if (openButton) {
       openButton.onclick = () => openCreateModal(root);
     }
+
+    root.querySelectorAll("[data-open-situation-drilldown]").forEach((node) => {
+      node.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const selectedSituationId = String(store.situationsView?.selectedSituationId || "").trim();
+        if (!selectedSituationId) return;
+        const selectedSituation = getSituationById(selectedSituationId);
+        if (!selectedSituation) return;
+
+        if (typeof openSituationDrilldownFromSelection === "function") {
+          openSituationDrilldownFromSelection(selectedSituationId, { context: "situation", variant: "situation-kanban" });
+        }
+
+        const drilldownBody = document.getElementById("drilldownBody");
+        if (!drilldownBody) return;
+        drilldownBody.innerHTML = renderProjectSituationDrilldown(selectedSituation, {
+          closeButtonId: "projectSituationDrilldownClose"
+        });
+
+        drilldownBody.querySelector("#projectSituationDrilldownClose")?.addEventListener("click", () => {
+          document.getElementById("drilldownClose")?.click();
+        });
+
+        drilldownBody.querySelector(".project-situation-drilldown__section-action")?.addEventListener("click", () => {
+          openEditPanel(root, selectedSituationId);
+        });
+      });
+    });
 
     root.querySelectorAll("button[data-open-situation]").forEach((node) => {
       node.addEventListener("click", async () => {

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -115,7 +115,13 @@ export function createProjectSituationsView({
                     <button type="button" class="gh-btn gh-action__main gh-btn--default gh-btn--md">
                       ${svgIcon("graph", { className: "octicon octicon-graph" })}<span>Indicateurs</span>
                     </button>
-                    <button type="button" class="gh-btn gh-action__main gh-btn--default gh-btn--md" aria-label="Étendre la barre latérale" title="Étendre la barre latérale">
+                    <button
+                      type="button"
+                      class="gh-btn gh-action__main gh-btn--default gh-btn--md"
+                      data-open-situation-drilldown
+                      aria-label="Étendre la barre latérale"
+                      title="Étendre la barre latérale"
+                    >
                       ${svgIcon("sidebar-expand", { className: "octicon octicon-sidebar-expand" })}
                     </button>
                   </div>

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -947,6 +947,10 @@ export function openSubjectDrilldownFromSituation(...args) {
   return projectSubjectDrilldown.openDrilldownFromSubject(...args);
 }
 
+export function openSituationDrilldownFromSelection(...args) {
+  return projectSubjectDrilldown.openDrilldownFromSituation(...args);
+}
+
 let collaboratorsHydrationInFlight = null;
 
 function ensureSubjectsCollaboratorsLoaded() {


### PR DESCRIPTION
### Motivation
- Dans l'onglet "Situations" on doit afficher un drilldown spécifique pour la situation sélectionnée quand l'utilisateur clique sur « Étendre la barre latérale » sans toucher au drilldown générique existant.

### Description
- Ajout d'un attribut de ciblage `data-open-situation-drilldown` sur le bouton d'extension de la barre latérale dans la vue Situations (`apps/web/js/views/project-situations/project-situations-view.js`).
- Ajout d'un handler dans `createProjectSituationsEvents` qui ouvre le drilldown global et injecte le HTML rendu par `renderProjectSituationDrilldown(...)` dans `#drilldownBody`, branche le bouton close du composant au close global et relie l'action « Modifier » à l'ouverture du panneau d'édition (`apps/web/js/views/project-situations/project-situations-events.js`).
- Exposition d'un petit pont d'appel `openSituationDrilldownFromSelection` depuis `project-subjects.js` et son injection dans l'assemblage des vues Situations pour réutiliser la logique d'ouverture existante sans modifier les autres usages du drilldown (`apps/web/js/views/project-subjects.js`, `apps/web/js/views/project-situations.js`).
- Aucune nouvelle requête réseau ajoutée et réutilisation du container drilldown global (pas de double mount ni de nouveau overlay).

### Testing
- Exécution du test unitaire `node --test apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs`, qui a réussi (3 tests passés).
- Aucune autre suite automatique lancée dans ce rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb522316ac83298f278efb4b24b12f)