### PR TITLE
Restore document scroll on project pages and scope Kanban local scroll sources

### DIFF
--- a/apps/web/js/views/project-actions.js
+++ b/apps/web/js/views/project-actions.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from "../utils/escape-html.js";
-import { setProjectViewHeader } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
 import { getRunLogEntries, getRunMetrics } from "../services/project-automation.js";
 import { syncProjectActionsFromSupabase } from "../services/project-supabase-sync.js";
 import { svgIcon } from "../ui/icons.js";
@@ -369,6 +369,7 @@ function renderProjectActionsContent(root) {
 
 export function renderProjectActions(root) {
   root.className = "project-shell__content";
+  clearProjectActiveScrollSource();
 
   setProjectViewHeader({
     contextLabel: "Actions",

--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1,5 +1,5 @@
 import { store } from "../store.js";
-import { setProjectViewHeader } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
 import {
   bindGhActionButtons,
   initGhActionButton,
@@ -2027,6 +2027,7 @@ export function renderProjectDocuments(root) {
   syncDocumentsSelectedPhase();
 
   root.className = "project-shell__content";
+  clearProjectActiveScrollSource();
 
   renderProjectDocumentsContent(root);
 

--- a/apps/web/js/views/project-insights-scroll-source.test.mjs
+++ b/apps/web/js/views/project-insights-scroll-source.test.mjs
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const insightsPath = path.resolve(__dirname, "./project-insights.js");
+const insightsSource = fs.readFileSync(insightsPath, "utf8");
+
+test("renderProjectInsights revient à la source de scroll document/window", () => {
+  assert.match(insightsSource, /export function renderProjectInsights\(root\)\s*\{[\s\S]*?clearProjectActiveScrollSource\(\);/);
+});

--- a/apps/web/js/views/project-insights.js
+++ b/apps/web/js/views/project-insights.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from "../utils/escape-html.js";
-import { setProjectViewHeader } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
 import { getRunMetrics } from "../services/project-automation.js";
 import { getProjectInsightsMetrics } from "../services/project-insights-metrics.js";
 import { renderSvgLineChart, getNiceChartTicks } from "../utils/svg-line-chart.js";
@@ -230,6 +230,7 @@ function renderChartsSection(insights) {
 
 export function renderProjectInsights(root) {
   root.className = "project-shell__content";
+  clearProjectActiveScrollSource();
 
   setProjectViewHeader({
     contextLabel: "Indicateurs",

--- a/apps/web/js/views/project-parametres.js
+++ b/apps/web/js/views/project-parametres.js
@@ -1,4 +1,4 @@
-import { setProjectViewHeader } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
 import {
   renderSideNavLayout,
   renderSideNavGroup,
@@ -96,6 +96,7 @@ function mountProjectParametresTab(root, tabId) {
 export function renderProjectParametres(root) {
   ensureProjectParametresSetup(root);
   setProjectParametresRerender(renderProjectParametres);
+  clearProjectActiveScrollSource();
 
   const uiState = getParametresUiState();
   const defaultTab = getProjectParametresTabById(uiState.activeSectionId || "parametres-general");

--- a/apps/web/js/views/project-scroll-policy.test.mjs
+++ b/apps/web/js/views/project-scroll-policy.test.mjs
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const stylePath = path.resolve(__dirname, "../../style.css");
+const styleSource = fs.readFileSync(stylePath, "utf8");
+
+test("le CSS projet ne force pas globalement project-simple-scroll en overflow visible", () => {
+  assert.doesNotMatch(styleSource, /body\.route--project\s+\.project-simple-scroll\s*\{[^}]*overflow\s*:\s*visible\s*;/s);
+});

--- a/apps/web/js/views/project-situations-scroll-source.test.mjs
+++ b/apps/web/js/views/project-situations-scroll-source.test.mjs
@@ -1,7 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { resolveKanbanScrollableSource } from "./project-situations-scroll-source.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const situationsPath = path.resolve(__dirname, "./project-situations.js");
+const situationsSource = fs.readFileSync(situationsPath, "utf8");
 
 function createMockNode({ classes = [], parent = null, cards = null } = {}) {
   const classSet = new Set(classes);
@@ -54,3 +61,10 @@ test("resolveKanbanScrollableSource returns null outside kanban column", () => {
   assert.equal(resolveKanbanScrollableSource(node), null);
 });
 
+test("la vue Situations conserve une source locale pour le Kanban", () => {
+  assert.match(situationsSource, /setProjectActiveScrollSource\(sourceEl,\s*\{\s*syncImmediately\s*\}\);/);
+});
+
+test("la vue Situations réinitialise la source active hors Kanban", () => {
+  assert.match(situationsSource, /if \(kanbanColumns\.length\) \{[\s\S]*?\} else \{[\s\S]*?clearProjectActiveScrollSource\(\);/);
+});

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -7,6 +7,7 @@ import {
   syncProjectShellCompactFromScrollSource,
   registerProjectScrollSources,
   setProjectActiveScrollSource,
+  clearProjectActiveScrollSource,
   setProjectViewHeader
 } from "./project-shell-chrome.js";
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
@@ -308,6 +309,7 @@ function rerender(root) {
   if (kanbanColumns.length) {
     registerProjectScrollSources(kanbanCardLists);
   } else {
+    clearProjectActiveScrollSource();
     registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
   }
 

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -986,6 +986,7 @@ function ensureSubjectsCollaboratorsLoaded() {
 
 export function renderProjectSubjects(root) {
   ensureSubjectsCollaboratorsLoaded();
+  clearProjectActiveScrollSource();
   const subjectsViewState = ensureViewUiState();
   projectSubjectDrilldown.ensureDrilldownDom();
   subjectsCurrentRoot = root;

--- a/apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs
@@ -22,3 +22,7 @@ test("la vue Sujets garde le compactage projet activé dans rerenderPanels", () 
 test("la page Sujets ne rend plus le conteneur scrollable projectSituationsScroll", () => {
   assert.doesNotMatch(subjectsEntrySource, /id="projectSituationsScroll"/);
 });
+
+test("renderProjectSubjects réinitialise la source active au montage de la page", () => {
+  assert.match(subjectsEntrySource, /export function renderProjectSubjects\(root\)\s*\{[\s\S]*?clearProjectActiveScrollSource\(\);/);
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -4361,34 +4361,8 @@ body.route--project.project-shell-compact{
   --app-top:var(--header-h-compact);
 }
 
-body.route--project.project-subject-normal-detail-flow{
-  --app-top:0px;
-}
-
-body.route--project.project-subject-normal-detail-flow .gh-header{
-  position:relative;
-  top:auto;
-  left:auto;
-  right:auto;
-}
-
 body.route--project .project-shell{
   min-height:calc(100dvh - var(--app-top));
-}
-
-body.route--project .project-shell__body,
-body.route--project .project-shell__content{
-  overflow:visible;
-}
-
-body.route--project .project-simple-page{
-  height:auto;
-  min-height:0;
-}
-
-body.route--project .project-simple-scroll{
-  overflow:visible;
-  min-height:0;
 }
 
 .global-nav{


### PR DESCRIPTION
### Motivation
- A global CSS override and missing scroll-source resets caused the document/window scroll to be disabled on many project pages (Sujets, Indicateurs, Actions, Documents, Paramètres), while only Situations/Kanban should use local scroll containers.
- The goal is to restore normal document scrolling for classic project pages while keeping local scrolling for Kanban, drilldowns and modals.

### Description
- Removed global CSS overrides under `body.route--project` that forced `.project-shell__body`, `.project-shell__content` and `.project-simple-scroll` to `overflow: visible` and removed the `project-subject-normal-detail-flow` block to avoid side effects. (file: `apps/web/style.css`).
- On render of classic project views (`renderProjectSubjects`, `renderProjectInsights`, `renderProjectActions`, `renderProjectDocuments`, `renderProjectParametres`) added `clearProjectActiveScrollSource()` to return scroll handling to the document/window. (files: `apps/web/js/views/project-subjects.js`, `project-insights.js`, `project-actions.js`, `project-documents.js`, `project-parametres.js`).
- In Situations view kept Kanban behaviour (`setProjectActiveScrollSource(...)`) but explicitly call `clearProjectActiveScrollSource()` when not in Kanban so the app falls back to document/window scrolling. (file: `apps/web/js/views/project-situations.js`).
- Added a small static CSS policy test and view tests to prevent regressions and to assert the intended scroll-source behaviour; preserved drilldown binding so it continues to use its internal scroll container. (new/updated tests under `apps/web/js/views/`).

### Testing
- Ran targeted node tests: `project-scroll-policy.test.mjs`, `project-subjects/project-subjects-scroll-source.test.mjs`, `project-insights-scroll-source.test.mjs`, `project-situations-scroll-source.test.mjs`, and `project-subject-drilldown-binding.test.mjs`. All tests passed (14 assertions, 0 failures).
- The new CSS policy test verifies there is no global rule `body.route--project .project-simple-scroll { overflow: visible; }` and it succeeded. 
- Situations tests verify Kanban keeps a local scroll source and that Situations resets the active scroll source when leaving Kanban, and these assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6dce05fc8329a4d325f25e397648)