### PR TITLE
Apply `route--project` early so subject detail compacting uses root scroll

### DIFF
--- a/apps/web/js/views/project-scroll-policy.test.mjs
+++ b/apps/web/js/views/project-scroll-policy.test.mjs
@@ -31,3 +31,7 @@ test("la vue Situations conserve le overflow hidden ciblé pour le kanban", () =
 test("la vue Situations conserve le overflow hidden ciblé pour project-simple-scroll--situation-view", () => {
   assert.match(styleSource, /\.project-simple-scroll(?:\.project-simple-scroll--situation-view|--situation-view)\s*\{[\s\S]*?overflow\s*:\s*hidden\s*;/);
 });
+
+test("le contexte route--project force #app en flux document", () => {
+  assert.match(styleSource, /body\.route--project\s+#app\s*\{[\s\S]*?position\s*:\s*relative\s*;[\s\S]*?overflow\s*:\s*visible\s*;/);
+});

--- a/apps/web/js/views/project-shell-chrome-scroll-source.test.mjs
+++ b/apps/web/js/views/project-shell-chrome-scroll-source.test.mjs
@@ -19,3 +19,18 @@ test("syncCompactState utilise la source locale quand elle est active", () => {
 test("clearProjectActiveScrollSource revient à document/window", () => {
   assert.match(chromeSource, /export function clearProjectActiveScrollSource\(el = null\) \{[\s\S]*?shellState\.activeScrollSourceEl = null;[\s\S]*?shellState\.activeScrollSourceResolver = null;[\s\S]*?syncCompactState\(\);/);
 });
+
+test("mountProjectShellChrome applique immédiatement le contexte route--project", () => {
+  assert.match(chromeSource, /export function mountProjectShellChrome\(\{ projectId, tab \}\) \{[\s\S]*?refreshProjectShellChromeRefs\(\);[\s\S]*?ensureProjectRouteClass\(\);/);
+});
+
+test("applyCompactState garantit route--project avant le early return", () => {
+  assert.match(chromeSource, /function applyCompactState\(isCompact\) \{[\s\S]*?ensureProjectRouteClass\(\);[\s\S]*?if \(!didChange\) \{/);
+});
+
+test("instrumentation project scroll policy loggue body, scrollingElement et appLayout", () => {
+  assert.match(chromeSource, /bodyClassName:\s*document\.body\?\.className\s*\|\|\s*""/);
+  assert.match(chromeSource, /scrollingElementTag:\s*scrollingElement\?\.tagName\s*\|\|\s*null/);
+  assert.match(chromeSource, /appLayout:\s*readAppLayout\(\)/);
+  assert.match(chromeSource, /function readAppLayout\(\)\s*\{[\s\S]*?position:[\s\S]*?overflow:[\s\S]*?scrollTop:[\s\S]*?scrollHeight:[\s\S]*?clientHeight:/);
+});

--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -64,6 +64,31 @@ function readComputedLayout(selector) {
   };
 }
 
+function readAppLayout() {
+  const appEl = document.getElementById("app");
+  if (!appEl) {
+    return {
+      found: false
+    };
+  }
+
+  const style = window.getComputedStyle(appEl);
+  return {
+    found: true,
+    className: appEl.className || "",
+    position: style.position,
+    top: style.top,
+    bottom: style.bottom,
+    height: style.height,
+    minHeight: style.minHeight,
+    overflow: style.overflow,
+    paddingTop: style.paddingTop,
+    scrollTop: Number(appEl.scrollTop || 0),
+    scrollHeight: Number(appEl.scrollHeight || 0),
+    clientHeight: Number(appEl.clientHeight || 0)
+  };
+}
+
 export function debugProjectScrollPolicy(label, extra = {}) {
   if (!isProjectScrollPolicyDebugEnabled()) return;
 
@@ -74,11 +99,14 @@ export function debugProjectScrollPolicy(label, extra = {}) {
   console.info("[project-scroll-policy]", {
     label,
     tab: shellState.tab || null,
+    bodyClassName: document.body?.className || "",
     scrollSource: activeScrollSourceEl ? "local-element" : "document/window",
     scrollSourceClass: activeScrollSourceEl?.className || null,
+    scrollingElementTag: scrollingElement?.tagName || null,
     documentScrollHeight: Number(scrollingElement?.scrollHeight || 0),
     documentClientHeight: Number(scrollingElement?.clientHeight || 0),
     windowScrollY: Number(window.scrollY || 0),
+    appLayout: readAppLayout(),
     projectContentClass: projectContent?.className || null,
     projectShell: readComputedLayout(".project-shell"),
     projectShellBody: readComputedLayout(".project-shell__body"),
@@ -201,29 +229,38 @@ function syncCompactTabLabel() {
   syncCompactPrimaryAction();
 }
 
+function ensureProjectRouteClass() {
+  document.body.classList.add("route--project");
+  document.body.classList.remove("route--projects-list");
+}
+
+function syncProjectShellStructuralClasses() {
+  document.body.classList.toggle("project-shell-compact", shellState.isCompact);
+  shellState.globalHeaderEl?.classList.toggle("gh-header--compact", shellState.isCompact);
+  shellState.projectTabsEl?.classList.toggle("project-tabs--hidden", shellState.isCompact);
+  getViewHeaderEl()?.classList.toggle("project-view-header--compact", shellState.isCompact);
+}
+
 function applyCompactState(isCompact) {
   refreshProjectShellChromeRefs();
+  ensureProjectRouteClass();
   const nextCompact = !!(shellState.compactEnabled && isCompact);
   const didChange = shellState.isCompact !== nextCompact;
+  shellState.isCompact = nextCompact;
+  syncProjectShellStructuralClasses();
+
   if (!didChange) {
     debugProjectShellKanbanScroll("[project-shell:apply-compact-state]", {
       requested: isCompact,
       applied: nextCompact,
       compactEnabled: shellState.compactEnabled,
       didChange,
+      routeProject: document.body.classList.contains("route--project"),
       skipped: true
     });
+    syncCompactTabLabel();
     return;
   }
-
-  shellState.isCompact = nextCompact;
-
-  document.body.classList.add("route--project");
-  document.body.classList.toggle("project-shell-compact", shellState.isCompact);
-
-  shellState.globalHeaderEl?.classList.toggle("gh-header--compact", shellState.isCompact);
-  shellState.projectTabsEl?.classList.toggle("project-tabs--hidden", shellState.isCompact);
-  getViewHeaderEl()?.classList.toggle("project-view-header--compact", shellState.isCompact);
 
   debugProjectShellKanbanScroll("[project-shell:apply-compact-state]", {
     requested: isCompact,
@@ -299,6 +336,7 @@ export function mountProjectShellChrome({ projectId, tab }) {
   shellState.projectId = projectId || null;
   shellState.tab = tab || "dashboard";
   refreshProjectShellChromeRefs();
+  ensureProjectRouteClass();
 
   if (shellState.viewHeaderHostEl) {
     shellState.viewHeaderHostEl.innerHTML = "";

--- a/apps/web/js/views/project-subjects/project-subject-scroll-binding.test.mjs
+++ b/apps/web/js/views/project-subjects/project-subject-scroll-binding.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const detailPath = path.resolve(__dirname, "./project-subject-detail.js");
+const drilldownPath = path.resolve(__dirname, "./project-subject-drilldown.js");
+const detailSource = fs.readFileSync(detailPath, "utf8");
+const drilldownSource = fs.readFileSync(drilldownPath, "utf8");
+
+test("le détail principal reste bindé au scroll document/window", () => {
+  assert.match(detailSource, /bindDetailsScroll\(document\);/);
+});
+
+test("le drilldown reste bindé au scroll interne du panel", () => {
+  assert.match(drilldownSource, /bindDetailsScroll\(panel\);/);
+});


### PR DESCRIPTION
### Motivation
- `applyCompactState(false)` could early-return before `body.route--project` was added, leaving `#app` with `position: fixed; overflow: auto;` so the page scrolled inside `#app` rather than the document and the subject-detail header compacting on root scroll never fired.

### Description
- Added `ensureProjectRouteClass()` and call it from `mountProjectShellChrome()` and at the start of `applyCompactState()` to guarantee `body.route--project` is present before any early-return.
- Added `syncProjectShellStructuralClasses()` and ensure `shellState.isCompact` plus structural classes (header/tabs/view classes) are synchronized even when the compact state did not change to avoid leaving layout classes out-of-sync.
- Extended instrumentation with `readAppLayout()` and added `bodyClassName`, `scrollingElementTag`, and `appLayout` (computed `#app` layout and scroll metrics) to `debugProjectScrollPolicy()` to make root-vs-local scroll diagnosable.
- Updated/added static tests to lock the behaviour and prevent regressions and modified code in: `apps/web/js/views/project-shell-chrome.js`, `apps/web/js/views/project-shell-chrome-scroll-source.test.mjs`, `apps/web/js/views/project-scroll-policy.test.mjs`, and added `apps/web/js/views/project-subjects/project-subject-scroll-binding.test.mjs`.

### Testing
- Ran the unit/test suite with `node --test apps/web/js/views/project-shell-chrome-scroll-source.test.mjs apps/web/js/views/project-scroll-policy.test.mjs apps/web/js/views/project-subjects/project-subject-drilldown-binding.test.mjs apps/web/js/views/project-subjects/project-subject-scroll-binding.test.mjs` and all tests passed.
- Tests added/updated assert that `mountProjectShellChrome()` applies `route--project` immediately, `applyCompactState()` guarantees `route--project` before early return, instrumentation includes the new fields, CSS contains the `body.route--project #app { position: relative; overflow: visible; }` rule, and subject detail/drilldown scroll bindings remain correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74afd268832980bc2772d98ae657)