### PR TITLE
Situation grid: add/remove assignees, improve dropdown UX, kanban/label visuals and debug logging

### DIFF
--- a/apps/web/js/services/project-subjects-supabase.js
+++ b/apps/web/js/services/project-subjects-supabase.js
@@ -1124,6 +1124,64 @@ export async function replaceSubjectAssignees(subjectId, personIds = []) {
   return uniquePersonIds;
 }
 
+export async function addSubjectAssignee(subjectId, personId) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  const normalizedPersonId = normalizeUuid(personId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  if (!normalizedPersonId) throw new Error("personId is required");
+
+  const projectId = await fetchSubjectProjectId(normalizedSubjectId);
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);
+  url.searchParams.set("on_conflict", "subject_id,person_id");
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates,return=representation"
+    }),
+    body: JSON.stringify({
+      project_id: projectId,
+      subject_id: normalizedSubjectId,
+      person_id: normalizedPersonId
+    })
+  });
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`subject_assignee create failed (${res.status}): ${txt}`);
+  }
+
+  return true;
+}
+
+export async function removeSubjectAssignee(subjectId, personId) {
+  const normalizedSubjectId = normalizeUuid(subjectId);
+  const normalizedPersonId = normalizeUuid(personId);
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  if (!normalizedPersonId) throw new Error("personId is required");
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_assignees`);
+  url.searchParams.set("subject_id", `eq.${normalizedSubjectId}`);
+  url.searchParams.set("person_id", `eq.${normalizedPersonId}`);
+
+  const res = await fetch(url.toString(), {
+    method: "DELETE",
+    headers: await getSupabaseAuthHeaders({
+      Accept: "application/json",
+      Prefer: "return=minimal"
+    })
+  });
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`subject_assignee delete failed (${res.status}): ${txt}`);
+  }
+
+  return true;
+}
+
 export async function replaceSubjectLabels(subjectId, labelIds = []) {
   const normalizedSubjectId = normalizeUuid(subjectId);
   if (!normalizedSubjectId) throw new Error("subjectId is required");

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -73,7 +73,9 @@ export function createProjectSituationsEvents({
 
   function isSituationGridDropdownDebugEnabled() {
     try {
-      return window.localStorage?.getItem("debug:situation-grid-dropdown") === "1";
+      const storageValue = String(window.localStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      const sessionValue = String(window.sessionStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      return storageValue === "1" || storageValue === "true" || sessionValue === "1" || sessionValue === "true";
     } catch (_) {
       return false;
     }
@@ -82,6 +84,36 @@ export function createProjectSituationsEvents({
   function logSituationGridDropdown(message, payload = {}) {
     if (!isSituationGridDropdownDebugEnabled()) return;
     console.info(`[situation-grid-dropdown] ${message}`, payload);
+  }
+
+  function logSituationGridSupabaseMutation(payload = {}) {
+    if (!isSituationGridDropdownDebugEnabled()) return;
+    console.info("[situation-grid-dropdown] supabase-mutation", payload);
+  }
+
+  function getSharedDropdownDebugMeta() {
+    const dropdown = store?.projectSubjectsView?.subjectMetaDropdown || {};
+    return {
+      openedFrom: String(dropdown?.openedFrom || ""),
+      metaScope: String(dropdown?.scope || "")
+    };
+  }
+
+  function buildSituationGridDropdownDebugPayload({
+    field = "",
+    subjectId = "",
+    situationId = "",
+    value = "",
+    event = null
+  } = {}) {
+    return {
+      field,
+      subjectId,
+      situationId,
+      value,
+      target: event?.target?.outerHTML?.slice?.(0, 200) || "",
+      ...getSharedDropdownDebugMeta()
+    };
   }
 
   function resolveCurrentProjectId() {
@@ -108,11 +140,17 @@ export function createProjectSituationsEvents({
 
   function closeSituationGridCellDropdown() {
     const state = ensureSituationGridCellDropdownState();
-    logSituationGridDropdown("close", {
+    const scrollNode = state.anchor?.closest?.(".project-situation-grid__scroll, .situation-grid__scroll") || null;
+    const preservedScrollTop = Number(scrollNode?.scrollTop || 0);
+    const preservedScrollLeft = Number(scrollNode?.scrollLeft || 0);
+    const host = document.getElementById("subjectMetaDropdownHost");
+    if (host?.dataset) delete host.dataset.situationGridOwned;
+    logSituationGridDropdown("close", buildSituationGridDropdownDebugPayload({
       field: state.field,
       subjectId: state.subjectId,
       situationId: state.situationId
-    });
+    }));
+    state.anchor?.closest?.(".situation-grid__cell")?.classList?.remove?.("situation-grid__cell--active");
     if (state.anchor?.setAttribute) state.anchor.setAttribute("aria-expanded", "false");
     state.open = false;
     state.field = "";
@@ -120,6 +158,10 @@ export function createProjectSituationsEvents({
     state.situationId = "";
     state.anchor = null;
     closeSharedSubjectDropdowns?.();
+    if (scrollNode) {
+      scrollNode.scrollTop = preservedScrollTop;
+      scrollNode.scrollLeft = preservedScrollLeft;
+    }
   }
 
   function setSituationGridDropdownRoot(root) {
@@ -140,18 +182,21 @@ export function createProjectSituationsEvents({
   function openSituationGridCellDropdown(root, { field = "", anchor = null, subjectId = "", situationId = "" } = {}) {
     if (!anchor) return;
     const state = ensureSituationGridCellDropdownState();
+    const host = document.getElementById("subjectMetaDropdownHost");
     closeSituationGridCellDropdown();
     state.open = true;
     state.field = String(field || "").trim().toLowerCase();
     state.subjectId = String(subjectId || "").trim();
     state.situationId = String(situationId || "").trim();
     state.anchor = anchor;
+    if (host?.dataset) host.dataset.situationGridOwned = "1";
+    anchor.closest?.(".situation-grid__cell")?.classList?.add?.("situation-grid__cell--active");
     anchor.setAttribute("aria-expanded", "true");
-    logSituationGridDropdown("open", {
+    logSituationGridDropdown("open", buildSituationGridDropdownDebugPayload({
       field: state.field,
       subjectId: state.subjectId,
       situationId: state.situationId
-    });
+    }));
     if (state.field === "kanban") {
       const opened = openSharedSubjectKanbanDropdown?.({
         root,
@@ -176,14 +221,25 @@ export function createProjectSituationsEvents({
   }
 
   function getKanbanLabel(status = "") {
-    const map = {
-      non_active: "Non activé",
-      to_activate: "À activer",
-      in_progress: "En cours",
-      in_arbitration: "En arbitrage",
-      resolved: "Résolu"
+    const meta = {
+      non_active: { label: "Non activé", bg: "rgba(46, 160, 67, 0.15)", border: "rgb(35, 134, 54)", text: "rgb(63, 185, 80)" },
+      to_activate: { label: "À activer", bg: "rgba(56, 139, 253, 0.1)", border: "rgb(31, 111, 235)", text: "rgb(88, 166, 255)" },
+      in_progress: { label: "En cours", bg: "rgba(187, 128, 9, 0.15)", border: "rgb(158, 106, 3)", text: "rgb(210, 153, 34)" },
+      in_arbitration: { label: "En arbitrage", bg: "rgba(171, 125, 248, 0.15)", border: "rgb(137, 87, 229)", text: "rgb(188, 140, 255)" },
+      resolved: { label: "Résolu", bg: "rgba(219, 109, 40, 0.1)", border: "rgb(189, 86, 29)", text: "rgb(255, 161, 107)" }
     };
-    return map[String(status || "").trim().toLowerCase()] || map.non_active;
+    return (meta[String(status || "").trim().toLowerCase()] || meta.non_active).label;
+  }
+
+  function getKanbanTone(status = "") {
+    const meta = {
+      non_active: { bg: "rgba(46, 160, 67, 0.15)", border: "rgb(35, 134, 54)", text: "rgb(63, 185, 80)" },
+      to_activate: { bg: "rgba(56, 139, 253, 0.1)", border: "rgb(31, 111, 235)", text: "rgb(88, 166, 255)" },
+      in_progress: { bg: "rgba(187, 128, 9, 0.15)", border: "rgb(158, 106, 3)", text: "rgb(210, 153, 34)" },
+      in_arbitration: { bg: "rgba(171, 125, 248, 0.15)", border: "rgb(137, 87, 229)", text: "rgb(188, 140, 255)" },
+      resolved: { bg: "rgba(219, 109, 40, 0.1)", border: "rgb(189, 86, 29)", text: "rgb(255, 161, 107)" }
+    };
+    return meta[String(status || "").trim().toLowerCase()] || meta.non_active;
   }
 
   function patchSituationGridKanbanCell({ root, subjectId = "", situationId = "" } = {}) {
@@ -196,6 +252,10 @@ export function createProjectSituationsEvents({
     const badge = trigger.querySelector(".subject-kanban-badge");
     if (!badge) return;
     badge.textContent = getKanbanLabel(nextStatus);
+    const tone = getKanbanTone(nextStatus);
+    badge.style.setProperty("--subject-kanban-badge-bg", tone.bg);
+    badge.style.setProperty("--subject-kanban-badge-border", tone.border);
+    badge.style.setProperty("--subject-kanban-badge-text", tone.text);
   }
 
   function showSituationGridInlineError(root, message = "") {
@@ -218,7 +278,17 @@ export function createProjectSituationsEvents({
     return String(actionNode?.getAttribute(attrName) || "").trim();
   }
 
-  async function handleSharedDropdownAction(root, actionNode) {
+  function findSituationGridEditAnchor(root, { field = "", subjectId = "", situationId = "" } = {}) {
+    const normalizedField = String(field || "").trim().toLowerCase();
+    const normalizedSubjectId = String(subjectId || "").trim();
+    const normalizedSituationId = String(situationId || "").trim();
+    if (!root || !normalizedField || !normalizedSubjectId) return null;
+    return [...root.querySelectorAll(`[data-situation-grid-edit-cell="${normalizedField}"]`)]
+      .find((node) => String(node.getAttribute("data-situation-grid-subject-id") || "").trim() === normalizedSubjectId
+        && String(node.getAttribute("data-situation-grid-situation-id") || "").trim() === normalizedSituationId) || null;
+  }
+
+  async function handleSharedDropdownAction(root, actionNode, event = null) {
     const state = ensureSituationGridCellDropdownState();
     const subjectId = String(state.subjectId || actionNode?.getAttribute("data-subject-id") || "").trim();
     const situationId = String(state.situationId || actionNode?.getAttribute("data-situation-id") || "").trim();
@@ -243,28 +313,70 @@ export function createProjectSituationsEvents({
       action = toggleSubjectObjectiveFromSharedDropdown;
     }
     if (!actionType) return false;
-    logSituationGridDropdown("item-click", { field, type: actionType, subjectId, situationId, value });
-    closeSituationGridCellDropdown();
+    const shouldKeepOpen = actionType === "assignee";
+    if (!shouldKeepOpen) closeSituationGridCellDropdown();
     if (!value) return true;
 
-    logSituationGridDropdown("shared-action:start", { field, type: actionType, subjectId, situationId, value });
+    const payload = {
+      ...buildSituationGridDropdownDebugPayload({ field, subjectId, situationId, value, event }),
+      type: actionType
+    };
+    logSituationGridDropdown("shared-action:start", payload);
+    logSituationGridSupabaseMutation({
+      action: actionType === "assignee"
+        ? "assignee:toggle"
+        : actionType === "label"
+          ? "label:toggle"
+          : "objective:toggle",
+      field,
+      subjectId,
+      situationId,
+      value,
+      method: actionType === "objective"
+        ? "POST|DELETE"
+        : actionType === "assignee"
+          ? "POST|DELETE"
+          : "POST|DELETE",
+      endpoint: actionType === "objective"
+        ? "/rest/v1/milestone_subjects"
+        : actionType === "assignee"
+          ? "/rest/v1/subject_assignees"
+          : "/rest/v1/subject_labels",
+      payload: actionType === "objective"
+        ? {
+            milestone_id: value,
+            subject_id: subjectId
+          }
+        : actionType === "assignee"
+          ? {
+              person_id: value,
+              subject_id: subjectId
+            }
+          : {
+              label_id: value,
+              subject_id: subjectId
+            }
+    });
     try {
       const success = await action?.(subjectId, value, { root, skipRerender: true });
       if (success === true) {
-        logSituationGridDropdown("shared-action:success", { field, type: actionType, subjectId, situationId, value });
+        logSituationGridDropdown("shared-action:success", payload);
+        if (!shouldKeepOpen) {
+          rerender(root);
+          return true;
+        }
         rerender(root);
+        const refreshedRoot = resolveSituationGridDropdownRoot();
+        const anchor = findSituationGridEditAnchor(refreshedRoot, { field, subjectId, situationId });
+        if (anchor) openSituationGridCellDropdown(refreshedRoot, { field, anchor, subjectId, situationId });
         return true;
       }
-      logSituationGridDropdown("shared-action:false-result", { field, type: actionType, subjectId, situationId, value });
+      logSituationGridDropdown("shared-action:false-result", payload);
       showSituationGridInlineError(root, "La mise à jour a échoué.");
       return false;
     } catch (error) {
       logSituationGridDropdown("shared-action:error", {
-        field,
-        type: actionType,
-        subjectId,
-        situationId,
-        value,
+        ...payload,
         message: error instanceof Error ? error.message : String(error || "")
       });
       throw error;
@@ -375,10 +487,77 @@ export function createProjectSituationsEvents({
     });
   }
 
+  async function handleSituationGridKanbanAction(root, actionNode, event = null) {
+    const state = ensureSituationGridCellDropdownState();
+    const field = String(state.field || "").trim().toLowerCase();
+    const subjectId = String(state.subjectId || "").trim();
+    const situationId = String(state.situationId || "").trim();
+    const nextStatus = String(actionNode?.getAttribute("data-subject-kanban-select") || "").trim().toLowerCase();
+    const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
+    const payload = buildSituationGridDropdownDebugPayload({ field, subjectId, situationId, value: nextStatus, event });
+    if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
+      closeSituationGridCellDropdown();
+      return;
+    }
+
+    if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+    store.situationsView.kanbanStatusBySituationId = {
+      ...(store.situationsView.kanbanStatusBySituationId || {}),
+      [situationId]: {
+        ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+        [subjectId]: nextStatus
+      }
+    };
+    patchSituationGridKanbanCell({ root, subjectId, situationId });
+    closeSituationGridCellDropdown();
+    try {
+      logSituationGridDropdown("kanban-action:start", payload);
+      logSituationGridSupabaseMutation({
+        action: "kanban:update",
+        field: "kanban",
+        subjectId,
+        situationId,
+        value: nextStatus,
+        method: "PATCH",
+        endpoint: "/rest/v1/situation_subjects",
+        payload: {
+          where: {
+            situation_id: `eq.${situationId}`,
+            subject_id: `eq.${subjectId}`
+          },
+          body: {
+            kanban_status: nextStatus
+          }
+        }
+      });
+      await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
+      logSituationGridDropdown("kanban-action:success", payload);
+    } catch (error) {
+      store.situationsView.kanbanStatusBySituationId = {
+        ...(store.situationsView.kanbanStatusBySituationId || {}),
+        [situationId]: {
+          ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
+          [subjectId]: previousStatus
+        }
+      };
+      patchSituationGridKanbanCell({ root, subjectId, situationId });
+      logSituationGridDropdown("kanban-action:error", {
+        ...payload,
+        message: error instanceof Error ? error.message : String(error || "")
+      });
+      console.error("situation grid kanban update failed", error);
+      showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
+    }
+  }
+
   function bindSituationGridEditableCells(root) {
     setSituationGridDropdownRoot(root);
     root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
       node.addEventListener("click", (event) => {
+        const caretNode = event.target instanceof Element
+          ? event.target.closest(".situation-grid__editable-caret")
+          : null;
+        if (!caretNode) return;
         event.preventDefault();
         event.stopPropagation();
         const field = String(node.getAttribute("data-situation-grid-edit-cell") || "").trim().toLowerCase();
@@ -403,12 +582,13 @@ export function createProjectSituationsEvents({
 
     const shouldIgnoreOutsideClose = (eventTarget, state) => {
       const host = document.getElementById("subjectMetaDropdownHost");
-      if (host?.contains(eventTarget)) return true;
+      const hostDropdown = host?.querySelector?.(".subject-meta-dropdown");
+      if (hostDropdown?.contains(eventTarget)) return true;
       if (state.anchor && (state.anchor === eventTarget || state.anchor.contains(eventTarget))) return true;
       return false;
     };
 
-    document.addEventListener("click", async (event) => {
+    const handleGridDropdownItemClickCapture = async (event) => {
       const eventTarget = event.target instanceof Element ? event.target : null;
       if (!eventTarget) return;
       const root = resolveSituationGridDropdownRoot();
@@ -418,63 +598,57 @@ export function createProjectSituationsEvents({
       if (actionNode) {
         const state = ensureSituationGridCellDropdownState();
         if (!state.open) return;
-        if (actionNode.matches("[data-subject-kanban-select]")) {
+        event.preventDefault();
+        event.stopPropagation();
+        try {
           const field = String(state.field || "").trim().toLowerCase();
           const subjectId = String(state.subjectId || "").trim();
           const situationId = String(state.situationId || "").trim();
-          const nextStatus = String(actionNode.getAttribute("data-subject-kanban-select") || "").trim();
-          const previousStatus = String(store?.situationsView?.kanbanStatusBySituationId?.[situationId]?.[subjectId] || "non_active").trim().toLowerCase();
-          logSituationGridDropdown("item-click", { field, type: "kanban", subjectId, situationId, value: nextStatus });
-          if (!subjectId || !situationId || !nextStatus || nextStatus === previousStatus) {
-            closeSituationGridCellDropdown();
+          const value = String(
+            actionNode.getAttribute("data-subject-kanban-select")
+            || actionNode.getAttribute("data-subject-assignee-toggle")
+            || actionNode.getAttribute("data-subject-label-toggle")
+            || actionNode.getAttribute("data-objective-select")
+            || ""
+          ).trim();
+          logSituationGridDropdown("host-capture:item-click", buildSituationGridDropdownDebugPayload({
+            field,
+            subjectId,
+            situationId,
+            value,
+            event
+          }));
+          if (actionNode.matches("[data-subject-kanban-select]")) {
+            await handleSituationGridKanbanAction(root, actionNode, event);
             return;
           }
-          if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
-          store.situationsView.kanbanStatusBySituationId = {
-            ...(store.situationsView.kanbanStatusBySituationId || {}),
-            [situationId]: {
-              ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
-              [subjectId]: nextStatus
-            }
-          };
-          patchSituationGridKanbanCell({ root, subjectId, situationId });
-          closeSituationGridCellDropdown();
-          try {
-            await setSituationGridKanbanStatus?.(situationId, subjectId, nextStatus);
-          } catch (error) {
-            store.situationsView.kanbanStatusBySituationId = {
-              ...(store.situationsView.kanbanStatusBySituationId || {}),
-              [situationId]: {
-                ...((store.situationsView.kanbanStatusBySituationId || {})[situationId] || {}),
-                [subjectId]: previousStatus
-              }
-            };
-            patchSituationGridKanbanCell({ root, subjectId, situationId });
-            console.error("situation grid kanban update failed", error);
-            showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour du statut kanban a échoué.");
-          }
-          return;
-        }
-
-        try {
-          await handleSharedDropdownAction(root, actionNode);
+          await handleSharedDropdownAction(root, actionNode, event);
         } catch (error) {
           console.error("situation grid shared dropdown action failed", error);
           showSituationGridInlineError(root, error instanceof Error ? error.message : "La mise à jour a échoué.");
         }
         return;
       }
+    };
+
+    const host = document.getElementById("subjectMetaDropdownHost");
+    host?.addEventListener("click", handleGridDropdownItemClickCapture, { capture: true, signal });
+    document.addEventListener("click", async (event) => {
+      await handleGridDropdownItemClickCapture(event);
+      const eventTarget = event.target instanceof Element ? event.target : null;
+      if (!eventTarget) return;
 
       const state = ensureSituationGridCellDropdownState();
       if (!state.open) return;
       if (shouldIgnoreOutsideClose(eventTarget, state)) return;
-      logSituationGridDropdown("outside-click-close", {
+      logSituationGridDropdown("outside-click-close", buildSituationGridDropdownDebugPayload({
         field: state.field,
         subjectId: state.subjectId,
-        situationId: state.situationId
-      });
+        situationId: state.situationId,
+        event
+      }));
       closeSituationGridCellDropdown();
-    }, { signal });
+    }, { capture: true, signal });
 
     document.addEventListener("input", (event) => {
       const eventTarget = event.target instanceof Element ? event.target : null;
@@ -505,11 +679,12 @@ export function createProjectSituationsEvents({
       const state = ensureSituationGridCellDropdownState();
       if (!state.open) return;
       if (shouldIgnoreOutsideClose(eventTarget, state)) return;
-      logSituationGridDropdown("outside-pointerdown-close", {
+      logSituationGridDropdown("outside-pointerdown-close", buildSituationGridDropdownDebugPayload({
         field: state.field,
         subjectId: state.subjectId,
-        situationId: state.situationId
-      });
+        situationId: state.situationId,
+        event
+      }));
       closeSituationGridCellDropdown();
     }, { capture: true, signal });
   }

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -362,6 +362,12 @@ function renderLabelsCell(subjectId, rawSubjectsResult = {}) {
 
   const visible = labels.slice(0, 2);
   const overflow = Math.max(0, labels.length - visible.length);
+  const getLabelBadgeStyle = (label) => {
+    const border = firstNonEmpty(label?.border_color, label?.borderColor, label?.text_color, label?.textColor, label?.hex_color, "#656d76");
+    const background = firstNonEmpty(label?.background_color, label?.backgroundColor, `${border}22`, "#21262d");
+    const text = firstNonEmpty(label?.text_color, label?.textColor, label?.hex_color, "#d0d7de");
+    return `--subject-label-border:${escapeHtml(border)};--subject-label-bg:${escapeHtml(background)};--subject-label-fg:${escapeHtml(text)};`;
+  };
   return `
     <button
       type="button"
@@ -376,7 +382,7 @@ function renderLabelsCell(subjectId, rawSubjectsResult = {}) {
       <span class="situation-grid__labels">
       ${visible.map((label) => {
         const labelName = firstNonEmpty(label?.name, label?.label, label?.key, label?.id, "Label");
-        return `<span class="subject-label-badge">${escapeHtml(labelName)}</span>`;
+        return `<span class="subject-label-badge" style="${getLabelBadgeStyle(label)}">${escapeHtml(labelName)}</span>`;
       }).join("")}
       ${overflow > 0 ? `<span class="situation-grid__pill-overflow mono">+${overflow}</span>` : ""}
       </span>

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -13,6 +13,8 @@ import {
   deleteLabel as deleteLabelInSupabase,
   addLabelToSubject as addLabelToSubjectInSupabase,
   removeLabelFromSubject as removeLabelFromSubjectInSupabase,
+  addSubjectAssignee as addSubjectAssigneeInSupabase,
+  removeSubjectAssignee as removeSubjectAssigneeInSupabase,
   replaceSubjectAssignees as replaceSubjectAssigneesInSupabase,
   replaceSubjectLabels as replaceSubjectLabelsInSupabase,
   replaceSubjectSituations as replaceSubjectSituationsInSupabase,
@@ -668,6 +670,8 @@ const projectSubjectsActions = createProjectSubjectsActions({
   getObjectives: (...args) => projectSubjectsView.getObjectives(...args),
   addLabelToSubjectInSupabase: (...args) => addLabelToSubjectInSupabase(...args),
   removeLabelFromSubjectInSupabase: (...args) => removeLabelFromSubjectInSupabase(...args),
+  addSubjectAssigneeInSupabase: (...args) => addSubjectAssigneeInSupabase(...args),
+  removeSubjectAssigneeInSupabase: (...args) => removeSubjectAssigneeInSupabase(...args),
   replaceSubjectAssigneesInSupabase: (...args) => replaceSubjectAssigneesInSupabase(...args),
   replaceSubjectLabelsInSupabase: (...args) => replaceSubjectLabelsInSupabase(...args),
   replaceSubjectSituationsInSupabase: (...args) => replaceSubjectSituationsInSupabase(...args),
@@ -998,9 +1002,11 @@ export function openSharedSubjectKanbanDropdown({
   return true;
 }
 
-export function closeSharedSubjectDropdowns() {
+export function closeSharedSubjectDropdowns(root = document) {
   closeSubjectMetaDropdown();
   closeSubjectKanbanDropdown();
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
 }
 
 export function setSharedSubjectMetaDropdownQuery(query = "", root = document) {

--- a/apps/web/js/views/project-subjects/project-subjects-actions.js
+++ b/apps/web/js/views/project-subjects/project-subjects-actions.js
@@ -36,16 +36,34 @@ export function createProjectSubjectsActions(config) {
     normalizeSubjectLabelKey,
     getSubjectLabelDefinition,
     getObjectives,
-    replaceSubjectLabelsInSupabase,
-    replaceSubjectAssigneesInSupabase,
+    addLabelToSubjectInSupabase,
+    removeLabelFromSubjectInSupabase,
+    addSubjectAssigneeInSupabase,
+    removeSubjectAssigneeInSupabase,
+    addSubjectToObjectiveInSupabase,
+    removeSubjectFromObjectiveInSupabase,
     replaceSubjectSituationsInSupabase,
-    replaceSubjectObjectivesInSupabase,
     setSubjectParentInSupabase,
     createBlockedByRelationInSupabase,
     deleteBlockedByRelationInSupabase,
     reorderSubjectChildrenInSupabase,
     rerenderPanels
   } = config;
+
+  function isSituationGridDropdownDebugEnabled() {
+    try {
+      const storageValue = String(window.localStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      const sessionValue = String(window.sessionStorage?.getItem("debug:situation-grid-dropdown") || "").trim().toLowerCase();
+      return storageValue === "1" || storageValue === "true" || sessionValue === "1" || sessionValue === "true";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function logSituationGridSupabaseMutation(payload = {}) {
+    if (!isSituationGridDropdownDebugEnabled()) return;
+    console.info("[situation-grid-dropdown] supabase-mutation", payload);
+  }
 
   function resolveDefaultHumanActorLabel() {
     const user = store?.user && typeof store.user === "object" ? store.user : {};
@@ -212,7 +230,24 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      await replaceSubjectAssigneesInSupabase(subjectKey, nextIds);
+      const action = hasAssignee ? "assignee:remove" : "assignee:add";
+      const method = hasAssignee ? "DELETE" : "POST";
+      const endpoint = "/rest/v1/subject_assignees";
+      const payload = hasAssignee
+        ? { subject_id: `eq.${subjectKey}`, person_id: `eq.${assigneeKey}` }
+        : { subject_id: subjectKey, person_id: assigneeKey };
+      logSituationGridSupabaseMutation({
+        action,
+        field: "assignees",
+        subjectId: subjectKey,
+        situationId: String(options.situationId || ""),
+        value: assigneeKey,
+        method,
+        endpoint,
+        payload
+      });
+      if (hasAssignee) await removeSubjectAssigneeInSupabase(subjectKey, assigneeKey);
+      else await addSubjectAssigneeInSupabase(subjectKey, assigneeKey);
       return true;
     } catch (error) {
       setSubjectAssigneeIds(subjectKey, currentIds);
@@ -607,15 +642,24 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      const nextLabelIds = Array.isArray(store.projectSubjectsView?.rawSubjectsResult?.labelIdsBySubjectId?.[subjectKey])
-        ? store.projectSubjectsView.rawSubjectsResult.labelIdsBySubjectId[subjectKey].map((value) => String(value || "").trim()).filter(Boolean)
-        : [];
-      await replaceSubjectLabelsInSupabase(subjectKey, nextLabelIds);
-
-      await reloadSubjectsFromSupabase(options.root, {
-        rerender: options.skipRerender ? false : true,
-        updateModal: options.skipRerender ? false : true
+      const action = hasLabel ? "label:remove" : "label:add";
+      const method = hasLabel ? "DELETE" : "POST";
+      const endpoint = "/rest/v1/subject_labels";
+      const payload = hasLabel
+        ? { subject_id: `eq.${subjectKey}`, label_id: `eq.${labelId}` }
+        : { subject_id: subjectKey, label_id: labelId };
+      logSituationGridSupabaseMutation({
+        action,
+        field: "labels",
+        subjectId: subjectKey,
+        situationId: String(options.situationId || ""),
+        value: labelId,
+        method,
+        endpoint,
+        payload
       });
+      if (hasLabel) await removeLabelFromSubjectInSupabase(subjectKey, labelId);
+      else await addLabelToSubjectInSupabase(subjectKey, labelId);
       return true;
     } catch (error) {
       setSubjectLabels(subjectKey, previousLabels);
@@ -697,7 +741,23 @@ export function createProjectSubjectsActions(config) {
     }
 
     try {
-      await replaceSubjectObjectivesInSupabase(subjectKey, nextIds);
+      const action = wasLinked ? "objective:remove" : "objective:add";
+      const method = wasLinked ? "DELETE" : "POST";
+      const endpoint = "/rest/v1/milestone_subjects";
+      logSituationGridSupabaseMutation({
+        action,
+        field: "objectives",
+        subjectId: subjectKey,
+        situationId: String(options.situationId || ""),
+        value: objectiveKey,
+        method,
+        endpoint,
+        payload: wasLinked
+          ? { milestone_id: `eq.${objectiveKey}`, subject_id: `eq.${subjectKey}` }
+          : { milestone_id: objectiveKey, subject_id: subjectKey }
+      });
+      if (wasLinked) await removeSubjectFromObjectiveInSupabase(objectiveKey, subjectKey);
+      else await addSubjectToObjectiveInSupabase(objectiveKey, subjectKey);
       return true;
     } catch (error) {
       setSubjectObjectiveIds(subjectKey, previousIds);

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -358,6 +358,23 @@ export function createProjectSubjectsEvents(config) {
     const toggleSubjectBlockingForRelation = getToggleSubjectBlockingForRelation?.();
     const reorderSubjectChildren = getReorderSubjectChildren?.();
 
+    function isSituationGridOwnedDropdown() {
+      const dropdown = getSubjectsViewState()?.subjectMetaDropdown || {};
+      const openedFrom = String(dropdown.openedFrom || "").trim().toLowerCase();
+      const scope = String(dropdown.scope || "").trim().toLowerCase();
+      const hostOwned = String(document.getElementById("subjectMetaDropdownHost")?.dataset?.situationGridOwned || "") === "1";
+      return hostOwned && (openedFrom === "situation-grid" || scope === "situation-grid");
+    }
+
+    function logSituationGridGenericSkip() {
+      try {
+        if (window.localStorage?.getItem("debug:situation-grid-dropdown") !== "1") return;
+      } catch (_) {
+        return;
+      }
+      console.info("[subject-meta-dropdown] skip generic handler for situation-grid.");
+    }
+
     dropdownHost.querySelectorAll("[data-subject-kanban-search]").forEach((input) => {
       input.oninput = () => {
         const subjectId = String(input.dataset.subjectKanbanSearch || "");
@@ -493,6 +510,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-objective-select]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -515,6 +536,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-label-toggle]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -526,6 +551,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-assignee-toggle]").forEach((btn) => {
       btn.onclick = async (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const targetSubject = getDropdownContextSubject(root);
@@ -742,6 +771,10 @@ export function createProjectSubjectsEvents(config) {
 
     dropdownHost.querySelectorAll("[data-subject-kanban-select]").forEach((btn) => {
       btn.onclick = (event) => {
+        if (isSituationGridOwnedDropdown()) {
+          logSituationGridGenericSkip();
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         const subjectId = String(btn.dataset.subjectKanbanSubjectId || "");

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -1789,6 +1789,7 @@ function buildSubjectMetaMenuItems(subject, field) {
     const selectedAssigneeIds = new Set(getSubjectSidebarMeta(subject.id).assignees.map((value) => String(value || "")));
     const collaborators = getActiveProjectCollaborators()
       .filter((collaborator) => matchSearch([collaborator.name, collaborator.role, collaborator.roleGroupLabel, collaborator.email], query));
+    const isLoadingAssignees = collaboratorsHydrationInFlight && collaborators.length === 0;
 
     const items = collaborators.map((collaborator) => ({
       key: collaborator.id,
@@ -1826,7 +1827,8 @@ function buildSubjectMetaMenuItems(subject, field) {
 
     return {
       groupedSections,
-      items
+      items,
+      isLoadingAssignees
     };
   }
 
@@ -2003,7 +2005,7 @@ function renderSubjectMetaDropdown(subject, field) {
   const query = String(dropdownState.query || "");
 
   if (field === "assignees") {
-    const { groupedSections = [] } = buildSubjectMetaMenuItems(subject, field);
+    const { groupedSections = [], isLoadingAssignees = false } = buildSubjectMetaMenuItems(subject, field);
     return `
       <div class="subject-meta-dropdown gh-menu gh-menu--open" role="dialog">
         <div class="subject-meta-dropdown__title">Sélectionner des assignés</div>
@@ -2013,7 +2015,18 @@ function renderSubjectMetaDropdown(subject, field) {
         </div>
         <div class="subject-kanban-dropdown__separator" aria-hidden="true"></div>
         <div class="subject-meta-dropdown__body">
-          ${groupedSections.length
+          ${isLoadingAssignees && !groupedSections.length
+            ? `
+              <section class="select-menu__section">
+                <div class="select-menu__section-body">
+                  <div class="select-menu__empty">
+                    <div class="select-menu__empty-title">Chargement des collaborateurs…</div>
+                    <div class="select-menu__empty-hint"><span class="ui-spinner ui-spinner--sm"><span class="ui-spinner__ring"></span></span></div>
+                  </div>
+                </div>
+              </section>
+            `
+            : groupedSections.length
             ? groupedSections.map((section) => renderSelectMenuSection({
               title: section.title,
               items: section.items,

--- a/apps/web/js/views/ui/select-dropdown-controller.js
+++ b/apps/web/js/views/ui/select-dropdown-controller.js
@@ -274,15 +274,25 @@ export function renderSelectDropdownHost({
   const explicitSubject = explicitSubjectId && typeof resolveSubjectById === "function"
     ? resolveSubjectById(explicitSubjectId)
     : null;
+  const fallbackExplicitSubject = !explicitSubject && explicitSubjectId
+    ? { id: explicitSubjectId }
+    : null;
   const explicitKanbanSubjectId = String(kanbanDropdown.subjectId || "").trim();
   const explicitKanbanSubject = !explicitSubject && explicitKanbanSubjectId && typeof resolveSubjectById === "function"
     ? resolveSubjectById(explicitKanbanSubjectId)
     : null;
+  const fallbackExplicitKanbanSubject = !explicitKanbanSubject && explicitKanbanSubjectId
+    ? { id: explicitKanbanSubjectId }
+    : null;
   const selection = explicitSubject
     ? { type: "sujet", item: explicitSubject }
+    : fallbackExplicitSubject
+      ? { type: "sujet", item: fallbackExplicitSubject }
     : explicitKanbanSubject
       ? { type: "sujet", item: explicitKanbanSubject }
-    : getScopedSelection?.(root);
+      : fallbackExplicitKanbanSubject
+        ? { type: "sujet", item: fallbackExplicitKanbanSubject }
+      : getScopedSelection?.(root);
   if (field) {
     if (selection?.type !== "sujet") {
       hideSelectDropdownHost(host);
@@ -292,7 +302,7 @@ export function renderSelectDropdownHost({
     host.setAttribute("aria-hidden", "false");
     return host;
   }
-  if (String(kanbanDropdown.subjectId || "") === String(selection.item.id || "") && String(kanbanDropdown.situationId || "")) {
+  if (String(kanbanDropdown.subjectId || "") === String(selection?.item?.id || "") && String(kanbanDropdown.situationId || "")) {
     host.innerHTML = renderKanbanDropdown(selection.item.id, String(kanbanDropdown.situationId || ""));
     host.setAttribute("aria-hidden", "false");
     return host;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10185,6 +10185,13 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   grid-template-columns:var(--situation-grid-cols);
   min-height:40px;
   padding:0;
+  width:max-content;
+  min-width:100%;
+}
+
+.situation-grid__row:hover .situation-grid__cell,
+.situation-grid__row:focus-within .situation-grid__cell{
+  background:var(--bgColor-muted, rgba(110,118,129,.06));
 }
 
 .situation-grid__cell{
@@ -10210,6 +10217,21 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   justify-content:space-between;
   gap:8px;
   text-align:left;
+  position:relative;
+}
+
+.situation-grid__cell{
+  position:relative;
+}
+
+.situation-grid__cell--active::before{
+  content:"";
+  position:absolute;
+  inset:-2px;
+  border:2px solid rgb(31, 111, 235);
+  border-radius:4px;
+  pointer-events:none;
+  z-index:2;
 }
 
 .situation-grid__editable-trigger:hover .situation-grid__editable-caret,


### PR DESCRIPTION
### Motivation
- Allow toggling a single assignee without calling the full replace RPC and surface clearer Supabase mutation intent for situation-grid interactions.
- Improve the situation-grid dropdown UX by preserving scroll/active state, avoiding conflicts with the shared dropdown host, and supporting re-opening after some actions.
- Provide richer debug logging for situation-grid dropdown actions and show better visual cues for kanban status and label badges.

### Description
- Added `addSubjectAssignee` and `removeSubjectAssignee` in `services/project-subjects-supabase.js` to create/delete `subject_assignees` via the Supabase REST API and used them instead of the replace RPC for single toggles.
- Updated subject actions in `project-subjects-actions.js` to call the new add/remove service functions and emit structured supabase mutation debug logs via `logSituationGridSupabaseMutation` instead of always calling the replace helpers.
- Enhanced dropdown behavior in `project-situations-events.js` and `project-subjects-events.js` to preserve scroll position, mark the host as owned by the situation-grid, re-open the anchor after assignee toggles, capture host clicks (with capture listeners), and skip generic dropdown handlers when the dropdown is owned by the grid.
- Improved visuals and rendering: added kanban tone styling and `getKanbanTone`/`getKanbanLabel` updates, per-label inline styling for badges in `project-situations-view-grid.js`, active cell outline and hover styles in `style.css`, and a loading state for assignee lists in `project-subjects-view.js`.
- Made defensive improvements to the select dropdown host rendering in `ui/select-dropdown-controller.js` by providing fallback explicit subject objects so the host can render when the resolved subject is unavailable.

### Testing
- Ran linting with `npm run lint` and it completed successfully.
- Ran the test suite with `npm test` and all JS unit tests passed.
- Built the frontend with `npm run build` to ensure bundling and CSS changes integrated and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecab8b21248329a09aa9aa818fbb00)