### PR TITLE
Enable multi-level DnD in Situation grid and add DnD wiring + persistence

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -14,6 +14,10 @@ import {
 import { renderProjectSituationsRunbar, bindProjectSituationsRunbar } from "./project-situations-runbar.js";
 import { loadFlatSubjectsForCurrentProject } from "../services/project-subjects-supabase.js";
 import {
+  setSubjectParentRelationInSupabase,
+  reorderSubjectChildrenInSupabase
+} from "../services/subject-parent-relation-service.js";
+import {
   loadSituationsForCurrentProject,
   createSituation,
   updateSituation,
@@ -473,6 +477,24 @@ const { bindEvents } = createProjectSituationsEvents({
       }).catch(() => undefined);
       throw error;
     }
+  },
+  setSituationGridSubjectParent: async (subjectId, parentSubjectId) => {
+    return setSubjectParentRelationInSupabase({
+      subjectId,
+      parentSubjectId,
+      rawSubjectsResult: store.projectSubjectsView?.rawSubjectsResult || null
+    });
+  },
+  reorderSituationGridSubjectChildren: async (parentSubjectId, orderedChildIds = []) => {
+    const normalizedParentId = String(parentSubjectId || "").trim();
+    const normalizedChildIds = [...new Set((Array.isArray(orderedChildIds) ? orderedChildIds : [])
+      .map((value) => String(value || "").trim())
+      .filter(Boolean))];
+    if (!normalizedParentId || !normalizedChildIds.length) return [];
+    return reorderSubjectChildrenInSupabase({
+      parentSubjectId: normalizedParentId,
+      orderedChildIds: normalizedChildIds
+    });
   }
 });
 

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -9,6 +9,7 @@ import {
   getSituationGridColumnDefinitions,
   normalizeSituationGridColumnWidths
 } from "./project-situations-view-grid.js";
+import { buildSubjectHierarchyIndexes } from "../../services/subject-hierarchy.js";
 
 function syncSubmitButtonState(button, { submitting = false, title = "" } = {}) {
   if (!button) return;
@@ -54,7 +55,9 @@ export function createProjectSituationsEvents({
   toggleSubjectAssigneeFromSharedDropdown,
   toggleSubjectLabelFromSharedDropdown,
   toggleSubjectObjectiveFromSharedDropdown,
-  setSituationGridKanbanStatus
+  setSituationGridKanbanStatus,
+  setSituationGridSubjectParent,
+  reorderSituationGridSubjectChildren
 }) {
   let insightsRequestId = 0;
 
@@ -689,6 +692,218 @@ export function createProjectSituationsEvents({
     }, { capture: true, signal });
   }
 
+  function isSituationGridDndDebugEnabled() {
+    try {
+      return window.localStorage?.getItem("mdall:debug-situation-grid-dnd") === "1";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function logSituationGridDnd(message, payload = {}) {
+    if (!isSituationGridDndDebugEnabled()) return;
+    console.info(`[situation-grid-dnd] ${message}`, payload);
+  }
+
+  function normalizeSubjectId(value) {
+    return String(value || "").trim();
+  }
+
+  function sortSubjectIdsByOrder(subjectIds = [], subjectsById = {}) {
+    return [...new Set((Array.isArray(subjectIds) ? subjectIds : []).map((value) => normalizeSubjectId(value)).filter(Boolean))]
+      .sort((leftId, rightId) => {
+        const left = subjectsById[leftId] || {};
+        const right = subjectsById[rightId] || {};
+        const leftOrder = Number(left?.parent_child_order ?? left?.raw?.parent_child_order);
+        const rightOrder = Number(right?.parent_child_order ?? right?.raw?.parent_child_order);
+        const leftHasOrder = Number.isFinite(leftOrder) && leftOrder > 0;
+        const rightHasOrder = Number.isFinite(rightOrder) && rightOrder > 0;
+        if (leftHasOrder && rightHasOrder && leftOrder !== rightOrder) return leftOrder - rightOrder;
+        if (leftHasOrder !== rightHasOrder) return leftHasOrder ? -1 : 1;
+        return String(left?.title || leftId).localeCompare(String(right?.title || rightId), "fr");
+      });
+  }
+
+  function applySituationGridHierarchyPatch({ subjectId = "", nextParentId = "", orderedByParentId = {} } = {}) {
+    const raw = store?.projectSubjectsView?.rawSubjectsResult;
+    if (!raw || typeof raw !== "object" || !raw.subjectsById || typeof raw.subjectsById !== "object") return false;
+
+    const normalizedSubjectId = normalizeSubjectId(subjectId);
+    if (!normalizedSubjectId || !raw.subjectsById[normalizedSubjectId]) return false;
+
+    const normalizedNextParentId = normalizeSubjectId(nextParentId);
+    const subject = raw.subjectsById[normalizedSubjectId];
+    subject.parent_subject_id = normalizedNextParentId || null;
+    if (subject.raw && typeof subject.raw === "object") {
+      subject.raw.parent_subject_id = normalizedNextParentId || null;
+    }
+
+    Object.entries(orderedByParentId || {}).forEach(([parentId, childIds]) => {
+      const normalizedParentId = normalizeSubjectId(parentId);
+      const normalizedChildIds = sortSubjectIdsByOrder(childIds, raw.subjectsById);
+      normalizedChildIds.forEach((childId, index) => {
+        const child = raw.subjectsById[childId];
+        if (!child) return;
+        child.parent_subject_id = normalizedParentId || null;
+        child.parent_child_order = index + 1;
+        if (child.raw && typeof child.raw === "object") {
+          child.raw.parent_subject_id = normalizedParentId || null;
+          child.raw.parent_child_order = index + 1;
+        }
+      });
+    });
+
+    const rows = Object.values(raw.subjectsById);
+    const hierarchy = buildSubjectHierarchyIndexes(rows, raw.subjectsById);
+    raw.childrenBySubjectId = hierarchy.childrenBySubjectId;
+    raw.parentBySubjectId = hierarchy.parentBySubjectId;
+    raw.rootSubjectIds = hierarchy.rootSubjectIds;
+    return true;
+  }
+
+  function bindSituationGridDnd(root) {
+    const sortableRows = Array.from(root.querySelectorAll(".situation-grid [data-subissue-sortable-row='true']"));
+    if (!sortableRows.length) return;
+    let draggingRow = null;
+    let dropPlacement = "";
+
+    const clearDropIndicators = () => {
+      sortableRows.forEach((row) => {
+        row.classList.remove("is-subissue-drop-before", "is-subissue-drop-after", "is-subissue-dragging");
+      });
+    };
+
+    sortableRows.forEach((row) => {
+      row.addEventListener("dragstart", (event) => {
+        const subjectId = normalizeSubjectId(row.dataset.childSubjectId);
+        if (!subjectId) {
+          event.preventDefault();
+          return;
+        }
+        draggingRow = row;
+        dropPlacement = "";
+        row.classList.add("is-subissue-dragging");
+        event.dataTransfer?.setData("text/plain", subjectId);
+        if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+        logSituationGridDnd("dragstart", {
+          subjectId,
+          parentSubjectId: normalizeSubjectId(row.dataset.parentSubjectId),
+          depth: Number(row.dataset.subissueDepth || 0)
+        });
+      });
+
+      row.addEventListener("dragover", (event) => {
+        if (!draggingRow || draggingRow === row) return;
+        event.preventDefault();
+        const rect = row.getBoundingClientRect();
+        const before = Number(event.clientY || 0) < (rect.top + rect.height / 2);
+        dropPlacement = before ? "before" : "after";
+        clearDropIndicators();
+        row.classList.add(before ? "is-subissue-drop-before" : "is-subissue-drop-after");
+        logSituationGridDnd("dragover", {
+          sourceId: normalizeSubjectId(draggingRow.dataset.childSubjectId),
+          targetId: normalizeSubjectId(row.dataset.childSubjectId),
+          placement: dropPlacement
+        });
+      });
+
+      row.addEventListener("drop", async (event) => {
+        if (!draggingRow || draggingRow === row) return;
+        event.preventDefault();
+        const sourceId = normalizeSubjectId(draggingRow.dataset.childSubjectId);
+        const targetId = normalizeSubjectId(row.dataset.childSubjectId);
+        const nextParentId = normalizeSubjectId(row.dataset.parentSubjectId);
+        if (!sourceId || !targetId || !dropPlacement || sourceId === targetId) {
+          clearDropIndicators();
+          draggingRow = null;
+          return;
+        }
+        if (!nextParentId) {
+          showSituationGridInlineError(root, "Le réordonnancement des sujets racine n’est pas encore disponible.");
+          clearDropIndicators();
+          draggingRow = null;
+          return;
+        }
+
+        const raw = store?.projectSubjectsView?.rawSubjectsResult || {};
+        const sourceParentId = normalizeSubjectId(
+          raw?.parentBySubjectId?.[sourceId]
+          || raw?.subjectsById?.[sourceId]?.parent_subject_id
+          || raw?.subjectsById?.[sourceId]?.raw?.parent_subject_id
+        );
+        const childrenBySubjectId = raw?.childrenBySubjectId && typeof raw.childrenBySubjectId === "object"
+          ? raw.childrenBySubjectId
+          : {};
+        const sourceSiblings = sortSubjectIdsByOrder(childrenBySubjectId[sourceParentId] || [], raw.subjectsById || {});
+        const targetSiblings = sortSubjectIdsByOrder(childrenBySubjectId[nextParentId] || [], raw.subjectsById || {});
+        const nextSourceSiblings = sourceSiblings.filter((id) => id !== sourceId);
+        const nextTargetSiblings = sourceParentId === nextParentId
+          ? nextSourceSiblings
+          : targetSiblings.filter((id) => id !== sourceId);
+        const targetIndex = nextTargetSiblings.indexOf(targetId);
+        if (targetIndex < 0) {
+          clearDropIndicators();
+          draggingRow = null;
+          return;
+        }
+        const insertionIndex = dropPlacement === "before" ? targetIndex : targetIndex + 1;
+        nextTargetSiblings.splice(Math.max(0, insertionIndex), 0, sourceId);
+
+        logSituationGridDnd("drop", {
+          sourceId,
+          targetId,
+          fromParentId: sourceParentId,
+          toParentId: nextParentId,
+          placement: dropPlacement
+        });
+
+        try {
+          if (sourceParentId !== nextParentId) {
+            await setSituationGridSubjectParent?.(sourceId, nextParentId || null);
+          }
+          await reorderSituationGridSubjectChildren?.(nextParentId, nextTargetSiblings);
+          if (sourceParentId && sourceParentId !== nextParentId) {
+            await reorderSituationGridSubjectChildren?.(sourceParentId, nextSourceSiblings);
+          }
+
+          applySituationGridHierarchyPatch({
+            subjectId: sourceId,
+            nextParentId,
+            orderedByParentId: {
+              [nextParentId]: nextTargetSiblings,
+              ...(sourceParentId && sourceParentId !== nextParentId ? { [sourceParentId]: nextSourceSiblings } : {})
+            }
+          });
+          logSituationGridDnd("persist-success", {
+            sourceId,
+            nextParentId,
+            nextTargetSiblings
+          });
+          rerender(root);
+        } catch (error) {
+          logSituationGridDnd("persist-error", {
+            sourceId,
+            targetId,
+            message: error instanceof Error ? error.message : String(error || "")
+          });
+          console.error("situation grid dnd persist failed", error);
+          showSituationGridInlineError(root, error instanceof Error ? error.message : "Impossible de déplacer ce sujet.");
+          rerender(root);
+        } finally {
+          clearDropIndicators();
+          draggingRow = null;
+          dropPlacement = "";
+        }
+      });
+
+      row.addEventListener("dragend", () => {
+        clearDropIndicators();
+        draggingRow = null;
+        dropPlacement = "";
+      });
+    });
+  }
+
   async function refreshInsightsData(root) {
     const situationId = String(store.situationsView?.selectedSituationId || "").trim();
     const selectedSituation = getSituationById(situationId);
@@ -1118,6 +1333,7 @@ export function createProjectSituationsEvents({
 
     bindSituationGridColumnResize(root);
     bindSituationGridEditableCells(root);
+    bindSituationGridDnd(root);
 
     bindCreateModalEvents(root);
     bindEditPanelEvents(root);

--- a/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
@@ -47,3 +47,16 @@ test("la fermeture extérieure utilise closeSituationGridCellDropdown et closeSh
   assert.match(eventsSource, /if \(shouldIgnoreOutsideClose\(eventTarget, state\)\) return;/);
   assert.match(eventsSource, /closeSituationGridCellDropdown\(\);/);
 });
+
+test("la grille situation bind un DnD multi-niveaux avec instrumentation dédiée", () => {
+  assert.match(eventsSource, /function bindSituationGridDnd\(root\)/);
+  assert.match(eventsSource, /data-subissue-sortable-row='true'/);
+  assert.match(eventsSource, /logSituationGridDnd\("dragstart"/);
+  assert.match(eventsSource, /logSituationGridDnd\("dragover"/);
+  assert.match(eventsSource, /logSituationGridDnd\("drop"/);
+  assert.match(eventsSource, /logSituationGridDnd\("persist-success"/);
+  assert.match(eventsSource, /logSituationGridDnd\("persist-error"/);
+  assert.match(eventsSource, /await setSituationGridSubjectParent\?\.\(sourceId, nextParentId \|\| null\);/);
+  assert.match(eventsSource, /await reorderSituationGridSubjectChildren\?\.\(nextParentId, nextTargetSiblings\);/);
+  assert.match(eventsSource, /bindSituationGridDnd\(root\);/);
+});

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -554,7 +554,7 @@ export function renderSituationGridView(situation, subjects = [], options = {}) 
     childrenBySubjectId,
     rootSubjectIds,
     expandedSubjectIds,
-    dndMode: "none",
+    dndMode: "all-levels",
     rowClassName: "situation-grid__row project-situation-grid__row",
     escapeHtml,
     context: {

--- a/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.test.mjs
@@ -59,6 +59,8 @@ test("renderSituationGridView rend la grille et la colonne titre sans balise tab
   assert.match(html, /situation-grid__cell--progress/);
   assert.match(html, /situation-grid__cell--labels/);
   assert.match(html, /situation-grid__cell--objectives/);
+  assert.match(html, /data-subissue-sortable-row="true"/);
+  assert.match(html, /draggable="true"/);
   assert.doesNotMatch(html, /<table|<tr|<td/i);
 });
 


### PR DESCRIPTION
### Motivation
- Permettre le déplacement multi-niveaux des sujets affichés dans la vue « Situation -> Grille » tout en conservant le DnD limité au niveau 1 dans le détail sujet.
- Réutiliser le composant mutualisé d’arborescence pour exposer un mode `dndMode: "all-levels"` spécifique à la grille sans refactor massif.

### Description
- Active `dndMode: "all-levels"` lors du rendu de la grille Situation en passant l’option au renderer partagé `renderSubjectTreeGrid`. (fichier modifié: `project-situations-view-grid.js`).
- Ajoute un binder dédié `bindSituationGridDnd(root)` dans `project-situations-events.js` qui gère `dragstart`, `dragover`, `drop` et `dragend`, affiche des indicateurs before/after, et nettoie les classes visuelles après interaction.
- Introduit une instrumentation debug optionnelle derrière la clé `localStorage["mdall:debug-situation-grid-dnd"] === "1"` et logge les événements attendus (`dragstart`, `dragover`, `drop`, `persist-success`, `persist-error`).
- Branche la persistance backend en injectant deux handlers dans la composition Situations: `setSituationGridSubjectParent` (délègue à `setSubjectParentRelationInSupabase`) et `reorderSituationGridSubjectChildren` (délègue à `reorderSubjectChildrenInSupabase`), puis applique un patch local de `rawSubjectsResult` et reconstruit les index hiérarchiques après succès.
- Protège le cas de réordonnancement racine (UI notifié par message inline) et prévoit rollback visuel/console en cas d’erreur.
- Ajoute/adjuste des assertions de tests pour vérifier que les lignes sont `draggable`/`data-subissue-sortable-row='true'` et que le wiring DnD + logs + appels de persistance existent dans le source des events (`project-situations-grid-dropdown.test.mjs` et `project-situations-view-grid.test.mjs`).

### Testing
- Tests unitaires exécutés : `node --test apps/web/js/views/project-situations/project-situations-view-grid.test.mjs apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs` et tous les tests ciblés sont passés (9/9 réussis).
- Les tests ajoutés/vérifiés confirment la présence du rendu draggable (`draggable="true"` et `data-subissue-sortable-row="true"`) et la présence du binder `bindSituationGridDnd` ainsi que des logs d’instrumentation et des appels de persistance.
- Scénarios d’échec backend : le code affiche un message inline et logge l’erreur en console, et les tests de wiring couvrent l’émission des hooks de persistance (mais n’exécutent pas d’appel réseau réel dans ces tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdcc86be483298a1290c57ea27ab4)