### PR TITLE
Enhance SVG charts: smooth curves, area baselines, series styling and legend markers

### DIFF
--- a/apps/web/js/services/project-situations-supabase.js
+++ b/apps/web/js/services/project-situations-supabase.js
@@ -371,8 +371,29 @@ function buildSituationBurnupChartData(subjects = [], range = "2w") {
     yTicks: buildEvenTicks(yMax, 5),
     yMax,
     series: [
-      { label: "Fermés", points: closedSeries },
-      { label: "Ouverts", points: openedSeries }
+      {
+        label: "Completed",
+        points: closedSeries,
+        fill: true,
+        color: "#8957e5",
+        areaColor: "#271052",
+        areaOpacity: 0.5,
+        lineDasharray: "6 2",
+        lineWidth: 2,
+        legendMarker: "circle"
+      },
+      {
+        label: "Open",
+        points: openedSeries,
+        fill: true,
+        color: "#238636",
+        areaColor: "#04260f",
+        areaOpacity: 0.5,
+        areaBaselinePoints: closedSeries,
+        lineDasharray: "none",
+        lineWidth: 2,
+        legendMarker: "circle"
+      }
     ]
   };
 }

--- a/apps/web/js/utils/svg-line-chart.js
+++ b/apps/web/js/utils/svg-line-chart.js
@@ -34,9 +34,27 @@ function getValidPoints(points = []) {
   return points.filter((point) => Number.isFinite(point?.x) && Number.isFinite(point?.y));
 }
 
-function buildLinePath(points, xScale, yScale) {
+function buildLinePath(points, xScale, yScale, curve = "linear") {
   const valid = getValidPoints(points);
   if (!valid.length) return "";
+  if (curve === "smooth" && valid.length > 2) {
+    const coords = valid.map((point) => ({
+      x: xScale(point.x),
+      y: yScale(point.y)
+    }));
+    let path = `M${coords[0].x.toFixed(3)},${coords[0].y.toFixed(3)}`;
+    for (let index = 1; index < coords.length - 1; index += 1) {
+      const current = coords[index];
+      const next = coords[index + 1];
+      const midX = ((current.x + next.x) / 2).toFixed(3);
+      const midY = ((current.y + next.y) / 2).toFixed(3);
+      path += `Q${current.x.toFixed(3)},${current.y.toFixed(3)} ${midX},${midY}`;
+    }
+    const penultimate = coords[coords.length - 2];
+    const last = coords[coords.length - 1];
+    path += `Q${penultimate.x.toFixed(3)},${penultimate.y.toFixed(3)} ${last.x.toFixed(3)},${last.y.toFixed(3)}`;
+    return path;
+  }
   return valid.map((point, index) => {
     const x = xScale(point.x).toFixed(3);
     const y = yScale(point.y).toFixed(3);
@@ -44,13 +62,29 @@ function buildLinePath(points, xScale, yScale) {
   }).join("");
 }
 
-function buildAreaPath(points, xScale, yScale, baselineValue) {
+function buildAreaPath(points, xScale, yScale, baselineValue, curve = "linear") {
   const valid = getValidPoints(points);
   if (!valid.length) return "";
+  const baselinePoints = Array.isArray(baselineValue)
+    ? getValidPoints(baselineValue)
+    : [];
+  if (baselinePoints.length) {
+    const baselineByX = new Map(baselinePoints.map((point) => [point.x, point.y]));
+    const linePath = buildLinePath(valid, xScale, yScale, curve);
+    const baselinePath = [...valid]
+      .reverse()
+      .map((point, index) => {
+        const baselineY = yScale(clampNumber(baselineByX.get(point.x), 0)).toFixed(3);
+        const x = xScale(point.x).toFixed(3);
+        return `${index === 0 ? "L" : "L"}${x},${baselineY}`;
+      })
+      .join("");
+    return `${linePath}${baselinePath}Z`;
+  }
   const firstX = xScale(valid[0].x).toFixed(3);
   const lastX = xScale(valid[valid.length - 1].x).toFixed(3);
   const baselineY = yScale(baselineValue).toFixed(3);
-  const linePath = buildLinePath(valid, xScale, yScale);
+  const linePath = buildLinePath(valid, xScale, yScale, curve);
   return `${linePath}L${lastX},${baselineY}L${firstX},${baselineY}Z`;
 }
 
@@ -149,16 +183,22 @@ export function renderSvgLineChart({
           </g>
           ${series.map((item, index) => {
             const className = `svg-line-chart__series svg-line-chart__series--${index + 1}`;
-            const linePath = buildLinePath(item?.points || [], xScale, yScale);
-            const areaPath = buildAreaPath(item?.points || [], xScale, yScale, yMin);
+            const curve = item?.curve === "smooth" ? "smooth" : "linear";
+            const linePath = buildLinePath(item?.points || [], xScale, yScale, curve);
+            const areaPath = buildAreaPath(item?.points || [], xScale, yScale, item?.areaBaselinePoints || yMin, curve);
             const showStroke = item?.stroke !== false;
             const showFill = item?.fill === true;
             const showPoints = item?.pointsVisible === true;
             const validPoints = getValidPoints(item?.points || []);
+            const seriesColor = typeof item?.color === "string" ? item.color : "";
+            const lineDasharray = typeof item?.lineDasharray === "string" ? item.lineDasharray : "";
+            const lineWidth = Number.isFinite(Number(item?.lineWidth)) ? Math.max(1, Number(item.lineWidth)) : null;
+            const areaColor = typeof item?.areaColor === "string" ? item.areaColor : "";
+            const areaOpacity = Number.isFinite(Number(item?.areaOpacity)) ? Math.max(0, Math.min(1, Number(item.areaOpacity))) : null;
             return `
-              <g class="${className}">
-                ${showFill && areaPath ? `<path class="svg-line-chart__area" d="${areaPath}"></path>` : ""}
-                ${showStroke && linePath ? `<path class="svg-line-chart__line" d="${linePath}"></path>` : ""}
+              <g class="${className}"${seriesColor ? ` style="color:${escapeHtml(seriesColor)};"` : ""}>
+                ${showFill && areaPath ? `<path class="svg-line-chart__area" d="${areaPath}"${areaColor || areaOpacity !== null ? ` style="${areaColor ? `fill:${escapeHtml(areaColor)};` : ""}${areaOpacity !== null ? `opacity:${areaOpacity};` : ""}"` : ""}></path>` : ""}
+                ${showStroke && linePath ? `<path class="svg-line-chart__line" d="${linePath}"${lineDasharray || lineWidth ? ` style="${lineDasharray ? `stroke-dasharray:${escapeHtml(lineDasharray)};` : ""}${lineWidth ? `stroke-width:${lineWidth};` : ""}"` : ""}></path>` : ""}
                 ${showPoints ? validPoints.map((point) => `<circle class="svg-line-chart__point" cx="${xScale(point.x).toFixed(3)}" cy="${yScale(point.y).toFixed(3)}" r="3.5"></circle>`).join("") : ""}
               </g>
             `;
@@ -176,7 +216,12 @@ export function renderSvgLineChart({
           ${subtitle ? `<div class="svg-line-chart__subtitle">${escapeHtml(subtitle)}</div>` : ""}
           ${series.some((item) => item?.label) ? `
             <div class="svg-line-chart__legend">
-              ${series.map((item, index) => item?.label ? `<div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--${index + 1}"></span><span>${escapeHtml(item.label)}</span></div>` : "").join("")}
+              ${series.map((item, index) => {
+                if (!item?.label) return "";
+                const markerClass = item?.legendMarker === "circle" ? "svg-line-chart__legend-swatch--circle" : "";
+                const markerStyle = item?.color ? ` style="color:${escapeHtml(String(item.color))};"` : "";
+                return `<div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--${index + 1} ${markerClass}"${markerStyle}></span><span>${escapeHtml(item.label)}</span></div>`;
+              }).join("")}
             </div>
           ` : ""}
         </div>

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -24,14 +24,14 @@ export function createProjectSituationsView({
     const safeValues = Array.isArray(values) ? values : [];
     const width = 964;
     const height = 478;
-    const margin = { top: 24, right: 24, bottom: 120, left: 56 };
+    const margin = { top: 24, right: 24, bottom: 78, left: 100 };
     const innerWidth = width - margin.left - margin.right;
     const innerHeight = height - margin.top - margin.bottom;
     const barGap = 10;
     const barCount = Math.max(1, safeLabels.length);
-    const barWidth = Math.max(12, (innerWidth - (barGap * (barCount - 1))) / barCount);
+    const barHeight = Math.max(12, (innerHeight - (barGap * (barCount - 1))) / barCount);
     const domainMax = Math.max(1, Number(yMax) || 1);
-    const scaleY = (value) => innerHeight - ((Math.max(0, Number(value) || 0) / domainMax) * innerHeight);
+    const scaleX = (value) => (Math.max(0, Number(value) || 0) / domainMax) * innerWidth;
     const truncate = (value, max = 14) => {
       const raw = String(value || "");
       return raw.length > max ? `${raw.slice(0, max - 1)}…` : raw;
@@ -42,36 +42,46 @@ export function createProjectSituationsView({
         <div class="svg-line-chart__frame">
           <svg class="svg-line-chart__svg" width="${width}" height="${height}" role="img" aria-label="Distribution des sujets">
             <g transform="translate(${margin.left},${margin.top})">
+              <g class="svg-line-chart__grid svg-line-chart__grid--x svg-line-chart__grid--dashed" transform="translate(0,${innerHeight})">
+                ${(Array.isArray(yTicks) ? yTicks : []).map((tick) => {
+                  const x = scaleX(tick);
+                  return `<g class="svg-line-chart__tick" transform="translate(${x.toFixed(3)},0)"><line y2="-${innerHeight}"></line></g>`;
+                }).join("")}
+              </g>
               <g class="svg-line-chart__grid svg-line-chart__grid--y svg-line-chart__grid--dashed">
-                ${(Array.isArray(yTicks) ? yTicks : []).filter((_, index) => index !== 0).map((tick) => {
-                  const y = scaleY(tick);
+                ${safeLabels.map((_, index) => {
+                  const y = index * (barHeight + barGap) + (barHeight / 2);
                   return `<g class="svg-line-chart__tick" transform="translate(0,${y.toFixed(3)})"><line x2="${innerWidth}" y2="0"></line></g>`;
                 }).join("")}
               </g>
-              <g class="svg-line-chart__axis svg-line-chart__axis--x" transform="translate(0,${innerHeight})">
+              <g class="svg-line-chart__axis svg-line-chart__axis--x" transform="translate(0,${(innerHeight + 0.5).toFixed(3)})">
                 <path d="M0.5,0.5H${(innerWidth + 0.5).toFixed(1)}"></path>
-                ${safeLabels.map((label, index) => {
-                  const x = index * (barWidth + barGap) + (barWidth / 2);
-                  return `<g class="svg-line-chart__axis-tick" transform="translate(${x.toFixed(3)},0)"><text y="16" transform="rotate(35 0 16)" text-anchor="start">${escapeHtml(truncate(label))}</text></g>`;
+                ${(Array.isArray(yTicks) ? yTicks : []).map((tick) => {
+                  const x = scaleX(tick);
+                  return `<g class="svg-line-chart__axis-tick" transform="translate(${x.toFixed(3)},0)"><text y="20">${escapeHtml(String(tick))}</text></g>`;
                 }).join("")}
               </g>
               <g class="svg-line-chart__axis svg-line-chart__axis--y">
                 <path d="M0.5,${(innerHeight + 0.5).toFixed(1)}V0.5"></path>
-                ${(Array.isArray(yTicks) ? yTicks : []).map((tick) => {
-                  const y = scaleY(tick);
-                  return `<g class="svg-line-chart__axis-tick" transform="translate(0,${y.toFixed(3)})"><text x="-8" dy="0.32em">${escapeHtml(String(tick))}</text></g>`;
+                ${safeLabels.map((label, index) => {
+                  const y = index * (barHeight + barGap) + (barHeight / 2);
+                  return `<g class="svg-line-chart__axis-tick" transform="translate(0,${y.toFixed(3)})"><text x="-12" dy="0.32em" text-anchor="end">${escapeHtml(truncate(label, 22))}</text></g>`;
                 }).join("")}
               </g>
               <g>
                 ${safeValues.map((value, index) => {
-                  const barHeight = Math.max(0, innerHeight - scaleY(value));
-                  const x = index * (barWidth + barGap);
-                  const y = innerHeight - barHeight;
-                  return `<rect x="${x.toFixed(3)}" y="${y.toFixed(3)}" width="${barWidth.toFixed(3)}" height="${barHeight.toFixed(3)}" rx="4" class="svg-line-chart__area"></rect>`;
+                  const widthValue = Math.max(0, scaleX(value));
+                  const y = index * (barHeight + barGap);
+                  return `<rect x="0" y="${y.toFixed(3)}" width="${widthValue.toFixed(3)}" height="${barHeight.toFixed(3)}" rx="3" style="fill:color(srgb 0 0.101961 0.278431 / 0.5);stroke:rgb(5, 118, 255);stroke-width:2;opacity:1;"></rect>`;
                 }).join("")}
               </g>
             </g>
           </svg>
+          <div class="svg-line-chart__meta">
+            <div class="svg-line-chart__legend">
+              <div class="svg-line-chart__legend-item"><span class="svg-line-chart__legend-swatch svg-line-chart__legend-swatch--circle" style="color:#0078ff;"></span><span>Count of Items</span></div>
+            </div>
+          </div>
         </div>
       </div>
     `;
@@ -186,11 +196,31 @@ export function createProjectSituationsView({
       yTicks: labelsData?.yTicks || [0, 1],
       yMax: labelsData?.yMax || 1
     });
-    const objectivesChartHtml = renderSituationInsightsBarChart({
-      labels: objectivesData?.labels || [],
-      values: objectivesData?.values || [],
-      yTicks: objectivesData?.yTicks || [0, 1],
-      yMax: objectivesData?.yMax || 1
+    const objectivesLineChartHtml = renderSvgLineChart({
+      width: 964,
+      height: 478,
+      xLabel: "",
+      yLabel: "",
+      xDomain: [0, Math.max(1, (objectivesData?.labels || []).length - 1)],
+      yDomain: [0, Math.max(1, Number(objectivesData?.yMax) || 1)],
+      xTicks: Array.from({ length: (objectivesData?.labels || []).length }, (_, index) => index),
+      yTicks: Array.isArray(objectivesData?.yTicks) ? objectivesData.yTicks : [0, 1],
+      xTickFormatter: (tick) => {
+        const label = (objectivesData?.labels || [])[Number(tick)] || "";
+        return label.length > 16 ? `${label.slice(0, 15)}…` : label;
+      },
+      series: [{
+        label: "Count of Items",
+        points: (objectivesData?.values || []).map((value, index) => ({ x: index, y: Number(value) || 0 })),
+        fill: true,
+        color: "#0078ff",
+        areaColor: "color(srgb 0 0.101961 0.278431 / 0.5)",
+        areaOpacity: 1,
+        lineWidth: 2,
+        lineDasharray: "none",
+        legendMarker: "circle",
+        curve: "smooth"
+      }]
     });
     let chartShellContent = "";
     if (uiState.insightsLoading) {
@@ -207,7 +237,7 @@ export function createProjectSituationsView({
         : `<div class="settings-empty-state">Aucun label trouvé pour les sujets de cette situation.</div>`;
     } else {
       chartShellContent = (objectivesData?.labels || []).length
-        ? objectivesChartHtml
+        ? objectivesLineChartHtml
         : `<div class="settings-empty-state">Aucun objectif trouvé pour les sujets de cette situation.</div>`;
     }
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9413,6 +9413,8 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 .svg-line-chart__line{
   stroke:currentColor;
   fill:none;
+  stroke-linecap:round;
+  stroke-linejoin:round;
 }
 
 .svg-line-chart__area{
@@ -9469,6 +9471,14 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   border-radius:999px;
   background:currentColor;
   display:inline-block;
+}
+
+.svg-line-chart__legend-swatch--circle{
+  width:12px;
+  height:12px;
+  border-radius:50%;
+  background:transparent;
+  border:1.5px solid currentColor;
 }
 
 .svg-line-chart__hover-point{
@@ -13549,6 +13559,15 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .project-situation-insights__chart-shell .svg-line-chart{
   height:100%;
+}
+
+.project-situation-insights__chart-shell .svg-line-chart__legend{
+  justify-content:flex-end;
+  margin:16px 6px 0 0;
+}
+
+.project-situation-insights__chart-shell .svg-line-chart__legend-item{
+  color:var(--text);
 }
 
 .project-situation-edit__main{


### PR DESCRIPTION
### Motivation
- Improve chart visuals and configurability for the project situations insights UI by adding smoother lines, area baseline support, richer series styling and clearer legends.
- Replace a couple of hard-coded series labels and adapt the insights views to use the enhanced chart primitives for objectives and labels.

### Description
- Add `curve` support to `buildLinePath` and `buildAreaPath` to render smoothed (quadratic) line paths and ensure area paths can use a per-point `areaBaselinePoints` array. 
- Extend series options in `renderSvgLineChart` to accept `color`, `areaColor`, `areaOpacity`, `lineDasharray`, `lineWidth`, `legendMarker` and `curve`, and use those values to inline-style SVG `path` and legend swatches. 
- Update `project-situations-supabase.js` series labels to `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb988c2e088329962763ff580b0bda)