### PR TITLE
Adjust situation edit layout to two-column flex

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -13554,12 +13554,15 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 .project-situation-edit__main{
   position:relative;
   min-height:calc(100dvh - 49px);
+  display:flex;
+  align-items:flex-start;
 }
 
 .project-situation-edit__aside{
-  position:fixed;
-  left:0;
+  position:sticky;
+  left:auto;
   width:329px;
+  flex:0 0 329px;
   height:calc(100dvh - var(--header-h) - var(--project-tabs-h) - 49px);
   border-right:1px solid var(--border);
   padding:12px 16px;
@@ -13573,10 +13576,41 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 }
 
 .project-situation-edit__content{
-  margin-left:329px;
+  flex:1;
   display:flex;
   justify-content:center;
   padding:20px 24px;
+}
+
+.project-situation-edit__aside .side-nav-layout__group.settings-nav__group--project{
+  width:100%;
+  max-width:296px;
+  margin:0 auto;
+}
+
+@media (max-width: 1120px){
+  .project-situation-edit__main{
+    display:block;
+    min-height:0;
+  }
+
+  .project-situation-edit__aside{
+    position:relative;
+    top:auto;
+    width:100%;
+    height:auto;
+    max-height:none;
+    border-right:none;
+    border-bottom:1px solid var(--border);
+  }
+
+  .settings-nav--situation-edit{
+    width:100%;
+  }
+
+  .project-situation-edit__content{
+    padding:20px 0;
+  }
 }
 .project-situation-edit__content .gh-panel__head--tight{background:none;font-size:24px;font-weight:400;margin-bottom:8px;padding-bottom:8px;}
 .settings-content--situation-edit{


### PR DESCRIPTION
### Motivation
- Improve layout for situation edit/insights views by switching to a two-column flow so the left navigation remains fixed-width while the main content uses the remaining space.
- Keep the left navigation visually identical in width but make it behave with the page flow (sticky) instead of being fixed-positioned to avoid overlap and scrolling issues.

### Description
- Changed `.project-situation-edit__main` to use `display: flex` with `align-items: flex-start` to create two columns for aside and content.
- Converted `.project-situation-edit__aside` from `position: fixed` to `position: sticky`, set `flex: 0 0 329px`, and removed the left margin approach so it sits as a fixed-width left column in the flex layout.
- Made `.project-situation-edit__content` use `flex: 1` (removed the left margin) and preserved centered content with existing internal max-width rules.
- Centered the `.side-nav-layout__group.settings-nav__group--project` inside the aside with `max-width: 296px` and added a responsive `@media (max-width: 1120px)` rule to stack the aside above the content and restore full-width nav behavior.

### Testing
- No automated tests were executed for this change (CSS/layout-only change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb907606008329ba66ea5c42080f32)