### PR TITLE
Refactor situation edit panel markup and styles in project situations view

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -2,7 +2,7 @@ import { escapeHtml } from "../../utils/escape-html.js";
 import { svgIcon } from "../../ui/icons.js";
 import { renderSettingsModal } from "../ui/settings-modal.js";
 import { renderStatusBadge } from "../ui/status-badges.js";
-import { renderSideNavLayout, renderSideNavGroup, renderSideNavItem } from "../ui/side-nav-layout.js";
+import { renderSideNavGroup, renderSideNavItem } from "../ui/side-nav-layout.js";
 import { renderLightTabs } from "../ui/light-tabs.js";
 import { renderSituationForm } from "./project-situations-form.js";
 import { renderSituationGridView } from "./project-situations-view-grid.js";
@@ -161,46 +161,43 @@ export function createProjectSituationsView({
       })]
     });
 
-    const contentHtml = `
-      <div class="project-situation-edit" data-side-nav-panel="situation-settings-panel">
-        <div class="project-situation-edit__header">
-          <button type="button" class="project-situation-edit__back" data-close-situation-edit>
-            <span class="project-situation-edit__back-icon">${svgIcon("chevron-left", { className: "octicon octicon-chevron-left" })}</span>
-            <span>Paramètres</span>
-          </button>
-        </div>
-        <section class="gh-panel gh-panel--details project-situation-edit__panel">
-          <div class="gh-panel__head gh-panel__head--tight">
-            <div>
-              <div class="details-title">Paramètres de la situation</div>
-              <div class="issue-row-meta-text" style="margin-top:6px;">Mets à jour les informations de la situation sans changer son mode.</div>
-            </div>
-          </div>
-          <div class="details-body project-situation-edit__body">
-            ${renderSituationForm({
-              form,
-              mode: "edit",
-              normalizeSituationMode,
-              error: uiState.editError,
-              submitting: uiState.editSubmitting,
-              submitButtonId: "projectEditSituationSubmit",
-              submitLabel: "Mettre à jour les paramètres",
-              submitPendingLabel: "Mise à jour…"
-            })}
-          </div>
-        </section>
-      </div>
-    `;
-
     return `
       <div class="settings-shell settings-shell--parametres settings-shell--situation-edit">
-        ${renderSideNavLayout({
-          className: "settings-layout settings-layout--parametres",
-          navClassName: "settings-nav settings-nav--parametres",
-          contentClassName: "settings-content settings-content--parametres",
-          navHtml,
-          contentHtml
-        })}
+        <div class="project-situation-edit">
+          <div class="project-situation-edit__header">
+            <button type="button" class="project-situation-edit__back" data-close-situation-edit>
+              <span class="project-situation-edit__back-icon">${svgIcon("arrow-left", { className: "octicon octicon-arrow-left route-title-module__Octicon__vxu4r", width: 24, height: 24 })}</span>
+            </button>
+            <h1 class="project-situation-edit__title">Paramètres</h1>
+          </div>
+          <div class="project-situation-edit__main">
+            <aside class="project-situation-edit__aside settings-nav settings-nav--parametres settings-nav--situation-edit">
+              ${navHtml}
+            </aside>
+            <div class="project-situation-edit__content settings-content settings-content--parametres settings-content--situation-edit" data-side-nav-panel="situation-settings-panel">
+              <section class="gh-panel gh-panel--details project-situation-edit__panel">
+                <div class="gh-panel__head gh-panel__head--tight">
+                  <div>
+                    <div class="details-title">Paramètres de la situation</div>
+                    <div class="issue-row-meta-text" style="margin-top:6px;">Mets à jour les informations de la situation sans changer son mode.</div>
+                  </div>
+                </div>
+                <div class="details-body project-situation-edit__body">
+                  ${renderSituationForm({
+                    form,
+                    mode: "edit",
+                    normalizeSituationMode,
+                    error: uiState.editError,
+                    submitting: uiState.editSubmitting,
+                    submitButtonId: "projectEditSituationSubmit",
+                    submitLabel: "Mettre à jour les paramètres",
+                    submitPendingLabel: "Mise à jour…"
+                  })}
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
       </div>
     `;
   }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13412,38 +13412,57 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 
 .settings-shell--situation-edit{
-  padding-top:4px;
+  max-width:none;
+  margin:0;
+  padding-top:0;
 }
 
 .project-situation-edit{
   display:flex;
   flex-direction:column;
-  gap:16px;
 }
 
 .project-situation-edit__header{
   display:flex;
   align-items:center;
+  gap:12px;
+  height:49px;
+  padding:0 12px;
+  border-bottom:1px solid var(--border);
+  background:var(--headbg);
 }
 
 .project-situation-edit__back{
   display:inline-flex;
   align-items:center;
-  gap:8px;
   border:0;
   background:transparent;
-  color:var(--text);
-  font-size:20px;
-  font-weight:600;
   padding:0;
+  color:var(--muted);
+  fill:var(--muted);
+  cursor:pointer;
+}
+
+.project-situation-edit__title{
+  margin:0;
+  font-size:20px;
+  line-height:1.2;
+  font-weight:600;
 }
 
 .project-situation-edit__back-icon{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  width:28px;
-  height:28px;
+  width:24px;
+  height:24px;
+  color:var(--muted);
+  fill:var(--muted);
+}
+
+.project-situation-edit__back-icon .ui-icon{
+  width:24px;
+  height:24px;
   border-radius:8px;
 }
 
@@ -13458,6 +13477,42 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-edit__body{
   max-width:720px;
+}
+
+.project-situation-edit__main{
+  position:relative;
+  min-height:calc(100dvh - 49px);
+}
+
+.project-situation-edit__aside{
+  position:fixed;
+  left:0;
+  width:329px;
+  height:calc(100dvh - var(--header-h) - var(--project-tabs-h) - 49px);
+  border-right:1px solid var(--border);
+  padding:12px 16px;
+  overflow:auto;
+  background:var(--bg);
+}
+
+.settings-nav--situation-edit{
+  width:329px;
+}
+
+.project-situation-edit__content{
+  margin-left:329px;
+  display:flex;
+  justify-content:center;
+  padding:20px 24px;
+}
+
+.settings-content--situation-edit{
+  width:100%;
+  max-width:920px;
+}
+
+.project-situation-edit__panel{
+  width:100%;
 }
 
 .project-lot-modal__radio--readonly{


### PR DESCRIPTION
### Motivation
- Replace the previous side-nav layout helper with a bespoke markup to provide a more compact, fixed-aside edit panel and better control over header and back button presentation.
- Improve visual consistency and spacing for the situation edit UI and ensure the settings nav stays fixed while content scrolls.

### Description
- Removed the `renderSideNavLayout` import and its usage and replaced it with inline markup that builds a header, fixed aside navigation, and a centered content area for the situation edit panel.
- Replaced the back icon usage from `chevron-left` to `arrow-left` and adjusted the icon element attributes for size and classes in the new header markup.
- Added and adjusted CSS rules (new classes under `.project-situation-edit`, `.project-situation-edit__header`, `.project-situation-edit__aside`, `.project-situation-edit__content`, etc.) to implement the fixed-side navigation, header styling, spacing, and responsive sizing, and changed `.settings-shell--situation-edit` padding/width behavior.
- Kept the `renderSituationForm` usage and existing form behavior while moving it into the new content container and preserved edit error/submitting behavior.

### Testing
- Ran the frontend test suite with `yarn test` and code style checks with `yarn lint`, and both succeeded without failures.
- Verified that the view compiles and the updated CSS rules are included in the build by running the local dev build command `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb789b283083298c6b0497e1577ed4)