### PR TITLE
Add Mdall ephemeral subject messaging: client service, UI flow and DB RPCs/migrations

### DIFF
--- a/apps/web/js/services/subject-mdall-service.js
+++ b/apps/web/js/services/subject-mdall-service.js
@@ -1,0 +1,347 @@
+import { ASK_LLM_URL_PROD } from "../constants.js";
+import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+
+const SUPABASE_URL = getSupabaseUrl();
+const DEBUG_FLAG = "mdall:debug-subject-mdall";
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function normalizeMarkdown(value) {
+  return String(value || "").trim();
+}
+
+function isMdallDebugEnabled() {
+  const values = [];
+  try {
+    values.push(globalThis?.localStorage?.getItem(DEBUG_FLAG));
+  } catch {
+    // noop
+  }
+  try {
+    values.push(globalThis?.sessionStorage?.getItem(DEBUG_FLAG));
+  } catch {
+    // noop
+  }
+  return values.some((value) => {
+    const raw = String(value || "").trim().toLowerCase();
+    return raw && raw !== "0" && raw !== "false" && raw !== "off" && raw !== "no";
+  });
+}
+
+function debugLog(event, payload = {}) {
+  if (!isMdallDebugEnabled()) return;
+  try {
+    console.info(`[subject-mdall] ${event}`, payload);
+  } catch {
+    // noop
+  }
+}
+
+function safeJsonParse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function parseAssistantReply(data) {
+  if (!data) return "Je n’ai pas reçu de réponse exploitable.";
+  if (typeof data === "string") return data.trim() || "Réponse vide.";
+  if (typeof data.reply_markdown === "string" && data.reply_markdown.trim()) return data.reply_markdown.trim();
+  if (typeof data.reply === "string" && data.reply.trim()) return data.reply.trim();
+  if (typeof data.message === "string" && data.message.trim()) return data.message.trim();
+  if (Array.isArray(data.messages) && data.messages.length) {
+    const last = data.messages[data.messages.length - 1];
+    if (typeof last?.content === "string" && last.content.trim()) return last.content.trim();
+  }
+  return JSON.stringify(data, null, 2);
+}
+
+async function getAuthHeaders(extra = {}) {
+  return buildSupabaseAuthHeaders(extra);
+}
+
+async function restFetch(pathname, searchParams = null, options = {}) {
+  const url = new URL(`${SUPABASE_URL}${pathname}`);
+  if (searchParams instanceof URLSearchParams) {
+    searchParams.forEach((value, key) => url.searchParams.append(key, value));
+  }
+
+  const response = await fetch(url.toString(), {
+    method: options.method || "GET",
+    headers: await getAuthHeaders({ Accept: "application/json", ...(options.headers || {}) }),
+    cache: options.cache || "no-store",
+    body: options.body
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`${pathname} failed (${response.status}): ${text}`);
+  }
+
+  if (response.status === 204) return null;
+  const text = await response.text().catch(() => "");
+  if (!text) return null;
+  return safeJsonParse(text);
+}
+
+async function rpcCall(functionName, payload = {}) {
+  return restFetch(`/rest/v1/rpc/${functionName}`, null, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+function isMessageVisible(row = {}) {
+  if (row?.deleted_at) return false;
+  if (String(row?.visibility || "normal") !== "ephemeral") return true;
+  const visibleUntil = Date.parse(String(row?.visible_until || ""));
+  if (!Number.isFinite(visibleUntil)) return false;
+  return visibleUntil > Date.now();
+}
+
+async function fetchSubjectContext(subjectId = "", projectId = "", isEphemeral = false) {
+  const normalizedSubjectId = normalizeId(subjectId);
+  const normalizedProjectId = normalizeId(projectId);
+
+  const subjectParams = new URLSearchParams();
+  subjectParams.set("select", "id,project_id,title,status,description");
+  subjectParams.set("id", `eq.${normalizedSubjectId}`);
+  subjectParams.set("limit", "1");
+
+  const projectParams = new URLSearchParams();
+  projectParams.set("select", "id,name");
+  projectParams.set("id", `eq.${normalizedProjectId}`);
+  projectParams.set("limit", "1");
+
+  const messagesParams = new URLSearchParams();
+  messagesParams.set(
+    "select",
+    "id,project_id,subject_id,parent_message_id,author_person_id,author_user_id,body_markdown,created_at,deleted_at,visibility,visible_until,origin,llm_request_id,metadata"
+  );
+  messagesParams.set("subject_id", `eq.${normalizedSubjectId}`);
+  messagesParams.set("deleted_at", "is.null");
+  messagesParams.set("order", "created_at.desc");
+  messagesParams.set("limit", "30");
+
+  const [subjectRows, projectRows, messageRows] = await Promise.all([
+    restFetch("/rest/v1/subjects", subjectParams).catch(() => []),
+    normalizedProjectId ? restFetch("/rest/v1/projects", projectParams).catch(() => []) : Promise.resolve([]),
+    restFetch("/rest/v1/subject_messages", messagesParams).catch(() => [])
+  ]);
+
+  const subject = (Array.isArray(subjectRows) ? subjectRows[0] : subjectRows) || null;
+  const project = (Array.isArray(projectRows) ? projectRows[0] : projectRows) || null;
+  const rows = Array.isArray(messageRows) ? messageRows : [];
+
+  return {
+    subject: {
+      id: normalizeId(subject?.id) || normalizedSubjectId,
+      project_id: normalizeId(subject?.project_id) || normalizedProjectId,
+      title: String(subject?.title || ""),
+      status: String(subject?.status || ""),
+      description: String(subject?.description || "")
+    },
+    project: {
+      id: normalizeId(project?.id) || normalizedProjectId,
+      name: String(project?.name || "")
+    },
+    is_ephemeral: !!isEphemeral,
+    recent_messages: rows
+      .filter((row) => isMessageVisible(row))
+      .reverse()
+      .map((row) => ({
+        id: normalizeId(row?.id),
+        parent_message_id: normalizeId(row?.parent_message_id),
+        author_person_id: normalizeId(row?.author_person_id),
+        origin: String(row?.origin || "human"),
+        visibility: String(row?.visibility || "normal"),
+        visible_until: row?.visible_until || null,
+        created_at: String(row?.created_at || ""),
+        body_markdown: String(row?.body_markdown || "")
+      }))
+  };
+}
+
+function normalizeRpcJsonResult(value) {
+  if (!value) return null;
+  if (Array.isArray(value)) return value[0] || null;
+  return value;
+}
+
+export async function sendSubjectMdallExchange({
+  subjectId,
+  bodyMarkdown,
+  isEphemeral = false,
+  parentMessageId = null,
+  mentions = []
+} = {}) {
+  const normalizedSubjectId = normalizeId(subjectId);
+  const normalizedBody = normalizeMarkdown(bodyMarkdown);
+
+  if (!normalizedSubjectId) throw new Error("subjectId is required");
+  if (!normalizedBody) throw new Error("bodyMarkdown is required");
+
+  debugLog("exchange-start", {
+    subjectId: normalizedSubjectId,
+    isEphemeral: !!isEphemeral,
+    hasParentMessageId: !!normalizeId(parentMessageId),
+    mentionsCount: Array.isArray(mentions) ? mentions.length : 0
+  });
+
+  const createdExchangeRaw = await rpcCall("create_subject_mdall_exchange", {
+    p_subject_id: normalizedSubjectId,
+    p_body_markdown: normalizedBody,
+    p_is_ephemeral: !!isEphemeral,
+    p_parent_message_id: normalizeId(parentMessageId) || null,
+    p_mentions: Array.isArray(mentions) ? mentions : []
+  });
+  const createdExchange = normalizeRpcJsonResult(createdExchangeRaw);
+
+  if (!createdExchange?.user_message_id || !createdExchange?.mdall_person_id) {
+    throw new Error("create_subject_mdall_exchange returned an invalid payload");
+  }
+
+  debugLog("user-message-created", {
+    userMessageId: createdExchange.user_message_id,
+    mdallPersonId: createdExchange.mdall_person_id,
+    projectId: createdExchange.project_id,
+    visibleUntil: createdExchange.visible_until || null,
+    clientRequestId: createdExchange.client_request_id || null
+  });
+
+  const context = await fetchSubjectContext(
+    normalizedSubjectId,
+    normalizeId(createdExchange.project_id),
+    !!isEphemeral
+  );
+
+  const llmPayload = {
+    channel: "subject_mdall",
+    user_message: normalizedBody,
+    subject_id: normalizedSubjectId,
+    project_id: normalizeId(createdExchange.project_id),
+    user_message_id: normalizeId(createdExchange.user_message_id),
+    client_request_id: createdExchange.client_request_id || null,
+    is_ephemeral: !!isEphemeral,
+    context
+  };
+
+  debugLog("llm-request", {
+    endpoint: ASK_LLM_URL_PROD,
+    subjectId: normalizedSubjectId,
+    projectId: normalizeId(createdExchange.project_id),
+    clientRequestId: createdExchange.client_request_id || null,
+    isEphemeral: !!isEphemeral
+  });
+
+  try {
+    const response = await fetch(ASK_LLM_URL_PROD, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(llmPayload)
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`Webhook Mdall en erreur (${response.status})${text ? ` — ${text.slice(0, 220)}` : ""}`);
+    }
+
+    const raw = await response.json().catch(() => null);
+    const parsedReply = parseAssistantReply(raw);
+
+    debugLog("llm-response", {
+      hasRaw: !!raw,
+      replyLength: String(parsedReply || "").length,
+      clientRequestId: createdExchange.client_request_id || null
+    });
+
+    const replyInsertRaw = await rpcCall("insert_subject_mdall_reply", {
+      p_subject_id: normalizedSubjectId,
+      p_body_markdown: parsedReply,
+      p_mdall_person_id: createdExchange.mdall_person_id,
+      p_is_ephemeral: !!isEphemeral,
+      p_parent_message_id: normalizeId(parentMessageId) || null,
+      p_llm_request_id: createdExchange.client_request_id || null,
+      p_metadata: {
+        mdall_exchange: true,
+        client_request_id: createdExchange.client_request_id || null,
+        llm_raw: raw && typeof raw === "object" ? raw : null
+      }
+    });
+
+    const insertedReply = normalizeRpcJsonResult(replyInsertRaw);
+
+    debugLog("reply-inserted", {
+      messageId: insertedReply?.message_id || null,
+      subjectId: normalizedSubjectId,
+      visibility: insertedReply?.visibility || (isEphemeral ? "ephemeral" : "normal")
+    });
+
+    return {
+      userMessageId: normalizeId(createdExchange.user_message_id),
+      mdallPersonId: normalizeId(createdExchange.mdall_person_id),
+      subjectId: normalizeId(createdExchange.subject_id) || normalizedSubjectId,
+      projectId: normalizeId(createdExchange.project_id),
+      visibleUntil: createdExchange.visible_until || null,
+      clientRequestId: createdExchange.client_request_id || null,
+      replyMessageId: normalizeId(insertedReply?.message_id),
+      replyMarkdown: parsedReply,
+      llmRaw: raw
+    };
+  } catch (error) {
+    debugLog("exchange-error", {
+      message: String(error?.message || error || "unknown error"),
+      subjectId: normalizedSubjectId,
+      isEphemeral: !!isEphemeral
+    });
+
+    if (isEphemeral) {
+      throw error;
+    }
+
+    const fallbackBody = "Mdall est momentanément indisponible. Réessayez dans un instant.";
+
+    const fallbackInsertRaw = await rpcCall("insert_subject_mdall_reply", {
+      p_subject_id: normalizedSubjectId,
+      p_body_markdown: fallbackBody,
+      p_mdall_person_id: createdExchange.mdall_person_id,
+      p_is_ephemeral: false,
+      p_parent_message_id: normalizeId(parentMessageId) || null,
+      p_llm_request_id: createdExchange.client_request_id || null,
+      p_metadata: {
+        mdall_exchange: true,
+        client_request_id: createdExchange.client_request_id || null,
+        error: String(error?.message || error || "unknown error")
+      }
+    }).catch(() => null);
+
+    const fallbackInserted = normalizeRpcJsonResult(fallbackInsertRaw);
+
+    debugLog("reply-inserted", {
+      messageId: fallbackInserted?.message_id || null,
+      subjectId: normalizedSubjectId,
+      visibility: "normal",
+      fallback: true
+    });
+
+    return {
+      userMessageId: normalizeId(createdExchange.user_message_id),
+      mdallPersonId: normalizeId(createdExchange.mdall_person_id),
+      subjectId: normalizeId(createdExchange.subject_id) || normalizedSubjectId,
+      projectId: normalizeId(createdExchange.project_id),
+      visibleUntil: createdExchange.visible_until || null,
+      clientRequestId: createdExchange.client_request_id || null,
+      replyMessageId: normalizeId(fallbackInserted?.message_id),
+      replyMarkdown: fallbackBody,
+      llmRaw: null,
+      error: String(error?.message || error || "unknown error")
+    };
+  }
+}

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -16,6 +16,7 @@ import {
   syncSelectDropdownPosition
 } from "../ui/select-dropdown-controller.js";
 import { extractStructuredMentions } from "../../utils/subject-mentions.js";
+import { sendSubjectMdallExchange } from "../../services/subject-mdall-service.js";
 import { renderCommentComposer } from "../ui/comment-composer.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
 import { renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
@@ -3131,7 +3132,90 @@ async function applyCommentAction(root) {
   if (!message && !hasAttachmentsForTarget) return;
   const mentions = extractStructuredMentions(message);
 
+  const logEphemeralFlow = (event, payload = {}) => {
+    try {
+      console.info(`[subject-mdall] ${event}`, payload);
+    } catch {}
+  };
+
+  const resolveScopeHost = () => {
+    const detailsHost = root?.closest?.("#drilldownPanel") || document.getElementById("situationsDetailsHost");
+    return detailsHost?.closest?.("#drilldownPanel") ? "drilldown" : "main";
+  };
+
+  const refreshTimelineForCurrentScope = (scopeHost = "main") => {
+    const scopedSelection = getSelectionForScope(scopeHost);
+    ensureTimelineLoadedForSelection(scopedSelection, { scopeHost, force: true });
+  };
+
+  const replyContext = store.situationsView?.replyContext || {};
+  const replySubjectId = String(replyContext?.subjectId || "").trim();
+  const parentMessageId = target.type === "sujet" && replySubjectId === String(target.id || "").trim()
+    ? String(replyContext?.parentMessageId || "").trim()
+    : "";
+
   const helpActive = !!store.situationsView.helpMode;
+  if (helpActive && target.type === "sujet") {
+    if (!message) return;
+
+    logEphemeralFlow("ephemeral-submit", {
+      subjectId: String(target.id || "").trim(),
+      hasParentMessageId: !!parentMessageId,
+      mentionsCount: Array.isArray(mentions) ? mentions.length : 0
+    });
+
+    await sendSubjectMdallExchange({
+      subjectId: target.id,
+      bodyMarkdown: message,
+      isEphemeral: true,
+      parentMessageId: parentMessageId || null,
+      mentions
+    });
+
+    ta.value = "";
+    store.situationsView.commentDraft = "";
+    store.situationsView.commentPreviewMode = false;
+
+    const scopeHost = resolveScopeHost();
+    refreshTimelineForCurrentScope(scopeHost);
+
+    if (store.situationsView?.replyContext) {
+      store.situationsView.replyContext.subjectId = "";
+      store.situationsView.replyContext.parentMessageId = "";
+      store.situationsView.replyContext.parentPreview = "";
+    }
+
+    if (store.situationsView?.ephemeralRefreshTimer) {
+      clearTimeout(store.situationsView.ephemeralRefreshTimer);
+      store.situationsView.ephemeralRefreshTimer = null;
+    }
+
+    const refreshDelayMs = 61_000;
+    logEphemeralFlow("ephemeral-refresh-scheduled", {
+      subjectId: String(target.id || "").trim(),
+      refreshDelayMs
+    });
+
+    store.situationsView.ephemeralRefreshTimer = setTimeout(() => {
+      logEphemeralFlow("ephemeral-expired-refresh", {
+        subjectId: String(target.id || "").trim()
+      });
+      refreshTimelineForCurrentScope(scopeHost);
+      store.situationsView.ephemeralRefreshTimer = null;
+    }, refreshDelayMs);
+
+    const detailsHost = document.getElementById("situationsDetailsHost");
+    const composerHost = root?.closest?.("[data-details-composer-host]")
+      || detailsHost?.querySelector?.("[data-details-composer-host]");
+    if (composerHost) {
+      scheduleDetailsComposerRerender({ scopeHost });
+    } else {
+      rerenderScope(root);
+    }
+
+    return;
+  }
+
   if (helpActive) {
     ta.value = "";
     store.situationsView.commentDraft = "";
@@ -3139,11 +3223,6 @@ async function applyCommentAction(root) {
     return;
   }
 
-  const replyContext = store.situationsView?.replyContext || {};
-  const replySubjectId = String(replyContext?.subjectId || "").trim();
-  const parentMessageId = target.type === "sujet" && replySubjectId === String(target.id || "").trim()
-    ? String(replyContext?.parentMessageId || "").trim()
-    : "";
   const uploadSessionId = hasAttachmentsForTarget ? String(composerAttachments?.uploadSessionId || "").trim() : "";
 
   await addComment(target.type, target.id, message, {

--- a/supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql
+++ b/supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql
@@ -1,0 +1,62 @@
+-- Add Mdall/ephemeral fields on subject messages while preserving existing data.
+
+alter table public.subject_messages
+  add column if not exists visibility text not null default 'normal',
+  add column if not exists visible_until timestamptz null,
+  add column if not exists origin text not null default 'human',
+  add column if not exists llm_request_id uuid null,
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'subject_messages_visibility_check'
+      AND conrelid = 'public.subject_messages'::regclass
+  ) THEN
+    ALTER TABLE public.subject_messages
+      ADD CONSTRAINT subject_messages_visibility_check
+      CHECK (visibility IN ('normal', 'ephemeral'));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'subject_messages_origin_check'
+      AND conrelid = 'public.subject_messages'::regclass
+  ) THEN
+    ALTER TABLE public.subject_messages
+      ADD CONSTRAINT subject_messages_origin_check
+      CHECK (origin IN ('human', 'mdall'));
+  END IF;
+END
+$$;
+
+create index if not exists idx_subject_messages_subject_created
+  on public.subject_messages(subject_id, created_at asc);
+
+create index if not exists idx_subject_messages_subject_visibility_visible_until
+  on public.subject_messages(subject_id, visibility, visible_until);
+
+create index if not exists idx_subject_messages_llm_request_id
+  on public.subject_messages(llm_request_id)
+  where llm_request_id is not null;
+
+-- Keep direct client inserts human-only. Mdall messages will be inserted via future
+-- security-definer RPCs that enforce project access and lock rules server-side.
+drop policy if exists subject_messages_insert on public.subject_messages;
+create policy subject_messages_insert
+on public.subject_messages
+for insert
+to authenticated
+with check (
+  public.can_access_project_subject_conversation(project_id)
+  and public.is_subject_conversation_locked(subject_id) = false
+  and author_person_id = public.current_person_id()
+  and origin = 'human'
+);

--- a/supabase/migrations/202606150034_create_subject_mdall_exchange_rpc.sql
+++ b/supabase/migrations/202606150034_create_subject_mdall_exchange_rpc.sql
@@ -1,0 +1,180 @@
+-- RPC for subject -> Mdall exchange bootstrap (creates human message only).
+
+create or replace function public.create_subject_mdall_exchange(
+  p_subject_id uuid,
+  p_body_markdown text,
+  p_is_ephemeral boolean default false,
+  p_parent_message_id uuid default null,
+  p_mentions jsonb default '[]'::jsonb,
+  p_client_request_id uuid default gen_random_uuid()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_person_id uuid;
+  v_mdall_person_id uuid;
+  v_user_message public.subject_messages;
+  v_visible_until timestamptz;
+  v_mentions jsonb;
+  v_mention_item jsonb;
+  v_mentioned_person_id_text text;
+  v_mentioned_person_id uuid;
+  v_display_label text;
+  v_client_request_id uuid;
+begin
+  if p_subject_id is null then
+    raise exception 'Subject is required';
+  end if;
+
+  if nullif(btrim(coalesce(p_body_markdown, '')), '') is null then
+    raise exception 'Message body cannot be empty';
+  end if;
+
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Not allowed to access this subject conversation';
+  end if;
+
+  if public.is_subject_conversation_locked(v_subject.id) then
+    raise exception 'Subject conversation is locked';
+  end if;
+
+  v_person_id := public.current_person_id();
+
+  if v_person_id is null then
+    raise exception 'No linked directory person for current user';
+  end if;
+
+  v_client_request_id := coalesce(p_client_request_id, gen_random_uuid());
+  v_visible_until := case when coalesce(p_is_ephemeral, false) then now() + interval '60 seconds' else null end;
+
+  insert into public.directory_people (
+    email,
+    first_name,
+    linked_user_id,
+    created_by_user_id
+  )
+  values (
+    'mdall@system.local',
+    'Mdall',
+    null,
+    auth.uid()
+  )
+  on conflict (email_normalized) do update
+  set
+    first_name = coalesce(public.directory_people.first_name, excluded.first_name),
+    linked_user_id = null,
+    updated_at = now()
+  returning id into v_mdall_person_id;
+
+  insert into public.subject_messages (
+    project_id,
+    subject_id,
+    parent_message_id,
+    author_person_id,
+    author_user_id,
+    body_markdown,
+    visibility,
+    visible_until,
+    origin,
+    llm_request_id,
+    metadata
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    p_parent_message_id,
+    v_person_id,
+    auth.uid(),
+    btrim(p_body_markdown),
+    case when coalesce(p_is_ephemeral, false) then 'ephemeral' else 'normal' end,
+    v_visible_until,
+    'human',
+    null,
+    jsonb_build_object(
+      'mdall_exchange', true,
+      'client_request_id', v_client_request_id
+    )
+  )
+  returning * into v_user_message;
+
+  v_mentions := coalesce(p_mentions, '[]'::jsonb);
+
+  if jsonb_typeof(v_mentions) <> 'array' then
+    raise exception 'Mentions must be a JSON array';
+  end if;
+
+  for v_mention_item in
+    select value
+    from jsonb_array_elements(v_mentions)
+  loop
+    v_mentioned_person_id_text := nullif(
+      coalesce(
+        v_mention_item->>'personId',
+        v_mention_item->>'mentioned_person_id',
+        v_mention_item->>'mentionedPersonId'
+      ),
+      ''
+    );
+
+    if v_mentioned_person_id_text is null
+       or v_mentioned_person_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      continue;
+    end if;
+
+    v_mentioned_person_id := v_mentioned_person_id_text::uuid;
+    v_display_label := nullif(
+      btrim(
+        coalesce(
+          v_mention_item->>'label',
+          v_mention_item->>'display_label',
+          v_mention_item->>'displayLabel',
+          ''
+        )
+      ),
+      ''
+    );
+
+    insert into public.subject_message_mentions (
+      project_id,
+      subject_id,
+      message_id,
+      mentioned_person_id,
+      display_label
+    )
+    values (
+      v_subject.project_id,
+      v_subject.id,
+      v_user_message.id,
+      v_mentioned_person_id,
+      v_display_label
+    )
+    on conflict (message_id, mentioned_person_id) do nothing;
+  end loop;
+
+  return jsonb_build_object(
+    'user_message_id', v_user_message.id,
+    'mdall_person_id', v_mdall_person_id,
+    'subject_id', v_subject.id,
+    'project_id', v_subject.project_id,
+    'is_ephemeral', coalesce(p_is_ephemeral, false),
+    'visible_until', v_visible_until,
+    'client_request_id', v_client_request_id
+  );
+end;
+$$;
+
+grant execute on function public.create_subject_mdall_exchange(uuid, text, boolean, uuid, jsonb, uuid)
+to authenticated;

--- a/supabase/migrations/202606150035_insert_subject_mdall_reply_rpc.sql
+++ b/supabase/migrations/202606150035_insert_subject_mdall_reply_rpc.sql
@@ -1,0 +1,112 @@
+-- RPC to insert Mdall replies as conversation messages.
+
+create or replace function public.insert_subject_mdall_reply(
+  p_subject_id uuid,
+  p_body_markdown text,
+  p_mdall_person_id uuid,
+  p_is_ephemeral boolean default false,
+  p_parent_message_id uuid default null,
+  p_llm_request_id uuid default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_subject public.subjects;
+  v_visible_until timestamptz;
+  v_inserted public.subject_messages;
+  v_metadata jsonb;
+  v_email_normalized text;
+begin
+  if p_subject_id is null then
+    raise exception 'Subject is required';
+  end if;
+
+  if p_mdall_person_id is null then
+    raise exception 'Mdall person id is required';
+  end if;
+
+  if nullif(btrim(coalesce(p_body_markdown, '')), '') is null then
+    raise exception 'Message body cannot be empty';
+  end if;
+
+  select *
+    into v_subject
+  from public.subjects s
+  where s.id = p_subject_id;
+
+  if v_subject.id is null then
+    raise exception 'Subject not found';
+  end if;
+
+  if not public.can_access_project_subject_conversation(v_subject.project_id) then
+    raise exception 'Not allowed to access this subject conversation';
+  end if;
+
+  if public.is_subject_conversation_locked(v_subject.id) then
+    raise exception 'Subject conversation is locked';
+  end if;
+
+  select dp.email_normalized
+    into v_email_normalized
+  from public.directory_people dp
+  where dp.id = p_mdall_person_id;
+
+  if v_email_normalized is null then
+    raise exception 'Mdall person not found';
+  end if;
+
+  if v_email_normalized <> 'mdall@system.local' then
+    raise exception 'Only mdall@system.local can be used for Mdall replies';
+  end if;
+
+  v_visible_until := case when coalesce(p_is_ephemeral, false) then now() + interval '60 seconds' else null end;
+  v_metadata := coalesce(p_metadata, '{}'::jsonb) || jsonb_build_object('mdall_reply', true);
+
+  insert into public.subject_messages (
+    project_id,
+    subject_id,
+    parent_message_id,
+    author_person_id,
+    author_user_id,
+    body_markdown,
+    visibility,
+    visible_until,
+    origin,
+    llm_request_id,
+    metadata
+  )
+  values (
+    v_subject.project_id,
+    v_subject.id,
+    p_parent_message_id,
+    p_mdall_person_id,
+    null,
+    btrim(p_body_markdown),
+    case when coalesce(p_is_ephemeral, false) then 'ephemeral' else 'normal' end,
+    v_visible_until,
+    'mdall',
+    p_llm_request_id,
+    v_metadata
+  )
+  returning * into v_inserted;
+
+  return jsonb_build_object(
+    'message_id', v_inserted.id,
+    'subject_id', v_inserted.subject_id,
+    'project_id', v_inserted.project_id,
+    'origin', v_inserted.origin,
+    'visibility', v_inserted.visibility,
+    'visible_until', v_inserted.visible_until,
+    'llm_request_id', v_inserted.llm_request_id
+  );
+end;
+$$;
+
+grant execute on function public.insert_subject_mdall_reply(uuid, text, uuid, boolean, uuid, uuid, jsonb)
+  to authenticated;
+revoke all on function public.insert_subject_mdall_reply(uuid, text, uuid, boolean, uuid, uuid, jsonb)
+  from public;


### PR DESCRIPTION
### Motivation
- Support ephemeral Mdall-driven replies on subject conversations and provide a client-side service to orchestrate the exchange. 
- Persist new message metadata and visibility fields so Mdall-origin and ephemeral messages can be stored and queried.

### Description
- Add `apps/web/js/services/subject-mdall-service.js` which implements `sendSubjectMdallExchange`, REST helpers, RPC callers, parsing, debug logging and context fetching for subject LLM exchanges. 
- Update `apps/web/js/views/project-subjects/project-subjects-view.js` to wire ephemeral help-mode comment submissions to `sendSubjectMdallExchange`, schedule timeline refreshes, and manage ephemeral composer state. 
- Add database migration `supabase/migrations/202606150033_subject_messages_mdall_ephemeral_fields.sql` to add `visibility`, `visible_until`, `origin`, `llm_request_id` and `metadata` columns, constraints, indexes and an insert policy restricting direct client inserts to human-origin messages. 
- Add RPC migration `supabase/migrations/202606150034_create_subject_mdall_exchange_rpc.sql` to create `create_subject_mdall_exchange(...)` which validates access, inserts the initiating human message and returns exchange metadata. 
- Add RPC migration `supabase/migrations/202606150035_insert_subject_mdall_reply_rpc.sql` to create `insert_subject_mdall_reply(...)` which enforces Mdall author constraints and inserts Mdall replies with proper visibility, llm_request_id and metadata.

### Testing
- No automated tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede9acffac8329a71ee9a4056f69a2)