### PR TITLE
Enhance SVG line chart styling and area-baseline support; update burnup series and legend

### DIFF
--- a/apps/web/js/services/project-situations-supabase.js
+++ b/apps/web/js/services/project-situations-supabase.js
@@ -371,8 +371,29 @@ function buildSituationBurnupChartData(subjects = [], range = "2w") {
     yTicks: buildEvenTicks(yMax, 5),
     yMax,
     series: [
-      { label: "Fermés", points: closedSeries },
-      { label: "Ouverts", points: openedSeries }
+      {
+        label: "Completed",
+        points: closedSeries,
+        fill: true,
+        color: "#8957e5",
+        areaColor: "#271052",
+        areaOpacity: 0.5,
+        lineDasharray: "6 2",
+        lineWidth: 2,
+        legendMarker: "circle"
+      },
+      {
+        label: "Open",
+        points: openedSeries,
+        fill: true,
+        color: "#238636",
+        areaColor: "#04260f",
+        areaOpacity: 0.5,
+        areaBaselinePoints: closedSeries,
+        lineDasharray: "none",
+        lineWidth: 2,
+        legendMarker: "circle"
+      }
     ]
   };
 }

--- a/apps/web/js/utils/svg-line-chart.js
+++ b/apps/web/js/utils/svg-line-chart.js
@@ -47,6 +47,22 @@ function buildLinePath(points, xScale, yScale) {
 function buildAreaPath(points, xScale, yScale, baselineValue) {
   const valid = getValidPoints(points);
   if (!valid.length) return "";
+  const baselinePoints = Array.isArray(baselineValue)
+    ? getValidPoints(baselineValue)
+    : [];
+  if (baselinePoints.length) {
+    const baselineByX = new Map(baselinePoints.map((point) => [point.x, point.y]));
+    const linePath = buildLinePath(valid, xScale, yScale);
+    const baselinePath = [...valid]
+      .reverse()
+      .map((point, index) => {
+        const baselineY = yScale(clampNumber(baselineByX.get(point.x), 0)).toFixed(3);
+        const x = xScale(point.x).toFixed(3);
+        return `${index === 0 ? "L" : "L"}${x},${baselineY}`;
+      })
+      .join("");
+    return `${linePath}${baselinePath}Z`;
+  }
   const firstX = xScale(valid[0].x).toFixed(3);
   const lastX = xScale(valid[valid.length - 1].x).toFixed(3);
   const baselineY = yScale(baselineValue).toFixed(3);
@@ -150,15 +166,20 @@ export function renderSvgLineChart({
           ${series.map((item, index) => {
             const className = `svg-line-chart__series svg-line-chart__series--${index + 1}`;
             const linePath = buildLinePath(item?.points || [], xScale, yScale);
-            const areaPath = buildAreaPath(item?.points || [], xScale, yScale, yMin);
+            const areaPath = buildAreaPath(item?.points || [], xScale, yScale, item?.areaBaselinePoints || yMin);
             const showStroke = item?.stroke !== false;
             const showFill = item?.fill === true;
             const showPoints = item?.pointsVisible === true;
             const validPoints = getValidPoints(item?.points || []);
+            const seriesColor = typeof item?.color === "string" ? item.color : "";
+            const lineDasharray = typeof item?.lineDasharray === "string" ? item.lineDasharray : "";
+            const lineWidth = Number.isFinite(Number(item?.lineWidth)) ? Math.max(1, Number(item.lineWidth)) : null;
+            const areaColor = typeof item?.areaColor === "string" ? item.areaColor : "";
+            const areaOpacity = Number.isFinite(Number(item?.areaOpacity)) ? Math.max(0, Math.min(1, Number(item.areaOpacity))) : null;
             return `
-              <g class="${className}">
-                ${showFill && areaPath ? `<path class="svg-line-chart__area" d="${areaPath}"></path>` : ""}
-                ${showStroke && linePath ? `<path class="svg-line-chart__line" d="${linePath}"></path>` : ""}
+              <g class="${className}"${seriesColor ? ` style="color:${escapeHtml(seriesColor)};"` : ""}>
+                ${showFill && areaPath ? `<path class="svg-line-chart__area" d="${areaPath}"${areaColor || areaOpacity !== null ? ` style="${areaColor ? `fill:${escapeHtml(areaColor)};` : ""}${areaOpacity !== null ? `opacity:${areaOpacity};` : ""}"` : ""}></path>` : ""}
+                ${showStroke && linePath ? `<path class="svg-line-chart__line" d="${linePath}"${lineDasharray || lineWidth ? ` style="${lineDasharray ? `stroke-dasharray:${escapeHtml(lineDasharray)};` : ""}${lineWidth ? `stroke-width:${lineWidth};` : ""}"` : ""}></path>` : ""}
                 ${showPoints ? validPoints.map((point) => `<circle class="svg-line-chart__point" cx="${xScale(point.x).toFixed(3)}" cy="${yScale(point.y).toFixed(3)}" r="3.5"></circle>`).join("") : ""}
               </g>
             `;
@@ -176,7 +197,12 @@ export function renderSvgLineChart({
           ${subtitle ? `<div class="svg-line-chart__subtitle">${escapeHtml(subtitle)}</div>` : ""}
           ${series.some((item) => item?.label) ? `
             <div class="svg-line-chart__legend">
-              ${series.map((item, index) => item?.label ? `<div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--${index + 1}"></span><span>${escapeHtml(item.label)}</span></div>` : "").join("")}
+              ${series.map((item, index) => {
+                if (!item?.label) return "";
+                const markerClass = item?.legendMarker === "circle" ? "svg-line-chart__legend-swatch--circle" : "";
+                const markerStyle = item?.color ? ` style="color:${escapeHtml(String(item.color))};"` : "";
+                return `<div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--${index + 1} ${markerClass}"${markerStyle}></span><span>${escapeHtml(item.label)}</span></div>`;
+              }).join("")}
             </div>
           ` : ""}
         </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9471,6 +9471,14 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   display:inline-block;
 }
 
+.svg-line-chart__legend-swatch--circle{
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  background:transparent;
+  border:1.5px solid currentColor;
+}
+
 .svg-line-chart__hover-point{
   fill:#0d1117;
   stroke:#2f81f7;
@@ -13549,6 +13557,15 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-insights__chart-shell .svg-line-chart{
   height:100%;
+}
+
+.project-situation-insights__chart-shell .svg-line-chart__legend{
+  justify-content:flex-end;
+  margin:16px 6px 0 0;
+}
+
+.project-situation-insights__chart-shell .svg-line-chart__legend-item{
+  color:var(--text);
 }
 
 .project-situation-edit__main{


### PR DESCRIPTION
### Motivation
- Improve the burnup chart visuals by replacing French labels, making series stylable, and supporting filled areas with baselines between series.
- Allow per-series styling (colors, opacity, dash, width, legend marker) so charts can better convey semantics and match UI theming.
- Adjust chart legend and layout styles to support the new marker types and right-aligned placement inside the chart shell.

### Description
- Replaced burnup series labels from `"Fermés"`/`"Ouverts"` to `"Completed"`/`"Open"` and added series metadata fields such as `color`, `fill`, `areaColor`, `areaOpacity`, `lineDasharray`, `lineWidth`, `areaBaselinePoints`, and `legendMarker` in `buildSituationBurnupChartData`.
- Extended `buildAreaPath` to accept an array baseline via `areaBaselinePoints` and construct an area path that follows another series' points when provided.
- Enhanced `renderSvgLineChart` to emit inline styles for series colors, area fill color/opacity, and stroke dash/width, to render `legendMarker` values (including a circular swatch), and to pass `areaBaselinePoints` into the area builder.
- Updated CSS to add `.svg-line-chart__legend-swatch--circle`, right-align and recolor the chart legend inside `.project-situation-insights__chart-shell`, and keep existing tooltip/hover styles.

### Testing
- Ran the JavaScript unit test suite with `yarn test` and lint checks; all tests and linters passed.
- Built the web bundle with `yarn build:web` to verify asset compilation; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb988c2e088329962763ff580b0bda)