### PR TITLE
Ajuste le drilldown situation (largeur, head, icônes, taille de police)

### DIFF
--- a/apps/web/js/views/project-situation-drilldown.js
+++ b/apps/web/js/views/project-situation-drilldown.js
@@ -34,7 +34,7 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
         <div class="project-situation-drilldown__section-head">
           <span class="project-situation-drilldown__section-title">
             <svg class="icon" aria-hidden="true" focusable="false">
-              <use href="#situation-description"></use>
+              <use href="assets/icons.svg#situation-description" xlink:href="assets/icons.svg#situation-description"></use>
             </svg>
             ${escapeHtml(shortDescriptionLabel)}
           </span>
@@ -45,7 +45,7 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
             title="${escapeHtml(editActionLabel)}"
           >
             <svg class="icon" aria-hidden="true" focusable="false">
-              <use href="#pencil"></use>
+              <use href="assets/icons.svg#pencil" xlink:href="assets/icons.svg#pencil"></use>
             </svg>
           </button>
         </div>

--- a/apps/web/js/views/project-situations/project-situations-view-kanban.js
+++ b/apps/web/js/views/project-situations/project-situations-view-kanban.js
@@ -156,7 +156,7 @@ export function createProjectSituationsKanbanView({
         event.stopPropagation();
         const subjectId = String(node.getAttribute("data-open-situation-subject") || "").trim();
         if (!subjectId) return;
-        openSubjectDrilldown(subjectId, { variant: "situation-kanban" });
+        openSubjectDrilldown(subjectId);
       });
     });
 

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -213,7 +213,24 @@ export function createProjectSubjectDrilldownController(config) {
   function applyDrilldownVariant(variant = "") {
     const panel = document.getElementById("drilldownPanel");
     if (!panel) return;
-    panel.classList.toggle("drilldown--situation-kanban", String(variant || "").trim() === "situation-kanban");
+    const isSituationKanban = String(variant || "").trim() === "situation-kanban";
+    panel.classList.toggle("drilldown--situation-kanban", isSituationKanban);
+    if (isSituationKanban) {
+      panel.querySelector(".overlay-chrome__head.drilldown__head")?.remove();
+      return;
+    }
+    if (panel.querySelector("#drilldownTitle")) return;
+    const headMarkup = renderOverlayChromeHead({
+      titleId: "drilldownTitle",
+      closeId: "drilldownClose",
+      closeLabel: "Fermer",
+      headClassName: "drilldown__head",
+      actionsHtml: promoteActionHtml
+    });
+    const body = panel.querySelector("#drilldownBody");
+    if (body) {
+      body.insertAdjacentHTML("beforebegin", headMarkup);
+    }
   }
   function syncWindowScrollLock(open) {
     if (open) {
@@ -261,7 +278,9 @@ export function createProjectSubjectDrilldownController(config) {
     applyDrilldownVariant(options?.variant);
     setOverlayChromeOpenState(panel, true);
     syncWindowScrollLock(true);
-    updateDrilldownPanel();
+    if (String(options?.variant || "").trim() !== "situation-kanban") {
+      updateDrilldownPanel();
+    }
   }
 
   function closeDrilldown() {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13299,8 +13299,6 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 }
 
 .project-situation-drilldown{
-  width:580px;
-  max-width:100%;
   display:flex;
   flex-direction:column;
   gap:16px;
@@ -13385,6 +13383,7 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-drilldown__section-content{
   color:var(--text);
+  font-size:14px;
   line-height:1.5;
 }
 


### PR DESCRIPTION
### Motivation
- Le drilldown affiché depuis le kanban situation devait conserver la largeur normale (comme le détail sujet) sauf quand l'utilisateur clique explicitement sur `Étendre la barre latérale` qui doit appliquer la largeur compacte de 580px.
- Les icônes SVG du drilldown doivent référencer explicitement le sprite `assets/icons.svg#...` pour une inclusion fiable.
- Le head overlay générique ne doit pas être présent dans le DOM lorsque la variante compacte du drilldown (`situation-kanban`) est utilisée.

### Description
- Met à jour les références SVG dans `renderProjectSituationDrilldown` pour utiliser `assets/icons.svg#...` avec `href` et `xlink:href` pour `situation-description` et `pencil` (fichier modifié: `apps/web/js/views/project-situation-drilldown.js`).
- Empêche l'ouverture du drilldown sujet en forçant la variante compacte depuis le kanban en supprimant le passage de `variant: "situation-kanban"` (fichier modifié: `apps/web/js/views/project-situations/project-situations-view-kanban.js`).
- Dans le contrôleur du drilldown (`project-subject-drilldown.js`) ajoute la gestion de la variante: quand `variant === "situation-kanban"` on applique la classe `drilldown--situation-kanban`, on retire le head overlay du DOM et on évite d'appeler `updateDrilldownPanel()` pour ce mode; pour les autres variantes on ré-injecte le head si nécessaire (fichier modifié: `apps/web/js/views/project-subjects/project-subject-drilldown.js`).
- Supprime la largeur fixe sur `.project-situation-drilldown` et passe `.project-situation-drilldown__section-content` en `font-size:14px` pour harmoniser l'affichage (fichier modifié: `apps/web/style.css`).

### Testing
- Exécution des tests Node: `node --test apps/web/js/views/project-subjects/project-subject-drilldown-style.test.mjs apps/web/js/utils/markdown-renderer.test.mjs` — tous les tests sont passés (`5/5` tests OK).
- Vérification statique et commit des fichiers modifiés: changements appliqués et commités localement (tests unitaires automatisés verts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a0d5a988329a3ffa3395bb346ca)