### PR TITLE
Resizable situation grid columns with per-scope persistence and CSS vars

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1,5 +1,11 @@
 import { bindLightTabs } from "../ui/light-tabs.js";
 import { renderProjectSituationDrilldown } from "../project-situation-drilldown.js";
+import {
+  buildSituationGridColumnWidthsScopeKey,
+  getSituationGridColumnCssVariables,
+  getSituationGridColumnDefinitions,
+  normalizeSituationGridColumnWidths
+} from "./project-situations-view-grid.js";
 
 function syncSubmitButtonState(button, { submitting = false, title = "" } = {}) {
   if (!button) return;
@@ -43,6 +49,119 @@ export function createProjectSituationsEvents({
   function logSituationInsights(message, payload = {}) {
     if (!isSituationInsightsDebugEnabled()) return;
     console.info(`[situation-insights] ${message}`, payload);
+  }
+
+  function resolveCurrentProjectId() {
+    return String(
+      store?.currentProjectId
+      || store?.projectForm?.projectId
+      || store?.projectForm?.id
+      || ""
+    ).trim();
+  }
+
+  function getGridColumnStorageKey(scopeKey = "") {
+    return scopeKey ? `mdall:situation-grid:column-widths:${scopeKey}` : "";
+  }
+
+  function readStoredGridColumnWidths(scopeKey = "") {
+    const storageKey = getGridColumnStorageKey(scopeKey);
+    if (!storageKey) return null;
+    try {
+      const raw = window.localStorage?.getItem(storageKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function persistGridColumnWidths(scopeKey = "", widths = {}) {
+    const storageKey = getGridColumnStorageKey(scopeKey);
+    if (!storageKey) return;
+    try {
+      window.localStorage?.setItem(storageKey, JSON.stringify(widths));
+    } catch (_) {
+      // No-op: localStorage may be blocked in private contexts.
+    }
+  }
+
+  function ensureGridColumnWidthsByScope() {
+    if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+    if (!store.situationsView.gridColumnWidthsByScope || typeof store.situationsView.gridColumnWidthsByScope !== "object") {
+      store.situationsView.gridColumnWidthsByScope = {};
+    }
+    return store.situationsView.gridColumnWidthsByScope;
+  }
+
+  function applyGridColumnWidthsToNode(gridNode, widths = {}) {
+    if (!gridNode || !gridNode.style) return;
+    const cssVars = getSituationGridColumnCssVariables(widths);
+    Object.entries(cssVars).forEach(([name, value]) => {
+      gridNode.style.setProperty(name, value);
+    });
+  }
+
+  function hydrateSituationGridColumnWidths(gridNode) {
+    if (!gridNode) return;
+    const situationId = String(gridNode.getAttribute("data-situation-grid") || "").trim();
+    if (!situationId) return;
+    const projectId = String(gridNode.getAttribute("data-situation-grid-project-id") || "").trim() || resolveCurrentProjectId();
+    const scopeKey = String(gridNode.getAttribute("data-situation-grid-scope") || "").trim()
+      || buildSituationGridColumnWidthsScopeKey(projectId, situationId);
+    const byScope = ensureGridColumnWidthsByScope();
+    const fromStore = byScope[scopeKey] && typeof byScope[scopeKey] === "object" ? byScope[scopeKey] : null;
+    const fromStorage = readStoredGridColumnWidths(scopeKey);
+    const normalized = normalizeSituationGridColumnWidths(fromStore || fromStorage || {});
+    byScope[scopeKey] = normalized;
+    applyGridColumnWidthsToNode(gridNode, normalized);
+    if (!gridNode.getAttribute("data-situation-grid-scope")) {
+      gridNode.setAttribute("data-situation-grid-scope", scopeKey);
+    }
+  }
+
+  function bindSituationGridColumnResize(root) {
+    const columnsByKey = new Map(getSituationGridColumnDefinitions().map((column) => [column.key, column]));
+    root.querySelectorAll(".situation-grid[data-situation-grid]").forEach((gridNode) => {
+      hydrateSituationGridColumnWidths(gridNode);
+      gridNode.querySelectorAll("[data-situation-grid-resize-handle]").forEach((handle) => {
+        handle.addEventListener("pointerdown", (event) => {
+          const target = event.currentTarget;
+          const columnKey = String(target?.getAttribute("data-situation-grid-resize-handle") || "").trim();
+          const columnMeta = columnsByKey.get(columnKey);
+          if (!columnMeta) return;
+
+          const scopeKey = String(gridNode.getAttribute("data-situation-grid-scope") || "").trim();
+          const byScope = ensureGridColumnWidthsByScope();
+          const scopedWidths = normalizeSituationGridColumnWidths(byScope[scopeKey] || {});
+          byScope[scopeKey] = scopedWidths;
+          const startX = Number(event.clientX) || 0;
+          const initialWidth = Number(scopedWidths[columnKey]) || columnMeta.minWidth;
+
+          const onPointerMove = (moveEvent) => {
+            const pointerX = Number(moveEvent.clientX) || 0;
+            const nextWidth = Math.max(columnMeta.minWidth, Math.round(initialWidth + (pointerX - startX)));
+            scopedWidths[columnKey] = nextWidth;
+            applyGridColumnWidthsToNode(gridNode, scopedWidths);
+          };
+
+          const onPointerUp = () => {
+            window.removeEventListener("pointermove", onPointerMove);
+            window.removeEventListener("pointerup", onPointerUp);
+            window.removeEventListener("pointercancel", onPointerUp);
+            byScope[scopeKey] = normalizeSituationGridColumnWidths(scopedWidths);
+            persistGridColumnWidths(scopeKey, byScope[scopeKey]);
+          };
+
+          event.preventDefault();
+          event.stopPropagation();
+          window.addEventListener("pointermove", onPointerMove);
+          window.addEventListener("pointerup", onPointerUp);
+          window.addEventListener("pointercancel", onPointerUp);
+        });
+      });
+    });
   }
 
   async function refreshInsightsData(root) {
@@ -471,6 +590,8 @@ export function createProjectSituationsEvents({
         rerender(root);
       });
     });
+
+    bindSituationGridColumnResize(root);
 
     bindCreateModalEvents(root);
     bindEditPanelEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-state.js
+++ b/apps/web/js/views/project-situations/project-situations-state.js
@@ -94,6 +94,9 @@ export function createProjectSituationsState({ store }) {
     if (!view.kanbanStatusBySituationId || typeof view.kanbanStatusBySituationId !== "object" || Array.isArray(view.kanbanStatusBySituationId)) {
       view.kanbanStatusBySituationId = {};
     }
+    if (!view.gridColumnWidthsByScope || typeof view.gridColumnWidthsByScope !== "object" || Array.isArray(view.gridColumnWidthsByScope)) {
+      view.gridColumnWidthsByScope = {};
+    }
     if (typeof view.selectedSituationLayout !== "string") {
       view.selectedSituationLayout = "tableau";
     }

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -2,6 +2,21 @@ import { escapeHtml } from "../../utils/escape-html.js";
 import { svgIcon } from "../../ui/icons.js";
 import { renderSubjectTreeGrid } from "../shared/subject-tree-grid.js";
 
+const GRID_COLUMN_DEFINITIONS = [
+  { key: "title", label: "Titre", minWidth: 320, className: "title" },
+  { key: "assignees", label: "Assignés", minWidth: 160, className: "assignees" },
+  { key: "kanban", label: "Statut", minWidth: 160, className: "kanban" },
+  { key: "progress", label: "Progression", minWidth: 180, className: "progress" },
+  { key: "labels", label: "Labels", minWidth: 220, className: "labels" },
+  { key: "objectives", label: "Objectifs", minWidth: 220, className: "objectives" },
+  { key: "priority", label: "Priorité", minWidth: 120, className: "priority" },
+  { key: "dates", label: "Créé · MAJ", minWidth: 160, className: "dates" }
+];
+
+export function getSituationGridColumnDefinitions() {
+  return GRID_COLUMN_DEFINITIONS.map((column) => ({ ...column }));
+}
+
 const KANBAN_STATUS_META = {
   non_active: { label: "Non activé", bg: "rgba(46, 160, 67, 0.15)", border: "rgb(35, 134, 54)", text: "rgb(63, 185, 80)" },
   to_activate: { label: "À activer", bg: "rgba(56, 139, 253, 0.1)", border: "rgb(31, 111, 235)", text: "rgb(88, 166, 255)" },
@@ -16,6 +31,45 @@ function normalizeIssueLifecycleStatus(status = "") {
 
 function normalizeId(value) {
   return String(value || "").trim();
+}
+
+export function buildSituationGridColumnWidthsScopeKey(projectId, situationId) {
+  const normalizedProjectId = normalizeId(projectId) || "project";
+  const normalizedSituationId = normalizeId(situationId) || "situation";
+  return `project:${normalizedProjectId}:situation:${normalizedSituationId}`;
+}
+
+export function normalizeSituationGridColumnWidths(rawWidths = {}) {
+  const source = rawWidths && typeof rawWidths === "object" ? rawWidths : {};
+  return GRID_COLUMN_DEFINITIONS.reduce((acc, column) => {
+    const rawValue = Number(source[column.key]);
+    const normalizedValue = Number.isFinite(rawValue)
+      ? Math.max(column.minWidth, Math.round(rawValue))
+      : column.minWidth;
+    acc[column.key] = normalizedValue;
+    return acc;
+  }, {});
+}
+
+export function getSituationGridColumnCssVariables(widths = {}) {
+  return GRID_COLUMN_DEFINITIONS.reduce((acc, column) => {
+    acc[`--situation-grid-col-${column.key}`] = `${Math.max(column.minWidth, Number(widths?.[column.key]) || 0)}px`;
+    return acc;
+  }, {});
+}
+
+function getGridContainerInlineStyle(widths = {}) {
+  const cssVars = getSituationGridColumnCssVariables(widths);
+  return Object.entries(cssVars)
+    .map(([name, value]) => `${name}:${value}`)
+    .join(";");
+}
+
+function getStoredGridColumnWidths(store = {}, scopeKey = "") {
+  if (!scopeKey) return normalizeSituationGridColumnWidths();
+  const widthsByScope = store?.situationsView?.gridColumnWidthsByScope;
+  const scoped = widthsByScope && typeof widthsByScope === "object" ? widthsByScope[scopeKey] : null;
+  return normalizeSituationGridColumnWidths(scoped || {});
 }
 
 function firstNonEmpty(...values) {
@@ -278,14 +332,17 @@ function renderDatesCell(subject = {}) {
 function renderGridHeaderRow() {
   return `
     <header class="project-situation-grid__header situation-grid__header" role="row">
-      <div class="project-situation-grid__head-cell situation-grid__head-cell situation-grid__head-cell--title" role="columnheader">Titre</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--assignees" role="columnheader">Assignés</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--kanban" role="columnheader">Statut</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--progress" role="columnheader">Progression</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--labels" role="columnheader">Labels</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--objectives" role="columnheader">Objectifs</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--priority" role="columnheader">Priorité</div>
-      <div class="project-situation-grid__head-cell situation-grid__head-cell--dates" role="columnheader">Créé · MAJ</div>
+      ${GRID_COLUMN_DEFINITIONS.map((column) => `
+        <div class="project-situation-grid__head-cell situation-grid__head-cell situation-grid__head-cell--${column.className}" role="columnheader" data-situation-grid-column-key="${escapeHtml(column.key)}">
+          <span class="situation-grid__head-cell-label">${escapeHtml(column.label)}</span>
+          <button
+            type="button"
+            class="situation-grid__resize-handle"
+            data-situation-grid-resize-handle="${escapeHtml(column.key)}"
+            aria-label="Redimensionner la colonne ${escapeHtml(column.label)}"
+          ></button>
+        </div>
+      `).join("")}
     </header>
   `;
 }
@@ -293,6 +350,12 @@ function renderGridHeaderRow() {
 export function renderSituationGridView(situation, subjects = [], options = {}) {
   const title = String(situation?.title || "Situation");
   const normalizedSituationId = normalizeId(situation?.id);
+  const normalizedProjectId = normalizeId(
+    options?.projectId
+      || options?.store?.currentProjectId
+      || options?.store?.projectForm?.projectId
+      || options?.store?.projectForm?.id
+  );
   if (!normalizedSituationId) {
     return `
       <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
@@ -334,6 +397,9 @@ export function renderSituationGridView(situation, subjects = [], options = {}) 
     rootSubjectIds,
     fallbackExpandedIds: [...selectedSubjectIds]
   });
+  const columnWidthsScopeKey = buildSituationGridColumnWidthsScopeKey(normalizedProjectId, normalizedSituationId);
+  const columnWidths = getStoredGridColumnWidths(options?.store || {}, columnWidthsScopeKey);
+  const gridContainerStyle = getGridContainerInlineStyle(columnWidths);
 
   const rowsHtml = renderSubjectTreeGrid({
     subjectsById,
@@ -386,7 +452,13 @@ export function renderSituationGridView(situation, subjects = [], options = {}) 
 
   return `
     <section class="project-situation-alt-view project-situation-alt-view--grid" aria-label="Vue grille">
-      <section class="project-situation-grid situation-grid" data-situation-grid="${escapeHtml(normalizedSituationId)}">
+      <section
+        class="project-situation-grid situation-grid"
+        data-situation-grid="${escapeHtml(normalizedSituationId)}"
+        data-situation-grid-project-id="${escapeHtml(normalizedProjectId)}"
+        data-situation-grid-scope="${escapeHtml(columnWidthsScopeKey)}"
+        style="${escapeHtml(gridContainerStyle)}"
+      >
         <div class="project-situation-grid__scroll situation-grid__scroll">
           ${renderGridHeaderRow()}
           <div class="project-situation-grid__body situation-grid__body" role="rowgroup">
@@ -402,6 +474,8 @@ export function __situationGridTestUtils() {
   return {
     resolveSituationTreeData,
     getSubjectProgress,
-    getKanbanStatusMeta
+    getKanbanStatusMeta,
+    normalizeSituationGridColumnWidths,
+    buildSituationGridColumnWidthsScopeKey
   };
 }

--- a/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
@@ -103,3 +103,20 @@ test("renderSituationGridView utilise le statut kanban de la situation et évite
   assert.match(html, /En cours/);
   assert.doesNotMatch(html, /undefined/);
 });
+
+test("normalizeSituationGridColumnWidths respecte les largeurs minimales par colonne", () => {
+  const { normalizeSituationGridColumnWidths } = __situationGridTestUtils();
+  const widths = normalizeSituationGridColumnWidths({
+    title: 120,
+    assignees: 400,
+    kanban: "20",
+    labels: 480
+  });
+
+  assert.equal(widths.title, 320);
+  assert.equal(widths.assignees, 400);
+  assert.equal(widths.kanban, 160);
+  assert.equal(widths.progress, 180);
+  assert.equal(widths.labels, 480);
+  assert.equal(widths.objectives, 220);
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10051,7 +10051,15 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .project-situation-grid,
 .situation-grid{
-  --situation-grid-cols:minmax(320px,2fr) minmax(160px,1fr) minmax(160px,1fr) minmax(180px,1fr) minmax(220px,1.2fr) minmax(220px,1.2fr) minmax(120px,.8fr) minmax(160px,1fr);
+  --situation-grid-col-title:420px;
+  --situation-grid-col-assignees:200px;
+  --situation-grid-col-kanban:180px;
+  --situation-grid-col-progress:220px;
+  --situation-grid-col-labels:240px;
+  --situation-grid-col-objectives:240px;
+  --situation-grid-col-priority:120px;
+  --situation-grid-col-dates:180px;
+  --situation-grid-cols:var(--situation-grid-col-title) var(--situation-grid-col-assignees) var(--situation-grid-col-kanban) var(--situation-grid-col-progress) var(--situation-grid-col-labels) var(--situation-grid-col-objectives) var(--situation-grid-col-priority) var(--situation-grid-col-dates);
   width:100%;
   min-height:0;
   height:100%;
@@ -10074,11 +10082,11 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   display:grid;
   grid-template-columns:var(--situation-grid-cols);
   background:var(--bgColor-default, #0d1117);
-  border-bottom:2px solid var(--borderColor-default, #30363d);
 }
 
 .project-situation-grid__head-cell,
 .situation-grid__head-cell{
+  position:relative;
   min-height:32px;
   padding:0 16px;
   display:flex;
@@ -10087,6 +10095,45 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   font-weight:500;
   color:var(--fgColor-muted, #8b949e);
   border-right:1px solid var(--borderColor-default, #30363d);
+  border-bottom:2px solid var(--borderColor-default, #30363d);
+}
+
+.situation-grid__head-cell-label{
+  min-width:0;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+.situation-grid__resize-handle{
+  position:absolute;
+  top:0;
+  right:-5px;
+  width:10px;
+  height:100%;
+  border:none;
+  padding:0;
+  margin:0;
+  background:transparent;
+  cursor:col-resize;
+  z-index:3;
+}
+
+.situation-grid__resize-handle::before{
+  content:"";
+  position:absolute;
+  top:8px;
+  bottom:8px;
+  left:4px;
+  width:1px;
+  background:var(--borderColor-default, #30363d);
+  opacity:.65;
+}
+
+.situation-grid__resize-handle:hover::before,
+.situation-grid__resize-handle:focus-visible::before{
+  background:var(--fgColor-accent, #2f81f7);
+  opacity:1;
 }
 
 .project-situation-grid__body,
@@ -10098,13 +10145,8 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-grid__row{
   display:grid;
   grid-template-columns:var(--situation-grid-cols);
-  border-bottom:1px solid var(--borderColor-default, #30363d);
   min-height:40px;
   padding:0;
-}
-
-.situation-grid__body .situation-grid__row:last-child{
-  border-bottom:1px solid var(--borderColor-default, #30363d);
 }
 
 .situation-grid__cell{
@@ -10114,6 +10156,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   align-items:center;
   min-width:0;
   border-right:1px solid var(--borderColor-default, #30363d);
+  border-bottom:1px solid var(--borderColor-default, #30363d);
 }
 
 .situation-grid__row .situation-grid__cell:last-child,


### PR DESCRIPTION
### Motivation
- Enable users to resize columns in the situation grid and persist those widths per project/situation so the grid layout is preserved across sessions.

### Description
- Added `apps/web/js/views/project-situations/project-situations-view-grid.js` which defines `GRID_COLUMN_DEFINITIONS` and exposes helpers like `buildSituationGridColumnWidthsScopeKey`, `normalizeSituationGridColumnWidths`, and `getSituationGridColumnCssVariables` to normalize widths and produce CSS variables.
- Updated `apps/web/js/views/project-situations/project-situations-events.js` to hydrate widths on render, bind pointer events to `[data-situation-grid-resize-handle]` to handle dragging, persist normalized widths to `localStorage`, and store them in `store.situationsView.gridColumnWidthsByScope`.
- Initialized `gridColumnWidthsByScope` in `apps/web/js/views/project-situations/project-situations-state.js` and modified `renderSituationGridView` to emit `data-situation-grid-project-id`, `data-situation-grid-scope`, inline style with CSS variables, and header cells with resize handles.
- Updated `apps/web/style.css` to use CSS variables for column widths and added styling for the header labels and resize handles.
- Added a unit test in `apps/web/js/views/project-situations/project-situations-view-grid.test.mjs` and exported test utilities used by the tests.

### Testing
- Ran the unit tests for `project-situations-view-grid.test.mjs`, including the new `normalizeSituationGridColumnWidths respecte les largeurs minimales par colonne` test, and they passed.
- Ran the existing grid rendering tests (including the kanban status rendering test) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec51f107248329afdb7a4bcc297a85)