### PR TITLE
Remove legacy situation description block from Situations view

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -127,7 +127,6 @@ export function createProjectSituationsView({
                   </div>
                 </div>
               </div>
-              ${selectedSituation.description ? `<div class="issue-row-meta-text project-situation-detail-head__description">${escapeHtml(selectedSituation.description)}</div>` : ""}
               ${renderSituationLayoutTabs()}
             </div>
           </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13297,11 +13297,6 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   flex:0 0 auto;
 }
 
-.project-situation-detail-head__description{
-  max-width:860px;
-}
-
-
 .project-situation-drilldown{
   width:580px;
   max-width:100%;


### PR DESCRIPTION
### Motivation
- Clean up the Situations detail header by removing the legacy description DOM node (`.issue-row-meta-text.project-situation-detail-head__description`) so the UI no longer renders the redundant inline description and to prepare for the new situation-specific drilldown.

### Description
- Remove the conditional rendering of the description from `apps/web/js/views/project-situations/project-situations-view.js` and delete the now-orphaned CSS rule for `.project-situation-detail-head__description` in `apps/web/style.css`, ensuring no other references remain.

### Testing
- Verified the modified file parses with `node --check apps/web/js/views/project-situations/project-situations-view.js` and confirmed absence of the selector with `rg -n "project-situation-detail-head__description|issue-row-meta-text project-situation-detail-head__description" apps/web`, both commands succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53d682e0832984ba73c1e5239fd3)