### PR TITLE
Corrige compactage header du détail Sujets — pilotage par le scroll document

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs
@@ -8,7 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const eventsPath = path.resolve(__dirname, "./project-subjects-events.js");
 const eventsSource = fs.readFileSync(eventsPath, "utf8");
 
-test("le compact du header détail principal est piloté par le scroll du body détail", () => {
-  assert.match(eventsSource, /const normalDetailsBody = root\.querySelector\("#situationsDetailsHost"\);/);
-  assert.match(eventsSource, /normalDetailsBody \|\| \(normalDetailsHead \? document : null\)/);
+test("le compact du header détail principal est piloté par le scroll du document", () => {
+  assert.match(eventsSource, /normalDetailsHead \? document : null/);
+  assert.doesNotMatch(eventsSource, /const normalDetailsBody = root\.querySelector\("#situationsDetailsHost"\);/);
 });

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -5420,9 +5420,8 @@ export function createProjectSubjectsEvents(config) {
   function bindDetailsScroll(root) {
     const normalDetailsHead = root.querySelector("#situationsDetailsTitle");
     const normalDetailsChrome = root.querySelector("#situationsDetailsChrome");
-    const normalDetailsBody = root.querySelector("#situationsDetailsHost");
     bindCondensedTitleScroll(
-      normalDetailsBody || (normalDetailsHead ? document : null),
+      normalDetailsHead ? document : null,
       normalDetailsChrome || normalDetailsHead,
       "details",
       {

--- a/apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs
@@ -14,6 +14,11 @@ test("la vue Sujets réinitialise la source de scroll active pour revenir au doc
   assert.match(subjectsViewSource, /clearProjectActiveScrollSource\?\.\(\);/);
 });
 
+test("la vue Sujets garde le compactage projet activé dans rerenderPanels", () => {
+  assert.match(subjectsViewSource, /setProjectCompactEnabled\(true\);/);
+  assert.doesNotMatch(subjectsViewSource, /setProjectCompactEnabled\(!shouldDisableProjectCompact\);/);
+});
+
 test("la page Sujets ne rend plus le conteneur scrollable projectSituationsScroll", () => {
   assert.doesNotMatch(subjectsEntrySource, /id="projectSituationsScroll"/);
 });

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -2797,7 +2797,6 @@ function rerenderSubissuesPanelScope(root, options = {}) {
 function rerenderPanels() {
   ensureViewUiState();
   document.body.classList.remove("project-subject-details-top-compact");
-  document.body.classList.remove("project-subject-normal-detail-flow");
 
   const detailsScrollState = getDocumentScrollState();
   const filteredSituations = getFilteredSituations();
@@ -2814,12 +2813,7 @@ function rerenderPanels() {
   const isStandardCreateMode = isCreateFormOpen && !isSubissueCreateMode;
   setSubissueModalScrollLock(isSubissueCreateMode);
 
-  const shouldDisableProjectCompact = !!panelHost
-    && !isCreateFormOpen
-    && String(store.situationsView.subjectsSubview || "subjects") === "subjects"
-    && !store.situationsView.showTableOnly;
-  document.body.classList.toggle("project-subject-normal-detail-flow", shouldDisableProjectCompact);
-  setProjectCompactEnabled(!shouldDisableProjectCompact);
+  setProjectCompactEnabled(true);
 
   if (panelHost) {
     if (isStandardCreateMode) {


### PR DESCRIPTION
### Motivation
- Une régression a désactivé le compactage du header pour le détail principal des Sujets en faisant de `#situationsDetailsHost` la source de scroll et en basculant la classe `project-subject-normal-detail-flow`/`--app-top:0`, ce qui casse le comportement sticky/compact attendu.
- L’intention est de restaurer le scroll du document comme source pour le détail principal, tout en conservant le comportement actuel du drilldown et du Kanban (scrolls internes restent pilotés localement). 

### Description
- Dans `apps/web/js/views/project-subjects/project-subjects-view.js` la logique qui basculait `project-subject-normal-detail-flow` et désactivait le compactage a été supprimée et `setProjectCompactEnabled(true)` est maintenant appelé explicitement dans `rerenderPanels()`.
- Dans `apps/web/js/views/project-subjects/project-subjects-events.js` `bindDetailsScroll(root)` lie désormais le compactage du détail principal sur `document` (via `normalDetailsHead ? document : null`) et n’utilise plus `#situationsDetailsHost`; le binding du drilldown sur `#drilldownPanel .drilldown__inner` est inchangé.
- Les tests ciblés ont été mis à jour/ajoutés : `project-subjects-events-compact-binding.test.mjs` vérifie l’usage du `document` pour le détail principal, et `project-subjects-scroll-source.test.mjs` vérifie que `setProjectCompactEnabled(true)` est présent et que l’ancien appel conditionnel a disparu.
- Fichiers modifiés : `project-subjects-view.js`, `project-subjects-events.js`, `project-subjects-events-compact-binding.test.mjs`, `project-subjects-scroll-source.test.mjs` (chemins sous `apps/web/js/views/project-subjects/`).

### Testing
- Tests unitaires lancés : `node --test apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs apps/web/js/views/project-subjects/project-subjects-events-compact-binding.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs` et tous les tests sont passés (`7` assertions, `0` échecs).
- Tests modifiés/ajoutés : `project-subjects-events-compact-binding.test.mjs` (mis à jour) et `project-subjects-scroll-source.test.mjs` (ajout de vérification du `setProjectCompactEnabled(true)`) et ils réussissent.
- Aucun test additionnel n’a échoué et aucun changement non nécessaire n’a été introduit dans le binding drilldown ou le Kanban; pas d’erreur console attendue par les tests automatisés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6a08ade4832990bd2d5a2343fe99)