### PR TITLE
Fix compact header regression in main subject detail panel

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+
+test("le compact du header détail principal est piloté par le scroll du body détail", () => {
+  assert.match(eventsSource, /const normalDetailsBody = root\.querySelector\("#situationsDetailsHost"\);/);
+  assert.match(eventsSource, /normalDetailsBody \|\| \(normalDetailsHead \? document : null\)/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -5420,8 +5420,9 @@ export function createProjectSubjectsEvents(config) {
   function bindDetailsScroll(root) {
     const normalDetailsHead = root.querySelector("#situationsDetailsTitle");
     const normalDetailsChrome = root.querySelector("#situationsDetailsChrome");
+    const normalDetailsBody = root.querySelector("#situationsDetailsHost");
     bindCondensedTitleScroll(
-      normalDetailsHead ? document : root.querySelector("#situationsDetailsHost"),
+      normalDetailsBody || (normalDetailsHead ? document : null),
       normalDetailsChrome || normalDetailsHead,
       "details",
       {


### PR DESCRIPTION
### Motivation
- A regression caused the main subject detail header to enter compact mode incorrectly because the compact binding was not driven by the detail panel scroll container, making the main view behave like the drilldown view.

### Description
- Use `root.querySelector("#situationsDetailsHost")` as the primary scroll source in `bindDetailsScroll` so the compact header is driven by the detail body instead of `document` when present.
- Preserve the previous behavior by falling back to `document` only when the detail body is not found in the DOM in `bindCondensedTitleScroll` call.
- Add a regression test `apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs` that asserts the new `normalDetailsBody` lookup and the binding fallback expression are present.

### Testing
- Ran `node --test apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs` which executed the existing drilldown binding test and the new regression test.
- All tests passed (`4` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb630fb6a88329bdfd010477996cc2)