### PR TITLE
Add subject tree grid renderer and situation grid view with expand/collapse support

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -448,6 +448,30 @@ export function createProjectSituationsEvents({
       }
     });
 
+    root.querySelectorAll("[data-situation-grid-toggle]").forEach((node) => {
+      node.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectId = String(node.getAttribute("data-situation-grid-toggle") || "").trim();
+        const situationId = String(node.getAttribute("data-situation-grid-situation-id") || "").trim();
+        if (!subjectId || !situationId) return;
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        if (!store.situationsView.gridExpandedSubjectIdsBySituationId || typeof store.situationsView.gridExpandedSubjectIdsBySituationId !== "object") {
+          store.situationsView.gridExpandedSubjectIdsBySituationId = {};
+        }
+        const currentValues = store.situationsView.gridExpandedSubjectIdsBySituationId[situationId];
+        const expandedSet = new Set(
+          Array.isArray(currentValues)
+            ? currentValues.map((value) => String(value || "").trim()).filter(Boolean)
+            : []
+        );
+        if (expandedSet.has(subjectId)) expandedSet.delete(subjectId);
+        else expandedSet.add(subjectId);
+        store.situationsView.gridExpandedSubjectIdsBySituationId[situationId] = [...expandedSet];
+        rerender(root);
+      });
+    });
+
     bindCreateModalEvents(root);
     bindEditPanelEvents(root);
   }

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -1,14 +1,225 @@
 import { escapeHtml } from "../../utils/escape-html.js";
+import { svgIcon } from "../../ui/icons.js";
+import { renderSubjectTreeGrid } from "../shared/subject-tree-grid.js";
 
-export function renderSituationGridView(situation, subjects = []) {
-  const subjectCount = Array.isArray(subjects) ? subjects.length : 0;
+function normalizeIssueLifecycleStatus(status = "") {
+  return String(status || "").trim().toLowerCase() === "closed" ? "closed" : "open";
+}
+
+function renderIssueStateIcon(subject) {
+  const isClosed = normalizeIssueLifecycleStatus(subject?.status) === "closed";
+  return `<span class="issue-status-icon situation-grid__status-icon" aria-hidden="true">${
+    isClosed
+      ? svgIcon("check-circle", { style: "color: var(--fgColor-done)" })
+      : svgIcon("issue-opened", { style: "color: var(--fgColor-open)" })
+  }</span>`;
+}
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function sortSubjectIds(subjectIds = [], subjectsById = {}) {
+  return [...subjectIds].sort((leftId, rightId) => {
+    const left = subjectsById[leftId] || {};
+    const right = subjectsById[rightId] || {};
+
+    const leftOrder = Number(left?.parent_child_order ?? left?.raw?.parent_child_order);
+    const rightOrder = Number(right?.parent_child_order ?? right?.raw?.parent_child_order);
+    const leftHasOrder = Number.isFinite(leftOrder) && leftOrder > 0;
+    const rightHasOrder = Number.isFinite(rightOrder) && rightOrder > 0;
+
+    if (leftHasOrder && rightHasOrder && leftOrder !== rightOrder) return leftOrder - rightOrder;
+    if (leftHasOrder !== rightHasOrder) return leftHasOrder ? -1 : 1;
+
+    const leftTs = Date.parse(String(left?.created_at || left?.raw?.created_at || "")) || 0;
+    const rightTs = Date.parse(String(right?.created_at || right?.raw?.created_at || "")) || 0;
+    if (leftTs !== rightTs) return leftTs - rightTs;
+
+    return String(left?.title || leftId).localeCompare(String(right?.title || rightId), "fr");
+  });
+}
+
+function resolveSituationTreeData(situationSubjects = [], rawSubjectsResult = {}) {
+  const selectedSubjectIds = new Set(
+    (Array.isArray(situationSubjects) ? situationSubjects : [])
+      .map((subject) => normalizeId(subject?.id))
+      .filter(Boolean)
+  );
+
+  const rawSubjectsById = rawSubjectsResult?.subjectsById && typeof rawSubjectsResult.subjectsById === "object"
+    ? rawSubjectsResult.subjectsById
+    : {};
+  const rawChildrenBySubjectId = rawSubjectsResult?.childrenBySubjectId && typeof rawSubjectsResult.childrenBySubjectId === "object"
+    ? rawSubjectsResult.childrenBySubjectId
+    : {};
+  const rawParentBySubjectId = rawSubjectsResult?.parentBySubjectId && typeof rawSubjectsResult.parentBySubjectId === "object"
+    ? rawSubjectsResult.parentBySubjectId
+    : {};
+
+  const subjectsById = {};
+  selectedSubjectIds.forEach((subjectId) => {
+    const selectedSubject = (situationSubjects || []).find((subject) => normalizeId(subject?.id) === subjectId);
+    subjectsById[subjectId] = rawSubjectsById[subjectId] || selectedSubject || null;
+  });
+
+  const childrenBySubjectId = {};
+  selectedSubjectIds.forEach((subjectId) => {
+    const childIds = Array.isArray(rawChildrenBySubjectId?.[subjectId])
+      ? rawChildrenBySubjectId[subjectId]
+      : [];
+    childrenBySubjectId[subjectId] = sortSubjectIds(
+      childIds
+        .map((childId) => normalizeId(childId))
+        .filter((childId) => selectedSubjectIds.has(childId)),
+      subjectsById
+    );
+  });
+
+  const rootSubjectIds = sortSubjectIds(
+    [...selectedSubjectIds].filter((subjectId) => {
+      const subject = subjectsById?.[subjectId] || {};
+      const parentFromRaw = normalizeId(rawParentBySubjectId?.[subjectId]);
+      const parentFromSubject = normalizeId(subject?.parent_subject_id || subject?.raw?.parent_subject_id);
+      const parentId = parentFromRaw || parentFromSubject;
+      return !parentId || !selectedSubjectIds.has(parentId);
+    }),
+    subjectsById
+  );
+
+  return {
+    selectedSubjectIds,
+    subjectsById,
+    childrenBySubjectId,
+    rootSubjectIds
+  };
+}
+
+function getExpandedSubjectIdsSet({ store, situationId, rootSubjectIds = [], fallbackExpandedIds = [] }) {
+  const bySituation = store?.situationsView?.gridExpandedSubjectIdsBySituationId;
+  const stored = bySituation && typeof bySituation === "object" ? bySituation[situationId] : null;
+
+  if (stored instanceof Set) return stored;
+  if (Array.isArray(stored)) {
+    return new Set(stored.map((value) => normalizeId(value)).filter(Boolean));
+  }
+
+  const seed = Array.isArray(fallbackExpandedIds) && fallbackExpandedIds.length
+    ? fallbackExpandedIds
+    : rootSubjectIds;
+  return new Set(seed.map((value) => normalizeId(value)).filter(Boolean));
+}
+
+function getSubjectDisplayIdentifier(subject = {}) {
+  const orderNumber = Number(subject?.subject_number ?? subject?.subjectNumber ?? subject?.raw?.subject_number ?? subject?.raw?.subjectNumber);
+  if (Number.isFinite(orderNumber) && orderNumber > 0) return `#${Math.floor(orderNumber)}`;
+  const subjectId = normalizeId(subject?.id);
+  return subjectId ? `#${subjectId}` : "";
+}
+
+export function renderSituationGridView(situation, subjects = [], options = {}) {
   const title = String(situation?.title || "Situation");
+  const normalizedSituationId = normalizeId(situation?.id);
+  if (!normalizedSituationId) {
+    return `
+      <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
+        <div class="settings-empty-state">Sélectionne une situation pour afficher la grille.</div>
+      </section>
+    `;
+  }
+
+  if (!Array.isArray(subjects) || !subjects.length) {
+    return `
+      <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
+        <div class="settings-empty-state">Aucun sujet n’est actuellement rattaché à <strong>${escapeHtml(title)}</strong>.</div>
+      </section>
+    `;
+  }
+
+  const rawSubjectsResult = options?.store?.projectSubjectsView?.rawSubjectsResult && typeof options.store.projectSubjectsView.rawSubjectsResult === "object"
+    ? options.store.projectSubjectsView.rawSubjectsResult
+    : {};
+  const {
+    selectedSubjectIds,
+    subjectsById,
+    childrenBySubjectId,
+    rootSubjectIds
+  } = resolveSituationTreeData(subjects, rawSubjectsResult);
+
+  if (!selectedSubjectIds.size || !rootSubjectIds.length) {
+    return `
+      <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
+        <div class="settings-empty-state">Aucun sujet exploitable n’a été trouvé pour cette situation.</div>
+      </section>
+    `;
+  }
+
+  const expandedSubjectIds = getExpandedSubjectIdsSet({
+    store: options?.store,
+    situationId: normalizedSituationId,
+    rootSubjectIds,
+    fallbackExpandedIds: [...selectedSubjectIds]
+  });
+
+  const rowsHtml = renderSubjectTreeGrid({
+    subjectsById,
+    childrenBySubjectId,
+    rootSubjectIds,
+    expandedSubjectIds,
+    dndMode: "none",
+    rowClassName: "situation-grid__row project-situation-grid__row",
+    escapeHtml,
+    context: {
+      situationId: normalizedSituationId
+    },
+    renderTitleCell: ({ subject, subjectId, depth, hasChildren, isExpanded }) => {
+      const indentWidth = Math.max(0, depth) * 20;
+      const identifier = getSubjectDisplayIdentifier(subject);
+      const subjectTitle = String(subject?.title || subjectId || "Sujet");
+      return `
+        <div class="situation-grid__cell situation-grid__cell--title project-situation-grid__cell project-situation-grid__cell--title">
+          <div class="situation-grid__title-content" style="--situation-grid-indent:${indentWidth}px;">
+            <span class="situation-grid__indent" aria-hidden="true"></span>
+            ${hasChildren
+              ? `<button
+                  type="button"
+                  class="situation-grid__toggle"
+                  data-situation-grid-toggle="${escapeHtml(subjectId)}"
+                  data-situation-grid-situation-id="${escapeHtml(normalizedSituationId)}"
+                  aria-expanded="${isExpanded ? "true" : "false"}"
+                  aria-label="${isExpanded ? "Replier" : "Déplier"} ${escapeHtml(subjectTitle)}"
+                >
+                  ${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}
+                </button>`
+              : `<span class="situation-grid__toggle situation-grid__toggle--placeholder" aria-hidden="true"></span>`}
+            ${renderIssueStateIcon(subject)}
+            <button type="button" class="situation-grid__subject-title" data-open-situation-subject="${escapeHtml(subjectId)}">${escapeHtml(subjectTitle)}</button>
+            <span class="situation-grid__subject-id mono">${escapeHtml(identifier)}</span>
+          </div>
+        </div>
+      `;
+    },
+    renderExtraCells: () => ""
+  });
 
   return `
     <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
-      <div class="settings-empty-state">
-        La vue grille de <strong>${escapeHtml(title)}</strong> sera affichée ici (${subjectCount} sujet(s)).
-      </div>
+      <section class="project-situation-grid situation-grid" data-situation-grid="${escapeHtml(normalizedSituationId)}">
+        <div class="project-situation-grid__scroll situation-grid__scroll">
+          <header class="project-situation-grid__header situation-grid__header" role="row">
+            <div class="project-situation-grid__head-cell situation-grid__head-cell situation-grid__head-cell--title" role="columnheader">Titre</div>
+          </header>
+          <div class="project-situation-grid__body situation-grid__body" role="rowgroup">
+            ${rowsHtml}
+          </div>
+        </div>
+      </section>
     </section>
   `;
+}
+
+export function __situationGridTestUtils() {
+  return {
+    resolveSituationTreeData
+  };
 }

--- a/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { __situationGridTestUtils, renderSituationGridView } from "./project-situations-view-grid.js";
+
+test("resolveSituationTreeData remonte en racine les sujets dont le parent n'est pas sélectionné", () => {
+  const { resolveSituationTreeData } = __situationGridTestUtils();
+  const data = resolveSituationTreeData(
+    [{ id: "child" }, { id: "sibling" }],
+    {
+      subjectsById: {
+        parent: { id: "parent", title: "Parent" },
+        child: { id: "child", title: "Child", parent_subject_id: "parent" },
+        sibling: { id: "sibling", title: "Sibling" }
+      },
+      childrenBySubjectId: {
+        parent: ["child"],
+        child: [],
+        sibling: []
+      },
+      parentBySubjectId: {
+        child: "parent",
+        sibling: null
+      }
+    }
+  );
+
+  assert.deepEqual(data.rootSubjectIds, ["child", "sibling"]);
+  assert.deepEqual(data.childrenBySubjectId.child, []);
+});
+
+test("renderSituationGridView rend la grille et la colonne titre sans balise table", () => {
+  const html = renderSituationGridView(
+    { id: "sit-1", title: "Situation" },
+    [{ id: "subject-1", title: "Sujet 1", status: "open" }],
+    {
+      store: {
+        situationsView: {},
+        projectSubjectsView: {
+          rawSubjectsResult: {
+            subjectsById: {
+              "subject-1": { id: "subject-1", title: "Sujet 1", status: "open" }
+            },
+            childrenBySubjectId: {
+              "subject-1": []
+            },
+            parentBySubjectId: {
+              "subject-1": null
+            }
+          }
+        }
+      }
+    }
+  );
+
+  assert.match(html, /project-situation-grid__header/);
+  assert.match(html, /situation-grid__subject-title/);
+  assert.doesNotMatch(html, /<table|<tr|<td/i);
+});

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -112,7 +112,7 @@ export function createProjectSituationsView({
       return renderSituationKanban(selectedSituation, uiState.selectedSituationSubjects, { loading: uiState.selectedSituationLoading });
     }
     if (selectedLayout === "grille") {
-      return renderSituationGridView(selectedSituation, uiState.selectedSituationSubjects);
+      return renderSituationGridView(selectedSituation, uiState.selectedSituationSubjects, { store, uiState });
     }
     return renderSituationRoadmapView(selectedSituation, uiState.selectedSituationSubjects);
   }

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -20,6 +20,7 @@ import { renderCommentComposer } from "../ui/comment-composer.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 import { renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 import { renderSettingsModal } from "../ui/settings-modal.js";
+import { renderSubjectTreeGrid } from "../shared/subject-tree-grid.js";
 export function createProjectSubjectsView(deps) {
   const {
     store,
@@ -2408,30 +2409,38 @@ function renderSubIssuesForSujet(sujet, options = {}) {
       return uiState.rightSubissuesExpandedSubjectIds;
     })();
   const openMenuId = String(firstNonEmpty(options.openMenuId, getSubjectsViewState().rightSubissueMenuOpenId, ""));
-  const rows = [];
-  const walkSubissueTree = (subjectNode, depth = 0, parentId = "") => {
-    const subjectId = String(subjectNode?.id || "");
-    if (!subjectId) return;
-    const nestedChildren = getChildSubjectList(subjectNode);
-    const hasChildren = nestedChildren.length > 0;
-    const isExpanded = hasChildren && expandedIds.has(subjectId);
-    const canDrag = depth === 0;
-    const isRowMenuOpen = openMenuId === subjectId;
-    const nestedSpacerCell = depth > 0
-      ? `<div class="cell cell-subissue-drag-spacer" style="width:${depth * 24}px" aria-hidden="true"></div>`
-      : "";
+  const subjectsById = {};
+  const childrenBySubjectId = {};
+  const collectTreeNodes = (nodes = []) => {
+    nodes.forEach((node) => {
+      const nodeId = String(node?.id || "");
+      if (!nodeId || subjectsById[nodeId]) return;
+      subjectsById[nodeId] = node;
+      const nestedChildren = getChildSubjectList(node);
+      childrenBySubjectId[nodeId] = nestedChildren.map((child) => String(child?.id || "")).filter(Boolean);
+      collectTreeNodes(nestedChildren);
+    });
+  };
+  collectTreeNodes(childSubjects);
 
-    rows.push(`
-      <div
-        class="issue-row issue-row--pb click ${sujetRowClass}${canDrag ? " subissues-sortable-row" : " subissues-tree-row"}"
-        data-sujet-id="${escapeHtml(subjectId)}"
-        ${canDrag ? `data-subissue-sortable-row="true"` : ""}
-        data-subissue-tree-row="${escapeHtml(subjectId)}"
-        data-subissue-depth="${depth}"
-        data-parent-subject-id="${escapeHtml(String(parentId || sujet?.id || ""))}"
-        data-child-subject-id="${escapeHtml(subjectId)}"
-        draggable="${canDrag ? "true" : "false"}"
-      >
+  const rows = renderSubjectTreeGrid({
+    subjectsById,
+    childrenBySubjectId,
+    rootSubjectIds: childSubjects.map((childSubject) => String(childSubject?.id || "")).filter(Boolean),
+    expandedSubjectIds: expandedIds,
+    dndMode: "first-level",
+    rowClassName: sujetRowClass,
+    escapeHtml,
+    context: {
+      rootParentId: String(sujet?.id || "")
+    },
+    getSubjectStatus: (subjectId) => getEffectiveSujetStatus(subjectId),
+    renderTitleCell: ({ subject, subjectId, depth, hasChildren, isExpanded, canDrag }) => {
+      const nestedSpacerCell = depth > 0
+        ? `<div class="cell cell-subissue-drag-spacer" style="width:${depth * 24}px" aria-hidden="true"></div>`
+        : "";
+      const nestedChildren = getChildSubjectList(subject);
+      return `
         <div class="cell cell-subissue-drag-handle">
           ${canDrag
             ? `<button type="button" class="subissue-drag-handle" data-subissue-drag-handle aria-label="Réordonner le sous-sujet">
@@ -2450,9 +2459,14 @@ function renderSubIssuesForSujet(sujet, options = {}) {
         <div class="subissue-row-main">
           <div class="cell cell-theme cell-theme--full">
             ${issueIcon(getEffectiveSujetStatus(subjectId))}
-            <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subjectNode.title, subjectId, ""))}</span>
-            ${renderSubissueInlineMetaHtml(subjectNode, nestedChildren)}
+            <span class="theme-text theme-text--pb">${escapeHtml(firstNonEmpty(subject.title, subjectId, ""))}</span>
+            ${renderSubissueInlineMetaHtml(subject, nestedChildren)}
           </div>
+      `;
+    },
+    renderExtraCells: ({ subjectId }) => {
+      const isRowMenuOpen = openMenuId === subjectId;
+      return `
           <div class="cell cell-subissue-assignees-value">
             ${renderSubissueAssigneesCellHtml(subjectId)}
           </div>
@@ -2471,18 +2485,13 @@ function renderSubIssuesForSujet(sujet, options = {}) {
               : ""}
           </div>
         </div>
-      </div>
-    `);
-
-    if (!isExpanded) return;
-    nestedChildren.forEach((nestedChild) => walkSubissueTree(nestedChild, depth + 1, subjectId));
-  };
-
-  childSubjects.forEach((childSujet) => walkSubissueTree(childSujet, 0, String(sujet?.id || "")));
+      `;
+    }
+  });
 
   const body = renderSubIssuesTable({
     className: "issues-table subissues-table subissues-table--sortable",
-    rowsHtml: rows.join(""),
+    rowsHtml: rows,
     emptyTitle: "Aucun sous-sujet"
   });
 

--- a/apps/web/js/views/shared/subject-tree-grid.js
+++ b/apps/web/js/views/shared/subject-tree-grid.js
@@ -1,0 +1,121 @@
+function normalizeSubjectId(value) {
+  return String(value || "").trim();
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function getExpandedIdsSet(expandedSubjectIds) {
+  if (expandedSubjectIds instanceof Set) return expandedSubjectIds;
+  if (Array.isArray(expandedSubjectIds)) return new Set(expandedSubjectIds.map((value) => normalizeSubjectId(value)).filter(Boolean));
+  return new Set();
+}
+
+function getChildrenList(childrenBySubjectId, subjectId) {
+  const key = normalizeSubjectId(subjectId);
+  if (!key) return [];
+  return toArray(childrenBySubjectId?.[key]);
+}
+
+function resolveSubjectNode(subjectsById, subjectId) {
+  const key = normalizeSubjectId(subjectId);
+  if (!key) return null;
+  return subjectsById?.[key] || null;
+}
+
+function resolveCanDrag(dndMode, depth) {
+  if (dndMode === "all-levels") return true;
+  if (dndMode === "first-level") return depth === 0;
+  return false;
+}
+
+export function renderSubjectTreeGrid(options = {}) {
+  const {
+    subjects = [],
+    subjectsById = {},
+    childrenBySubjectId = {},
+    rootSubjectIds = [],
+    rootIds = rootSubjectIds,
+    expandedSubjectIds = new Set(),
+    getSubjectStatus = () => "",
+    renderTitleCell = () => "",
+    renderExtraCells = () => "",
+    dndMode = "none",
+    className = "",
+    rowClassName = "",
+    context = {},
+    escapeHtml = (value) => String(value || "")
+  } = options;
+
+  const expandedIdsSet = getExpandedIdsSet(expandedSubjectIds);
+  const normalizedRootIds = toArray(rootIds)
+    .map((value) => normalizeSubjectId(value))
+    .filter(Boolean);
+
+  const fallbackSubjectsById = normalizedRootIds.length
+    ? subjectsById
+    : Object.fromEntries(toArray(subjects).map((subject) => [normalizeSubjectId(subject?.id), subject]));
+
+  const rows = [];
+
+  const walkTree = (subjectId, depth = 0, parentId = "") => {
+    const normalizedSubjectId = normalizeSubjectId(subjectId);
+    if (!normalizedSubjectId) return;
+
+    const subjectNode = resolveSubjectNode(fallbackSubjectsById, normalizedSubjectId);
+    if (!subjectNode) return;
+
+    const nestedChildren = getChildrenList(childrenBySubjectId, normalizedSubjectId)
+      .map((value) => normalizeSubjectId(value))
+      .filter(Boolean);
+    const hasChildren = nestedChildren.length > 0;
+    const isExpanded = hasChildren && expandedIdsSet.has(normalizedSubjectId);
+    const canDrag = resolveCanDrag(dndMode, depth);
+
+    const rowContext = {
+      subject: subjectNode,
+      subjectId: normalizedSubjectId,
+      depth,
+      parentId,
+      hasChildren,
+      isExpanded,
+      canDrag,
+      status: getSubjectStatus(normalizedSubjectId),
+      context
+    };
+
+    const titleCellHtml = renderTitleCell(rowContext);
+    const extraCellsHtml = renderExtraCells(rowContext);
+
+    rows.push(`
+      <div
+        class="issue-row issue-row--pb click ${rowClassName}${canDrag ? " subissues-sortable-row" : " subissues-tree-row"}"
+        data-sujet-id="${escapeHtml(normalizedSubjectId)}"
+        ${canDrag ? 'data-subissue-sortable-row="true"' : ""}
+        data-subissue-tree-row="${escapeHtml(normalizedSubjectId)}"
+        data-subissue-depth="${depth}"
+        data-parent-subject-id="${escapeHtml(normalizeSubjectId(parentId))}"
+        data-child-subject-id="${escapeHtml(normalizedSubjectId)}"
+        draggable="${canDrag ? "true" : "false"}"
+      >
+        ${titleCellHtml}
+        ${extraCellsHtml}
+      </div>
+    `);
+
+    if (!isExpanded) return;
+    nestedChildren.forEach((childId) => walkTree(childId, depth + 1, normalizedSubjectId));
+  };
+
+  normalizedRootIds.forEach((subjectId) => walkTree(subjectId, 0, context?.rootParentId || ""));
+
+  if (!className) return rows.join("");
+  return `<div class="${className}">${rows.join("")}</div>`;
+}
+
+export function __subjectTreeGridTestUtils() {
+  return {
+    resolveCanDrag
+  };
+}

--- a/apps/web/js/views/shared/subject-tree-grid.test.mjs
+++ b/apps/web/js/views/shared/subject-tree-grid.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderSubjectTreeGrid } from "./subject-tree-grid.js";
+
+test("renderSubjectTreeGrid limite le drag au premier niveau en mode first-level", () => {
+  const html = renderSubjectTreeGrid({
+    subjectsById: {
+      root: { id: "root", title: "Root" },
+      child: { id: "child", title: "Child" }
+    },
+    childrenBySubjectId: {
+      root: ["child"],
+      child: []
+    },
+    rootSubjectIds: ["root"],
+    expandedSubjectIds: new Set(["root"]),
+    dndMode: "first-level",
+    renderTitleCell: () => "<div></div>",
+    renderExtraCells: () => ""
+  });
+
+  assert.match(html, /data-child-subject-id="root"[\s\S]*?draggable="true"/);
+  assert.match(html, /data-child-subject-id="child"[\s\S]*?draggable="false"/);
+  assert.match(html, /subissues-sortable-row[\s\S]*data-child-subject-id="root"/);
+  assert.match(html, /subissues-tree-row[\s\S]*data-child-subject-id="child"/);
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10049,6 +10049,132 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   overflow:auto;
 }
 
+.project-situation-grid,
+.situation-grid{
+  width:100%;
+  min-height:0;
+  height:100%;
+  border:1px solid var(--borderColor-default, #30363d);
+  border-radius:8px;
+  background:var(--bgColor-default, #0d1117);
+}
+
+.project-situation-grid__scroll,
+.situation-grid__scroll{
+  min-height:0;
+  height:100%;
+  overflow:auto;
+}
+
+.project-situation-grid__header,
+.situation-grid__header{
+  position:sticky;
+  top:0;
+  z-index:2;
+  display:grid;
+  grid-template-columns:minmax(460px, 1fr);
+  background:var(--bgColor-default, #0d1117);
+  border-bottom:1px solid var(--borderColor-default, #30363d);
+}
+
+.project-situation-grid__head-cell,
+.situation-grid__head-cell{
+  min-height:32px;
+  padding:0 16px;
+  display:flex;
+  align-items:center;
+  font-size:12px;
+  font-weight:500;
+  color:var(--fgColor-muted, #8b949e);
+}
+
+.project-situation-grid__body,
+.situation-grid__body{
+  display:block;
+}
+
+.project-situation-grid__row,
+.situation-grid__row{
+  display:grid;
+  grid-template-columns:minmax(460px, 1fr);
+  border-bottom:1px solid var(--borderColor-default, #30363d);
+  min-height:40px;
+}
+
+.situation-grid__cell{
+  padding:0 16px;
+  display:flex;
+  align-items:center;
+  min-width:0;
+}
+
+.situation-grid__title-content{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  min-width:0;
+  width:100%;
+}
+
+.situation-grid__indent{
+  width:var(--situation-grid-indent, 0px);
+  min-width:var(--situation-grid-indent, 0px);
+  height:1px;
+}
+
+.situation-grid__toggle{
+  width:20px;
+  height:20px;
+  min-width:20px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border:none;
+  background:transparent;
+  color:var(--fgColor-muted, #8b949e);
+  border-radius:6px;
+  padding:0;
+}
+
+.situation-grid__toggle:hover{
+  background:var(--bgColor-muted, rgba(110,118,129,.1));
+  color:var(--fgColor-default, #e6edf3);
+}
+
+.situation-grid__toggle--placeholder{
+  pointer-events:none;
+}
+
+.situation-grid__status-icon{
+  flex:0 0 16px;
+}
+
+.situation-grid__subject-title{
+  border:none;
+  background:transparent;
+  padding:0;
+  margin:0;
+  color:var(--fgColor-default, #e6edf3);
+  font-size:14px;
+  line-height:1.35;
+  text-align:left;
+  min-width:0;
+  max-width:100%;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+.situation-grid__subject-title:hover{
+  color:var(--fgColor-accent, #2f81f7);
+}
+
+.situation-grid__subject-id{
+  color:var(--fgColor-muted, #8b949e);
+  font-size:12px;
+  flex:0 0 auto;
+}
+
 .situation-kanban__empty{
   border:1px dashed var(--borderColor-default, #30363d);
   border-radius:10px;


### PR DESCRIPTION
### Motivation

- Provide a reusable tree-grid renderer for subject lists to enable a structured, non-table grid presentation of subjects and subissues. 
- Replace ad-hoc subissue tree HTML generation with a single renderer to unify behavior (expand/collapse, drag modes) and simplify situation grid rendering.

### Description

- Add `renderSubjectTreeGrid` in `shared/subject-tree-grid.js` as a reusable function to render tree rows, handle expansion, and control drag modes. 
- Implement a new situation grid view in `project-situations-view-grid.js` that resolves tree data, renders rows via `renderSubjectTreeGrid`, shows open/closed icons, and reads/writes expanded subject ids from `store.situationsView.gridExpandedSubjectIdsBySituationId`. 
- Wire a click handler in `project-situations-events.js` for elements with `data-situation-grid-toggle` to toggle expansion state per situation and trigger `rerender`. 
- Replace the manual subissue tree builder in `project-subjects-view.js` with `renderSubjectTreeGrid` to reuse the same rendering logic and dnd behavior. 
- Add styling for the grid in `style.css` and expose `__situationGridTestUtils` and `__subjectTreeGridTestUtils` for unit testing. 
- Add unit tests `project-situations-view-grid.test.mjs` and `shared/subject-tree-grid.test.mjs` to cover tree resolution, rendering rules, and drag-level behavior.

### Testing

- Ran the new unit tests with `node:test` for `apps/web/js/views/project-situations/project-situations-view-grid.test.mjs` which passed. 
- Ran the new unit tests with `node:test` for `apps/web/js/views/shared/subject-tree-grid.test.mjs` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec42e723948329a002f9272cbaa06d)