### PR TITLE
Add Mdall/ephemeral fields to subject_messages and add `create_subject_mdall_exchange` RPC

### DIFF
--- a/supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql
+++ b/supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql
@@ -1,0 +1,62 @@
+-- Add Mdall/ephemeral fields on subject messages while preserving existing data.
+
+alter table public.subject_messages
+  add column if not exists visibility text not null default 'normal',
+  add column if not exists visible_until timestamptz null,
+  add column if not exists origin text not null default 'human',
+  add column if not exists llm_request_id uuid null,
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'subject_messages_visibility_check'
+      AND conrelid = 'public.subject_messages'::regclass
+  ) THEN
+    ALTER TABLE public.subject_messages
+      ADD CONSTRAINT subject_messages_visibility_check
+      CHECK (visibility IN ('normal', 'ephemeral'));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'subject_messages_origin_check'
+      AND conrelid = 'public.subject_messages'::regclass
+  ) THEN
+    ALTER TABLE public.subject_messages
+      ADD CONSTRAINT subject_messages_origin_check
+      CHECK (origin IN ('human', 'mdall'));
+  END IF;
+END
+$$;
+
+create index if not exists idx_subject_messages_subject_created
+  on public.subject_messages(subject_id, created_at asc);
+
+create index if not exists idx_subject_messages_subject_visibility_visible_until
+  on public.subject_messages(subject_id, visibility, visible_until);
+
+create index if not exists idx_subject_messages_llm_request_id
+  on public.subject_messages(llm_request_id)
+  where llm_request_id is not null;
+
+-- Keep direct client inserts human-only. Mdall messages will be inserted via future
+-- security-definer RPCs that enforce project access and lock rules server-side.
+drop policy if exists subject_messages_insert on public.subject_messages;
+create policy subject_messages_insert
+on public.subject_messages
+for insert
+to authenticated
+with check (
+  public.can_access_project_subject_conversation(project_id)
+  and public.is_subject_conversation_locked(subject_id) = false
+  and author_person_id = public.current_person_id()
+  and origin = 'human'
+);

--- a/supabase/migrations/202606150034_create_subject_mdall_exchange_rpc.sql
+++ b/supabase/migrations/202606150034_create_subject_mdall_exchange_rpc.sql
@@ -1,0 +1,180 @@
+-- RPC for subject -> Mdall exchange bootstrap (creates human message only).
+
+create or replace function public.create_subject_mdall_exchange(
+  p_subject_id uuid,
+  p_body_markdown text,
+  p_is_ephemeral boolean default false,
+  p_parent_message_id uuid default null,
+  p_mentions jsonb default '[]'::jsonb,
+  p_client_request_id uuid default gen_random_uuid()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_mdall_person_id uuid;
+  v_user_message public.subject_messages;
+  v_visible_until timestamptz;
+  v_mentions jsonb;
+  v_mention_item jsonb;
+  v_mentioned_person_id_text text;
+  v_mentioned_person_id uuid;
+  v_display_label text;
+  v_client_request_id uuid;
+begin
+  if p_subject_id is null then
+    raise exception 'Subject is required';
+  end if;
+
+  if nullif(btrim(coalesce(p_body_markdown, '')), '') is null then
+    raise exception 'Message body cannot be empty';
+  end if;
+
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Not allowed to access this subject conversation';
+  end if;
+
+  if public.is_subject_conversation_locked(v_subject.id) then
+    raise exception 'Subject conversation is locked';
+  end if;
+
+  v_person_id := public.current_person_id();
+
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  v_client_request_id := coalesce(p_client_request_id, gen_random_uuid());
+  v_visible_until := case when coalesce(p_is_ephemeral, false) then now() + interval '60 seconds' else null end;
+
+  insert into public.directory_people (
+    email,
+    first_name,
+    linked_user_id,
+    created_by_user_id
+  )
+  values (
+    'mdall@system.local',
+    'Mdall',
+    null,
+    auth.uid()
+  )
+  on conflict (email_normalized) do update
+  set
+    first_name = coalesce(public.directory_people.first_name, excluded.first_name),
+    linked_user_id = null,
+    updated_at = now()
+  returning id into v_mdall_person_id;
+
+  insert into public.subject_messages (
+    project_id,
+    subject_id,
+    parent_message_id,
+    author_person_id,
+    author_user_id,
+    body_markdown,
+    visibility,
+    visible_until,
+    origin,
+    llm_request_id,
+    metadata
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    p_parent_message_id,
+    v_person_id,
+    auth.uid(),
+    btrim(p_body_markdown),
+    case when coalesce(p_is_ephemeral, false) then 'ephemeral' else 'normal' end,
+    v_visible_until,
+    'human',
+    null,
+    jsonb_build_object(
+      'mdall_exchange', true,
+      'client_request_id', v_client_request_id
+    )
+  )
+  returning * into v_user_message;
+
+  v_mentions := coalesce(p_mentions, '[]'::jsonb);
+
+  if jsonb_typeof(v_mentions) <> 'array' then
+    raise exception 'Mentions must be a JSON array';
+  end if;
+
+  for v_mention_item in
+    select value
+    from jsonb_array_elements(v_mentions)
+  loop
+    v_mentioned_person_id_text := nullif(
+      coalesce(
+        v_mention_item->>'personId',
+        v_mention_item->>'mentioned_person_id',
+        v_mention_item->>'mentionedPersonId'
+      ),
+      ''
+    );
+
+    if v_mentioned_person_id_text is null
+       or v_mentioned_person_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      continue;
+    end if;
+
+    v_mentioned_person_id := v_mentioned_person_id_text::uuid;
+    v_display_label := nullif(
+      btrim(
+        coalesce(
+          v_mention_item->>'label',
+          v_mention_item->>'display_label',
+          v_mention_item->>'displayLabel',
+          ''
+        )
+      ),
+      ''
+    );
+
+    insert into public.subject_message_mentions (
+      project_id,
+      subject_id,
+      message_id,
+      mentioned_person_id,
+      display_label
+    )
+    values (
+      v_subject.project_id,
+      v_subject.id,
+      v_user_message.id,
+      v_mentioned_person_id,
+      v_display_label
+    )
+    on conflict (message_id, mentioned_person_id) do nothing;
+  end loop;
+
+  return jsonb_build_object(
+    'user_message_id', v_user_message.id,
+    'mdall_person_id', v_mdall_person_id,
+    'subject_id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'is_ephemeral', coalesce(p_is_ephemeral, false),
+    'visible_until', v_visible_until,
+    'client_request_id', v_client_request_id
+  );
+end;
+$$;
+
+grant execute on function public.create_subject_mdall_exchange(uuid, text, boolean, uuid, jsonb, uuid)
+to authenticated;


### PR DESCRIPTION
### Motivation

- Introduce ephemeral message support and Mdall-origin messages for subject conversations so server-side Mdall inserts can be enforced. 
- Preserve existing data while adding new fields and constraints to `public.subject_messages`. 
- Provide a security-definer RPC to bootstrap the human side of a Mdall exchange and handle mention routing.

### Description

- Add columns to `public.subject_messages`: `visibility`, `visible_until`, `origin`, `llm_request_id`, and `metadata`, and add check constraints for `visibility` (`'normal'|'ephemeral'`) and `origin` (`'human'|'mdall'`).
- Create indexes `idx_subject_messages_subject_created`, `idx_subject_messages_subject_visibility_visible_until`, and `idx_subject_messages_llm_request_id` (partial) to support queries on subject, visibility, and LLM request lookups.
- Replace the insert policy on `public.subject_messages` to keep direct client inserts limited to `authenticated` users with checks that ensure project access, unlocked conversations, matching `author_person_id`, and `origin = 'human'`.
- Add the security-definer RPC `public.create_subject_mdall_exchange(uuid, text, boolean, uuid, jsonb, uuid)` which creates or upserts a `Mdall` directory person, inserts the user message (with ephemeral handling and `metadata` containing `mdall_exchange` and `client_request_id`), persists mention rows into `subject_message_mentions`, and returns relevant ids and metadata; and grant execute on the function to `authenticated`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede9acffac8329a71ee9a4056f69a2)