### PR TITLE
Amélioration UI de l’écran Paramètres d’une situation

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -165,9 +165,9 @@ export function createProjectSituationsView({
       <div class="project-situation-edit" data-side-nav-panel="situation-settings-panel">
         <div class="project-situation-edit__header">
           <button type="button" class="project-situation-edit__back" data-close-situation-edit>
-            <span class="project-situation-edit__back-icon">${svgIcon("chevron-left", { className: "octicon octicon-chevron-left" })}</span>
-            <span>Paramètres</span>
+            <span class="project-situation-edit__back-icon">${svgIcon("arrow-left", { className: "octicon octicon-arrow-left route-title-module__Octicon__vxu4r", width: 24, height: 24 })}</span>
           </button>
+          <h1 class="project-situation-edit__title">Paramètres</h1>
         </div>
         <section class="gh-panel gh-panel--details project-situation-edit__panel">
           <div class="gh-panel__head gh-panel__head--tight">
@@ -195,9 +195,9 @@ export function createProjectSituationsView({
     return `
       <div class="settings-shell settings-shell--parametres settings-shell--situation-edit">
         ${renderSideNavLayout({
-          className: "settings-layout settings-layout--parametres",
-          navClassName: "settings-nav settings-nav--parametres",
-          contentClassName: "settings-content settings-content--parametres",
+          className: "settings-layout settings-layout--parametres settings-layout--situation-edit",
+          navClassName: "settings-nav settings-nav--parametres settings-nav--situation-edit",
+          contentClassName: "settings-content settings-content--parametres settings-content--situation-edit",
           navHtml,
           contentHtml
         })}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13412,7 +13412,9 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 
 .settings-shell--situation-edit{
-  padding-top:4px;
+  max-width:none;
+  margin:0;
+  padding-top:0;
 }
 
 .project-situation-edit{
@@ -13424,26 +13426,44 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 .project-situation-edit__header{
   display:flex;
   align-items:center;
+  gap:12px;
+  height:49px;
+  padding:0 12px;
+  border-bottom:1px solid var(--border);
+  background:var(--headbg);
 }
 
 .project-situation-edit__back{
   display:inline-flex;
   align-items:center;
-  gap:8px;
   border:0;
   background:transparent;
-  color:var(--text);
-  font-size:20px;
-  font-weight:600;
   padding:0;
+  color:var(--muted);
+  fill:var(--muted);
+  cursor:pointer;
+}
+
+.project-situation-edit__title{
+  margin:0;
+  font-size:20px;
+  line-height:1.2;
+  font-weight:600;
 }
 
 .project-situation-edit__back-icon{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:28px;
-  height:28px;
+  width:24px;
+  height:24px;
+  color:var(--muted);
+  fill:var(--muted);
+}
+
+.project-situation-edit__back-icon .ui-icon{
+  width:24px;
+  height:24px;
   border-radius:8px;
 }
 
@@ -13458,6 +13478,31 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-edit__body{
   max-width:720px;
+}
+
+.settings-layout--situation-edit{
+  grid-template-columns:329px minmax(0, 1fr);
+  justify-content:stretch;
+  gap:0;
+}
+
+.settings-nav--situation-edit{
+  width:329px;
+}
+
+.settings-layout--situation-edit .side-nav-layout__nav{
+  padding:0 16px;
+}
+
+.settings-layout--situation-edit .side-nav-layout__content{
+  display:flex;
+  justify-content:center;
+}
+
+.settings-content--situation-edit{
+  width:100%;
+  max-width:920px;
+  padding:0 24px;
 }
 
 .project-lot-modal__radio--readonly{


### PR DESCRIPTION
### Motivation
- Rendre l’écran « Paramètres » accessible et visuellement cohérent lorsque l’on clique sur le bouton `title="Modifier la situation"` en améliorant l’en-tête et la répartition de la navigation et du contenu.
- Ajouter une top bar compacte et claire (hauteur fixe, séparation visuelle) pour faciliter la navigation retour.
- Placer le menu de navigation complètement à gauche avec une largeur fixe afin de laisser la zone de contenu centrée et lisible.

### Description
- Mise à jour de `renderEditSituationPanel()` dans `apps/web/js/views/project-situations/project-situations-view.js` pour remplacer l’icône `chevron-left` par `arrow-left` (utilisation de l’icône existante du sprite en `24x24`) et pour ajouter un titre séparé `<h1 class="project-situation-edit__title">Paramètres</h1>` à droite du bouton retour.
- Ajout de classes spécifiques à l’écran d’édition (`settings-layout--situation-edit`, `settings-nav--situation-edit`, `settings-content--situation-edit`) et propagation de ces classes à l’appel de `renderSideNavLayout` pour cibler le style de cette vue.
- Modifications CSS dans `apps/web/style.css` pour implémenter la top bar (hauteur `49px`, `border-bottom: 1px solid var(--border)`, `background: var(--headbg)`), styliser le bouton retour et l’icône (`color: var(--muted)`, `fill: var(--muted)`, icône `24x24`) et ajuster le layout en deux colonnes avec la navigation à gauche `329px` et le contenu paramètres centré.
- Vérification que l’icône `arrow-left` existe déjà dans `apps/web/assets/icons.svg` (pas d’ajout d’asset nécessaire).

### Testing
- Exécution de la vérification de cohérence des diffs et de l’état du dépôt avec `git diff --check && git status --short`, qui a réussi.
- Le changement a été ajouté et commité localement (commit message: `Améliore l'UI des paramètres de situation`).
- Aucune suite de tests unitaires ou visuels automatisés n’a été exécutée dans cet environnement; aucun screenshot n’a été généré.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb789b283083298c6b0497e1577ed4)