### PR TITLE
Restore project pages to document/window scrolling and add debug instrumentation

### DIFF
--- a/apps/web/js/views/project-actions-scroll-source.test.mjs
+++ b/apps/web/js/views/project-actions-scroll-source.test.mjs
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const actionsPath = path.resolve(__dirname, "./project-actions.js");
+const actionsSource = fs.readFileSync(actionsPath, "utf8");
+
+test("renderProjectActions revient à la source de scroll document/window", () => {
+  assert.match(actionsSource, /export function renderProjectActions\(root\)\s*\{[\s\S]*?clearProjectActiveScrollSource\(\);/);
+});

--- a/apps/web/js/views/project-actions.js
+++ b/apps/web/js/views/project-actions.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from "../utils/escape-html.js";
-import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrollPolicy } from "./project-shell-chrome.js";
 import { getRunLogEntries, getRunMetrics } from "../services/project-automation.js";
 import { syncProjectActionsFromSupabase } from "../services/project-supabase-sync.js";
 import { svgIcon } from "../ui/icons.js";
@@ -377,6 +377,7 @@ export function renderProjectActions(root) {
   });
 
   renderProjectActionsContent(root);
+  debugProjectScrollPolicy("render-project-actions");
 
   syncProjectActionsFromSupabase({ force: true })
     .then(() => {

--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1,5 +1,5 @@
 import { store } from "../store.js";
-import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrollPolicy } from "./project-shell-chrome.js";
 import {
   bindGhActionButtons,
   initGhActionButton,
@@ -2030,6 +2030,7 @@ export function renderProjectDocuments(root) {
   clearProjectActiveScrollSource();
 
   renderProjectDocumentsContent(root);
+  debugProjectScrollPolicy("render-project-documents", { mode: docsViewState.mode });
 
   syncProjectDocumentsFromSupabase({ force: true })
     .then(() => {

--- a/apps/web/js/views/project-insights.js
+++ b/apps/web/js/views/project-insights.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from "../utils/escape-html.js";
-import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrollPolicy } from "./project-shell-chrome.js";
 import { getRunMetrics } from "../services/project-automation.js";
 import { getProjectInsightsMetrics } from "../services/project-insights-metrics.js";
 import { renderSvgLineChart, getNiceChartTicks } from "../utils/svg-line-chart.js";
@@ -248,4 +248,5 @@ export function renderProjectInsights(root) {
       </div>
     </section>
   `;
+  debugProjectScrollPolicy("render-project-insights");
 }

--- a/apps/web/js/views/project-layout.js
+++ b/apps/web/js/views/project-layout.js
@@ -15,7 +15,7 @@ import { renderProjectParametres } from "./project-parametres.js";
 
 import { renderProjectHeader, bindProjectHeaderNavigation } from "./project-header.js";
 import { renderProjectSituationsTopBanner } from "./project-situations-runbar.js";
-import { mountProjectShellChrome } from "./project-shell-chrome.js";
+import { mountProjectShellChrome, debugProjectScrollPolicy } from "./project-shell-chrome.js";
 
 
 function normalizeProjectTab(tab) {
@@ -103,4 +103,8 @@ export function renderProjectLayout(root, projectId, tab) {
       renderProjectDocuments(content);
       break;
   }
+
+  debugProjectScrollPolicy("project-tab-render", {
+    tab: normalizedTab
+  });
 }

--- a/apps/web/js/views/project-parametres.js
+++ b/apps/web/js/views/project-parametres.js
@@ -1,4 +1,4 @@
-import { setProjectViewHeader, clearProjectActiveScrollSource } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrollPolicy } from "./project-shell-chrome.js";
 import {
   renderSideNavLayout,
   renderSideNavGroup,
@@ -138,4 +138,7 @@ export function renderProjectParametres(root) {
 
   root.addEventListener("click", root.__projectParametresNavHandler);
   mountProjectParametresTab(root, defaultTab.id);
+  debugProjectScrollPolicy("render-project-parametres", {
+    activeSection: defaultTab.id
+  });
 }

--- a/apps/web/js/views/project-scroll-policy.test.mjs
+++ b/apps/web/js/views/project-scroll-policy.test.mjs
@@ -11,3 +11,23 @@ const styleSource = fs.readFileSync(stylePath, "utf8");
 test("le CSS projet ne force pas globalement project-simple-scroll en overflow visible", () => {
   assert.doesNotMatch(styleSource, /body\.route--project\s+\.project-simple-scroll\s*\{[^}]*overflow\s*:\s*visible\s*;/s);
 });
+
+test("project-shell__body n'applique pas overflow hidden par défaut", () => {
+  assert.match(styleSource, /\.project-shell__body\s*\{[\s\S]*?overflow\s*:\s*visible\s*;/);
+});
+
+test("project-shell__content n'applique pas overflow hidden par défaut", () => {
+  assert.match(styleSource, /\.project-shell__content\s*\{[\s\S]*?overflow\s*:\s*visible\s*;/);
+});
+
+test("project-simple-page n'impose pas height:100% globalement", () => {
+  assert.match(styleSource, /\.project-simple-page\s*\{[\s\S]*?height\s*:\s*auto\s*;/);
+});
+
+test("la vue Situations conserve le overflow hidden ciblé pour le kanban", () => {
+  assert.match(styleSource, /\.project-shell__content--situation-kanban\s*\{[\s\S]*?overflow\s*:\s*hidden\s*;/);
+});
+
+test("la vue Situations conserve le overflow hidden ciblé pour project-simple-scroll--situation-view", () => {
+  assert.match(styleSource, /\.project-simple-scroll(?:\.project-simple-scroll--situation-view|--situation-view)\s*\{[\s\S]*?overflow\s*:\s*hidden\s*;/);
+});

--- a/apps/web/js/views/project-shell-chrome-scroll-source.test.mjs
+++ b/apps/web/js/views/project-shell-chrome-scroll-source.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const chromePath = path.resolve(__dirname, "./project-shell-chrome.js");
+const chromeSource = fs.readFileSync(chromePath, "utf8");
+
+test("syncCompactState utilise document/window quand aucune source locale n'est active", () => {
+  assert.match(chromeSource, /const scrollTop = activeScrollSourceEl\s*\?\s*getScrollTopFromElement\(activeScrollSourceEl\)\s*:\s*getDocumentScrollTop\(\);/);
+});
+
+test("syncCompactState utilise la source locale quand elle est active", () => {
+  assert.match(chromeSource, /const scrollTop = activeScrollSourceEl\s*\?\s*getScrollTopFromElement\(activeScrollSourceEl\)/);
+});
+
+test("clearProjectActiveScrollSource revient à document/window", () => {
+  assert.match(chromeSource, /export function clearProjectActiveScrollSource\(el = null\) \{[\s\S]*?shellState\.activeScrollSourceEl = null;[\s\S]*?shellState\.activeScrollSourceResolver = null;[\s\S]*?syncCompactState\(\);/);
+});

--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -37,6 +37,58 @@ function debugProjectShellKanbanScroll(label, payload) {
   console.info(label, payload);
 }
 
+function isProjectScrollPolicyDebugEnabled() {
+  try {
+    return window.localStorage?.getItem("debug:project-scroll-policy") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function readComputedLayout(selector) {
+  const el = document.querySelector(selector);
+  if (!el) {
+    return {
+      selector,
+      found: false
+    };
+  }
+  const style = window.getComputedStyle(el);
+  return {
+    selector,
+    found: true,
+    className: el.className || "",
+    height: style.height,
+    minHeight: style.minHeight,
+    overflow: style.overflow
+  };
+}
+
+export function debugProjectScrollPolicy(label, extra = {}) {
+  if (!isProjectScrollPolicyDebugEnabled()) return;
+
+  const activeScrollSourceEl = getActiveScrollSourceEl();
+  const scrollingElement = document.scrollingElement || document.documentElement || document.body || null;
+  const projectContent = document.getElementById("project-content");
+
+  console.info("[project-scroll-policy]", {
+    label,
+    tab: shellState.tab || null,
+    scrollSource: activeScrollSourceEl ? "local-element" : "document/window",
+    scrollSourceClass: activeScrollSourceEl?.className || null,
+    documentScrollHeight: Number(scrollingElement?.scrollHeight || 0),
+    documentClientHeight: Number(scrollingElement?.clientHeight || 0),
+    windowScrollY: Number(window.scrollY || 0),
+    projectContentClass: projectContent?.className || null,
+    projectShell: readComputedLayout(".project-shell"),
+    projectShellBody: readComputedLayout(".project-shell__body"),
+    projectShellContent: readComputedLayout(".project-shell__content"),
+    projectSimplePage: readComputedLayout(".project-simple-page"),
+    projectSimpleScroll: readComputedLayout(".project-simple-scroll"),
+    ...extra
+  });
+}
+
 function getStickyChromeHostEl() {
   return document.getElementById("projectStickyChromeHost");
 }
@@ -352,6 +404,9 @@ export function setProjectActiveScrollSource(el, { resolve = null, syncImmediate
   if (syncImmediately !== false) {
     syncCompactState();
   }
+  debugProjectScrollPolicy("set-active-scroll-source", {
+    syncImmediately: syncImmediately !== false
+  });
 }
 
 export function useProjectScrollSource(el) {
@@ -361,6 +416,7 @@ export function useProjectScrollSource(el) {
   shellState.cleanupActiveScrollSource = null;
   shellState.activeScrollSourceEl = el;
   shellState.activeScrollSourceResolver = null;
+  debugProjectScrollPolicy("use-scroll-source");
 }
 
 export function clearProjectActiveScrollSource(el = null) {
@@ -374,6 +430,7 @@ export function clearProjectActiveScrollSource(el = null) {
   shellState.activeScrollSourceEl = null;
   shellState.activeScrollSourceResolver = null;
   syncCompactState();
+  debugProjectScrollPolicy("clear-active-scroll-source");
 }
 
 export function setProjectCompactEnabled(enabled = true) {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -8,7 +8,8 @@ import {
   registerProjectScrollSources,
   setProjectActiveScrollSource,
   clearProjectActiveScrollSource,
-  setProjectViewHeader
+  setProjectViewHeader,
+  debugProjectScrollPolicy
 } from "./project-shell-chrome.js";
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
 import { loadFlatSubjectsForCurrentProject } from "../services/project-subjects-supabase.js";
@@ -312,6 +313,10 @@ function rerender(root) {
     clearProjectActiveScrollSource();
     registerProjectScrollSources(primaryScrollRoot, tableScrollBody, gridScrollBody, roadmapScrollBody);
   }
+  debugProjectScrollPolicy("render-project-situations", {
+    hasSelectedSituation,
+    hasKanbanColumns: kanbanColumns.length > 0
+  });
 
   const unbindColumnHandlers = [];
   const kanbanScrollElements = kanbanColumns.length

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -40,7 +40,8 @@ import {
   setProjectViewHeader,
   refreshProjectShellChrome,
   setProjectCompactEnabled,
-  clearProjectActiveScrollSource
+  clearProjectActiveScrollSource,
+  debugProjectScrollPolicy
 } from "./project-shell-chrome.js";
 import { svgIcon } from "../ui/icons.js";
 import { renderGhActionButton } from "./ui/gh-split-button.js";
@@ -1058,4 +1059,5 @@ export function renderProjectSubjects(root) {
     meta: store.ui?.systemStatus?.meta || "",
     isBusy: store.ui?.systemStatus?.state === "running"
   });
+  debugProjectScrollPolicy("render-project-subjects");
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -4515,8 +4515,8 @@ body.route--project .project-shell{
   isolation:isolate;
 }
 .project-shell{
-  height:100%;
-  min-height:0;
+  height:auto;
+  min-height:calc(100dvh - var(--app-top));
   min-width:0;
   display:flex;
   flex-direction:column;
@@ -4534,7 +4534,7 @@ body.route--project .project-shell{
   min-height:0;
   display:flex;
   flex-direction:column;
-  overflow:hidden;
+  overflow:visible;
   padding:0 12px;
 }
 
@@ -4552,7 +4552,7 @@ body.route--project .project-shell{
 .project-shell__content{
   flex:1 1 auto;
   min-height:0;
-  overflow:hidden;
+  overflow:visible;
 }
 body.route--project.project-shell-compact .project-view-header__bar{
   display:none;
@@ -4652,7 +4652,7 @@ body.route--project:not(.project-shell-compact) [data-chrome-visibility="compact
 }
 
 .project-simple-page{
-  height:100%;
+  height:auto;
   min-height:0;
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
### Motivation
- Le shell projet forçait un layout plein écran contraint (`height:100%` + `overflow:hidden`) qui empêchait le scroll global `document/window` sur les pages classiques, il faut revenir à un flux document pour ces pages tout en conservant les scrolls internes ciblés (Kanban, drilldown, modales). 
- Aucune skill externe utilisée pour cette modification.

### Description
- Modifie le CSS par défaut pour les pages projet afin que ` .project-shell` utilise `height:auto` et `min-height:calc(100dvh - var(--app-top))`, que ` .project-shell__body` et ` .project-shell__content` aient `overflow:visible`, et que ` .project-simple-page` n’impose plus `height:100%` (filtres ciblés situational restent inchangés). 
- Introduit une instrumentation activable via `localStorage.setItem("debug:project-scroll-policy", "1")` et la fonction utilitaire `debugProjectScrollPolicy(label, extra = {})` dans `project-shell-chrome.js` pour logger l’onglet courant, métriques de document, classes et styles calculés des containers et la source de scroll active. 
- Ajoute des appels à `debugProjectScrollPolicy` lors du rendu des onglets projet et lors des changements de source de scroll (`setProjectActiveScrollSource`, `useProjectScrollSource`, `clearProjectActiveScrollSource`). 
- Garantit que les renderers de pages classiques (`renderProjectSubjects`, `renderProjectInsights`, `renderProjectActions`, `renderProjectDocuments`, `renderProjectParametres`) appellent `clearProjectActiveScrollSource()` pour revenir à la source `document/window`, tandis que la logique Kanban/Situations conserve ses sources locales et ses règles d’overflow ciblées.

### Testing
- Tests unitaires ajoutés/étendus et exécutés avec `node --test` couvrant le CSS statique et les comportements de sélection/clear de la source de scroll, et tous sont passés (20/20). 
- Commande de test exécutée : `node --test apps/web/js/views/project-scroll-policy.test.mjs apps/web/js/views/project-insights-scroll-source.test.mjs apps/web/js/views/project-subjects/project-subjects-scroll-source.test.mjs apps/web/js/views/project-situations-scroll-source.test.mjs apps/web/js/views/project-actions-scroll-source.test.mjs apps/web/js/views/project-shell-chrome-scroll-source.test.mjs` (résultat : tous les sous-tests OK). 
- Fichiers modifiés : `apps/web/style.css`, `apps/web/js/views/project-shell-chrome.js`, `apps/web/js/views/project-layout.js`, `apps/web/js/views/project-subjects.js`, `apps/web/js/views/project-insights.js`, `apps/web/js/views/project-actions.js`, `apps/web/js/views/project-documents.js`, `apps/web/js/views/project-parametres.js`, `apps/web/js/views/project-situations.js`, `apps/web/js/views/project-scroll-policy.test.mjs`, `apps/web/js/views/project-actions-scroll-source.test.mjs`, `apps/web/js/views/project-shell-chrome-scroll-source.test.mjs`. 
- Pour activer la debug-instrumentation temporaire, exécuter `localStorage.setItem("debug:project-scroll-policy", "1")` dans la console du navigateur puis naviguer entre onglets projet pour obtenir les logs concis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb70cb083c8329867120c7f3ead4f3)