### PR TITLE
feat(situations-grid): editable cells with anchored dropdown for kanban/labels/objectives

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -430,7 +430,34 @@ const { bindEvents } = createProjectSituationsEvents({
   getSituationById,
   loadSituationSelection,
   loadSituationInsightsData,
-  openSituationDrilldownFromSelection
+  openSituationDrilldownFromSelection,
+  setSituationGridKanbanStatus: async (situationId, subjectId, nextStatus) => {
+    const normalizedSituationId = String(situationId || "").trim();
+    const normalizedSubjectId = String(subjectId || "").trim();
+    const normalizedNextStatus = String(nextStatus || "").trim().toLowerCase();
+    if (!normalizedSituationId || !normalizedSubjectId || !normalizedNextStatus) return false;
+    try {
+      await setSituationSubjectKanbanStatus(normalizedSituationId, normalizedSubjectId, normalizedNextStatus);
+      if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+      store.situationsView.kanbanStatusBySituationId = {
+        ...(store.situationsView.kanbanStatusBySituationId || {}),
+        [normalizedSituationId]: {
+          ...((store.situationsView.kanbanStatusBySituationId || {})[normalizedSituationId] || {}),
+          [normalizedSubjectId]: normalizedNextStatus
+        }
+      };
+      return true;
+    } catch (error) {
+      await loadSituationKanbanStatusMap([normalizedSituationId]).then((map) => {
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        store.situationsView.kanbanStatusBySituationId = {
+          ...(store.situationsView.kanbanStatusBySituationId || {}),
+          ...(map || {})
+        };
+      }).catch(() => undefined);
+      throw error;
+    }
+  }
 });
 
 export function renderProjectSituations(root) {

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1,5 +1,8 @@
 import { bindLightTabs } from "../ui/light-tabs.js";
 import { renderProjectSituationDrilldown } from "../project-situation-drilldown.js";
+import { escapeHtml } from "../../utils/escape-html.js";
+import { svgIcon } from "../../ui/icons.js";
+import { renderSelectMenuSection } from "../ui/select-menu.js";
 import {
   buildSituationGridColumnWidthsScopeKey,
   getSituationGridColumnCssVariables,
@@ -19,6 +22,14 @@ function parseCsvList(value) {
     .filter(Boolean))];
 }
 
+const SITUATION_GRID_KANBAN_OPTIONS = [
+  { key: "non_active", label: "Non activé", hint: "Hors de la pile active." },
+  { key: "to_activate", label: "À activer", hint: "Prêt à être pris en charge." },
+  { key: "in_progress", label: "En cours", hint: "Travail en cours." },
+  { key: "in_arbitration", label: "En arbitrage", hint: "Décision en attente." },
+  { key: "resolved", label: "Résolu", hint: "Sujet clôturé côté situation." }
+];
+
 export function createProjectSituationsEvents({
   store,
   uiState,
@@ -34,7 +45,8 @@ export function createProjectSituationsEvents({
   getSituationById,
   loadSituationSelection,
   loadSituationInsightsData,
-  openSituationDrilldownFromSelection
+  openSituationDrilldownFromSelection,
+  setSituationGridKanbanStatus
 }) {
   let insightsRequestId = 0;
 
@@ -58,6 +70,168 @@ export function createProjectSituationsEvents({
       || store?.projectForm?.id
       || ""
     ).trim();
+  }
+
+  function ensureSituationGridCellDropdownState() {
+    if (!uiState.situationGridCellDropdown || typeof uiState.situationGridCellDropdown !== "object") {
+      uiState.situationGridCellDropdown = {
+        open: false,
+        field: "",
+        subjectId: "",
+        situationId: "",
+        anchor: null
+      };
+    }
+    return uiState.situationGridCellDropdown;
+  }
+
+  function ensureSituationGridCellDropdownHost() {
+    let host = document.getElementById("situationGridCellDropdownHost");
+    if (!host) {
+      host = document.createElement("div");
+      host.id = "situationGridCellDropdownHost";
+      host.className = "subject-meta-dropdown-host situation-grid__dropdown-host";
+      host.setAttribute("aria-hidden", "true");
+      document.body.appendChild(host);
+    }
+    return host;
+  }
+
+  function closeSituationGridCellDropdown() {
+    const state = ensureSituationGridCellDropdownState();
+    if (state.anchor?.setAttribute) state.anchor.setAttribute("aria-expanded", "false");
+    state.open = false;
+    state.field = "";
+    state.subjectId = "";
+    state.situationId = "";
+    state.anchor = null;
+    const host = ensureSituationGridCellDropdownHost();
+    host.innerHTML = "";
+    host.setAttribute("aria-hidden", "true");
+  }
+
+  function positionSituationGridCellDropdown() {
+    const state = ensureSituationGridCellDropdownState();
+    const host = ensureSituationGridCellDropdownHost();
+    const anchor = state.anchor;
+    if (!state.open || !anchor || !host.firstElementChild) return;
+    const rect = anchor.getBoundingClientRect();
+    const panel = host.firstElementChild;
+    const panelWidth = Math.max(280, panel.offsetWidth || 280);
+    const viewportWidth = window.innerWidth || document.documentElement?.clientWidth || 1280;
+    const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 720;
+    const preferredLeft = rect.left;
+    const left = Math.max(8, Math.min(preferredLeft, viewportWidth - panelWidth - 8));
+    const top = rect.bottom + 6 + window.scrollY;
+    panel.style.left = `${left + window.scrollX}px`;
+    if (top + (panel.offsetHeight || 0) > viewportHeight + window.scrollY - 8) {
+      const fallbackTop = Math.max(window.scrollY + 8, rect.top + window.scrollY - (panel.offsetHeight || 0) - 6);
+      panel.style.top = `${fallbackTop}px`;
+    } else {
+      panel.style.top = `${top}px`;
+    }
+  }
+
+  function renderSituationGridKanbanDropdown({ subjectId = "", situationId = "" } = {}) {
+    const currentStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+    const items = SITUATION_GRID_KANBAN_OPTIONS.map((option) => ({
+      key: option.key,
+      title: option.label,
+      metaHtml: escapeHtml(option.hint),
+      isSelected: option.key === currentStatus,
+      rightHtml: option.key === currentStatus ? svgIcon("check", { className: "octicon octicon-check" }) : "",
+      dataAttrs: {
+        "situation-grid-dropdown-action": "set-kanban",
+        "situation-grid-status": option.key
+      }
+    }));
+    return `
+      <div class="subject-meta-dropdown subject-kanban-dropdown situation-grid__dropdown-panel gh-menu gh-menu--open" role="menu" aria-label="Modifier le statut kanban">
+        <div class="subject-meta-dropdown__title">Statut kanban</div>
+        <div class="subject-kanban-dropdown__separator" aria-hidden="true"></div>
+        <div class="subject-meta-dropdown__body">
+          ${renderSelectMenuSection({ items })}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderSituationGridTodoDropdown(title = "") {
+    return `
+      <div class="subject-meta-dropdown situation-grid__dropdown-panel gh-menu gh-menu--open" role="menu" aria-label="${escapeHtml(title)}">
+        <div class="subject-meta-dropdown__title">${escapeHtml(title)}</div>
+        <div class="subject-kanban-dropdown__separator" aria-hidden="true"></div>
+        <div class="subject-meta-dropdown__body">
+          <div class="select-menu__section">
+            <div class="select-menu__section-body">
+              <div class="select-menu__empty">
+                <div class="select-menu__empty-title">TODO explicite</div>
+                <div class="select-menu__empty-hint">Édition non branchée ici pour éviter d'inventer une API.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function openSituationGridCellDropdown({ field = "", anchor = null, subjectId = "", situationId = "" } = {}) {
+    if (!anchor) return;
+    const state = ensureSituationGridCellDropdownState();
+    const host = ensureSituationGridCellDropdownHost();
+    closeSituationGridCellDropdown();
+    state.open = true;
+    state.field = String(field || "").trim().toLowerCase();
+    state.subjectId = String(subjectId || "").trim();
+    state.situationId = String(situationId || "").trim();
+    state.anchor = anchor;
+    anchor.setAttribute("aria-expanded", "true");
+    if (state.field === "kanban") {
+      host.innerHTML = renderSituationGridKanbanDropdown({ subjectId: state.subjectId, situationId: state.situationId });
+    } else if (state.field === "labels") {
+      host.innerHTML = renderSituationGridTodoDropdown("Labels");
+    } else if (state.field === "objectives") {
+      host.innerHTML = renderSituationGridTodoDropdown("Objectifs");
+    } else if (state.field === "assignees") {
+      host.innerHTML = renderSituationGridTodoDropdown("Assignés");
+    } else {
+      host.innerHTML = "";
+    }
+    if (!host.innerHTML) {
+      closeSituationGridCellDropdown();
+      return;
+    }
+    host.setAttribute("aria-hidden", "false");
+    positionSituationGridCellDropdown();
+  }
+
+  function patchSituationGridKanbanCell({ root, subjectId = "", situationId = "" } = {}) {
+    if (!root || !subjectId || !situationId) return;
+    const trigger = [...root.querySelectorAll('[data-situation-grid-edit-cell="kanban"]')]
+      .find((node) => String(node.getAttribute("data-situation-grid-subject-id") || "").trim() === subjectId
+        && String(node.getAttribute("data-situation-grid-situation-id") || "").trim() === situationId);
+    if (!trigger) return;
+    const nextStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+    const option = SITUATION_GRID_KANBAN_OPTIONS.find((entry) => entry.key === nextStatus) || SITUATION_GRID_KANBAN_OPTIONS[0];
+    const badge = trigger.querySelector(".subject-kanban-badge");
+    if (!badge) return;
+    badge.textContent = option.label;
+  }
+
+  function showSituationGridInlineError(root, message = "") {
+    const grid = root?.querySelector?.(".situation-grid");
+    if (!grid) return;
+    const text = String(message || "").trim() || "Mise à jour impossible.";
+    let node = grid.querySelector(".situation-grid__inline-error");
+    if (!node) {
+      node = document.createElement("div");
+      node.className = "settings-inline-error situation-grid__inline-error";
+      grid.prepend(node);
+    }
+    node.textContent = text;
+    window.setTimeout(() => {
+      node?.remove();
+    }, 3500);
   }
 
   function getGridColumnStorageKey(scopeKey = "") {
@@ -162,6 +336,96 @@ export function createProjectSituationsEvents({
         });
       });
     });
+  }
+
+  function bindSituationGridEditableCells(root) {
+    root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
+      node.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const field = String(node.getAttribute("data-situation-grid-edit-cell") || "").trim().toLowerCase();
+        const subjectId = String(node.getAttribute("data-situation-grid-subject-id") || "").trim();
+        const situationId = String(node.getAttribute("data-situation-grid-situation-id") || store?.situationsView?.selectedSituationId || "").trim();
+        if (!field || !subjectId) return;
+        const dropdownState = ensureSituationGridCellDropdownState();
+        if (dropdownState.open
+          && dropdownState.field === field
+          && dropdownState.subjectId === subjectId
+          && dropdownState.situationId === situationId) {
+          closeSituationGridCellDropdown();
+          return;
+        }
+        openSituationGridCellDropdown({ field, anchor: node, subjectId, situationId });
+      });
+    });
+
+    const host = ensureSituationGridCellDropdownHost();
+    if (host.dataset.situationGridDropdownBound !== "true") {
+      host.dataset.situationGridDropdownBound = "true";
+      host.addEventListener("click", async (event) => {
+        const actionNode = event.target.closest("[data-situation-grid-dropdown-action]");
+        if (!actionNode) return;
+        const action = String(actionNode.getAttribute("data-situation-grid-dropdown-action") || "").trim();
+        if (action !== "set-kanban") return;
+        const state = ensureSituationGridCellDropdownState();
+        if (state.field !== "kanban" || !state.subjectId || !state.situationId) return;
+        const nextStatus = String(actionNode.getAttribute("data-situation-grid-status") || "").trim();
+        const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[state.situationId]?.[state.subjectId] || "non_active").trim().toLowerCase();
+        if (!nextStatus || nextStatus === previousStatus) {
+          closeSituationGridCellDropdown();
+          return;
+        }
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        store.situationsView.kanbanStatusBySituationId = {
+          ...(store.situationsView.kanbanStatusBySituationId || {}),
+          [state.situationId]: {
+            ...((store.situationsView.kanbanStatusBySituationId || {})[state.situationId] || {}),
+            [state.subjectId]: nextStatus
+          }
+        };
+        patchSituationGridKanbanCell({ root, subjectId: state.subjectId, situationId: state.situationId });
+        closeSituationGridCellDropdown();
+        try {
+          await setSituationGridKanbanStatus?.(state.situationId, state.subjectId, nextStatus);
+        } catch (error) {
+          store.situationsView.kanbanStatusBySituationId = {
+            ...(store.situationsView.kanbanStatusBySituationId || {}),
+            [state.situationId]: {
+              ...((store.situationsView.kanbanStatusBySituationId || {})[state.situationId] || {}),
+              [state.subjectId]: previousStatus
+            }
+          };
+          patchSituationGridKanbanCell({ root, subjectId: state.subjectId, situationId: state.situationId });
+          console.error("situation grid kanban update failed", error);
+          showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
+        }
+      });
+    }
+
+    if (document.body.dataset.situationGridDropdownGlobalBound !== "true") {
+      document.body.dataset.situationGridDropdownGlobalBound = "true";
+      document.addEventListener("click", (event) => {
+        const hostNode = ensureSituationGridCellDropdownHost();
+        const state = ensureSituationGridCellDropdownState();
+        if (!state.open) return;
+        const target = event.target;
+        if (hostNode.contains(target)) return;
+        if (state.anchor && state.anchor.contains(target)) return;
+        closeSituationGridCellDropdown();
+      });
+      document.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        if (!ensureSituationGridCellDropdownState().open) return;
+        event.preventDefault();
+        closeSituationGridCellDropdown();
+      });
+      window.addEventListener("resize", () => {
+        positionSituationGridCellDropdown();
+      }, { passive: true });
+      window.addEventListener("scroll", () => {
+        positionSituationGridCellDropdown();
+      }, { passive: true });
+    }
   }
 
   async function refreshInsightsData(root) {
@@ -592,6 +856,7 @@ export function createProjectSituationsEvents({
     });
 
     bindSituationGridColumnResize(root);
+    bindSituationGridEditableCells(root);
 
     bindCreateModalEvents(root);
     bindEditPanelEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const eventsSource = fs.readFileSync(path.resolve(__dirname, "./project-situations-events.js"), "utf8");
+
+test("la grille situation ouvre un dropdown éditable ancré aux cellules", () => {
+  assert.match(eventsSource, /openSituationGridCellDropdown\(\{ field, anchor: node, subjectId, situationId \}\)/);
+  assert.match(eventsSource, /set-kanban/);
+  assert.match(eventsSource, /document\.addEventListener\("keydown", \(event\) => \{\s*if \(event\.key !== "Escape"\) return;/s);
+});
+
+test("la mise à jour kanban utilise le service dédié avec rollback local", () => {
+  assert.match(eventsSource, /await setSituationGridKanbanStatus\?\.\(state\.situationId, state\.subjectId, nextStatus\)/);
+  assert.match(eventsSource, /store\.situationsView\.kanbanStatusBySituationId = \{[\s\S]*\[state\.subjectId\]: previousStatus/s);
+  assert.match(eventsSource, /showSituationGridInlineError\(root, error instanceof Error \? error\.message : "La mise à jour du statut kanban a échoué\."\)/);
+});
+
+test("labels et objectifs exposent un TODO explicite au lieu d'une API inventée", () => {
+  assert.match(eventsSource, /TODO explicite/);
+  assert.match(eventsSource, /Édition non branchée ici pour éviter d'inventer une API\./);
+});

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -248,7 +248,21 @@ function renderAssigneesCell(subjectId, rawSubjectsResult = {}, store = {}) {
 
 function renderKanbanCell(subjectId, situationId, store) {
   const meta = getKanbanStatusMeta(subjectId, situationId, store);
-  return `<span class="subject-kanban-badge" style="--subject-kanban-badge-bg:${meta.bg};--subject-kanban-badge-border:${meta.border};--subject-kanban-badge-text:${meta.text};">${escapeHtml(meta.label)}</span>`;
+  return `
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="kanban"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      data-situation-grid-situation-id="${escapeHtml(situationId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier le statut kanban"
+    >
+      <span class="subject-kanban-badge" style="--subject-kanban-badge-bg:${meta.bg};--subject-kanban-badge-border:${meta.border};--subject-kanban-badge-text:${meta.text};">${escapeHtml(meta.label)}</span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
+  `;
 }
 
 function renderProgressCell(subject, subjectsById = {}, childrenBySubjectId = {}) {
@@ -267,23 +281,64 @@ function renderLabelsCell(subjectId, rawSubjectsResult = {}) {
   const labelsById = rawSubjectsResult?.labelsById && typeof rawSubjectsResult.labelsById === "object" ? rawSubjectsResult.labelsById : {};
   const labelIdsBySubjectId = rawSubjectsResult?.labelIdsBySubjectId && typeof rawSubjectsResult.labelIdsBySubjectId === "object" ? rawSubjectsResult.labelIdsBySubjectId : {};
   const labelIds = Array.isArray(labelIdsBySubjectId?.[subjectId]) ? labelIdsBySubjectId[subjectId] : [];
-  if (!labelIds.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!labelIds.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="labels"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les labels"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const labels = labelIds
     .map((labelId) => labelsById[normalizeId(labelId)] || null)
     .filter(Boolean);
-  if (!labels.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!labels.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="labels"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les labels"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const visible = labels.slice(0, 2);
   const overflow = Math.max(0, labels.length - visible.length);
   return `
-    <span class="situation-grid__labels">
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="labels"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier les labels"
+    >
+      <span class="situation-grid__labels">
       ${visible.map((label) => {
         const labelName = firstNonEmpty(label?.name, label?.label, label?.key, label?.id, "Label");
         return `<span class="subject-label-badge">${escapeHtml(labelName)}</span>`;
       }).join("")}
       ${overflow > 0 ? `<span class="situation-grid__pill-overflow mono">+${overflow}</span>` : ""}
-    </span>
+      </span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
   `;
 }
 
@@ -291,20 +346,61 @@ function renderObjectivesCell(subjectId, rawSubjectsResult = {}) {
   const objectivesById = rawSubjectsResult?.objectivesById && typeof rawSubjectsResult.objectivesById === "object" ? rawSubjectsResult.objectivesById : {};
   const objectiveIdsBySubjectId = rawSubjectsResult?.objectiveIdsBySubjectId && typeof rawSubjectsResult.objectiveIdsBySubjectId === "object" ? rawSubjectsResult.objectiveIdsBySubjectId : {};
   const objectiveIds = Array.isArray(objectiveIdsBySubjectId?.[subjectId]) ? objectiveIdsBySubjectId[subjectId] : [];
-  if (!objectiveIds.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!objectiveIds.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="objectives"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les objectifs"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const objectives = objectiveIds
     .map((objectiveId) => objectivesById[normalizeId(objectiveId)] || null)
     .filter(Boolean);
-  if (!objectives.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!objectives.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="objectives"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les objectifs"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const visible = objectives.slice(0, 1);
   const overflow = Math.max(0, objectives.length - visible.length);
   return `
-    <span class="situation-grid__objectives">
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="objectives"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier les objectifs"
+    >
+      <span class="situation-grid__objectives">
       ${visible.map((objective) => `<span class="situation-grid__objective-pill"><span class="situation-grid__objective-icon" aria-hidden="true">${svgIcon("milestone", { className: "octicon octicon-milestone" })}</span>${escapeHtml(firstNonEmpty(objective?.title, objective?.name, objective?.id, "Objectif"))}</span>`).join("")}
       ${overflow > 0 ? `<span class="situation-grid__pill-overflow mono">+${overflow}</span>` : ""}
-    </span>
+      </span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
   `;
 }
 

--- a/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
@@ -101,6 +101,8 @@ test("renderSituationGridView utilise le statut kanban de la situation et évite
   );
 
   assert.match(html, /En cours/);
+  assert.match(html, /data-situation-grid-edit-cell="kanban"/);
+  assert.match(html, /situation-grid__editable-caret/);
   assert.doesNotMatch(html, /undefined/);
 });
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10197,6 +10197,60 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   border-bottom:1px solid var(--borderColor-default, #30363d);
 }
 
+.situation-grid__editable-trigger{
+  width:100%;
+  min-width:0;
+  border:none;
+  background:transparent;
+  color:inherit;
+  padding:0;
+  margin:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  text-align:left;
+}
+
+.situation-grid__editable-trigger:hover .situation-grid__editable-caret,
+.situation-grid__editable-trigger:focus-visible .situation-grid__editable-caret{
+  color:var(--fgColor-default, #e6edf3);
+}
+
+.situation-grid__editable-trigger:focus-visible{
+  outline:1px solid var(--fgColor-accent, #2f81f7);
+  outline-offset:2px;
+  border-radius:6px;
+}
+
+.situation-grid__editable-trigger--empty{
+  min-height:20px;
+}
+
+.situation-grid__editable-caret{
+  display:inline-flex;
+  align-items:center;
+  color:var(--fgColor-muted, #8b949e);
+  flex:0 0 auto;
+}
+
+.situation-grid__dropdown-host{
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  z-index:180;
+}
+
+.situation-grid__dropdown-panel{
+  position:absolute;
+  pointer-events:auto;
+  width:min(360px, calc(100vw - 16px));
+}
+
+.situation-grid__inline-error{
+  margin:8px;
+}
+
 .situation-grid__row .situation-grid__cell:last-child,
 .situation-grid__header .situation-grid__head-cell:last-child{
   border-right:none;


### PR DESCRIPTION
### Motivation
- Rendre éditables certaines cellules de la vue "Situation → Grille" (statut kanban, labels, objectifs) via un déclencheur ancré, sans remplacer le rendu existant en div.
- Permettre une édition UX non modale (dropdown ancré à la cellule) avec fermeture par Escape et clic extérieur, sans rerender global.
- Prioriser le statut kanban avec persistance existante et rollback en cas d'erreur, et laisser labels/objectifs comme TODOs si aucune API propre n'existe.

### Description
- Transforme les cellules Kanban / Labels / Objectifs en triggers bouton éditables dans `apps/web/js/views/project-situations/project-situations-view-grid.js`, en ajoutant des attributs `data-situation-grid-edit-cell`, caret visuel et markup accessible.
- Ajoute la logique de dropdown ancré et son host global dans `apps/web/js/views/project-situations/project-situations-events.js`, comprenant ouverture/positionnement, fermeture (Escape / clic extérieur), rendu du panel et helpers de positionnement.
- Implémente le flux d'édition Kanban optimiste: mise à jour locale du store, appel au service via un callback `setSituationGridKanbanStatus`, puis rollback + message inline si persistance échoue; le callback est exposé depuis `apps/web/js/views/project-situations.js` en réutilisant `setSituationSubjectKanbanStatus` et `loadSituationKanbanStatusMap` pour resync.
- Ajoute styles CSS pour les triggers éditables, caret, host dropdown et message d'erreur inline dans `apps/web/style.css`.
- Ne branche pas les appels labels/objectives/assignés vers une API inexistante; ces cellules ouvrent un dropdown affichant un TODO explicite conformément à la contrainte.
- Ajoute/ adapte des tests: `project-situations-view-grid.test.mjs` (markup rendu) et nouveau `project-situations-grid-dropdown.test.mjs` (vérifie l'existence des helpers d'ouverture, actions kanban et rollback attendu).

### Testing
- Command exécuté: `node --test apps/web/js/views/project-situations/project-situations-view-grid.test.mjs apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs`.
- Résultat: la suite de tests automatique est passée avec succès (7 tests exécutés, 7 passés).
- Tests vérifient le rendu HTML attendu (absence de table, présence des attributs `data-situation-grid-edit-cell` et du caret) et la présence du code d'ouverture/gestion du dropdown et du mécanisme de rollback kanban.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5634710083298c4b5a41487888da)