### PR TITLE
Fix drilldown kanban variant behavior, use external SVG sprite, and update styles

### DIFF
--- a/apps/web/js/views/project-situation-drilldown.js
+++ b/apps/web/js/views/project-situation-drilldown.js
@@ -33,8 +33,8 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
       <div class="project-situation-drilldown__section">
         <div class="project-situation-drilldown__section-head">
           <span class="project-situation-drilldown__section-title">
-            <svg class="icon" aria-hidden="true" focusable="false">
-              <use href="#situation-description"></use>
+            <svg class="icon project-situation-drilldown__section-icon" aria-hidden="true" focusable="false">
+              <use href="assets/icons.svg#situation-description" xlink:href="assets/icons.svg#situation-description"></use>
             </svg>
             ${escapeHtml(shortDescriptionLabel)}
           </span>
@@ -44,8 +44,8 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
             aria-label="${escapeHtml(editActionLabel)}"
             title="${escapeHtml(editActionLabel)}"
           >
-            <svg class="icon" aria-hidden="true" focusable="false">
-              <use href="#pencil"></use>
+            <svg class="icon project-situation-drilldown__action-icon" aria-hidden="true" focusable="false">
+              <use href="assets/icons.svg#pencil" xlink:href="assets/icons.svg#pencil"></use>
             </svg>
           </button>
         </div>

--- a/apps/web/js/views/project-situations/project-situations-view-kanban.js
+++ b/apps/web/js/views/project-situations/project-situations-view-kanban.js
@@ -156,7 +156,7 @@ export function createProjectSituationsKanbanView({
         event.stopPropagation();
         const subjectId = String(node.getAttribute("data-open-situation-subject") || "").trim();
         if (!subjectId) return;
-        openSubjectDrilldown(subjectId, { variant: "situation-kanban" });
+        openSubjectDrilldown(subjectId);
       });
     });
 

--- a/apps/web/js/views/project-subjects/project-subject-drilldown.js
+++ b/apps/web/js/views/project-subjects/project-subject-drilldown.js
@@ -213,7 +213,24 @@ export function createProjectSubjectDrilldownController(config) {
   function applyDrilldownVariant(variant = "") {
     const panel = document.getElementById("drilldownPanel");
     if (!panel) return;
-    panel.classList.toggle("drilldown--situation-kanban", String(variant || "").trim() === "situation-kanban");
+    const isSituationKanban = String(variant || "").trim() === "situation-kanban";
+    panel.classList.toggle("drilldown--situation-kanban", isSituationKanban);
+    if (isSituationKanban) {
+      panel.querySelector(".overlay-chrome__head.drilldown__head")?.remove();
+      return;
+    }
+    if (panel.querySelector("#drilldownTitle")) return;
+    const headMarkup = renderOverlayChromeHead({
+      titleId: "drilldownTitle",
+      closeId: "drilldownClose",
+      closeLabel: "Fermer",
+      headClassName: "drilldown__head",
+      actionsHtml: promoteActionHtml
+    });
+    const body = panel.querySelector("#drilldownBody");
+    if (body) {
+      body.insertAdjacentHTML("beforebegin", headMarkup);
+    }
   }
   function syncWindowScrollLock(open) {
     if (open) {
@@ -261,7 +278,9 @@ export function createProjectSubjectDrilldownController(config) {
     applyDrilldownVariant(options?.variant);
     setOverlayChromeOpenState(panel, true);
     syncWindowScrollLock(true);
-    updateDrilldownPanel();
+    if (String(options?.variant || "").trim() !== "situation-kanban") {
+      updateDrilldownPanel();
+    }
   }
 
   function closeDrilldown() {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13299,8 +13299,6 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 }
 
 .project-situation-drilldown{
-  width:580px;
-  max-width:100%;
   display:flex;
   flex-direction:column;
   gap:16px;
@@ -13362,6 +13360,18 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   justify-content:flex-start;
 }
 
+.project-situation-drilldown__section-icon{
+  width:16px;
+  height:16px;
+  color:var(--muted);
+  fill:var(--muted);
+}
+
+.project-situation-drilldown__action-icon{
+  color:var(--muted);
+  fill:var(--muted);
+}
+
 .project-situation-drilldown__section-action{
   border:0;
   background:transparent;
@@ -13385,6 +13395,7 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-drilldown__section-content{
   color:var(--text);
+  font-size:14px;
   line-height:1.5;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure SVG icons render reliably by referencing the external sprite and allow per-icon styling. 
- Make the subject drilldown behave correctly when opened from the kanban view by removing duplicated overlay chrome and skipping unnecessary panel updates. 
- Adjust drilldown layout and icon styles for better visual consistency and responsive sizing. 

### Description
- Updated `renderProjectSituationDrilldown` to add per-icon classes and reference the external sprite with `href="assets/icons.svg#..."` and `xlink:href="assets/icons.svg#..."` on `<use>` elements. 
- Removed the `variant` argument when calling `openSubjectDrilldown` from the kanban view by changing `openSubjectDrilldown(subjectId, { variant: "situation-kanban" })` to `openSubjectDrilldown(subjectId)`. 
- Reworked `applyDrilldownVariant` to detect the `situation-kanban` variant, remove the overlay head for that variant, inject the overlay head markup for non-kanban drilldowns using `renderOverlayChromeHead`, and avoid calling `updateDrilldownPanel` when opening a kanban drilldown. 
- Updated stylesheet by removing the fixed width on `.project-situation-drilldown`, adding `.project-situation-drilldown__section-icon` and `.project-situation-drilldown__action-icon` rules, and adjusting text sizing in `.project-situation-drilldown__section-content`. 

### Testing
- Ran linter via `npm run lint` and it completed successfully. 
- Executed unit tests via `npm test` and all tests passed. 
- Performed a production build with `npm run build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a0d5a988329a3ffa3395bb346ca)