### PR TITLE
Add subject-assignee create/delete, route kanban actions, and enhance situation-grid dropdown logging/handling

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1124,6 +1124,64 @@ export async function replaceSubjectAssignees(subjectId, personIds = []) {
   return uniquePersonIds;
 }
 
+export async function addSubjectAssignee(subjectId, personId) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  const normalizedPersonId = normalizeUuid(personId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  if (!normalizedPersonId) throw new Error("personId is required");
+
+  const projectId = await fetchSubjectProjectId(normalizedSubjectId);
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);
+  url.searchParams.set("on_conflict", "subject_id,person_id");
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates,return=representation"
+    }),
+    body: JSON.stringify({
+      project_id: projectId,
+      subject_id: normalizedSubjectId,
+      person_id: normalizedPersonId
+    })
+  });
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`subject_assignee create failed (${res.status}): ${txt}`);
+  }
+
+  return true;
+}
+
+export async function removeSubjectAssignee(subjectId, personId) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  const normalizedPersonId = normalizeUuid(personId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  if (!normalizedPersonId) throw new Error("personId is required");
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);
+  url.searchParams.set("subject_id", `eq.${normalizedSubjectId}`);
+  url.searchParams.set("person_id", `eq.${normalizedPersonId}`);
+
+  const res = await fetch(url.toString(), {
+    method: "DELETE",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      Prefer: "return=minimal"
+    })
+  });
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`subject_assignee delete failed (${res.status}): ${txt}`);
+  }
+
+  return true;
+}
+
 export async function replaceSubjectLabels(subjectId, labelIds = []) {
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -73,7 +73,9 @@ export function createProjectSituationsEvents({
 
   function isSituationGridDropdownDebugEnabled() {
     try {
-      return window.localStorage?.getItem("debug:situation-grid-dropdown") === "1";
+      const storageValue = String(window.localStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      const sessionValue = String(window.sessionStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      return storageValue === "1" || storageValue === "true" || sessionValue === "1" || sessionValue === "true";
     } catch (_) {
       return false;
     }
@@ -82,6 +84,36 @@ export function createProjectSituationsEvents({
   function logSituationGridDropdown(message, payload = {}) {
     if (!isSituationGridDropdownDebugEnabled()) return;
     console.info(`[situation-grid-dropdown] ${message}`, payload);
+  }
+
+  function logSituationGridSupabaseMutation(payload = {}) {
+    if (!isSituationGridDropdownDebugEnabled()) return;
+    console.info("[situation-grid-dropdown] supabase-mutation", payload);
+  }
+
+  function getSharedDropdownDebugMeta() {
+    const dropdown = store?.projectSubjectsView?.subjectMetaDropdown || {};
+    return {
+      openedFrom: String(dropdown?.openedFrom || ""),
+      metaScope: String(dropdown?.scope || "")
+    };
+  }
+
+  function buildSituationGridDropdownDebugPayload({
+    field = "",
+    subjectId = "",
+    situationId = "",
+    value = "",
+    event = null
+  } = {}) {
+    return {
+      field,
+      subjectId,
+      situationId,
+      value,
+      target: event?.target?.outerHTML?.slice?.(0, 200) || "",
+      ...getSharedDropdownDebugMeta()
+    };
   }
 
   function resolveCurrentProjectId() {
@@ -108,11 +140,13 @@ export function createProjectSituationsEvents({
 
   function closeSituationGridCellDropdown() {
     const state = ensureSituationGridCellDropdownState();
-    logSituationGridDropdown("close", {
+    const host = document.getElementById("subjectMetaDropdownHost");
+    if (host?.dataset) delete host.dataset.situationGridOwned;
+    logSituationGridDropdown("close", buildSituationGridDropdownDebugPayload({
       field: state.field,
       subjectId: state.subjectId,
       situationId: state.situationId
-    });
+    }));
     if (state.anchor?.setAttribute) state.anchor.setAttribute("aria-expanded", "false");
     state.open = false;
     state.field = "";
@@ -140,18 +174,20 @@ export function createProjectSituationsEvents({
   function openSituationGridCellDropdown(root, { field = "", anchor = null, subjectId = "", situationId = "" } = {}) {
     if (!anchor) return;
     const state = ensureSituationGridCellDropdownState();
+    const host = document.getElementById("subjectMetaDropdownHost");
     closeSituationGridCellDropdown();
     state.open = true;
     state.field = String(field || "").trim().toLowerCase();
     state.subjectId = String(subjectId || "").trim();
     state.situationId = String(situationId || "").trim();
     state.anchor = anchor;
+    if (host?.dataset) host.dataset.situationGridOwned = "1";
     anchor.setAttribute("aria-expanded", "true");
-    logSituationGridDropdown("open", {
+    logSituationGridDropdown("open", buildSituationGridDropdownDebugPayload({
       field: state.field,
       subjectId: state.subjectId,
       situationId: state.situationId
-    });
+    }));
     if (state.field === "kanban") {
       const opened = openSharedSubjectKanbanDropdown?.({
         root,
@@ -218,7 +254,7 @@ export function createProjectSituationsEvents({
     return String(actionNode?.getAttribute(attrName) || "").trim();
   }
 
-  async function handleSharedDropdownAction(root, actionNode) {
+  async function handleSharedDropdownAction(root, actionNode, event = null) {
     const state = ensureSituationGridCellDropdownState();
     const subjectId = String(state.subjectId || actionNode?.getAttribute("data-subject-id") || "").trim();
     const situationId = String(state.situationId || actionNode?.getAttribute("data-situation-id") || "").trim();
@@ -243,28 +279,62 @@ export function createProjectSituationsEvents({
       action = toggleSubjectObjectiveFromSharedDropdown;
     }
     if (!actionType) return false;
-    logSituationGridDropdown("item-click", { field, type: actionType, subjectId, situationId, value });
     closeSituationGridCellDropdown();
     if (!value) return true;
 
-    logSituationGridDropdown("shared-action:start", { field, type: actionType, subjectId, situationId, value });
+    const payload = {
+      ...buildSituationGridDropdownDebugPayload({ field, subjectId, situationId, value, event }),
+      type: actionType
+    };
+    logSituationGridDropdown("shared-action:start", payload);
+    logSituationGridSupabaseMutation({
+      action: actionType === "assignee"
+        ? "assignee:toggle"
+        : actionType === "label"
+          ? "label:toggle"
+          : "objective:toggle",
+      field,
+      subjectId,
+      situationId,
+      value,
+      method: actionType === "objective"
+        ? "POST|DELETE"
+        : actionType === "assignee"
+          ? "POST|DELETE"
+          : "POST|DELETE",
+      endpoint: actionType === "objective"
+        ? "/rest/v1/milestone_subjects"
+        : actionType === "assignee"
+          ? "/rest/v1/subject_assignees"
+          : "/rest/v1/subject_labels",
+      payload: actionType === "objective"
+        ? {
+            milestone_id: value,
+            subject_id: subjectId
+          }
+        : actionType === "assignee"
+          ? {
+              person_id: value,
+              subject_id: subjectId
+            }
+          : {
+              label_id: value,
+              subject_id: subjectId
+            }
+    });
     try {
       const success = await action?.(subjectId, value, { root, skipRerender: true });
       if (success === true) {
-        logSituationGridDropdown("shared-action:success", { field, type: actionType, subjectId, situationId, value });
+        logSituationGridDropdown("shared-action:success", payload);
         rerender(root);
         return true;
       }
-      logSituationGridDropdown("shared-action:false-result", { field, type: actionType, subjectId, situationId, value });
+      logSituationGridDropdown("shared-action:false-result", payload);
       showSituationGridInlineError(root, "La mise à jour a échoué.");
       return false;
     } catch (error) {
       logSituationGridDropdown("shared-action:error", {
-        field,
-        type: actionType,
-        subjectId,
-        situationId,
-        value,
+        ...payload,
         message: error instanceof Error ? error.message : String(error || "")
       });
       throw error;
@@ -375,6 +445,69 @@ export function createProjectSituationsEvents({
     });
   }
 
+  async function handleSituationGridKanbanAction(root, actionNode, event = null) {
+    const state = ensureSituationGridCellDropdownState();
+    const field = String(state.field || "").trim().toLowerCase();
+    const subjectId = String(state.subjectId || "").trim();
+    const situationId = String(state.situationId || "").trim();
+    const nextStatus = String(actionNode?.getAttribute("data-subject-kanban-select") || "").trim().toLowerCase();
+    const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+    const payload = buildSituationGridDropdownDebugPayload({ field, subjectId, situationId, value: nextStatus, event });
+    if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
+      closeSituationGridCellDropdown();
+      return;
+    }
+
+    if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+    store.situationsView.kanbanStatusBySituationId = {
+      ...(store.situationsView.kanbanStatusBySituationId || {}),
+      [situationId]: {
+        ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+        [subjectId]: nextStatus
+      }
+    };
+    patchSituationGridKanbanCell({ root, subjectId, situationId });
+    closeSituationGridCellDropdown();
+    try {
+      logSituationGridDropdown("kanban-action:start", payload);
+      logSituationGridSupabaseMutation({
+        action: "kanban:update",
+        field: "kanban",
+        subjectId,
+        situationId,
+        value: nextStatus,
+        method: "PATCH",
+        endpoint: "/rest/v1/situation_subjects",
+        payload: {
+          where: {
+            situation_id: `eq.${situationId}`,
+            subject_id: `eq.${subjectId}`
+          },
+          body: {
+            kanban_status: nextStatus
+          }
+        }
+      });
+      await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
+      logSituationGridDropdown("kanban-action:success", payload);
+    } catch (error) {
+      store.situationsView.kanbanStatusBySituationId = {
+        ...(store.situationsView.kanbanStatusBySituationId || {}),
+        [situationId]: {
+          ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+          [subjectId]: previousStatus
+        }
+      };
+      patchSituationGridKanbanCell({ root, subjectId, situationId });
+      logSituationGridDropdown("kanban-action:error", {
+        ...payload,
+        message: error instanceof Error ? error.message : String(error || "")
+      });
+      console.error("situation grid kanban update failed", error);
+      showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
+    }
+  }
+
   function bindSituationGridEditableCells(root) {
     setSituationGridDropdownRoot(root);
     root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
@@ -403,12 +536,13 @@ export function createProjectSituationsEvents({
 
     const shouldIgnoreOutsideClose = (eventTarget, state) => {
       const host = document.getElementById("subjectMetaDropdownHost");
-      if (host?.contains(eventTarget)) return true;
+      const hostDropdown = host?.querySelector?.(".subject-meta-dropdown");
+      if (hostDropdown?.contains(eventTarget)) return true;
       if (state.anchor && (state.anchor === eventTarget || state.anchor.contains(eventTarget))) return true;
       return false;
     };
 
-    document.addEventListener("click", async (event) => {
+    const handleGridDropdownItemClickCapture = async (event) => {
       const eventTarget = event.target instanceof Element ? event.target : null;
       if (!eventTarget) return;
       const root = resolveSituationGridDropdownRoot();
@@ -418,63 +552,57 @@ export function createProjectSituationsEvents({
       if (actionNode) {
         const state = ensureSituationGridCellDropdownState();
         if (!state.open) return;
-        if (actionNode.matches("[data-subject-kanban-select]")) {
+        event.preventDefault();
+        event.stopPropagation();
+        try {
           const field = String(state.field || "").trim().toLowerCase();
           const subjectId = String(state.subjectId || "").trim();
           const situationId = String(state.situationId || "").trim();
-          const nextStatus = String(actionNode.getAttribute("data-subject-kanban-select") || "").trim();
-          const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
-          logSituationGridDropdown("item-click", { field, type: "kanban", subjectId, situationId, value: nextStatus });
-          if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
-            closeSituationGridCellDropdown();
+          const value = String(
+            actionNode.getAttribute("data-subject-kanban-select")
+            || actionNode.getAttribute("data-subject-assignee-toggle")
+            || actionNode.getAttribute("data-subject-label-toggle")
+            || actionNode.getAttribute("data-objective-select")
+            || ""
+          ).trim();
+          logSituationGridDropdown("host-capture:item-click", buildSituationGridDropdownDebugPayload({
+            field,
+            subjectId,
+            situationId,
+            value,
+            event
+          }));
+          if (actionNode.matches("[data-subject-kanban-select]")) {
+            await handleSituationGridKanbanAction(root, actionNode, event);
             return;
           }
-          if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
-          store.situationsView.kanbanStatusBySituationId = {
-            ...(store.situationsView.kanbanStatusBySituationId || {}),
-            [situationId]: {
-              ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
-              [subjectId]: nextStatus
-            }
-          };
-          patchSituationGridKanbanCell({ root, subjectId, situationId });
-          closeSituationGridCellDropdown();
-          try {
-            await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
-          } catch (error) {
-            store.situationsView.kanbanStatusBySituationId = {
-              ...(store.situationsView.kanbanStatusBySituationId || {}),
-              [situationId]: {
-                ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
-                [subjectId]: previousStatus
-              }
-            };
-            patchSituationGridKanbanCell({ root, subjectId, situationId });
-            console.error("situation grid kanban update failed", error);
-            showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
-          }
-          return;
-        }
-
-        try {
-          await handleSharedDropdownAction(root, actionNode);
+          await handleSharedDropdownAction(root, actionNode, event);
         } catch (error) {
           console.error("situation grid shared dropdown action failed", error);
           showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour a échoué.");
         }
         return;
       }
+    };
+
+    const host = document.getElementById("subjectMetaDropdownHost");
+    host?.addEventListener("click", handleGridDropdownItemClickCapture, { capture: true, signal });
+    document.addEventListener("click", async (event) => {
+      await handleGridDropdownItemClickCapture(event);
+      const eventTarget = event.target instanceof Element ? event.target : null;
+      if (!eventTarget) return;
 
       const state = ensureSituationGridCellDropdownState();
       if (!state.open) return;
       if (shouldIgnoreOutsideClose(eventTarget, state)) return;
-      logSituationGridDropdown("outside-click-close", {
+      logSituationGridDropdown("outside-click-close", buildSituationGridDropdownDebugPayload({
         field: state.field,
         subjectId: state.subjectId,
-        situationId: state.situationId
-      });
+        situationId: state.situationId,
+        event
+      }));
       closeSituationGridCellDropdown();
-    }, { signal });
+    }, { capture: true, signal });
 
     document.addEventListener("input", (event) => {
       const eventTarget = event.target instanceof Element ? event.target : null;
@@ -505,11 +633,12 @@ export function createProjectSituationsEvents({
       const state = ensureSituationGridCellDropdownState();
       if (!state.open) return;
       if (shouldIgnoreOutsideClose(eventTarget, state)) return;
-      logSituationGridDropdown("outside-pointerdown-close", {
+      logSituationGridDropdown("outside-pointerdown-close", buildSituationGridDropdownDebugPayload({
         field: state.field,
         subjectId: state.subjectId,
-        situationId: state.situationId
-      });
+        situationId: state.situationId,
+        event
+      }));
       closeSituationGridCellDropdown();
     }, { capture: true, signal });
   }

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -13,6 +13,8 @@ import {
   deleteLabel as deleteLabelInSupabase,
   addLabelToSubject as addLabelToSubjectInSupabase,
   removeLabelFromSubject as removeLabelFromSubjectInSupabase,
+  addSubjectAssignee as addSubjectAssigneeInSupabase,
+  removeSubjectAssignee as removeSubjectAssigneeInSupabase,
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase,
   replaceSubjectLabels as replaceSubjectLabelsInSupabase,
   replaceSubjectSituations as replaceSubjectSituationsInSupabase,
@@ -668,6 +670,8 @@ const projectSubjectsActions = createProjectSubjectsActions({
   getObjectives: (...args) => projectSubjectsView.getObjectives(...args),
   addLabelToSubjectInSupabase: (...args) => addLabelToSubjectInSupabase(...args),
   removeLabelFromSubjectInSupabase: (...args) => removeLabelFromSubjectInSupabase(...args),
+  addSubjectAssigneeInSupabase: (...args) => addSubjectAssigneeInSupabase(...args),
+  removeSubjectAssigneeInSupabase: (...args) => removeSubjectAssigneeInSupabase(...args),
   replaceSubjectAssigneesInSupabase: (...args) => replaceSubjectAssigneesInSupabase(...args),
   replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
   replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
@@ -998,9 +1002,11 @@ export function openSharedSubjectKanbanDropdown({
   return true;
 }
 
-export function closeSharedSubjectDropdowns() {
+export function closeSharedSubjectDropdowns(root = document) {
   closeSubjectMetaDropdown();
   closeSubjectKanbanDropdown();
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
 }
 
 export function setSharedSubjectMetaDropdownQuery(query = "", root = document) {

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -36,16 +36,34 @@ export function createProjectSubjectsActions(config) {
     normalizeSubjectLabelKey,
     getSubjectLabelDefinition,
     getObjectives,
-    replaceSubjectLabelsInSupabase,
-    replaceSubjectAssigneesInSupabase,
+    addLabelToSubjectInSupabase,
+    removeLabelFromSubjectInSupabase,
+    addSubjectAssigneeInSupabase,
+    removeSubjectAssigneeInSupabase,
+    addSubjectToObjectiveInSupabase,
+    removeSubjectFromObjectiveInSupabase,
     replaceSubjectSituationsInSupabase,
-    replaceSubjectObjectivesInSupabase,
     setSubjectParentInSupabase,
     createBlockedByRelationInSupabase,
     deleteBlockedByRelationInSupabase,
     reorderSubjectChildrenInSupabase,
     rerenderPanels
   } = config;
+
+  function isSituationGridDropdownDebugEnabled() {
+    try {
+      const storageValue = String(window.localStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      const sessionValue = String(window.sessionStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      return storageValue === "1" || storageValue === "true" || sessionValue === "1" || sessionValue === "true";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function logSituationGridSupabaseMutation(payload = {}) {
+    if (!isSituationGridDropdownDebugEnabled()) return;
+    console.info("[situation-grid-dropdown] supabase-mutation", payload);
+  }
 
   function resolveDefaultHumanActorLabel() {
     const user = store?.user && typeof store.user === "object" ? store.user : {};
@@ -212,7 +230,24 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      await replaceSubjectAssigneesInSupabase(subjectKey, nextIds);
+      const action = hasAssignee ? "assignee:remove" : "assignee:add";
+      const method = hasAssignee ? "DELETE" : "POST";
+      const endpoint = "/rest/v1/subject_assignees";
+      const payload = hasAssignee
+        ? { subject_id: `eq.${subjectKey}`, person_id: `eq.${assigneeKey}` }
+        : { subject_id: subjectKey, person_id: assigneeKey };
+      logSituationGridSupabaseMutation({
+        action,
+        field: "assignees",
+        subjectId: subjectKey,
+        situationId: String(options.situationId || ""),
+        value: assigneeKey,
+        method,
+        endpoint,
+        payload
+      });
+      if (hasAssignee) await removeSubjectAssigneeInSupabase(subjectKey, assigneeKey);
+      else await addSubjectAssigneeInSupabase(subjectKey, assigneeKey);
       return true;
     } catch (error) {
       setSubjectAssigneeIds(subjectKey, currentIds);
@@ -607,15 +642,24 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      const nextLabelIds = Array.isArray(store.projectSubjectsView?.rawSubjectsResult?.labelIdsBySubjectId?.[subjectKey])
-        ? store.projectSubjectsView.rawSubjectsResult.labelIdsBySubjectId[subjectKey].map((value) => String(value || "").trim()).filter(Boolean)
-        : [];
-      await replaceSubjectLabelsInSupabase(subjectKey, nextLabelIds);
-
-      await reloadSubjectsFromSupabase(options.root, {
-        rerender: options.skipRerender ? false : true,
-        updateModal: options.skipRerender ? false : true
+      const action = hasLabel ? "label:remove" : "label:add";
+      const method = hasLabel ? "DELETE" : "POST";
+      const endpoint = "/rest/v1/subject_labels";
+      const payload = hasLabel
+        ? { subject_id: `eq.${subjectKey}`, label_id: `eq.${labelId}` }
+        : { subject_id: subjectKey, label_id: labelId };
+      logSituationGridSupabaseMutation({
+        action,
+        field: "labels",
+        subjectId: subjectKey,
+        situationId: String(options.situationId || ""),
+        value: labelId,
+        method,
+        endpoint,
+        payload
       });
+      if (hasLabel) await removeLabelFromSubjectInSupabase(subjectKey, labelId);
+      else await addLabelToSubjectInSupabase(subjectKey, labelId);
       return true;
     } catch (error) {
       setSubjectLabels(subjectKey, previousLabels);
@@ -697,7 +741,23 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      await replaceSubjectObjectivesInSupabase(subjectKey, nextIds);
+      const action = wasLinked ? "objective:remove" : "objective:add";
+      const method = wasLinked ? "DELETE" : "POST";
+      const endpoint = "/rest/v1/milestone_subjects";
+      logSituationGridSupabaseMutation({
+        action,
+        field: "objectives",
+        subjectId: subjectKey,
+        situationId: String(options.situationId || ""),
+        value: objectiveKey,
+        method,
+        endpoint,
+        payload: wasLinked
+          ? { milestone_id: `eq.${objectiveKey}`, subject_id: `eq.${subjectKey}` }
+          : { milestone_id: objectiveKey, subject_id: subjectKey }
+      });
+      if (wasLinked) await removeSubjectFromObjectiveInSupabase(objectiveKey, subjectKey);
+      else await addSubjectToObjectiveInSupabase(objectiveKey, subjectKey);
       return true;
     } catch (error) {
       setSubjectObjectiveIds(subjectKey, previousIds);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -358,6 +358,23 @@ export function createProjectSubjectsEvents(config) {
     const toggleSubjectBlockingForRelation = getToggleSubjectBlockingForRelation?.();
     const reorderSubjectChildren = getReorderSubjectChildren?.();
 
+    function isSituationGridOwnedDropdown() {
+      const dropdown = getSubjectsViewState()?.subjectMetaDropdown || {};
+      const openedFrom = String(dropdown.openedFrom || "").trim().toLowerCase();
+      const scope = String(dropdown.scope || "").trim().toLowerCase();
+      const hostOwned = String(document.getElementById("subjectMetaDropdownHost")?.dataset?.situationGridOwned || "") === "1";
+      return hostOwned && (openedFrom === "situation-grid" || scope === "situation-grid");
+    }
+
+    function logSituationGridGenericSkip() {
+      try {
+        if (window.localStorage?.getItem("debug:situation-grid-dropdown") !== "1") return;
+      } catch (_) {
+        return;
+      }
+      console.info("[subject-meta-dropdown] skip generic handler for situation-grid.");
+    }
+
     dropdownHost.querySelectorAll("[data-subject-kanban-search]").forEach((input) => {
       input.oninput = () => {
         const subjectId = String(input.dataset.subjectKanbanSearch || "");
@@ -493,6 +510,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-objective-select]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -515,6 +536,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-label-toggle]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -526,6 +551,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-assignee-toggle]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -742,6 +771,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-kanban-select]").forEach((btn) => {
       btn.onclick = (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const subjectId = String(btn.dataset.subjectKanbanSubjectId || "");


### PR DESCRIPTION
### Motivation

- Enable toggling individual subject assignees via REST endpoints instead of always using bulk replace, and improve UX and debuggability for the situation-grid shared dropdowns. 

### Description

- Added `addSubjectAssignee(subjectId, personId)` and `removeSubjectAssignee(subjectId, personId)` to `project-subjects-supabase.js` and exported them for use by the UI. 
- Changed label/objective/assignee toggles to call the appropriate add/remove endpoints (`/rest/v1/subject_assignees`, `/rest/v1/subject_labels`, `/rest/v1/milestone_subjects`) and emit structured debug logs via `logSituationGridSupabaseMutation` instead of always invoking the bulk `replace_...` RPC. 
- Implemented richer situation-grid dropdown debug tooling including `buildSituationGridDropdownDebugPayload`, host ownership flag (`subjectMetaDropdownHost.dataset.situationGridOwned`), and a dedicated kanban handler `handleSituationGridKanbanAction` that updates local state, patches the cell UI optimistically, and calls `setSituationGridKanbanStatus`. 
- Switched dropdown click handling to a capture-phase host listener to route kanban and shared actions reliably, added guards so the shared dropdown generic handlers skip when the dropdown is owned by the situation-grid, and improved outside-click/ptrdown logging with event payloads. 
- Minor UI host behavior updates: `closeSharedSubjectDropdowns` now accepts a `root` and re-renders/positions the host, and dropdown open/close now sets/clears the host dataset ownership flag.

### Testing

- Ran the JavaScript unit test suite (`yarn test`) against the changed modules and the test run completed successfully. 
- Ran linting (`yarn lint`) and static checks and they passed without new warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecab8b21248329a09aa9aa818fbb00)