### PR TITLE
Reset active scroll source and prefer details host for compact header; remove extra scroll wrapper

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -39,7 +39,8 @@ import { closeGlobalNav } from "./global-nav.js";
 import {
   setProjectViewHeader,
   refreshProjectShellChrome,
-  setProjectCompactEnabled
+  setProjectCompactEnabled,
+  clearProjectActiveScrollSource
 } from "./project-shell-chrome.js";
 import { svgIcon } from "../ui/icons.js";
 import { renderGhActionButton } from "./ui/gh-split-button.js";
@@ -855,6 +856,7 @@ const projectSubjectsView = createProjectSubjectsView({
   bindDetailsScroll: (...args) => projectSubjectsEvents.bindDetailsScroll(...args),
   refreshProjectShellChrome,
   setProjectCompactEnabled,
+  clearProjectActiveScrollSource,
   currentDecisionTarget: (...args) => currentDecisionTarget(...args),
   addComment: (...args) => addComment(...args),
   getSelectionForScope: (...args) => getSelectionForScope(...args),
@@ -1027,12 +1029,10 @@ export function renderProjectSubjects(root) {
 
   root.innerHTML = `
     <section class="project-simple-page project-simple-page--settings">
-      <div class="project-simple-scroll" id="projectSituationsScroll">
-        <div class="settings-content project-page-shell project-page-shell--content">
-          <section class="gh-panel gh-panel--results" aria-label="Results">
-            <div id="situationsPanelHost"></div>
-          </section>
-        </div>
+      <div class="settings-content project-page-shell project-page-shell--content">
+        <section class="gh-panel gh-panel--results" aria-label="Results">
+          <div id="situationsPanelHost"></div>
+        </section>
       </div>
     </section>
   `;

--- a/apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
+const eventsSource = fs.readFileSync(eventsPath, "utf8");
+
+test("le compact du header détail principal est piloté par le scroll du body détail", () => {
+  assert.match(eventsSource, /const normalDetailsBody = root\.querySelector\("#situationsDetailsHost"\);/);
+  assert.match(eventsSource, /normalDetailsBody \|\| \(normalDetailsHead \? document : null\)/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -5420,8 +5420,9 @@ export function createProjectSubjectsEvents(config) {
   function bindDetailsScroll(root) {
     const normalDetailsHead = root.querySelector("#situationsDetailsTitle");
     const normalDetailsChrome = root.querySelector("#situationsDetailsChrome");
+    const normalDetailsBody = root.querySelector("#situationsDetailsHost");
     bindCondensedTitleScroll(
-      normalDetailsHead ? document : root.querySelector("#situationsDetailsHost"),
+      normalDetailsBody || (normalDetailsHead ? document : null),
       normalDetailsChrome || normalDetailsHead,
       "details",
       {

--- a/apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const subjectsViewPath = path.resolve(__dirname, "./project-subjects-view.js");
+const subjectsViewSource = fs.readFileSync(subjectsViewPath, "utf8");
+const subjectsEntryPath = path.resolve(__dirname, "../project-subjects.js");
+const subjectsEntrySource = fs.readFileSync(subjectsEntryPath, "utf8");
+
+test("la vue Sujets réinitialise la source de scroll active pour revenir au document", () => {
+  assert.match(subjectsViewSource, /clearProjectActiveScrollSource\?\.\(\);/);
+});
+
+test("la page Sujets ne rend plus le conteneur scrollable projectSituationsScroll", () => {
+  assert.doesNotMatch(subjectsEntrySource, /id="projectSituationsScroll"/);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -89,6 +89,7 @@ export function createProjectSubjectsView(deps) {
     bindDetailsScroll,
     refreshProjectShellChrome,
     setProjectCompactEnabled,
+    clearProjectActiveScrollSource,
     currentDecisionTarget,
     addComment,
     getSelectionForScope,
@@ -2628,6 +2629,7 @@ function restoreDocumentScrollState(state) {
 }
 
 function syncSituationsPrimaryScrollSource() {
+  clearProjectActiveScrollSource?.();
   refreshProjectShellChrome("situations");
 }
 


### PR DESCRIPTION
### Motivation

- Ensure the project subjects view resets the active scroll source so the document becomes the primary scroll container when switching to situations. 
- Make the details header "compact" behavior driven by the actual details body element when present instead of always falling back to `document`.
- Remove an unnecessary scrollable wrapper element in the Subjects page layout to avoid nested/duplicated scrolling contexts.

### Description

- Import and wire `clearProjectActiveScrollSource` from `project-shell-chrome.js` into the subjects view and expose it through the view API. 
- Call `clearProjectActiveScrollSource?.()` from `syncSituationsPrimaryScrollSource` so the active scroll source is reset before refreshing the shell chrome. 
- Change `bindDetailsScroll` to prefer the details body host (`#situationsDetailsHost`) and pass `normalDetailsBody || (normalDetailsHead ? document : null)` into the compact binding. 
- Remove the `id="projectSituationsScroll"` scroll wrapper from the rendered Subjects template to avoid an extra scroll container. 
- Add two unit tests: `project-subjects-events-compact-binding.test.mjs` asserting the details body is referenced for compact binding, and `project-subjects-scroll-source.test.mjs` asserting the scroll source reset call and that the wrapper id is removed.

### Testing

- Added and ran the new unit tests `project-subjects-events-compact-binding.test.mjs` and `project-subjects-scroll-source.test.mjs` which verify the compact binding and scroll-source reset, and both tests passed. 
- Ran the repository test suite (`npm test`) after the changes and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb630fb6a88329bdfd010477996cc2)