### PR TITLE
feat(situations): ajouter couche de données Burnup pour les indicateurs

### DIFF
--- a/apps/web/js/services/project-situations-supabase.js
+++ b/apps/web/js/services/project-situations-supabase.js
@@ -273,6 +273,110 @@ function sortSubjects(subjects = []) {
   });
 }
 
+function getRangeDayCount(range) {
+  if (range === "1m") return 30;
+  if (range === "3m") return 90;
+  return 14;
+}
+
+function toDayStartTimestamp(value) {
+  const timestamp = Date.parse(value || "");
+  if (!Number.isFinite(timestamp)) return NaN;
+  const date = new Date(timestamp);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+function buildEvenTicks(maxValue, targetSteps = 5) {
+  const safeMax = Math.max(0, Number(maxValue) || 0);
+  const step = Math.max(1, Math.ceil(safeMax / Math.max(1, targetSteps)));
+  const ticks = [0];
+  for (let value = step; value <= safeMax; value += step) ticks.push(value);
+  if (ticks[ticks.length - 1] !== safeMax) ticks.push(safeMax);
+  return [...new Set(ticks)];
+}
+
+function buildSituationBurnupChartData(subjects = [], range = "2w") {
+  const safeSubjects = safeArray(subjects);
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const todayTs = today.getTime();
+
+  const filteredRange = String(range || "2w").trim().toLowerCase();
+  let startTs = todayTs;
+  if (filteredRange === "max") {
+    const minCreatedTs = safeSubjects
+      .map((subject) => toDayStartTimestamp(subject?.created_at))
+      .filter(Number.isFinite)
+      .sort((a, b) => a - b)[0];
+    startTs = Number.isFinite(minCreatedTs) ? minCreatedTs : todayTs;
+  } else {
+    startTs = todayTs - ((getRangeDayCount(filteredRange) - 1) * 86400000);
+  }
+
+  const dayCount = Math.max(1, Math.floor((todayTs - startTs) / 86400000) + 1);
+  const dayTimestamps = Array.from({ length: dayCount }, (_, index) => startTs + (index * 86400000));
+
+  const openedSeries = [];
+  const closedSeries = [];
+
+  // NOTE: la précision historique dépend des colonnes disponibles (status/created_at/updated_at/closed_at) ;
+  // sans journal d'événements complet, on ne peut pas reconstruire parfaitement les fermetures/réouvertures successives.
+  dayTimestamps.forEach((dayTs, index) => {
+    const dayEndTs = dayTs + 86399999;
+    let openCount = 0;
+    let closedCount = 0;
+
+    safeSubjects.forEach((subject) => {
+      const createdTs = Date.parse(subject?.created_at || "");
+      if (!Number.isFinite(createdTs) || createdTs > dayEndTs) return;
+
+      const closedAtTs = Date.parse(subject?.closed_at || "");
+      const effectiveClosedTs = Number.isFinite(closedAtTs) ? closedAtTs : NaN;
+      const effectiveStatus = String(subject?.status || "open").trim().toLowerCase() === "closed" ? "closed" : "open";
+
+      if (Number.isFinite(effectiveClosedTs) && effectiveClosedTs <= dayEndTs) {
+        closedCount += 1;
+        return;
+      }
+      if (effectiveStatus === "closed" && !Number.isFinite(effectiveClosedTs)) {
+        closedCount += 1;
+        return;
+      }
+      openCount += 1;
+    });
+
+    openedSeries.push({ x: index, y: openCount });
+    closedSeries.push({ x: index, y: closedCount });
+  });
+
+  const yMax = Math.max(
+    1,
+    ...openedSeries.map((point) => point.y),
+    ...closedSeries.map((point) => point.y)
+  );
+
+  const xTicks = (() => {
+    if (dayCount <= 7) return Array.from({ length: dayCount }, (_, index) => index);
+    const step = Math.max(1, Math.floor(dayCount / 6));
+    const ticks = [0];
+    for (let tick = step; tick < dayCount - 1; tick += step) ticks.push(tick);
+    if (ticks[ticks.length - 1] !== dayCount - 1) ticks.push(dayCount - 1);
+    return [...new Set(ticks)];
+  })();
+
+  return {
+    labels: dayTimestamps.map((dayTs) => new Date(dayTs).toISOString().slice(0, 10)),
+    xTicks,
+    yTicks: buildEvenTicks(yMax, 5),
+    yMax,
+    series: [
+      { label: "Fermés", points: closedSeries },
+      { label: "Ouverts", points: openedSeries }
+    ]
+  };
+}
+
 export async function loadSituationsForCurrentProject(projectId) {
   const resolvedProjectId = await getResolvedProjectId(projectId);
   if (!resolvedProjectId) throw new Error("projectId is required");
@@ -572,6 +676,15 @@ export async function loadSubjectsForSituation(situation, projectSubjectsState =
 
   const flatSubjects = Object.values(subjectsById);
   return sortSubjects(flatSubjects.filter((subject) => subjectMatchesAutomaticFilter(subject, normalizedSituation.filter_definition, projectSubjectsState)));
+}
+
+export async function loadSituationInsightsData(situation, options = {}) {
+  const range = String(options?.range || "2w").trim().toLowerCase();
+  const normalizedRange = ["2w", "1m", "3m", "max"].includes(range) ? range : "2w";
+  const subjects = await loadSubjectsForSituation(situation, store.projectSubjectsView);
+  return {
+    burnup: buildSituationBurnupChartData(subjects, normalizedRange)
+  };
 }
 
 export function resetSituationsForCurrentProject() {

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -18,6 +18,7 @@ import {
   createSituation,
   updateSituation,
   loadSubjectsForSituation,
+  loadSituationInsightsData,
   setSituationSubjectKanbanStatus,
   loadSituationKanbanStatusMap
 } from "../services/project-situations-supabase.js";
@@ -428,6 +429,7 @@ const { bindEvents } = createProjectSituationsEvents({
   setSelectedSituationId,
   getSituationById,
   loadSituationSelection,
+  loadSituationInsightsData,
   openSituationDrilldownFromSelection
 });
 

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -27,8 +27,56 @@ export function createProjectSituationsEvents({
   setSelectedSituationId,
   getSituationById,
   loadSituationSelection,
+  loadSituationInsightsData,
   openSituationDrilldownFromSelection
 }) {
+  function isSituationInsightsDebugEnabled() {
+    try {
+      return window.localStorage?.getItem("debug:situation-insights") === "1";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function logSituationInsights(message, payload = {}) {
+    if (!isSituationInsightsDebugEnabled()) return;
+    console.info(`[situation-insights] ${message}`, payload);
+  }
+
+  async function refreshInsightsData(root) {
+    const situationId = String(store.situationsView?.selectedSituationId || "").trim();
+    const selectedSituation = getSituationById(situationId);
+    if (!selectedSituation) return;
+
+    uiState.insightsLoading = true;
+    uiState.insightsError = "";
+    rerender(root);
+
+    const startedAt = Date.now();
+    logSituationInsights("load:start", { situationId, range: uiState.insightsRange });
+    try {
+      const insightsData = await loadSituationInsightsData(selectedSituation, { range: uiState.insightsRange });
+      uiState.insightsData = insightsData;
+      uiState.insightsLoading = false;
+      uiState.insightsError = "";
+      logSituationInsights("load:success", {
+        situationId,
+        range: uiState.insightsRange,
+        durationMs: Date.now() - startedAt
+      });
+      rerender(root);
+    } catch (error) {
+      uiState.insightsLoading = false;
+      uiState.insightsError = error instanceof Error ? error.message : "Impossible de charger les indicateurs.";
+      logSituationInsights("load:error", {
+        situationId,
+        range: uiState.insightsRange,
+        durationMs: Date.now() - startedAt,
+        error: uiState.insightsError
+      });
+      rerender(root);
+    }
+  }
   function buildEditSituationPayload() {
     const form = uiState.editForm || getDefaultCreateForm();
     const mode = normalizeSituationMode(form.mode);
@@ -100,7 +148,9 @@ export function createProjectSituationsEvents({
   function openInsightsPanel(root) {
     uiState.insightsPanelOpen = true;
     uiState.editPanelOpen = false;
+    uiState.insightsActiveChart = "burnup";
     rerender(root);
+    refreshInsightsData(root).catch(() => undefined);
   }
 
   function closeInsightsPanel(root) {
@@ -239,11 +289,11 @@ export function createProjectSituationsEvents({
     });
 
     root.querySelectorAll("[data-situation-insights-range]").forEach((node) => {
-      node.addEventListener("click", () => {
+      node.addEventListener("click", async () => {
         const nextRange = String(node.getAttribute("data-situation-insights-range") || "").trim().toLowerCase();
         if (!nextRange || uiState.insightsRange === nextRange) return;
         uiState.insightsRange = nextRange;
-        rerender(root);
+        await refreshInsightsData(root);
       });
     });
 

--- a/apps/web/js/views/project-situations/project-situations-state.js
+++ b/apps/web/js/views/project-situations/project-situations-state.js
@@ -66,7 +66,11 @@ export function createProjectSituationsState({ store }) {
     editError: "",
     editForm: getDefaultSituationForm(),
     insightsPanelOpen: false,
-    insightsRange: "2w"
+    insightsRange: "2w",
+    insightsLoading: false,
+    insightsError: "",
+    insightsActiveChart: "burnup",
+    insightsData: null
   };
 
   function ensureSituationsViewState() {

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -66,20 +66,23 @@ export function createProjectSituationsView({
     });
 
     const activeRange = String(uiState.insightsRange || "2w");
+    const burnupData = uiState.insightsData?.burnup || null;
+    const labels = Array.isArray(burnupData?.labels) ? burnupData.labels : [];
     const chartHtml = renderSvgLineChart({
       width: 964,
       height: 478,
       xLabel: "",
       yLabel: "",
-      xDomain: [0, 13],
-      yDomain: [0, 10],
-      xTicks: [0, 2, 4, 6, 8, 10, 12],
-      yTicks: [0, 2, 4, 6, 8, 10],
-      xTickFormatter: () => "",
-      series: [
-        { label: "Terminés", points: [] },
-        { label: "Ouverts", points: [] }
-      ]
+      xDomain: [0, Math.max(1, labels.length - 1)],
+      yDomain: [0, Math.max(1, Number(burnupData?.yMax) || 1)],
+      xTicks: Array.isArray(burnupData?.xTicks) ? burnupData.xTicks : [0],
+      yTicks: Array.isArray(burnupData?.yTicks) ? burnupData.yTicks : [0, 1],
+      xTickFormatter: (tick) => {
+        const index = Number(tick);
+        const label = labels[index] || "";
+        return label ? label.slice(5) : "";
+      },
+      series: Array.isArray(burnupData?.series) ? burnupData.series : []
     });
 
     return `
@@ -111,7 +114,11 @@ export function createProjectSituationsView({
                     <button type="button" class="project-situation-insights__range ${activeRange === "max" ? "is-active" : ""}" data-situation-insights-range="max">Max</button>
                   </div>
                   <div class="project-situation-insights__chart-shell">
-                    ${chartHtml}
+                    ${uiState.insightsLoading
+                      ? `<div class="settings-empty-state">Chargement des indicateurs…</div>`
+                      : (uiState.insightsError
+                        ? `<div class="settings-inline-error">${escapeHtml(uiState.insightsError)}</div>`
+                        : chartHtml)}
                   </div>
                 </div>
               </section>


### PR DESCRIPTION
### Motivation
- Fournir une couche de données dédiée pour alimenter le graphique Burn up des Indicateurs depuis les sujets réels Supabase sans mélanger la logique dans la vue.
- Charger les données asynchrones à l'ouverture du panneau Indicateurs et lors du changement de période, sans bloquer le reste de la page.

### Description
- Ajout de la fonction exportée `loadSituationInsightsData(situation, options)` qui réutilise `loadSubjectsForSituation(...)` et retourne un objet normalisé contenant `burnup: { labels, xTicks, yTicks, yMax, series }` (fichiers modifiés : `apps/web/js/services/project-situations-supabase.js`).
- Implémentation de l'agrégation Burn up reconstruisant par jour les séries `Fermés` et `Ouverts` à partir des champs disponibles (`status`, `created_at`, `closed_at`), avec un commentaire signalant la dépendance à la qualité historique des colonnes (pas d'invention d'historique). (voir fonctions utilitaires et `buildSituationBurnupChartData`).
- Extension de l'état UI (`uiState`) avec `insightsLoading`, `insightsError`, `insightsActiveChart`, `insightsData` et réutilisation de `insightsRange` (fichier modifié : `apps/web/js/views/project-situations/project-situations-state.js`).
- Liaison du chargement asynchrone à l'ouverture du panneau Indicateurs et au changement de période, affichage d'un état `loading` et d'une erreur sans bloquer la page, et injection des données dans le `renderSvgLineChart` (fichiers modifiés : `apps/web/js/views/project-situations/project-situations-events.js`, `apps/web/js/views/project-situations/project-situations-view.js`).
- Instrumentation de debug temporaire activable via `localStorage.setItem("debug:situation-insights","1")` avec logs `[situation-insights] load:start|load:success|load:error` (implémentée dans `project-situations-events.js`).
- Export/imports raccordés pour rendre la nouvelle fonction disponible à la vue (modification de `apps/web/js/views/project-situations.js`).

### Testing
- Exécution de vérificateurs de syntaxe JavaScript : `node --check apps/web/js/services/project-situations-supabase.js` (succès).
- `node --check apps/web/js/views/project-situations/project-situations-events.js` (succès).
- `node --check apps/web/js/views/project-situations/project-situations-view.js` (succès).
- `node --check apps/web/js/views/project-situations.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb880eb1e08329b029d1b176e067a8)