### PR TITLE
Corrige mises à jour dropdown grille Situations (kanban / meta)

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -71,6 +71,19 @@ export function createProjectSituationsEvents({
     console.info(`[situation-insights] ${message}`, payload);
   }
 
+  function isSituationGridDropdownDebugEnabled() {
+    try {
+      return window.localStorage?.getItem("debug:situation-grid-dropdown") === "1";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function logSituationGridDropdown(message, payload = {}) {
+    if (!isSituationGridDropdownDebugEnabled()) return;
+    console.info(`[situation-grid-dropdown] ${message}`, payload);
+  }
+
   function resolveCurrentProjectId() {
     return String(
       store?.currentProjectId
@@ -95,6 +108,11 @@ export function createProjectSituationsEvents({
 
   function closeSituationGridCellDropdown() {
     const state = ensureSituationGridCellDropdownState();
+    logSituationGridDropdown("close", {
+      field: state.field,
+      subjectId: state.subjectId,
+      situationId: state.situationId
+    });
     if (state.anchor?.setAttribute) state.anchor.setAttribute("aria-expanded", "false");
     state.open = false;
     state.field = "";
@@ -102,6 +120,21 @@ export function createProjectSituationsEvents({
     state.situationId = "";
     state.anchor = null;
     closeSharedSubjectDropdowns?.();
+  }
+
+  function setSituationGridDropdownRoot(root) {
+    if (uiState && typeof uiState === "object") {
+      uiState.situationGridDropdownRoot = root || null;
+    }
+  }
+
+  function resolveSituationGridDropdownRoot() {
+    if (uiState?.situationGridDropdownRoot?.isConnected) return uiState.situationGridDropdownRoot;
+    const state = ensureSituationGridCellDropdownState();
+    if (state.anchor?.isConnected) {
+      return state.anchor.closest(".project-shell__content") || state.anchor.ownerDocument?.querySelector?.(".project-shell__content") || document;
+    }
+    return document.querySelector(".project-shell__content") || document;
   }
 
   function openSituationGridCellDropdown(root, { field = "", anchor = null, subjectId = "", situationId = "" } = {}) {
@@ -114,6 +147,11 @@ export function createProjectSituationsEvents({
     state.situationId = String(situationId || "").trim();
     state.anchor = anchor;
     anchor.setAttribute("aria-expanded", "true");
+    logSituationGridDropdown("open", {
+      field: state.field,
+      subjectId: state.subjectId,
+      situationId: state.situationId
+    });
     if (state.field === "kanban") {
       const opened = openSharedSubjectKanbanDropdown?.({
         root,
@@ -187,21 +225,27 @@ export function createProjectSituationsEvents({
     if (actionNode.matches("[data-subject-assignee-toggle]")) {
       const assigneeId = normalizeGridDropdownTogglePayload(actionNode, "data-subject-assignee-toggle");
       if (!assigneeId) return true;
-      await toggleSubjectAssigneeFromSharedDropdown?.(subjectId, assigneeId, { rerender: false });
+      logSituationGridDropdown("item-click", { type: "assignee", subjectId, situationId: state.situationId, value: assigneeId });
+      logSituationGridDropdown("supabase:before-mutation", { type: "assignee", subjectId, situationId: state.situationId, value: assigneeId });
+      await toggleSubjectAssigneeFromSharedDropdown?.(subjectId, assigneeId, { root, skipRerender: true });
       rerender(root);
       return true;
     }
     if (actionNode.matches("[data-subject-label-toggle]")) {
       const labelKey = normalizeGridDropdownTogglePayload(actionNode, "data-subject-label-toggle");
       if (!labelKey) return true;
-      await toggleSubjectLabelFromSharedDropdown?.(subjectId, labelKey, { rerender: false });
+      logSituationGridDropdown("item-click", { type: "label", subjectId, situationId: state.situationId, value: labelKey });
+      logSituationGridDropdown("supabase:before-mutation", { type: "label", subjectId, situationId: state.situationId, value: labelKey });
+      await toggleSubjectLabelFromSharedDropdown?.(subjectId, labelKey, { root, skipRerender: true });
       rerender(root);
       return true;
     }
     if (actionNode.matches("[data-objective-select]")) {
       const objectiveId = normalizeGridDropdownTogglePayload(actionNode, "data-objective-select");
       if (!objectiveId) return true;
-      await toggleSubjectObjectiveFromSharedDropdown?.(subjectId, objectiveId, { rerender: false });
+      logSituationGridDropdown("item-click", { type: "objective", subjectId, situationId: state.situationId, value: objectiveId });
+      logSituationGridDropdown("supabase:before-mutation", { type: "objective", subjectId, situationId: state.situationId, value: objectiveId });
+      await toggleSubjectObjectiveFromSharedDropdown?.(subjectId, objectiveId, { root, skipRerender: true });
       rerender(root);
       return true;
     }
@@ -313,6 +357,7 @@ export function createProjectSituationsEvents({
   }
 
   function bindSituationGridEditableCells(root) {
+    setSituationGridDropdownRoot(root);
     root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
       node.addEventListener("click", (event) => {
         event.preventDefault();
@@ -339,6 +384,7 @@ export function createProjectSituationsEvents({
       document.addEventListener("click", async (event) => {
         const eventTarget = event.target instanceof Element ? event.target : null;
         if (!eventTarget) return;
+        const root = resolveSituationGridDropdownRoot();
         const actionNode = eventTarget.closest(
           "[data-subject-kanban-select],[data-subject-assignee-toggle],[data-subject-label-toggle],[data-objective-select]"
         );
@@ -346,33 +392,39 @@ export function createProjectSituationsEvents({
           const state = ensureSituationGridCellDropdownState();
           if (!state.open) return;
           if (actionNode.matches("[data-subject-kanban-select]")) {
+            const subjectId = String(state.subjectId || "").trim();
+            const situationId = String(state.situationId || "").trim();
             const nextStatus = String(actionNode.getAttribute("data-subject-kanban-select") || "").trim();
-            const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[state.situationId]?.[state.subjectId] || "non_active").trim().toLowerCase();
-            if (!nextStatus || nextStatus === previousStatus) {
+            const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+            logSituationGridDropdown("item-click", { type: "kanban", subjectId, situationId, value: nextStatus });
+            if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
               closeSituationGridCellDropdown();
               return;
             }
             if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
             store.situationsView.kanbanStatusBySituationId = {
               ...(store.situationsView.kanbanStatusBySituationId || {}),
-              [state.situationId]: {
-                ...((store.situationsView.kanbanStatusBySituationId || {})[state.situationId] || {}),
-                [state.subjectId]: nextStatus
+              [situationId]: {
+                ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+                [subjectId]: nextStatus
               }
             };
-            patchSituationGridKanbanCell({ root, subjectId: state.subjectId, situationId: state.situationId });
+            patchSituationGridKanbanCell({ root, subjectId, situationId });
             closeSituationGridCellDropdown();
             try {
-              await setSituationGridKanbanStatus?.(state.situationId, state.subjectId, nextStatus);
+              logSituationGridDropdown("supabase:before-mutation", { type: "kanban", subjectId, situationId, value: nextStatus });
+              await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
+              logSituationGridDropdown("supabase:success", { type: "kanban", subjectId, situationId, value: nextStatus });
             } catch (error) {
               store.situationsView.kanbanStatusBySituationId = {
                 ...(store.situationsView.kanbanStatusBySituationId || {}),
-                [state.situationId]: {
-                  ...((store.situationsView.kanbanStatusBySituationId || {})[state.situationId] || {}),
-                  [state.subjectId]: previousStatus
+                [situationId]: {
+                  ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+                  [subjectId]: previousStatus
                 }
               };
-              patchSituationGridKanbanCell({ root, subjectId: state.subjectId, situationId: state.situationId });
+              patchSituationGridKanbanCell({ root, subjectId, situationId });
+              logSituationGridDropdown("supabase:rollback", { type: "kanban", subjectId, situationId, value: previousStatus });
               console.error("situation grid kanban update failed", error);
               showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
             }
@@ -381,6 +433,7 @@ export function createProjectSituationsEvents({
 
           try {
             await handleSharedDropdownAction(root, actionNode);
+            logSituationGridDropdown("supabase:success", { type: "shared", subjectId: ensureSituationGridCellDropdownState().subjectId, situationId: ensureSituationGridCellDropdownState().situationId });
           } catch (error) {
             console.error("situation grid shared dropdown action failed", error);
             showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour a échoué.");
@@ -401,6 +454,7 @@ export function createProjectSituationsEvents({
       document.addEventListener("input", (event) => {
         const eventTarget = event.target instanceof Element ? event.target : null;
         if (!eventTarget) return;
+        const root = resolveSituationGridDropdownRoot();
         const metaSearch = eventTarget.closest("[data-subject-meta-search]");
         if (metaSearch && ensureSituationGridCellDropdownState().open) {
           setSharedSubjectMetaDropdownQuery?.(metaSearch.value || "", root);

--- a/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
@@ -13,19 +13,21 @@ test("la grille situation ouvre un dropdown éditable ancré aux cellules", () =
   assert.match(eventsSource, /openSharedSubjectMetaDropdown\?\.\(/);
   assert.match(eventsSource, /openSharedSubjectKanbanDropdown\?\.\(/);
   assert.match(eventsSource, /const eventTarget = event\.target instanceof Element \? event\.target : null;/);
-  assert.match(eventsSource, /document\.addEventListener\(\"pointerdown\", \(event\) => \{/);
+  assert.match(eventsSource, /document\.addEventListener\("pointerdown", \(event\) => \{/);
   assert.match(eventsSource, /document\.addEventListener\("keydown", \(event\) => \{\s*if \(event\.key !== "Escape"\) return;/s);
 });
 
-test("la mise à jour kanban utilise le service dédié avec rollback local", () => {
-  assert.match(eventsSource, /await setSituationGridKanbanStatus\?\.\(state\.situationId, state\.subjectId, nextStatus\)/);
-  assert.match(eventsSource, /store\.situationsView\.kanbanStatusBySituationId = \{[\s\S]*\[state\.subjectId\]: previousStatus/s);
-  assert.match(eventsSource, /showSituationGridInlineError\(root, error instanceof Error \? error\.message : "La mise à jour du statut kanban a échoué\."\)/);
+test("la mise à jour kanban snapshot les ids avant fermeture et rollback avec ces constantes", () => {
+  assert.match(eventsSource, /const subjectId = String\(state\.subjectId \|\| ""\)\.trim\(\);/);
+  assert.match(eventsSource, /const situationId = String\(state\.situationId \|\| ""\)\.trim\(\);/);
+  assert.match(eventsSource, /closeSituationGridCellDropdown\(\);\s*try \{\s*[\s\S]*await setSituationGridKanbanStatus\?\.\(situationId, subjectId, nextStatus\);/s);
+  assert.match(eventsSource, /\[situationId\]: \{[\s\S]*\[subjectId\]: previousStatus/s);
+  assert.match(eventsSource, /patchSituationGridKanbanCell\(\{ root, subjectId, situationId \}\);/);
 });
 
-test("la grille réutilise les actions dropdown mutualisées pour assignés, labels et objectifs", () => {
-  assert.match(eventsSource, /toggleSubjectAssigneeFromSharedDropdown\?\.\(/);
-  assert.match(eventsSource, /toggleSubjectLabelFromSharedDropdown\?\.\(/);
-  assert.match(eventsSource, /toggleSubjectObjectiveFromSharedDropdown\?\.\(/);
-  assert.match(eventsSource, /data-objective-select/);
+test("les actions assignés labels objectifs utilisent skipRerender true et rerender de la grille", () => {
+  assert.match(eventsSource, /toggleSubjectAssigneeFromSharedDropdown\?\.\(subjectId, assigneeId, \{ root, skipRerender: true \}\);/);
+  assert.match(eventsSource, /toggleSubjectLabelFromSharedDropdown\?\.\(subjectId, labelKey, \{ root, skipRerender: true \}\);/);
+  assert.match(eventsSource, /toggleSubjectObjectiveFromSharedDropdown\?\.\(subjectId, objectiveId, \{ root, skipRerender: true \}\);/);
+  assert.match(eventsSource, /await toggleSubjectObjectiveFromSharedDropdown\?\.\([\s\S]*\);\s*rerender\(root\);/s);
 });


### PR DESCRIPTION
### Motivation
- Corriger un bug où la sélection dans les dropdowns de la grille Situations n’appliquait pas correctement la mise à jour (optimistic update / appel Supabase / rollback) à cause d’un vidage de `uiState` lors de la fermeture du dropdown.
- Éviter les rerenders globaux inutiles lors d’actions `assignees`/`labels`/`objectives` et rendre le binding global des dropdowns robuste après rerender.

### Description
- Snapshot immuable des ids avant fermeture : la branche `data-subject-kanban-select` prend désormais des constantes `subjectId` et `situationId` (issues de `state`) AVANT d’appeler `closeSituationGridCellDropdown()` et utilise ces constantes pour l’optimistic update, l’appel `setSituationGridKanbanStatus(...)` et le rollback local en cas d’erreur.
- Options pour actions mutualisées : les appels à `toggleSubjectAssigneeFromSharedDropdown`, `toggleSubjectLabelFromSharedDropdown` et `toggleSubjectObjectiveFromSharedDropdown` utilisent maintenant `{ root, skipRerender: true }` au lieu de `{ rerender: false }`, puis on appelle un `rerender(root)` ciblé pour rafraîchir la grille.
- Robustesse du root actif : ajout de `setSituationGridDropdownRoot` et `resolveSituationGridDropdownRoot` et utilisation de la racine résolue par les handlers globaux (`click`/`input`) pour éviter l’utilisation d’un `root` périmé après rerender.
- Instrumentation temporaire : ajout d’un flag debug activable via `localStorage.setItem("debug:situation-grid-dropdown","1")` et de logs limités (ouverture, clic item, avant mutation, succès, rollback, fermeture) activés seulement si le flag est présent.
- Tests renforcés : mise à jour de `apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs` pour vérifier le snapshot des ids kanban avant fermeture, l’usage des constantes pour l’appel/rollback et l’utilisation de `skipRerender: true` pour les actions meta.
- Fichiers modifiés : `apps/web/js/views/project-situations/project-situations-events.js` et `apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs`.

### Testing
- Test exécuté : `node --test apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs`.
- Résultat : la suite de tests exécutée localement a passé avec succès (3 tests OK).
- Aucune autre suite automatisée n’a été modifiée dans cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec64eb499c83299e98ccfd5f6bfb36)