### PR TITLE
Customize “Évolution des sujets” burnup chart styling and legend

### DIFF
--- a/apps/web/js/services/project-situations-supabase.js
+++ b/apps/web/js/services/project-situations-supabase.js
@@ -371,8 +371,28 @@ function buildSituationBurnupChartData(subjects = [], range = "2w") {
     yTicks: buildEvenTicks(yMax, 5),
     yMax,
     series: [
-      { label: "Fermés", points: closedSeries },
-      { label: "Ouverts", points: openedSeries }
+      {
+        label: "Completed",
+        points: closedSeries,
+        fill: true,
+        color: "#8957e5",
+        areaColor: "#271052",
+        areaOpacity: 0.5,
+        lineDasharray: "6 2",
+        lineWidth: 2,
+        legendMarker: "circle"
+      },
+      {
+        label: "Open",
+        points: openedSeries,
+        fill: true,
+        color: "#238636",
+        areaColor: "#04260f",
+        areaOpacity: 0.5,
+        lineDasharray: "none",
+        lineWidth: 2,
+        legendMarker: "circle"
+      }
     ]
   };
 }

--- a/apps/web/js/utils/svg-line-chart.js
+++ b/apps/web/js/utils/svg-line-chart.js
@@ -155,10 +155,15 @@ export function renderSvgLineChart({
             const showFill = item?.fill === true;
             const showPoints = item?.pointsVisible === true;
             const validPoints = getValidPoints(item?.points || []);
+            const seriesColor = typeof item?.color === "string" ? item.color : "";
+            const lineDasharray = typeof item?.lineDasharray === "string" ? item.lineDasharray : "";
+            const lineWidth = Number.isFinite(Number(item?.lineWidth)) ? Math.max(1, Number(item.lineWidth)) : null;
+            const areaColor = typeof item?.areaColor === "string" ? item.areaColor : "";
+            const areaOpacity = Number.isFinite(Number(item?.areaOpacity)) ? Math.max(0, Math.min(1, Number(item.areaOpacity))) : null;
             return `
-              <g class="${className}">
-                ${showFill && areaPath ? `<path class="svg-line-chart__area" d="${areaPath}"></path>` : ""}
-                ${showStroke && linePath ? `<path class="svg-line-chart__line" d="${linePath}"></path>` : ""}
+              <g class="${className}"${seriesColor ? ` style="color:${escapeHtml(seriesColor)};"` : ""}>
+                ${showFill && areaPath ? `<path class="svg-line-chart__area" d="${areaPath}"${areaColor || areaOpacity !== null ? ` style="${areaColor ? `fill:${escapeHtml(areaColor)};` : ""}${areaOpacity !== null ? `opacity:${areaOpacity};` : ""}"` : ""}></path>` : ""}
+                ${showStroke && linePath ? `<path class="svg-line-chart__line" d="${linePath}"${lineDasharray || lineWidth ? ` style="${lineDasharray ? `stroke-dasharray:${escapeHtml(lineDasharray)};` : ""}${lineWidth ? `stroke-width:${lineWidth};` : ""}"` : ""}></path>` : ""}
                 ${showPoints ? validPoints.map((point) => `<circle class="svg-line-chart__point" cx="${xScale(point.x).toFixed(3)}" cy="${yScale(point.y).toFixed(3)}" r="3.5"></circle>`).join("") : ""}
               </g>
             `;
@@ -176,7 +181,12 @@ export function renderSvgLineChart({
           ${subtitle ? `<div class="svg-line-chart__subtitle">${escapeHtml(subtitle)}</div>` : ""}
           ${series.some((item) => item?.label) ? `
             <div class="svg-line-chart__legend">
-              ${series.map((item, index) => item?.label ? `<div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--${index + 1}"></span><span>${escapeHtml(item.label)}</span></div>` : "").join("")}
+              ${series.map((item, index) => {
+                if (!item?.label) return "";
+                const markerClass = item?.legendMarker === "circle" ? "svg-line-chart__legend-swatch--circle" : "";
+                const markerStyle = item?.color ? ` style="color:${escapeHtml(String(item.color))};"` : "";
+                return `<div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--${index + 1} ${markerClass}"${markerStyle}></span><span>${escapeHtml(item.label)}</span></div>`;
+              }).join("")}
             </div>
           ` : ""}
         </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9471,6 +9471,14 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   display:inline-block;
 }
 
+.svg-line-chart__legend-swatch--circle{
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  background:transparent;
+  border:1.5px solid currentColor;
+}
+
 .svg-line-chart__hover-point{
   fill:#0d1117;
   stroke:#2f81f7;
@@ -13549,6 +13557,15 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-insights__chart-shell .svg-line-chart{
   height:100%;
+}
+
+.project-situation-insights__chart-shell .svg-line-chart__legend{
+  justify-content:flex-end;
+  margin:16px 6px 0 0;
+}
+
+.project-situation-insights__chart-shell .svg-line-chart__legend-item{
+  color:var(--text);
 }
 
 .project-situation-edit__main{


### PR DESCRIPTION
### Motivation
- Reproduire le rendu demandé pour le graphique « Évolution des sujets » en appliquant les couleurs, traits et légende visibles sur le screenshot (courbe Ouverts en vert pleine, Fermés en violet en pointillé, zones remplies sombres). 

### Description
- Étendu le renderer SVG pour accepter des options par série (`color`, `lineDasharray`, `lineWidth`, `areaColor`, `areaOpacity`, `legendMarker`) en `apps/web/js/utils/svg-line-chart.js` afin d’autoriser un style de ligne/zone/legend personnalisé. 
- Mis à jour la fonction de génération des données du burnup pour fournir des séries stylées : `Completed` (violet, dash `6 2`, zone `#271052` 50% opacity) et `Open` (vert `#238636`, trait continu, zone `#04260f` 50% opacity) dans `apps/web/js/services/project-situations-supabase.js`. 
- Ajouté des styles CSS pour le marqueur de légende circulaire et l’alignement/teinte de la légende dans `apps/web/style.css` afin d’approcher le rendu du screenshot. 

### Testing
- Vérification statique des fichiers modifiés avec `node --check apps/web/js/utils/svg-line-chart.js` — réussite. 
- Vérification statique de `apps/web/js/services/project-situations-supabase.js` avec `node --check` — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb988c2e088329962763ff580b0bda)