### PR TITLE
Paramètres de situation — supprimer aide, ajouter bouton Indicateurs, adapter CTA

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -169,6 +169,11 @@ export function createProjectSituationsView({
               <span class="project-situation-edit__back-icon">${svgIcon("arrow-left", { className: "octicon octicon-arrow-left route-title-module__Octicon__vxu4r", width: 24, height: 24 })}</span>
             </button>
             <h1 class="project-situation-edit__title">Paramètres</h1>
+            <div class="project-situation-edit__header-actions">
+              <button type="button" class="gh-btn gh-action__main gh-btn--default gh-btn--md">
+                ${svgIcon("graph", { className: "octicon octicon-graph" })}<span>Indicateurs</span>
+              </button>
+            </div>
           </div>
           <div class="project-situation-edit__main">
             <aside class="project-situation-edit__aside settings-nav settings-nav--parametres settings-nav--situation-edit">
@@ -179,7 +184,6 @@ export function createProjectSituationsView({
                 <div class="gh-panel__head gh-panel__head--tight">
                   <div>
                     <div class="details-title">Paramètres de la situation</div>
-                    <div class="issue-row-meta-text" style="margin-top:6px;">Mets à jour les informations de la situation sans changer son mode.</div>
                   </div>
                 </div>
                 <div class="details-body project-situation-edit__body">

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13450,6 +13450,18 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   font-weight:600;
 }
 
+.project-situation-edit__header-actions{
+  margin-left:auto;
+  display:inline-flex;
+  align-items:center;
+}
+
+.project-situation-edit__header-actions .gh-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+
 .project-situation-edit__back-icon{
   display:inline-flex;
   align-items:center;
@@ -13477,6 +13489,10 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-edit__body{
   max-width:720px;
+}
+
+.project-situation-edit__body .settings-modal__submit{
+  width:fit-content;
 }
 
 .project-situation-edit__main{


### PR DESCRIPTION
### Motivation
- Clarifier l’écran d’édition de situation en retirant un texte d’aide redondant, exposer l’action « Indicateurs » dans la top bar et adapter le bouton de soumission à son contenu.

### Description
- Dans `apps/web/js/views/project-situations/project-situations-view.js` j’ai supprimé la ligne d’aide sous « Paramètres de la situation » et ajouté, dans l’entête d’édition, un bouton aligné à droite avec les classes `gh-btn gh-action__main gh-btn--default gh-btn--md` et l’icône `graph` via `svgIcon("graph")`.
- Dans `apps/web/style.css` j’ai ajouté la classe `.project-situation-edit__header-actions` pour aligner le nouveau bouton à droite et une règle `.project-situation-edit__body .settings-modal__submit{ width:fit-content; }` pour que le bouton « Mettre à jour les paramètres » prenne la largeur de son contenu.
- Changements purement markup / CSS sans modification de logique métier.

### Testing
- Exécution de `node --check apps/web/js/views/project-situations/project-situations-view.js` — succès.
- Exécution de `git diff --check` — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7f96e2608329b50edee8a46364bf)