### PR TITLE
Extract shared subject tree grid renderer

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -20,6 +20,7 @@ import { renderCommentComposer } from "../ui/comment-composer.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 import { renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 import { renderSettingsModal } from "../ui/settings-modal.js";
+import { renderSubjectTreeGrid } from "../shared/subject-tree-grid.js";
 export function createProjectSubjectsView(deps) {
   const {
     store,
@@ -2408,30 +2409,38 @@ function renderSubIssuesForSujet(sujet, options = {}) {
       return uiState.rightSubissuesExpandedSubjectIds;
     })();
   const openMenuId = String(firstNonEmpty(options.openMenuId, getSubjectsViewState().rightSubissueMenuOpenId, ""));
-  const rows = [];
-  const walkSubissueTree = (subjectNode, depth = 0, parentId = "") => {
-    const subjectId = String(subjectNode?.id || "");
-    if (!subjectId) return;
-    const nestedChildren = getChildSubjectList(subjectNode);
-    const hasChildren = nestedChildren.length > 0;
-    const isExpanded = hasChildren && expandedIds.has(subjectId);
-    const canDrag = depth === 0;
-    const isRowMenuOpen = openMenuId === subjectId;
-    const nestedSpacerCell = depth > 0
-      ? `<div class="cell cell-subissue-drag-spacer" style="width:${depth * 24}px" aria-hidden="true"></div>`
-      : "";
+  const subjectsById = {};
+  const childrenBySubjectId = {};
+  const collectTreeNodes = (nodes = []) => {
+    nodes.forEach((node) => {
+      const nodeId = String(node?.id || "");
+      if (!nodeId || subjectsById[nodeId]) return;
+      subjectsById[nodeId] = node;
+      const nestedChildren = getChildSubjectList(node);
+      childrenBySubjectId[nodeId] = nestedChildren.map((child) => String(child?.id || "")).filter(Boolean);
+      collectTreeNodes(nestedChildren);
+    });
+  };
+  collectTreeNodes(childSubjects);
 
-    rows.push(`
-      <div
-        class="issue-row issue-row--pb click ${sujetRowClass}${canDrag ? " subissues-sortable-row" : " subissues-tree-row"}"
-        data-sujet-id="${escapeHtml(subjectId)}"
-        ${canDrag ? `data-subissue-sortable-row="true"` : ""}
-        data-subissue-tree-row="${escapeHtml(subjectId)}"
-        data-subissue-depth="${depth}"
-        data-parent-subject-id="${escapeHtml(String(parentId || sujet?.id || ""))}"
-        data-child-subject-id="${escapeHtml(subjectId)}"
-        draggable="${canDrag ? "true" : "false"}"
-      >
+  const rows = renderSubjectTreeGrid({
+    subjectsById,
+    childrenBySubjectId,
+    rootSubjectIds: childSubjects.map((childSubject) => String(childSubject?.id || "")).filter(Boolean),
+    expandedSubjectIds: expandedIds,
+    dndMode: "first-level",
+    rowClassName: sujetRowClass,
+    escapeHtml,
+    context: {
+      rootParentId: String(sujet?.id || "")
+    },
+    getSubjectStatus: (subjectId) => getEffectiveSujetStatus(subjectId),
+    renderTitleCell: ({ subject, subjectId, depth, hasChildren, isExpanded, canDrag }) => {
+      const nestedSpacerCell = depth > 0
+        ? `<div class="cell cell-subissue-drag-spacer" style="width:${depth * 24}px" aria-hidden="true"></div>`
+        : "";
+      const nestedChildren = getChildSubjectList(subject);
+      return `
         <div class="cell cell-subissue-drag-handle">
           ${canDrag
             ? `<button type="button" class="subissue-drag-handle" data-subissue-drag-handle aria-label="Réordonner le sous-sujet">
@@ -2450,9 +2459,14 @@ function renderSubIssuesForSujet(sujet, options = {}) {
         <div class="subissue-row-main">
           <div class="cell cell-theme cell-theme--full">
             ${issueIcon(getEffectiveSujetStatus(subjectId))}
-            <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>
-            ${renderSubissueInlineMetaHtml(subjectNode, nestedChildren)}
+            <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subject.title, subjectId, ""))}</span>
+            ${renderSubissueInlineMetaHtml(subject, nestedChildren)}
           </div>
+      `;
+    },
+    renderExtraCells: ({ subjectId }) => {
+      const isRowMenuOpen = openMenuId === subjectId;
+      return `
           <div class="cell cell-subissue-assignees-value">
             ${renderSubissueAssigneesCellHtml(subjectId)}
           </div>
@@ -2471,18 +2485,13 @@ function renderSubIssuesForSujet(sujet, options = {}) {
               : ""}
           </div>
         </div>
-      </div>
-    `);
-
-    if (!isExpanded) return;
-    nestedChildren.forEach((nestedChild) => walkSubissueTree(nestedChild, depth + 1, subjectId));
-  };
-
-  childSubjects.forEach((childSujet) => walkSubissueTree(childSujet, 0, String(sujet?.id || "")));
+      `;
+    }
+  });
 
   const body = renderSubIssuesTable({
     className: "issues-table subissues-table subissues-table--sortable",
-    rowsHtml: rows.join(""),
+    rowsHtml: rows,
     emptyTitle: "Aucun sous-sujet"
   });
 

--- a/apps/web/js/views/shared/subject-tree-grid.js
+++ b/apps/web/js/views/shared/subject-tree-grid.js
@@ -1,0 +1,121 @@
+function normalizeSubjectId(value) {
+  return String(value || "").trim();
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function getExpandedIdsSet(expandedSubjectIds) {
+  if (expandedSubjectIds instanceof Set) return expandedSubjectIds;
+  if (Array.isArray(expandedSubjectIds)) return new Set(expandedSubjectIds.map((value) => normalizeSubjectId(value)).filter(Boolean));
+  return new Set();
+}
+
+function getChildrenList(childrenBySubjectId, subjectId) {
+  const key = normalizeSubjectId(subjectId);
+  if (!key) return [];
+  return toArray(childrenBySubjectId?.[key]);
+}
+
+function resolveSubjectNode(subjectsById, subjectId) {
+  const key = normalizeSubjectId(subjectId);
+  if (!key) return null;
+  return subjectsById?.[key] || null;
+}
+
+function resolveCanDrag(dndMode, depth) {
+  if (dndMode === "all-levels") return true;
+  if (dndMode === "first-level") return depth === 0;
+  return false;
+}
+
+export function renderSubjectTreeGrid(options = {}) {
+  const {
+    subjects = [],
+    subjectsById = {},
+    childrenBySubjectId = {},
+    rootSubjectIds = [],
+    rootIds = rootSubjectIds,
+    expandedSubjectIds = new Set(),
+    getSubjectStatus = () => "",
+    renderTitleCell = () => "",
+    renderExtraCells = () => "",
+    dndMode = "none",
+    className = "",
+    rowClassName = "",
+    context = {},
+    escapeHtml = (value) => String(value || "")
+  } = options;
+
+  const expandedIdsSet = getExpandedIdsSet(expandedSubjectIds);
+  const normalizedRootIds = toArray(rootIds)
+    .map((value) => normalizeSubjectId(value))
+    .filter(Boolean);
+
+  const fallbackSubjectsById = normalizedRootIds.length
+    ? subjectsById
+    : Object.fromEntries(toArray(subjects).map((subject) => [normalizeSubjectId(subject?.id), subject]));
+
+  const rows = [];
+
+  const walkTree = (subjectId, depth = 0, parentId = "") => {
+    const normalizedSubjectId = normalizeSubjectId(subjectId);
+    if (!normalizedSubjectId) return;
+
+    const subjectNode = resolveSubjectNode(fallbackSubjectsById, normalizedSubjectId);
+    if (!subjectNode) return;
+
+    const nestedChildren = getChildrenList(childrenBySubjectId, normalizedSubjectId)
+      .map((value) => normalizeSubjectId(value))
+      .filter(Boolean);
+    const hasChildren = nestedChildren.length > 0;
+    const isExpanded = hasChildren && expandedIdsSet.has(normalizedSubjectId);
+    const canDrag = resolveCanDrag(dndMode, depth);
+
+    const rowContext = {
+      subject: subjectNode,
+      subjectId: normalizedSubjectId,
+      depth,
+      parentId,
+      hasChildren,
+      isExpanded,
+      canDrag,
+      status: getSubjectStatus(normalizedSubjectId),
+      context
+    };
+
+    const titleCellHtml = renderTitleCell(rowContext);
+    const extraCellsHtml = renderExtraCells(rowContext);
+
+    rows.push(`
+      <div
+        class="issue-row issue-row--pb click ${rowClassName}${canDrag ? " subissues-sortable-row" : " subissues-tree-row"}"
+        data-sujet-id="${escapeHtml(normalizedSubjectId)}"
+        ${canDrag ? 'data-subissue-sortable-row="true"' : ""}
+        data-subissue-tree-row="${escapeHtml(normalizedSubjectId)}"
+        data-subissue-depth="${depth}"
+        data-parent-subject-id="${escapeHtml(normalizeSubjectId(parentId))}"
+        data-child-subject-id="${escapeHtml(normalizedSubjectId)}"
+        draggable="${canDrag ? "true" : "false"}"
+      >
+        ${titleCellHtml}
+        ${extraCellsHtml}
+      </div>
+    `);
+
+    if (!isExpanded) return;
+    nestedChildren.forEach((childId) => walkTree(childId, depth + 1, normalizedSubjectId));
+  };
+
+  normalizedRootIds.forEach((subjectId) => walkTree(subjectId, 0, context?.rootParentId || ""));
+
+  if (!className) return rows.join("");
+  return `<div class="${className}">${rows.join("")}</div>`;
+}
+
+export function __subjectTreeGridTestUtils() {
+  return {
+    resolveCanDrag
+  };
+}

--- a/apps/web/js/views/shared/subject-tree-grid.test.mjs
+++ b/apps/web/js/views/shared/subject-tree-grid.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderSubjectTreeGrid } from "./subject-tree-grid.js";
+
+test("renderSubjectTreeGrid limite le drag au premier niveau en mode first-level", () => {
+  const html = renderSubjectTreeGrid({
+    subjectsById: {
+      root: { id: "root", title: "Root" },
+      child: { id: "child", title: "Child" }
+    },
+    childrenBySubjectId: {
+      root: ["child"],
+      child: []
+    },
+    rootSubjectIds: ["root"],
+    expandedSubjectIds: new Set(["root"]),
+    dndMode: "first-level",
+    renderTitleCell: () => "<div></div>",
+    renderExtraCells: () => ""
+  });
+
+  assert.match(html, /data-child-subject-id="root"[\s\S]*?draggable="true"/);
+  assert.match(html, /data-child-subject-id="child"[\s\S]*?draggable="false"/);
+  assert.match(html, /subissues-sortable-row[\s\S]*data-child-subject-id="root"/);
+  assert.match(html, /subissues-tree-row[\s\S]*data-child-subject-id="child"/);
+});


### PR DESCRIPTION
### Motivation
- Éviter la duplication de la logique d’arborescence des sous‑sujets en extrayant un rendu réutilisable pour pouvoir l’utiliser ensuite dans la vue Grille sans refactor massif.
- Conserver strictement le rendu actuel du détail d’un sujet (y compris la limitation DnD au premier niveau) tout en préparant la réutilisation multi‑niveaux pour la grille Situation.

### Description
- Ajout du module `renderSubjectTreeGrid` dans `apps/web/js/views/shared/subject-tree-grid.js` qui rend une arborescence en lignes `div` et accepte les props attendues (`subjects`, `subjectsById`, `childrenBySubjectId`, `rootSubjectIds`/`rootIds`, `expandedSubjectIds`, `getSubjectStatus`, `renderTitleCell`, `renderExtraCells`, `dndMode`, `className`, `rowClassName`, `context`, `escapeHtml`).
- Refactor léger de `renderSubIssuesForSujet()` dans `apps/web/js/views/project-subjects/project-subjects-view.js` pour construire `subjectsById` et `childrenBySubjectId` localement et déléguer le rendu au composant partagé en passant `dndMode: "first-level"` et les callbacks pour préserver l’HTML et les classes existantes.
- Ajout d’un test ciblé `apps/web/js/views/shared/subject-tree-grid.test.mjs` pour garantir que le mode `first-level` limite bien le drag aux éléments de profondeur 0.
- Le composant produit toujours des lignes en `div` et maintient les classes (`subissues-sortable-row` / `subissues-tree-row`, etc.) pour éviter toute régression visuelle.

### Testing
- Vérification de syntaxe via `node --check apps/web/js/views/shared/subject-tree-grid.js && node --check apps/web/js/views/project-subjects/project-subjects-view.js` a réussi.
- Exécution des tests ciblés via `node --test apps/web/js/views/shared/subject-tree-grid.test.mjs apps/web/js/views/project-subjects/project-subjects-events-subissues-dnd.test.mjs` a réussi et tous les tests sont passés.
- Une exécution locale complémentaire de `node --check` sur les fichiers modifiés a confirmé l’absence d’erreurs d’analyse statique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec42e723948329a002f9272cbaa06d)