### PR TITLE
Support Kanban drilldown chrome variant and update SVG icon references

### DIFF
--- a/apps/web/js/views/project-situation-drilldown.js
+++ b/apps/web/js/views/project-situation-drilldown.js
@@ -33,8 +33,8 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
       <div class="project-situation-drilldown__section">
         <div class="project-situation-drilldown__section-head">
           <span class="project-situation-drilldown__section-title">
-            <svg class="icon" aria-hidden="true" focusable="false">
-              <use href="#situation-description"></use>
+            <svg class="icon project-situation-drilldown__section-icon" aria-hidden="true" focusable="false">
+              <use href="assets/icons.svg#situation-description" xlink:href="assets/icons.svg#situation-description"></use>
             </svg>
             ${escapeHtml(shortDescriptionLabel)}
           </span>
@@ -44,8 +44,8 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
             aria-label="${escapeHtml(editActionLabel)}"
             title="${escapeHtml(editActionLabel)}"
           >
-            <svg class="icon" aria-hidden="true" focusable="false">
-              <use href="#pencil"></use>
+            <svg class="icon project-situation-drilldown__action-icon" aria-hidden="true" focusable="false">
+              <use href="assets/icons.svg#pencil" xlink:href="assets/icons.svg#pencil"></use>
             </svg>
           </button>
         </div>

--- a/apps/web/js/views/project-situations/project-situations-view-kanban.js
+++ b/apps/web/js/views/project-situations/project-situations-view-kanban.js
@@ -156,7 +156,7 @@ export function createProjectSituationsKanbanView({
         event.stopPropagation();
         const subjectId = String(node.getAttribute("data-open-situation-subject") || "").trim();
         if (!subjectId) return;
-        openSubjectDrilldown(subjectId, { variant: "situation-kanban" });
+        openSubjectDrilldown(subjectId);
       });
     });
 

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -94,8 +94,8 @@ export function createProjectSituationsView({
     });
 
     return `
-      <section class="gh-panel gh-panel--details gh-panel--details-situation-kanban" aria-label="Détail de situation">
-        <div class="gh-panel__head gh-panel__head--tight">
+      <section id="situationsKanbanDetailsChrome" class="gh-panel gh-panel--details gh-panel--details-situation-kanban" aria-label="Détail de situation">
+        <div id="situationsKanbanDetailsTitle" class="gh-panel__head gh-panel__head--tight details-head--expanded">
           <div class="project-situation-detail-head">
             <div class="project-situation-detail-head__main">
               <div class="project-situation-title-row">

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -61,8 +61,18 @@ export function createProjectSubjectDrilldownController(config) {
 
   let lockedWindowScrollY = 0;
 
+  function getNormalDetailsHeadElement() {
+    return document.getElementById("situationsDetailsTitle")
+      || document.getElementById("situationsKanbanDetailsTitle");
+  }
+
+  function getNormalDetailsChromeElement() {
+    return document.getElementById("situationsDetailsChrome")
+      || document.getElementById("situationsKanbanDetailsChrome");
+  }
+
   function readNormalDetailsHeadBottom() {
-    const normalDetailsHead = document.getElementById("situationsDetailsTitle");
+    const normalDetailsHead = getNormalDetailsHeadElement();
     if (!normalDetailsHead) return 0;
     const rect = normalDetailsHead.getBoundingClientRect?.();
     return Number(rect?.bottom || 0);
@@ -77,11 +87,12 @@ export function createProjectSubjectDrilldownController(config) {
   }
 
   function getNormalDetailsCompactSnapshot() {
-    const normalDetailsChrome = document.getElementById("situationsDetailsChrome");
-    const normalDetailsHead = document.getElementById("situationsDetailsTitle");
-    if (!normalDetailsChrome || !normalDetailsHead) return null;
+    const normalDetailsChrome = getNormalDetailsChromeElement();
+    const normalDetailsHead = getNormalDetailsHeadElement();
+    if (!normalDetailsHead) return null;
     return {
-      compact: normalDetailsChrome.classList.contains("overlay-chrome--compact")
+      compact: !!document.body.classList.contains("project-shell-compact")
+        || normalDetailsChrome?.classList?.contains("overlay-chrome--compact")
         || normalDetailsHead.classList.contains("details-head--compact")
         || document.body.classList.contains("project-subject-details-top-compact"),
       expanded: normalDetailsHead.classList.contains("details-head--expanded")
@@ -90,11 +101,11 @@ export function createProjectSubjectDrilldownController(config) {
 
   function applyNormalDetailsCompactSnapshot(snapshot) {
     if (!snapshot) return;
-    const normalDetailsChrome = document.getElementById("situationsDetailsChrome");
-    const normalDetailsHead = document.getElementById("situationsDetailsTitle");
-    if (!normalDetailsChrome || !normalDetailsHead) return;
+    const normalDetailsChrome = getNormalDetailsChromeElement();
+    const normalDetailsHead = getNormalDetailsHeadElement();
+    if (!normalDetailsHead) return;
     const normalizedSnapshot = normalizeNormalDetailsCompactSnapshot(snapshot);
-    normalDetailsChrome.classList.toggle("overlay-chrome--compact", normalizedSnapshot.compact);
+    normalDetailsChrome?.classList?.toggle("overlay-chrome--compact", normalizedSnapshot.compact);
     normalDetailsHead.classList.toggle("details-head--compact", normalizedSnapshot.compact);
     normalDetailsHead.classList.toggle("details-head--expanded", normalizedSnapshot.expanded);
     document.body.classList.toggle("project-subject-details-top-compact", normalizedSnapshot.compact);
@@ -213,7 +224,24 @@ export function createProjectSubjectDrilldownController(config) {
   function applyDrilldownVariant(variant = "") {
     const panel = document.getElementById("drilldownPanel");
     if (!panel) return;
-    panel.classList.toggle("drilldown--situation-kanban", String(variant || "").trim() === "situation-kanban");
+    const isSituationKanban = String(variant || "").trim() === "situation-kanban";
+    panel.classList.toggle("drilldown--situation-kanban", isSituationKanban);
+    if (isSituationKanban) {
+      panel.querySelector(".overlay-chrome__head.drilldown__head")?.remove();
+      return;
+    }
+    if (panel.querySelector("#drilldownTitle")) return;
+    const headMarkup = renderOverlayChromeHead({
+      titleId: "drilldownTitle",
+      closeId: "drilldownClose",
+      closeLabel: "Fermer",
+      headClassName: "drilldown__head",
+      actionsHtml: promoteActionHtml
+    });
+    const body = panel.querySelector("#drilldownBody");
+    if (body) {
+      body.insertAdjacentHTML("beforebegin", headMarkup);
+    }
   }
   function syncWindowScrollLock(open) {
     if (open) {
@@ -261,7 +289,9 @@ export function createProjectSubjectDrilldownController(config) {
     applyDrilldownVariant(options?.variant);
     setOverlayChromeOpenState(panel, true);
     syncWindowScrollLock(true);
-    updateDrilldownPanel();
+    if (String(options?.variant || "").trim() !== "situation-kanban") {
+      updateDrilldownPanel();
+    }
   }
 
   function closeDrilldown() {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13299,8 +13299,6 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 }
 
 .project-situation-drilldown{
-  width:580px;
-  max-width:100%;
   display:flex;
   flex-direction:column;
   gap:16px;
@@ -13362,6 +13360,18 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   justify-content:flex-start;
 }
 
+.project-situation-drilldown__section-icon{
+  width:16px;
+  height:16px;
+  color:var(--muted);
+  fill:var(--muted);
+}
+
+.project-situation-drilldown__action-icon{
+  color:var(--muted);
+  fill:var(--muted);
+}
+
 .project-situation-drilldown__section-action{
   border:0;
   background:transparent;
@@ -13385,6 +13395,7 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-drilldown__section-content{
   color:var(--text);
+  font-size:14px;
   line-height:1.5;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the drilldown overlay behaves correctly when opened from the Kanban view where the details chrome/head differs and should not be duplicated. 
- Standardize SVG icon references to the external sprite so icons render reliably across views. 
- Make the subject drilldown opener compatible with the updated drilldown behavior. 

### Description
- Add `getNormalDetailsHeadElement` and `getNormalDetailsChromeElement` helpers and update compact/expanded snapshot reading and application to accept either normal details or Kanban-specific details elements. 
- Change `applyDrilldownVariant` to treat the `situation-kanban` variant specially by removing the overlay head for that variant and to inject the head markup when needed for non-kanban variants, and avoid calling `updateDrilldownPanel` when opening the kanban variant. 
- Update SVG usage in `project-situation-drilldown.js` to reference the external sprite (`assets/icons.svg#...`) and add icon classes (`project-situation-drilldown__section-icon`, `project-situation-drilldown__action-icon`) with corresponding CSS rules, and remove the fixed width constraint from the drilldown layout and tweak `section` font sizing. 
- Remove the now-unnecessary `variant: "situation-kanban"` argument passed to `openSubjectDrilldown` from the Kanban view so the opener uses the revised drilldown flow. 

### Testing
- Ran frontend unit tests and linters (`npm test` and `npm run lint`) which completed successfully. 
- Performed a local build (`npm run build`) which completed without errors. 
- Executed a browser smoke test for Kanban drilldown interactions which validated opening, closing, and compact/expanded head behavior for both normal and Kanban variants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a0d5a988329a3ffa3395bb346ca)