### PR TITLE
Corrige l’arbitrage et la fermeture des dropdowns inline de la grille Situations

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -84,6 +84,31 @@ export function createProjectSituationsEvents({
     console.info(`[situation-grid-dropdown] ${message}`, payload);
   }
 
+  function getSharedDropdownDebugMeta() {
+    const dropdown = store?.projectSubjectsView?.subjectMetaDropdown || {};
+    return {
+      openedFrom: String(dropdown?.openedFrom || ""),
+      metaScope: String(dropdown?.scope || "")
+    };
+  }
+
+  function buildSituationGridDropdownDebugPayload({
+    field = "",
+    subjectId = "",
+    situationId = "",
+    value = "",
+    event = null
+  } = {}) {
+    return {
+      field,
+      subjectId,
+      situationId,
+      value,
+      target: event?.target?.outerHTML?.slice?.(0, 200) || "",
+      ...getSharedDropdownDebugMeta()
+    };
+  }
+
   function resolveCurrentProjectId() {
     return String(
       store?.currentProjectId
@@ -108,11 +133,11 @@ export function createProjectSituationsEvents({
 
   function closeSituationGridCellDropdown() {
     const state = ensureSituationGridCellDropdownState();
-    logSituationGridDropdown("close", {
+    logSituationGridDropdown("close", buildSituationGridDropdownDebugPayload({
       field: state.field,
       subjectId: state.subjectId,
       situationId: state.situationId
-    });
+    }));
     if (state.anchor?.setAttribute) state.anchor.setAttribute("aria-expanded", "false");
     state.open = false;
     state.field = "";
@@ -147,11 +172,11 @@ export function createProjectSituationsEvents({
     state.situationId = String(situationId || "").trim();
     state.anchor = anchor;
     anchor.setAttribute("aria-expanded", "true");
-    logSituationGridDropdown("open", {
+    logSituationGridDropdown("open", buildSituationGridDropdownDebugPayload({
       field: state.field,
       subjectId: state.subjectId,
       situationId: state.situationId
-    });
+    }));
     if (state.field === "kanban") {
       const opened = openSharedSubjectKanbanDropdown?.({
         root,
@@ -218,7 +243,7 @@ export function createProjectSituationsEvents({
     return String(actionNode?.getAttribute(attrName) || "").trim();
   }
 
-  async function handleSharedDropdownAction(root, actionNode) {
+  async function handleSharedDropdownAction(root, actionNode, event = null) {
     const state = ensureSituationGridCellDropdownState();
     const subjectId = String(state.subjectId || actionNode?.getAttribute("data-subject-id") || "").trim();
     const situationId = String(state.situationId || actionNode?.getAttribute("data-situation-id") || "").trim();
@@ -243,28 +268,27 @@ export function createProjectSituationsEvents({
       action = toggleSubjectObjectiveFromSharedDropdown;
     }
     if (!actionType) return false;
-    logSituationGridDropdown("item-click", { field, type: actionType, subjectId, situationId, value });
     closeSituationGridCellDropdown();
     if (!value) return true;
 
-    logSituationGridDropdown("shared-action:start", { field, type: actionType, subjectId, situationId, value });
+    const payload = {
+      ...buildSituationGridDropdownDebugPayload({ field, subjectId, situationId, value, event }),
+      type: actionType
+    };
+    logSituationGridDropdown("shared-action:start", payload);
     try {
       const success = await action?.(subjectId, value, { root, skipRerender: true });
       if (success === true) {
-        logSituationGridDropdown("shared-action:success", { field, type: actionType, subjectId, situationId, value });
+        logSituationGridDropdown("shared-action:success", payload);
         rerender(root);
         return true;
       }
-      logSituationGridDropdown("shared-action:false-result", { field, type: actionType, subjectId, situationId, value });
+      logSituationGridDropdown("shared-action:false-result", payload);
       showSituationGridInlineError(root, "La mise à jour a échoué.");
       return false;
     } catch (error) {
       logSituationGridDropdown("shared-action:error", {
-        field,
-        type: actionType,
-        subjectId,
-        situationId,
-        value,
+        ...payload,
         message: error instanceof Error ? error.message : String(error || "")
       });
       throw error;
@@ -375,6 +399,51 @@ export function createProjectSituationsEvents({
     });
   }
 
+  async function handleSituationGridKanbanAction(root, actionNode, event = null) {
+    const state = ensureSituationGridCellDropdownState();
+    const field = String(state.field || "").trim().toLowerCase();
+    const subjectId = String(state.subjectId || "").trim();
+    const situationId = String(state.situationId || "").trim();
+    const nextStatus = String(actionNode?.getAttribute("data-subject-kanban-select") || "").trim().toLowerCase();
+    const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+    const payload = buildSituationGridDropdownDebugPayload({ field, subjectId, situationId, value: nextStatus, event });
+    if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
+      closeSituationGridCellDropdown();
+      return;
+    }
+
+    if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+    store.situationsView.kanbanStatusBySituationId = {
+      ...(store.situationsView.kanbanStatusBySituationId || {}),
+      [situationId]: {
+        ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+        [subjectId]: nextStatus
+      }
+    };
+    patchSituationGridKanbanCell({ root, subjectId, situationId });
+    closeSituationGridCellDropdown();
+    try {
+      logSituationGridDropdown("kanban-action:start", payload);
+      await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
+      logSituationGridDropdown("kanban-action:success", payload);
+    } catch (error) {
+      store.situationsView.kanbanStatusBySituationId = {
+        ...(store.situationsView.kanbanStatusBySituationId || {}),
+        [situationId]: {
+          ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+          [subjectId]: previousStatus
+        }
+      };
+      patchSituationGridKanbanCell({ root, subjectId, situationId });
+      logSituationGridDropdown("kanban-action:error", {
+        ...payload,
+        message: error instanceof Error ? error.message : String(error || "")
+      });
+      console.error("situation grid kanban update failed", error);
+      showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
+    }
+  }
+
   function bindSituationGridEditableCells(root) {
     setSituationGridDropdownRoot(root);
     root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
@@ -403,7 +472,8 @@ export function createProjectSituationsEvents({
 
     const shouldIgnoreOutsideClose = (eventTarget, state) => {
       const host = document.getElementById("subjectMetaDropdownHost");
-      if (host?.contains(eventTarget)) return true;
+      const hostDropdown = host?.querySelector?.(".subject-meta-dropdown");
+      if (hostDropdown?.contains(eventTarget)) return true;
       if (state.anchor && (state.anchor === eventTarget || state.anchor.contains(eventTarget))) return true;
       return false;
     };
@@ -418,46 +488,31 @@ export function createProjectSituationsEvents({
       if (actionNode) {
         const state = ensureSituationGridCellDropdownState();
         if (!state.open) return;
-        if (actionNode.matches("[data-subject-kanban-select]")) {
+        event.preventDefault();
+        event.stopPropagation();
+        try {
           const field = String(state.field || "").trim().toLowerCase();
           const subjectId = String(state.subjectId || "").trim();
           const situationId = String(state.situationId || "").trim();
-          const nextStatus = String(actionNode.getAttribute("data-subject-kanban-select") || "").trim();
-          const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
-          logSituationGridDropdown("item-click", { field, type: "kanban", subjectId, situationId, value: nextStatus });
-          if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
-            closeSituationGridCellDropdown();
+          const value = String(
+            actionNode.getAttribute("data-subject-kanban-select")
+            || actionNode.getAttribute("data-subject-assignee-toggle")
+            || actionNode.getAttribute("data-subject-label-toggle")
+            || actionNode.getAttribute("data-objective-select")
+            || ""
+          ).trim();
+          logSituationGridDropdown("host-capture:item-click", buildSituationGridDropdownDebugPayload({
+            field,
+            subjectId,
+            situationId,
+            value,
+            event
+          }));
+          if (actionNode.matches("[data-subject-kanban-select]")) {
+            await handleSituationGridKanbanAction(root, actionNode, event);
             return;
           }
-          if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
-          store.situationsView.kanbanStatusBySituationId = {
-            ...(store.situationsView.kanbanStatusBySituationId || {}),
-            [situationId]: {
-              ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
-              [subjectId]: nextStatus
-            }
-          };
-          patchSituationGridKanbanCell({ root, subjectId, situationId });
-          closeSituationGridCellDropdown();
-          try {
-            await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
-          } catch (error) {
-            store.situationsView.kanbanStatusBySituationId = {
-              ...(store.situationsView.kanbanStatusBySituationId || {}),
-              [situationId]: {
-                ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
-                [subjectId]: previousStatus
-              }
-            };
-            patchSituationGridKanbanCell({ root, subjectId, situationId });
-            console.error("situation grid kanban update failed", error);
-            showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
-          }
-          return;
-        }
-
-        try {
-          await handleSharedDropdownAction(root, actionNode);
+          await handleSharedDropdownAction(root, actionNode, event);
         } catch (error) {
           console.error("situation grid shared dropdown action failed", error);
           showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour a échoué.");
@@ -468,13 +523,14 @@ export function createProjectSituationsEvents({
       const state = ensureSituationGridCellDropdownState();
       if (!state.open) return;
       if (shouldIgnoreOutsideClose(eventTarget, state)) return;
-      logSituationGridDropdown("outside-click-close", {
+      logSituationGridDropdown("outside-click-close", buildSituationGridDropdownDebugPayload({
         field: state.field,
         subjectId: state.subjectId,
-        situationId: state.situationId
-      });
+        situationId: state.situationId,
+        event
+      }));
       closeSituationGridCellDropdown();
-    }, { signal });
+    }, { capture: true, signal });
 
     document.addEventListener("input", (event) => {
       const eventTarget = event.target instanceof Element ? event.target : null;
@@ -505,11 +561,12 @@ export function createProjectSituationsEvents({
       const state = ensureSituationGridCellDropdownState();
       if (!state.open) return;
       if (shouldIgnoreOutsideClose(eventTarget, state)) return;
-      logSituationGridDropdown("outside-pointerdown-close", {
+      logSituationGridDropdown("outside-pointerdown-close", buildSituationGridDropdownDebugPayload({
         field: state.field,
         subjectId: state.subjectId,
-        situationId: state.situationId
-      });
+        situationId: state.situationId,
+        event
+      }));
       closeSituationGridCellDropdown();
     }, { capture: true, signal });
   }

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -358,6 +358,22 @@ export function createProjectSubjectsEvents(config) {
     const toggleSubjectBlockingForRelation = getToggleSubjectBlockingForRelation?.();
     const reorderSubjectChildren = getReorderSubjectChildren?.();
 
+    function isSituationGridOwnedDropdown() {
+      const dropdown = getSubjectsViewState()?.subjectMetaDropdown || {};
+      const openedFrom = String(dropdown.openedFrom || "").trim().toLowerCase();
+      const scope = String(dropdown.scope || "").trim().toLowerCase();
+      return openedFrom === "situation-grid" || scope === "situation-grid";
+    }
+
+    function logSituationGridGenericSkip() {
+      try {
+        if (window.localStorage?.getItem("debug:situation-grid-dropdown") !== "1") return;
+      } catch (_) {
+        return;
+      }
+      console.info("[subject-meta-dropdown] skip generic handler for situation-grid.");
+    }
+
     dropdownHost.querySelectorAll("[data-subject-kanban-search]").forEach((input) => {
       input.oninput = () => {
         const subjectId = String(input.dataset.subjectKanbanSearch || "");
@@ -493,6 +509,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-objective-select]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -515,6 +535,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-label-toggle]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -526,6 +550,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-assignee-toggle]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -742,6 +770,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-kanban-select]").forEach((btn) => {
       btn.onclick = (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const subjectId = String(btn.dataset.subjectKanbanSubjectId || "");


### PR DESCRIPTION
### Motivation
- Résoudre les collisions d’événements entre le dropdown partagé `#subjectMetaDropdownHost` (module Subjects) et les dropdowns inline de la grille Situations qui empêchaient la sélection d’items et la fermeture correcte.

### Description
- Interception en phase capture des clics d’items partagés (`[data-subject-kanban-select]`, `[data-subject-assignee-toggle]`, `[data-subject-label-toggle]`, `[data-objective-select]`) depuis la grille Situations et routage vers la logique spécifique à la grille pour traitement (snapshot contexte, update optimiste, fermeture, persistance, rollback en erreur). (F: `apps/web/js/views/project-situations/project-situations-events.js`)
- Ajout d’un handler dédié pour l’action Kanban en grille (`handleSituationGridKanbanAction`) qui fait snapshot de `subjectId`/`situationId`, met à jour l’UI de manière optimiste, ferme le dropdown, appelle la persistance (`setSituationGridKanbanStatus`) et effectue le rollback + message d’erreur inline si nécessaire. (F: `project-situations-events.js`)
- Ajustement de la logique de fermeture extérieure pour ne considérer comme « intérieur » que le contenu `.subject-meta-dropdown` et l’ancre active, et fermer proprement via `closeSituationGridCellDropdown()` (qui ferme aussi les dropdowns partagés et remet `aria-expanded=false`). (F: `project-situations-events.js`)
- Modification des handlers génériques Subjects pour ignorer volontairement les clics quand `subjectMetaDropdown.openedFrom === "situation-grid"` ou `scope === "situation-grid"`, afin de laisser la logique Situations gérer ces interactions et éviter la consommation prématurée des événements; ajout d’un log ciblé lors du skip. (F: `apps/web/js/views/project-subjects/project-subjects-events.js`)
- Ajout d’une instrumentation debug activable via `localStorage.setItem("debug:situation-grid-dropdown", "1")` et logs structurés (`open`, `host-capture:item-click`, `shared-action:*`, `kanban-action:*`, `outside-pointerdown-close`, `close`) contenant `field`, `subjectId`, `situationId`, `value`, `target`, `openedFrom`, `metaScope`. (F: `project-situations-events.js`)

### Testing
- Exécuté: `node apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs` et tous les tests du fichier sont passés (4/4). 
- Tests automatisés couvés: ouverture du dropdown ancré aux cellules, snapshot/rollback du Kanban, actions partagées avec `skipRerender:true` et `rerender(root)` conditionnel, fermeture extérieure via `closeSituationGridCellDropdown()` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecab8b21248329a09aa9aa818fbb00)