### PR TITLE
Add idempotent migration: subject_messages fields for Mdall & ephemeral messages

### DIFF
--- a/supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql
+++ b/supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql
@@ -1,0 +1,62 @@
+-- Add Mdall/ephemeral fields on subject messages while preserving existing data.
+
+alter table public.subject_messages
+  add column if not exists visibility text not null default 'normal',
+  add column if not exists visible_until timestamptz null,
+  add column if not exists origin text not null default 'human',
+  add column if not exists llm_request_id uuid null,
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'subject_messages_visibility_check'
+      AND conrelid = 'public.subject_messages'::regclass
+  ) THEN
+    ALTER TABLE public.subject_messages
+      ADD CONSTRAINT subject_messages_visibility_check
+      CHECK (visibility IN ('normal', 'ephemeral'));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'subject_messages_origin_check'
+      AND conrelid = 'public.subject_messages'::regclass
+  ) THEN
+    ALTER TABLE public.subject_messages
+      ADD CONSTRAINT subject_messages_origin_check
+      CHECK (origin IN ('human', 'mdall'));
+  END IF;
+END
+$$;
+
+create index if not exists idx_subject_messages_subject_created
+  on public.subject_messages(subject_id, created_at asc);
+
+create index if not exists idx_subject_messages_subject_visibility_visible_until
+  on public.subject_messages(subject_id, visibility, visible_until);
+
+create index if not exists idx_subject_messages_llm_request_id
+  on public.subject_messages(llm_request_id)
+  where llm_request_id is not null;
+
+-- Keep direct client inserts human-only. Mdall messages will be inserted via future
+-- security-definer RPCs that enforce project access and lock rules server-side.
+drop policy if exists subject_messages_insert on public.subject_messages;
+create policy subject_messages_insert
+on public.subject_messages
+for insert
+to authenticated
+with check (
+  public.can_access_project_subject_conversation(project_id)
+  and public.is_subject_conversation_locked(subject_id) = false
+  and author_person_id = public.current_person_id()
+  and origin = 'human'
+);


### PR DESCRIPTION
### Motivation
- Support ephemeral messages and system/LLM-origin messages in `public.subject_messages` while preserving existing data and behaviour. 
- Allow storing an LLM request correlation id and arbitrary message metadata for future Mdall flows. 
- Prevent clients from forging Mdall-origin inserts by keeping RLS tight and preparing server-side RPC insertion.

### Description
- Added an idempotent Supabase migration `supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql` that adds columns `visibility`, `visible_until`, `origin`, `llm_request_id`, and `metadata` to `public.subject_messages` with safe defaults. 
- Adds check constraints (guarded with `DO` blocks) enforcing `visibility IN ('normal','ephemeral')` and `origin IN ('human','mdall')`. 
- Creates indexes `idx_subject_messages_subject_created`, `idx_subject_messages_subject_visibility_visible_until`, and `idx_subject_messages_llm_request_id` to support efficient timeline queries and request correlation. 
- Recreates the `subject_messages_insert` policy to require `origin = 'human'` for direct client inserts so Mdall/system messages must come through future `security definer` RPCs.

### Testing
- Ran `git status --short` to verify the new migration file appears in the repo (succeeded). 
- Committed the migration with `git add supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql && git commit -m "Add subject message fields for ephemeral and Mdall origins"` (commit succeeded). 
- No database migration or runtime tests were executed in this change; applying the migration and running DB-level checks should be done in the deployment environment before enabling Mdall flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede9acffac8329a71ee9a4056f69a2)