### PR TITLE
Make situation grid cells editable with shared dropdowns and kanban updates

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -40,7 +40,15 @@ import {
   getSujetKanbanStatusForSituation,
   setSujetKanbanStatusForSituation,
   openSubjectDrilldownFromSituation,
-  openSituationDrilldownFromSelection
+  openSituationDrilldownFromSelection,
+  openSharedSubjectMetaDropdown,
+  openSharedSubjectKanbanDropdown,
+  closeSharedSubjectDropdowns,
+  setSharedSubjectMetaDropdownQuery,
+  setSharedSubjectKanbanDropdownQuery,
+  toggleSubjectAssigneeFromSharedDropdown,
+  toggleSubjectLabelFromSharedDropdown,
+  toggleSubjectObjectiveFromSharedDropdown
 } from "./project-subjects.js";
 
 const { uiState, ensureSituationsViewState } = createProjectSituationsState({ store });
@@ -430,7 +438,42 @@ const { bindEvents } = createProjectSituationsEvents({
   getSituationById,
   loadSituationSelection,
   loadSituationInsightsData,
-  openSituationDrilldownFromSelection
+  openSituationDrilldownFromSelection,
+  openSharedSubjectMetaDropdown: (...args) => openSharedSubjectMetaDropdown(...args),
+  openSharedSubjectKanbanDropdown: (...args) => openSharedSubjectKanbanDropdown(...args),
+  closeSharedSubjectDropdowns: (...args) => closeSharedSubjectDropdowns(...args),
+  setSharedSubjectMetaDropdownQuery: (...args) => setSharedSubjectMetaDropdownQuery(...args),
+  setSharedSubjectKanbanDropdownQuery: (...args) => setSharedSubjectKanbanDropdownQuery(...args),
+  toggleSubjectAssigneeFromSharedDropdown: (...args) => toggleSubjectAssigneeFromSharedDropdown(...args),
+  toggleSubjectLabelFromSharedDropdown: (...args) => toggleSubjectLabelFromSharedDropdown(...args),
+  toggleSubjectObjectiveFromSharedDropdown: (...args) => toggleSubjectObjectiveFromSharedDropdown(...args),
+  setSituationGridKanbanStatus: async (situationId, subjectId, nextStatus) => {
+    const normalizedSituationId = String(situationId || "").trim();
+    const normalizedSubjectId = String(subjectId || "").trim();
+    const normalizedNextStatus = String(nextStatus || "").trim().toLowerCase();
+    if (!normalizedSituationId || !normalizedSubjectId || !normalizedNextStatus) return false;
+    try {
+      await setSituationSubjectKanbanStatus(normalizedSituationId, normalizedSubjectId, normalizedNextStatus);
+      if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+      store.situationsView.kanbanStatusBySituationId = {
+        ...(store.situationsView.kanbanStatusBySituationId || {}),
+        [normalizedSituationId]: {
+          ...((store.situationsView.kanbanStatusBySituationId || {})[normalizedSituationId] || {}),
+          [normalizedSubjectId]: normalizedNextStatus
+        }
+      };
+      return true;
+    } catch (error) {
+      await loadSituationKanbanStatusMap([normalizedSituationId]).then((map) => {
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        store.situationsView.kanbanStatusBySituationId = {
+          ...(store.situationsView.kanbanStatusBySituationId || {}),
+          ...(map || {})
+        };
+      }).catch(() => undefined);
+      throw error;
+    }
+  }
 });
 
 export function renderProjectSituations(root) {

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -34,7 +34,16 @@ export function createProjectSituationsEvents({
   getSituationById,
   loadSituationSelection,
   loadSituationInsightsData,
-  openSituationDrilldownFromSelection
+  openSituationDrilldownFromSelection,
+  openSharedSubjectMetaDropdown,
+  openSharedSubjectKanbanDropdown,
+  closeSharedSubjectDropdowns,
+  setSharedSubjectMetaDropdownQuery,
+  setSharedSubjectKanbanDropdownQuery,
+  toggleSubjectAssigneeFromSharedDropdown,
+  toggleSubjectLabelFromSharedDropdown,
+  toggleSubjectObjectiveFromSharedDropdown,
+  setSituationGridKanbanStatus
 }) {
   let insightsRequestId = 0;
 
@@ -58,6 +67,134 @@ export function createProjectSituationsEvents({
       || store?.projectForm?.id
       || ""
     ).trim();
+  }
+
+  function ensureSituationGridCellDropdownState() {
+    if (!uiState.situationGridCellDropdown || typeof uiState.situationGridCellDropdown !== "object") {
+      uiState.situationGridCellDropdown = {
+        open: false,
+        field: "",
+        subjectId: "",
+        situationId: "",
+        anchor: null
+      };
+    }
+    return uiState.situationGridCellDropdown;
+  }
+
+  function closeSituationGridCellDropdown() {
+    const state = ensureSituationGridCellDropdownState();
+    if (state.anchor?.setAttribute) state.anchor.setAttribute("aria-expanded", "false");
+    state.open = false;
+    state.field = "";
+    state.subjectId = "";
+    state.situationId = "";
+    state.anchor = null;
+    closeSharedSubjectDropdowns?.();
+  }
+
+  function openSituationGridCellDropdown(root, { field = "", anchor = null, subjectId = "", situationId = "" } = {}) {
+    if (!anchor) return;
+    const state = ensureSituationGridCellDropdownState();
+    closeSituationGridCellDropdown();
+    state.open = true;
+    state.field = String(field || "").trim().toLowerCase();
+    state.subjectId = String(subjectId || "").trim();
+    state.situationId = String(situationId || "").trim();
+    state.anchor = anchor;
+    anchor.setAttribute("aria-expanded", "true");
+    if (state.field === "kanban") {
+      const opened = openSharedSubjectKanbanDropdown?.({
+        root,
+        subjectId: state.subjectId,
+        situationId: state.situationId
+      });
+      if (!opened) closeSituationGridCellDropdown();
+      return;
+    }
+
+    const opened = openSharedSubjectMetaDropdown?.({
+      root,
+      field: state.field,
+      subjectId: state.subjectId,
+      anchor,
+      scope: "situation-grid",
+      scopeHost: "main",
+      instanceKey: "situation-grid",
+      openedFrom: "situation-grid"
+    });
+    if (!opened) closeSituationGridCellDropdown();
+  }
+
+  function getKanbanLabel(status = "") {
+    const map = {
+      non_active: "Non activé",
+      to_activate: "À activer",
+      in_progress: "En cours",
+      in_arbitration: "En arbitrage",
+      resolved: "Résolu"
+    };
+    return map[String(status || "").trim().toLowerCase()] || map.non_active;
+  }
+
+  function patchSituationGridKanbanCell({ root, subjectId = "", situationId = "" } = {}) {
+    if (!root || !subjectId || !situationId) return;
+    const trigger = [...root.querySelectorAll('[data-situation-grid-edit-cell="kanban"]')]
+      .find((node) => String(node.getAttribute("data-situation-grid-subject-id") || "").trim() === subjectId
+        && String(node.getAttribute("data-situation-grid-situation-id") || "").trim() === situationId);
+    if (!trigger) return;
+    const nextStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+    const badge = trigger.querySelector(".subject-kanban-badge");
+    if (!badge) return;
+    badge.textContent = getKanbanLabel(nextStatus);
+  }
+
+  function showSituationGridInlineError(root, message = "") {
+    const grid = root?.querySelector?.(".situation-grid");
+    if (!grid) return;
+    const text = String(message || "").trim() || "Mise à jour impossible.";
+    let node = grid.querySelector(".situation-grid__inline-error");
+    if (!node) {
+      node = document.createElement("div");
+      node.className = "settings-inline-error situation-grid__inline-error";
+      grid.prepend(node);
+    }
+    node.textContent = text;
+    window.setTimeout(() => {
+      node?.remove();
+    }, 3500);
+  }
+
+  function normalizeGridDropdownTogglePayload(actionNode, attrName) {
+    return String(actionNode?.getAttribute(attrName) || "").trim();
+  }
+
+  async function handleSharedDropdownAction(root, actionNode) {
+    const state = ensureSituationGridCellDropdownState();
+    const subjectId = String(state.subjectId || actionNode?.getAttribute("data-subject-id") || "").trim();
+    if (!subjectId) return false;
+    if (actionNode.matches("[data-subject-assignee-toggle]")) {
+      const assigneeId = normalizeGridDropdownTogglePayload(actionNode, "data-subject-assignee-toggle");
+      if (!assigneeId) return true;
+      await toggleSubjectAssigneeFromSharedDropdown?.(subjectId, assigneeId, { rerender: false });
+      rerender(root);
+      return true;
+    }
+    if (actionNode.matches("[data-subject-label-toggle]")) {
+      const labelKey = normalizeGridDropdownTogglePayload(actionNode, "data-subject-label-toggle");
+      if (!labelKey) return true;
+      await toggleSubjectLabelFromSharedDropdown?.(subjectId, labelKey, { rerender: false });
+      rerender(root);
+      return true;
+    }
+    if (actionNode.matches("[data-subject-objective-toggle]")) {
+      const objectiveId = normalizeGridDropdownTogglePayload(actionNode, "data-subject-objective-toggle");
+      if (!objectiveId) return true;
+      await toggleSubjectObjectiveFromSharedDropdown?.(subjectId, objectiveId, { rerender: false });
+      rerender(root);
+      return true;
+    }
+    return false;
   }
 
   function getGridColumnStorageKey(scopeKey = "") {
@@ -162,6 +299,111 @@ export function createProjectSituationsEvents({
         });
       });
     });
+  }
+
+  function bindSituationGridEditableCells(root) {
+    root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
+      node.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const field = String(node.getAttribute("data-situation-grid-edit-cell") || "").trim().toLowerCase();
+        const subjectId = String(node.getAttribute("data-situation-grid-subject-id") || "").trim();
+        const situationId = String(node.getAttribute("data-situation-grid-situation-id") || store?.situationsView?.selectedSituationId || "").trim();
+        if (!field || !subjectId) return;
+        const dropdownState = ensureSituationGridCellDropdownState();
+        if (dropdownState.open
+          && dropdownState.field === field
+          && dropdownState.subjectId === subjectId
+          && dropdownState.situationId === situationId) {
+          closeSituationGridCellDropdown();
+          return;
+        }
+        openSituationGridCellDropdown(root, { field, anchor: node, subjectId, situationId });
+      });
+    });
+
+    if (document.body.dataset.situationGridDropdownGlobalBound !== "true") {
+      document.body.dataset.situationGridDropdownGlobalBound = "true";
+
+      document.addEventListener("click", async (event) => {
+        const actionNode = event.target.closest(
+          "[data-subject-kanban-select],[data-subject-assignee-toggle],[data-subject-label-toggle],[data-subject-objective-toggle]"
+        );
+        if (actionNode) {
+          const state = ensureSituationGridCellDropdownState();
+          if (!state.open) return;
+          if (actionNode.matches("[data-subject-kanban-select]")) {
+            const nextStatus = String(actionNode.getAttribute("data-subject-kanban-select") || "").trim();
+            const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[state.situationId]?.[state.subjectId] || "non_active").trim().toLowerCase();
+            if (!nextStatus || nextStatus === previousStatus) {
+              closeSituationGridCellDropdown();
+              return;
+            }
+            if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+            store.situationsView.kanbanStatusBySituationId = {
+              ...(store.situationsView.kanbanStatusBySituationId || {}),
+              [state.situationId]: {
+                ...((store.situationsView.kanbanStatusBySituationId || {})[state.situationId] || {}),
+                [state.subjectId]: nextStatus
+              }
+            };
+            patchSituationGridKanbanCell({ root, subjectId: state.subjectId, situationId: state.situationId });
+            closeSituationGridCellDropdown();
+            try {
+              await setSituationGridKanbanStatus?.(state.situationId, state.subjectId, nextStatus);
+            } catch (error) {
+              store.situationsView.kanbanStatusBySituationId = {
+                ...(store.situationsView.kanbanStatusBySituationId || {}),
+                [state.situationId]: {
+                  ...((store.situationsView.kanbanStatusBySituationId || {})[state.situationId] || {}),
+                  [state.subjectId]: previousStatus
+                }
+              };
+              patchSituationGridKanbanCell({ root, subjectId: state.subjectId, situationId: state.situationId });
+              console.error("situation grid kanban update failed", error);
+              showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
+            }
+            return;
+          }
+
+          try {
+            const handled = await handleSharedDropdownAction(root, actionNode);
+            if (handled) closeSituationGridCellDropdown();
+          } catch (error) {
+            console.error("situation grid shared dropdown action failed", error);
+            showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour a échoué.");
+          }
+          return;
+        }
+
+        const state = ensureSituationGridCellDropdownState();
+        if (!state.open) return;
+        const host = document.getElementById("subjectMetaDropdownHost");
+        const target = event.target;
+        if (host?.contains(target)) return;
+        if (state.anchor && state.anchor.contains(target)) return;
+        closeSituationGridCellDropdown();
+      });
+
+      document.addEventListener("input", (event) => {
+        const metaSearch = event.target.closest("[data-subject-meta-search]");
+        if (metaSearch && ensureSituationGridCellDropdownState().open) {
+          setSharedSubjectMetaDropdownQuery?.(metaSearch.value || "", root);
+          return;
+        }
+        const kanbanSearch = event.target.closest("[data-subject-kanban-search]");
+        if (kanbanSearch && ensureSituationGridCellDropdownState().open) {
+          setSharedSubjectKanbanDropdownQuery?.(kanbanSearch.value || "", root);
+        }
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        if (!ensureSituationGridCellDropdownState().open) return;
+        event.preventDefault();
+        closeSituationGridCellDropdown();
+      });
+    }
   }
 
   async function refreshInsightsData(root) {
@@ -592,6 +834,7 @@ export function createProjectSituationsEvents({
     });
 
     bindSituationGridColumnResize(root);
+    bindSituationGridEditableCells(root);
 
     bindCreateModalEvents(root);
     bindEditPanelEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const eventsSource = fs.readFileSync(path.resolve(__dirname, "./project-situations-events.js"), "utf8");
+
+test("la grille situation ouvre un dropdown éditable ancré aux cellules", () => {
+  assert.match(eventsSource, /openSituationGridCellDropdown\(root, \{ field, anchor: node, subjectId, situationId \}\)/);
+  assert.match(eventsSource, /openSharedSubjectMetaDropdown\?\.\(/);
+  assert.match(eventsSource, /openSharedSubjectKanbanDropdown\?\.\(/);
+  assert.match(eventsSource, /document\.addEventListener\("keydown", \(event\) => \{\s*if \(event\.key !== "Escape"\) return;/s);
+});
+
+test("la mise à jour kanban utilise le service dédié avec rollback local", () => {
+  assert.match(eventsSource, /await setSituationGridKanbanStatus\?\.\(state\.situationId, state\.subjectId, nextStatus\)/);
+  assert.match(eventsSource, /store\.situationsView\.kanbanStatusBySituationId = \{[\s\S]*\[state\.subjectId\]: previousStatus/s);
+  assert.match(eventsSource, /showSituationGridInlineError\(root, error instanceof Error \? error\.message : "La mise à jour du statut kanban a échoué\."\)/);
+});
+
+test("la grille réutilise les actions dropdown mutualisées pour assignés, labels et objectifs", () => {
+  assert.match(eventsSource, /toggleSubjectAssigneeFromSharedDropdown\?\.\(/);
+  assert.match(eventsSource, /toggleSubjectLabelFromSharedDropdown\?\.\(/);
+  assert.match(eventsSource, /toggleSubjectObjectiveFromSharedDropdown\?\.\(/);
+});

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -222,14 +222,38 @@ function renderAssigneesCell(subjectId, rawSubjectsResult = {}, store = {}) {
     ? rawSubjectsResult.assigneePersonIdsBySubjectId
     : {};
   const assigneeIds = Array.isArray(assigneeMap?.[subjectId]) ? assigneeMap[subjectId].map((value) => normalizeId(value)).filter(Boolean) : [];
-  if (!assigneeIds.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!assigneeIds.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="assignees"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les assignés"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const collaboratorsById = new Map(getActiveProjectCollaborators(store).map((item) => [item.id, item]));
   const firstAssignees = assigneeIds.slice(0, 3).map((id) => collaboratorsById.get(id) || { id, name: `Collaborateur ${id.slice(0, 8)}`, avatarUrl: "" });
   const overflowCount = Math.max(0, assigneeIds.length - firstAssignees.length);
 
   return `
-    <span class="situation-grid__assignees" aria-label="${escapeHtml(`${assigneeIds.length} assigné(s)`)}">
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="assignees"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier les assignés"
+    >
+      <span class="situation-grid__assignees" aria-label="${escapeHtml(`${assigneeIds.length} assigné(s)`)}">
       ${firstAssignees.map((assignee) => {
         const initials = String(assignee?.name || "U")
           .split(/\s+/)
@@ -242,13 +266,29 @@ function renderAssigneesCell(subjectId, rawSubjectsResult = {}, store = {}) {
           : `<span class="situation-grid__assignee-avatar situation-grid__assignee-avatar--fallback" aria-hidden="true">${escapeHtml(initials)}</span>`;
       }).join("")}
       ${overflowCount > 0 ? `<span class="situation-grid__assignee-overflow mono">+${overflowCount}</span>` : ""}
-    </span>
+      </span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
   `;
 }
 
 function renderKanbanCell(subjectId, situationId, store) {
   const meta = getKanbanStatusMeta(subjectId, situationId, store);
-  return `<span class="subject-kanban-badge" style="--subject-kanban-badge-bg:${meta.bg};--subject-kanban-badge-border:${meta.border};--subject-kanban-badge-text:${meta.text};">${escapeHtml(meta.label)}</span>`;
+  return `
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="kanban"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      data-situation-grid-situation-id="${escapeHtml(situationId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier le statut kanban"
+    >
+      <span class="subject-kanban-badge" style="--subject-kanban-badge-bg:${meta.bg};--subject-kanban-badge-border:${meta.border};--subject-kanban-badge-text:${meta.text};">${escapeHtml(meta.label)}</span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
+  `;
 }
 
 function renderProgressCell(subject, subjectsById = {}, childrenBySubjectId = {}) {
@@ -267,23 +307,64 @@ function renderLabelsCell(subjectId, rawSubjectsResult = {}) {
   const labelsById = rawSubjectsResult?.labelsById && typeof rawSubjectsResult.labelsById === "object" ? rawSubjectsResult.labelsById : {};
   const labelIdsBySubjectId = rawSubjectsResult?.labelIdsBySubjectId && typeof rawSubjectsResult.labelIdsBySubjectId === "object" ? rawSubjectsResult.labelIdsBySubjectId : {};
   const labelIds = Array.isArray(labelIdsBySubjectId?.[subjectId]) ? labelIdsBySubjectId[subjectId] : [];
-  if (!labelIds.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!labelIds.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="labels"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les labels"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const labels = labelIds
     .map((labelId) => labelsById[normalizeId(labelId)] || null)
     .filter(Boolean);
-  if (!labels.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!labels.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="labels"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les labels"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const visible = labels.slice(0, 2);
   const overflow = Math.max(0, labels.length - visible.length);
   return `
-    <span class="situation-grid__labels">
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="labels"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier les labels"
+    >
+      <span class="situation-grid__labels">
       ${visible.map((label) => {
         const labelName = firstNonEmpty(label?.name, label?.label, label?.key, label?.id, "Label");
         return `<span class="subject-label-badge">${escapeHtml(labelName)}</span>`;
       }).join("")}
       ${overflow > 0 ? `<span class="situation-grid__pill-overflow mono">+${overflow}</span>` : ""}
-    </span>
+      </span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
   `;
 }
 
@@ -291,20 +372,61 @@ function renderObjectivesCell(subjectId, rawSubjectsResult = {}) {
   const objectivesById = rawSubjectsResult?.objectivesById && typeof rawSubjectsResult.objectivesById === "object" ? rawSubjectsResult.objectivesById : {};
   const objectiveIdsBySubjectId = rawSubjectsResult?.objectiveIdsBySubjectId && typeof rawSubjectsResult.objectiveIdsBySubjectId === "object" ? rawSubjectsResult.objectiveIdsBySubjectId : {};
   const objectiveIds = Array.isArray(objectiveIdsBySubjectId?.[subjectId]) ? objectiveIdsBySubjectId[subjectId] : [];
-  if (!objectiveIds.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!objectiveIds.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="objectives"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les objectifs"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const objectives = objectiveIds
     .map((objectiveId) => objectivesById[normalizeId(objectiveId)] || null)
     .filter(Boolean);
-  if (!objectives.length) return "<span class=\"situation-grid__empty-cell\"></span>";
+  if (!objectives.length) {
+    return `
+      <button
+        type="button"
+        class="situation-grid__editable-trigger situation-grid__editable-trigger--empty"
+        data-situation-grid-edit-cell="objectives"
+        data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        title="Modifier les objectifs"
+      >
+        <span class="situation-grid__empty-cell"></span>
+        <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+      </button>
+    `;
+  }
 
   const visible = objectives.slice(0, 1);
   const overflow = Math.max(0, objectives.length - visible.length);
   return `
-    <span class="situation-grid__objectives">
+    <button
+      type="button"
+      class="situation-grid__editable-trigger"
+      data-situation-grid-edit-cell="objectives"
+      data-situation-grid-subject-id="${escapeHtml(subjectId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      title="Modifier les objectifs"
+    >
+      <span class="situation-grid__objectives">
       ${visible.map((objective) => `<span class="situation-grid__objective-pill"><span class="situation-grid__objective-icon" aria-hidden="true">${svgIcon("milestone", { className: "octicon octicon-milestone" })}</span>${escapeHtml(firstNonEmpty(objective?.title, objective?.name, objective?.id, "Objectif"))}</span>`).join("")}
       ${overflow > 0 ? `<span class="situation-grid__pill-overflow mono">+${overflow}</span>` : ""}
-    </span>
+      </span>
+      <span class="situation-grid__editable-caret" aria-hidden="true">${svgIcon("chevron-down", { className: "octicon octicon-chevron-down" })}</span>
+    </button>
   `;
 }
 

--- a/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
@@ -101,6 +101,9 @@ test("renderSituationGridView utilise le statut kanban de la situation et évite
   );
 
   assert.match(html, /En cours/);
+  assert.match(html, /data-situation-grid-edit-cell="kanban"/);
+  assert.match(html, /data-situation-grid-edit-cell="assignees"/);
+  assert.match(html, /situation-grid__editable-caret/);
   assert.doesNotMatch(html, /undefined/);
 });
 

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -954,6 +954,79 @@ export function openSituationDrilldownFromSelection(...args) {
   return projectSubjectDrilldown.openDrilldownFromSituation(...args);
 }
 
+export function openSharedSubjectMetaDropdown({
+  root = document,
+  field = "",
+  subjectId = "",
+  anchor = null,
+  scope = "main",
+  scopeHost = "main",
+  instanceKey = "external",
+  openedFrom = "external"
+} = {}) {
+  const normalizedField = String(field || "").trim();
+  const normalizedSubjectId = String(subjectId || "").trim();
+  if (!normalizedField || !normalizedSubjectId) return false;
+  projectSubjectsView.dropdownController?.openMeta?.({
+    field: normalizedField,
+    scope,
+    scopeHost,
+    subjectId: normalizedSubjectId,
+    anchor,
+    instanceKey,
+    openedFrom
+  });
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
+  return true;
+}
+
+export function openSharedSubjectKanbanDropdown({
+  root = document,
+  subjectId = "",
+  situationId = ""
+} = {}) {
+  const normalizedSubjectId = String(subjectId || "").trim();
+  const normalizedSituationId = String(situationId || "").trim();
+  if (!normalizedSubjectId || !normalizedSituationId) return false;
+  projectSubjectsView.dropdownController?.openKanban?.({
+    subjectId: normalizedSubjectId,
+    situationId: normalizedSituationId
+  });
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
+  return true;
+}
+
+export function closeSharedSubjectDropdowns() {
+  closeSubjectMetaDropdown();
+  closeSubjectKanbanDropdown();
+}
+
+export function setSharedSubjectMetaDropdownQuery(query = "", root = document) {
+  projectSubjectsView.dropdownController?.setMetaQuery?.(query);
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
+}
+
+export function setSharedSubjectKanbanDropdownQuery(query = "", root = document) {
+  projectSubjectsView.dropdownController?.setKanbanQuery?.(query);
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
+}
+
+export function toggleSubjectAssigneeFromSharedDropdown(...args) {
+  return toggleSubjectAssignee(...args);
+}
+
+export function toggleSubjectLabelFromSharedDropdown(...args) {
+  return toggleSubjectLabel(...args);
+}
+
+export function toggleSubjectObjectiveFromSharedDropdown(...args) {
+  return toggleSubjectObjective(...args);
+}
+
 let collaboratorsHydrationInFlight = null;
 
 function ensureSubjectsCollaboratorsLoaded() {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10197,6 +10197,47 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   border-bottom:1px solid var(--borderColor-default, #30363d);
 }
 
+.situation-grid__editable-trigger{
+  width:100%;
+  min-width:0;
+  border:none;
+  background:transparent;
+  color:inherit;
+  padding:0;
+  margin:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  text-align:left;
+}
+
+.situation-grid__editable-trigger:hover .situation-grid__editable-caret,
+.situation-grid__editable-trigger:focus-visible .situation-grid__editable-caret{
+  color:var(--fgColor-default, #e6edf3);
+}
+
+.situation-grid__editable-trigger:focus-visible{
+  outline:1px solid var(--fgColor-accent, #2f81f7);
+  outline-offset:2px;
+  border-radius:6px;
+}
+
+.situation-grid__editable-trigger--empty{
+  min-height:20px;
+}
+
+.situation-grid__editable-caret{
+  display:inline-flex;
+  align-items:center;
+  color:var(--fgColor-muted, #8b949e);
+  flex:0 0 auto;
+}
+
+.situation-grid__inline-error{
+  margin:8px;
+}
+
 .situation-grid__row .situation-grid__cell:last-child,
 .situation-grid__header .situation-grid__head-cell:last-child{
   border-right:none;


### PR DESCRIPTION
### Motivation

- Allow inline editing of subjects inside the situation grid (assignees, labels, objectives and kanban) via reusable dropdown components.  
- Reuse existing shared subject dropdowns and actions so the grid delegates metadata updates to the centralized subject UI.  
- Provide optimistic kanban status updates with local rollback and user-visible inline errors on failure.

### Description

- Add interactive editable triggers in `project-situations-view-grid.js` for `assignees`, `labels`, `objectives` and `kanban` using `data-situation-grid-edit-cell` attributes and visual carets.  
- Implement dropdown state and handlers in `project-situations-events.js`, including `ensureSituationGridCellDropdownState`, `openSituationGridCellDropdown`, `closeSituationGridCellDropdown`, `bindSituationGridEditableCells`, `handleSharedDropdownAction`, `patchSituationGridKanbanCell` and `showSituationGridInlineError`, and wire global click/input/keydown listeners to support anchor-based dropdowns and search input.  
- Expose shared dropdown and toggle APIs from `project-subjects.js`: `openSharedSubjectMetaDropdown`, `openSharedSubjectKanbanDropdown`, `closeSharedSubjectDropdowns`, `setSharedSubjectMetaDropdownQuery`, `setSharedSubjectKanbanDropdownQuery`, `toggleSubjectAssigneeFromSharedDropdown`, `toggleSubjectLabelFromSharedDropdown`, and `toggleSubjectObjectiveFromSharedDropdown`.  
- Add `setSituationGridKanbanStatus` plumbing in `project-situations.js` to call `setSituationSubjectKanbanStatus`, update `store.situationsView.kanbanStatusBySituationId` optimistically and reload on error; wire that into the events module.  
- Add styles in `apps/web/style.css` for `.situation-grid__editable-trigger`, `.situation-grid__editable-caret` and `.situation-grid__inline-error` to support the new interactive elements.  
- Add/adjust unit tests: new `project-situations-grid-dropdown.test.mjs` and updates to `project-situations-view-grid.test.mjs` to assert presence of edit triggers and kanban update flow.

### Testing

- Ran the node test suite with `node --test` covering the modified files and new tests; all tests passed.  
- New test `project-situations-grid-dropdown.test.mjs` validates presence of dropdown wiring and kanban rollback behavior and succeeded.  
- Updated `project-situations-view-grid.test.mjs` assertions for editable triggers and carets succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5634710083298c4b5a41487888da)