### PR TITLE
Move subject Mdall exchange to Supabase Edge Function and update client to call it

### DIFF
--- a/apps/web/js/services/subject-mdall-service.js
+++ b/apps/web/js/services/subject-mdall-service.js
@@ -1,7 +1,7 @@
-import { ASK_LLM_URL_PROD } from "../constants.js";
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
 
 const SUPABASE_URL = getSupabaseUrl();
+const SUBJECT_MDALL_EXCHANGE_FN_URL = `${SUPABASE_URL}/functions/v1/subject-mdall-exchange`;
 const DEBUG_FLAG = "mdall:debug-subject-mdall";
 
 function normalizeId(value) {
@@ -53,10 +53,6 @@ function parseAssistantReply(data) {
   if (typeof data.reply_markdown === "string" && data.reply_markdown.trim()) return data.reply_markdown.trim();
   if (typeof data.reply === "string" && data.reply.trim()) return data.reply.trim();
   if (typeof data.message === "string" && data.message.trim()) return data.message.trim();
-  if (Array.isArray(data.messages) && data.messages.length) {
-    const last = data.messages[data.messages.length - 1];
-    if (typeof last?.content === "string" && last.content.trim()) return last.content.trim();
-  }
   return JSON.stringify(data, null, 2);
 }
 
@@ -64,113 +60,28 @@ async function getAuthHeaders(extra = {}) {
   return buildSupabaseAuthHeaders(extra);
 }
 
-async function restFetch(pathname, searchParams = null, options = {}) {
-  const url = new URL(`${SUPABASE_URL}${pathname}`);
-  if (searchParams instanceof URLSearchParams) {
-    searchParams.forEach((value, key) => url.searchParams.append(key, value));
-  }
-
-  const response = await fetch(url.toString(), {
-    method: options.method || "GET",
-    headers: await getAuthHeaders({ Accept: "application/json", ...(options.headers || {}) }),
-    cache: options.cache || "no-store",
-    body: options.body
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`${pathname} failed (${response.status}): ${text}`);
-  }
-
-  if (response.status === 204) return null;
-  const text = await response.text().catch(() => "");
-  if (!text) return null;
-  return safeJsonParse(text);
-}
-
-async function rpcCall(functionName, payload = {}) {
-  return restFetch(`/rest/v1/rpc/${functionName}`, null, {
+async function invokeSubjectMdallExchange(payload = {}) {
+  const response = await fetch(SUBJECT_MDALL_EXCHANGE_FN_URL, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: await getAuthHeaders({
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    }),
+    cache: "no-store",
     body: JSON.stringify(payload)
   });
-}
 
-function isMessageVisible(row = {}) {
-  if (row?.deleted_at) return false;
-  if (String(row?.visibility || "normal") !== "ephemeral") return true;
-  const visibleUntil = Date.parse(String(row?.visible_until || ""));
-  if (!Number.isFinite(visibleUntil)) return false;
-  return visibleUntil > Date.now();
-}
+  const text = await response.text().catch(() => "");
+  const json = text ? safeJsonParse(text) : null;
 
-async function fetchSubjectContext(subjectId = "", projectId = "", isEphemeral = false) {
-  const normalizedSubjectId = normalizeId(subjectId);
-  const normalizedProjectId = normalizeId(projectId);
+  if (!response.ok) {
+    const details = typeof json?.error === "string" && json.error.trim()
+      ? json.error.trim()
+      : text || `HTTP ${response.status}`;
+    throw new Error(`Mdall est momentanément indisponible. ${details}`.trim());
+  }
 
-  const subjectParams = new URLSearchParams();
-  subjectParams.set("select", "id,project_id,title,status,description");
-  subjectParams.set("id", `eq.${normalizedSubjectId}`);
-  subjectParams.set("limit", "1");
-
-  const projectParams = new URLSearchParams();
-  projectParams.set("select", "id,name");
-  projectParams.set("id", `eq.${normalizedProjectId}`);
-  projectParams.set("limit", "1");
-
-  const messagesParams = new URLSearchParams();
-  messagesParams.set(
-    "select",
-    "id,project_id,subject_id,parent_message_id,author_person_id,author_user_id,body_markdown,created_at,deleted_at,visibility,visible_until,origin,llm_request_id,metadata"
-  );
-  messagesParams.set("subject_id", `eq.${normalizedSubjectId}`);
-  messagesParams.set("deleted_at", "is.null");
-  messagesParams.set("order", "created_at.desc");
-  messagesParams.set("limit", "30");
-
-  const [subjectRows, projectRows, messageRows] = await Promise.all([
-    restFetch("/rest/v1/subjects", subjectParams).catch(() => []),
-    normalizedProjectId ? restFetch("/rest/v1/projects", projectParams).catch(() => []) : Promise.resolve([]),
-    restFetch("/rest/v1/subject_messages", messagesParams).catch(() => [])
-  ]);
-
-  const subject = (Array.isArray(subjectRows) ? subjectRows[0] : subjectRows) || null;
-  const project = (Array.isArray(projectRows) ? projectRows[0] : projectRows) || null;
-  const rows = Array.isArray(messageRows) ? messageRows : [];
-
-  return {
-    subject: {
-      id: normalizeId(subject?.id) || normalizedSubjectId,
-      project_id: normalizeId(subject?.project_id) || normalizedProjectId,
-      title: String(subject?.title || ""),
-      status: String(subject?.status || ""),
-      description: String(subject?.description || "")
-    },
-    project: {
-      id: normalizeId(project?.id) || normalizedProjectId,
-      name: String(project?.name || "")
-    },
-    is_ephemeral: !!isEphemeral,
-    recent_messages: rows
-      .filter((row) => isMessageVisible(row))
-      .reverse()
-      .map((row) => ({
-        id: normalizeId(row?.id),
-        parent_message_id: normalizeId(row?.parent_message_id),
-        author_person_id: normalizeId(row?.author_person_id),
-        origin: String(row?.origin || "human"),
-        visibility: String(row?.visibility || "normal"),
-        visible_until: row?.visible_until || null,
-        created_at: String(row?.created_at || ""),
-        body_markdown: String(row?.body_markdown || "")
-      }))
-  };
-}
-
-function normalizeRpcJsonResult(value) {
-  if (!value) return null;
-  if (Array.isArray(value)) return value[0] || null;
-  return value;
+  return json;
 }
 
 export async function sendSubjectMdallExchange({
@@ -193,118 +104,50 @@ export async function sendSubjectMdallExchange({
     mentionsCount: Array.isArray(mentions) ? mentions.length : 0
   });
 
-  const createdExchangeRaw = await rpcCall("create_subject_mdall_exchange", {
-    p_subject_id: normalizedSubjectId,
-    p_body_markdown: normalizedBody,
-    p_is_ephemeral: !!isEphemeral,
-    p_parent_message_id: normalizeId(parentMessageId) || null,
-    p_mentions: Array.isArray(mentions) ? mentions : []
-  });
-  const createdExchange = normalizeRpcJsonResult(createdExchangeRaw);
-
-  if (!createdExchange?.user_message_id || !createdExchange?.mdall_person_id) {
-    throw new Error("create_subject_mdall_exchange returned an invalid payload");
-  }
-
-  debugLog("user-message-created", {
-    userMessageId: createdExchange.user_message_id,
-    mdallPersonId: createdExchange.mdall_person_id,
-    projectId: createdExchange.project_id,
-    visibleUntil: createdExchange.visible_until || null,
-    clientRequestId: createdExchange.client_request_id || null
-  });
-
-  const context = await fetchSubjectContext(
-    normalizedSubjectId,
-    normalizeId(createdExchange.project_id),
-    !!isEphemeral
-  );
-
-  const llmPayload = {
-    channel: "subject_mdall",
-    user_message: normalizedBody,
-    subject_id: normalizedSubjectId,
-    project_id: normalizeId(createdExchange.project_id),
-    user_message_id: normalizeId(createdExchange.user_message_id),
-    client_request_id: createdExchange.client_request_id || null,
-    is_ephemeral: !!isEphemeral,
-    context
-  };
-
-  debugLog("llm-request", {
-    endpoint: ASK_LLM_URL_PROD,
-    subjectId: normalizedSubjectId,
-    projectId: normalizeId(createdExchange.project_id),
-    clientRequestId: createdExchange.client_request_id || null,
-    isEphemeral: !!isEphemeral
-  });
-
   try {
-    let response = null;
-    try {
-      response = await fetch(ASK_LLM_URL_PROD, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify(llmPayload)
-      });
-    } catch (networkError) {
-      const isFetchFailure = /failed to fetch/i.test(String(networkError?.message || ""));
-      if (isFetchFailure) {
-        throw new Error(
-          "Impossible de contacter le webhook Mdall (erreur réseau/CORS). Vérifiez Access-Control-Allow-Origin."
-        );
-      }
-      throw networkError;
+    const payload = {
+      subject_id: normalizedSubjectId,
+      body_markdown: normalizedBody,
+      is_ephemeral: !!isEphemeral,
+      parent_message_id: normalizeId(parentMessageId) || null,
+      mentions: Array.isArray(mentions) ? mentions : []
+    };
+
+    const raw = await invokeSubjectMdallExchange(payload);
+
+    if (!raw?.user_message_id || !raw?.subject_id) {
+      throw new Error("Réponse serveur Mdall invalide.");
     }
 
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      throw new Error(`Webhook Mdall en erreur (${response.status})${text ? ` — ${text.slice(0, 220)}` : ""}`);
-    }
+    debugLog("user-message-created", {
+      userMessageId: raw.user_message_id,
+      subjectId: raw.subject_id,
+      projectId: raw.project_id || null,
+      visibleUntil: raw.visible_until || null
+    });
 
-    const raw = await response.json().catch(() => null);
     const parsedReply = parseAssistantReply(raw);
 
     debugLog("llm-response", {
       hasRaw: !!raw,
       replyLength: String(parsedReply || "").length,
-      clientRequestId: createdExchange.client_request_id || null
+      userMessageId: raw.user_message_id,
+      replyMessageId: raw.reply_message_id || null
     });
 
-    const replyInsertRaw = await rpcCall("insert_subject_mdall_reply", {
-      p_subject_id: normalizedSubjectId,
-      p_body_markdown: parsedReply,
-      p_mdall_person_id: createdExchange.mdall_person_id,
-      p_is_ephemeral: !!isEphemeral,
-      p_parent_message_id: normalizeId(parentMessageId) || null,
-      p_llm_request_id: createdExchange.client_request_id || null,
-      p_metadata: {
-        mdall_exchange: true,
-        client_request_id: createdExchange.client_request_id || null,
-        llm_raw: raw && typeof raw === "object" ? raw : null
-      }
-    });
-
-    const insertedReply = normalizeRpcJsonResult(replyInsertRaw);
-
-    debugLog("reply-inserted", {
-      messageId: insertedReply?.message_id || null,
-      subjectId: normalizedSubjectId,
-      visibility: insertedReply?.visibility || (isEphemeral ? "ephemeral" : "normal")
+    debugLog("exchange-completed", {
+      subjectId: raw.subject_id,
+      projectId: raw.project_id || null,
+      isEphemeral: !!raw.is_ephemeral
     });
 
     return {
-      userMessageId: normalizeId(createdExchange.user_message_id),
-      mdallPersonId: normalizeId(createdExchange.mdall_person_id),
-      subjectId: normalizeId(createdExchange.subject_id) || normalizedSubjectId,
-      projectId: normalizeId(createdExchange.project_id),
-      visibleUntil: createdExchange.visible_until || null,
-      clientRequestId: createdExchange.client_request_id || null,
-      replyMessageId: normalizeId(insertedReply?.message_id),
-      replyMarkdown: parsedReply,
-      llmRaw: raw
+      userMessageId: normalizeId(raw.user_message_id),
+      subjectId: normalizeId(raw.subject_id) || normalizedSubjectId,
+      projectId: normalizeId(raw.project_id),
+      visibleUntil: raw.visible_until || null,
+      replyMessageId: normalizeId(raw.reply_message_id),
+      replyMarkdown: parsedReply
     };
   } catch (error) {
     debugLog("exchange-error", {
@@ -313,46 +156,6 @@ export async function sendSubjectMdallExchange({
       isEphemeral: !!isEphemeral
     });
 
-    if (isEphemeral) {
-      throw error;
-    }
-
-    const fallbackBody = "Mdall est momentanément indisponible. Réessayez dans un instant.";
-
-    const fallbackInsertRaw = await rpcCall("insert_subject_mdall_reply", {
-      p_subject_id: normalizedSubjectId,
-      p_body_markdown: fallbackBody,
-      p_mdall_person_id: createdExchange.mdall_person_id,
-      p_is_ephemeral: false,
-      p_parent_message_id: normalizeId(parentMessageId) || null,
-      p_llm_request_id: createdExchange.client_request_id || null,
-      p_metadata: {
-        mdall_exchange: true,
-        client_request_id: createdExchange.client_request_id || null,
-        error: String(error?.message || error || "unknown error")
-      }
-    }).catch(() => null);
-
-    const fallbackInserted = normalizeRpcJsonResult(fallbackInsertRaw);
-
-    debugLog("reply-inserted", {
-      messageId: fallbackInserted?.message_id || null,
-      subjectId: normalizedSubjectId,
-      visibility: "normal",
-      fallback: true
-    });
-
-    return {
-      userMessageId: normalizeId(createdExchange.user_message_id),
-      mdallPersonId: normalizeId(createdExchange.mdall_person_id),
-      subjectId: normalizeId(createdExchange.subject_id) || normalizedSubjectId,
-      projectId: normalizeId(createdExchange.project_id),
-      visibleUntil: createdExchange.visible_until || null,
-      clientRequestId: createdExchange.client_request_id || null,
-      replyMessageId: normalizeId(fallbackInserted?.message_id),
-      replyMarkdown: fallbackBody,
-      llmRaw: null,
-      error: String(error?.message || error || "unknown error")
-    };
+    throw new Error("Mdall est momentanément indisponible.");
   }
 }

--- a/supabase/functions/subject-mdall-exchange/index.ts
+++ b/supabase/functions/subject-mdall-exchange/index.ts
@@ -1,0 +1,492 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+type ExchangeRequest = {
+  subject_id?: string;
+  body_markdown?: string;
+  is_ephemeral?: boolean;
+  parent_message_id?: string | null;
+  mentions?: unknown[];
+};
+
+type MessageContextItem = {
+  id: string;
+  created_at: string;
+  origin: string;
+  visibility: string;
+  visible_until: string | null;
+  body_markdown: string;
+};
+
+type SubjectMdallContext = {
+  project: {
+    id: string;
+    name: string;
+  };
+  subject: {
+    id: string;
+    title: string;
+    status: string;
+    description: string;
+    created_at: string | null;
+    updated_at: string | null;
+  };
+  relations: {
+    parent_subject: { id: string; title: string; status: string } | null;
+    children_subjects: Array<{ id: string; title: string; status: string }>;
+    labels: Array<{ id: string; name: string }>;
+    assignees: Array<{ id: string; display_name: string }>;
+    objectives: Array<{ id: string; title: string; status: string; due_date: string | null }>;
+  };
+  recent_messages: MessageContextItem[];
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const openAiApiKey = Deno.env.get("OPENAI_API_KEY")!;
+
+const MODEL = "gpt-4.1-mini";
+const MAX_MESSAGE_HISTORY = 25;
+const MAX_MESSAGE_HISTORY_EPHEMERAL = 30;
+const MAX_SUBJECT_DESCRIPTION_CHARS = 4000;
+const MAX_MESSAGE_CHARS = 1000;
+const MAX_PROMPT_CHARS = 28000;
+const MAX_RELATIONS_ITEMS = 10;
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, Authorization, x-client-info, apikey, content-type, Content-Type",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Max-Age": "86400",
+  "Vary": "Origin"
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  "Content-Type": "application/json"
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { status: 200, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization") || req.headers.get("authorization") || "";
+    if (!authHeader.toLowerCase().startsWith("bearer ")) {
+      return json({ error: "Missing Authorization bearer token" }, 401);
+    }
+
+    const body = (await req.json().catch(() => null)) as ExchangeRequest | null;
+    const subjectId = String(body?.subject_id || "").trim();
+    const bodyMarkdown = String(body?.body_markdown || "").trim();
+    const isEphemeral = !!body?.is_ephemeral;
+    const parentMessageId = normalizeUuid(body?.parent_message_id);
+    const mentions = Array.isArray(body?.mentions) ? body?.mentions : [];
+
+    if (!subjectId) {
+      return json({ error: "subject_id is required" }, 400);
+    }
+
+    if (!bodyMarkdown) {
+      return json({ error: "body_markdown is required" }, 400);
+    }
+
+    console.log("subject-mdall-exchange:start", {
+      subject_id: subjectId,
+      is_ephemeral: isEphemeral,
+      has_parent_message_id: !!parentMessageId,
+      mentions_count: mentions.length
+    });
+
+    const userSupabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } }
+    });
+
+    const serviceSupabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+
+    const { data: exchangeRaw, error: createExchangeError } = await userSupabase.rpc("create_subject_mdall_exchange", {
+      p_subject_id: subjectId,
+      p_body_markdown: bodyMarkdown,
+      p_is_ephemeral: isEphemeral,
+      p_parent_message_id: parentMessageId,
+      p_mentions: mentions
+    });
+
+    if (createExchangeError) {
+      throw new Error(`create_subject_mdall_exchange failed: ${createExchangeError.message}`);
+    }
+
+    const exchange = normalizeRpcJsonResult(exchangeRaw);
+
+    if (!exchange?.user_message_id || !exchange?.subject_id || !exchange?.project_id || !exchange?.mdall_person_id) {
+      throw new Error("create_subject_mdall_exchange returned invalid payload");
+    }
+
+    const context = await buildSubjectMdallContext(serviceSupabase, {
+      subjectId: String(exchange.subject_id),
+      projectId: String(exchange.project_id),
+      userMessageId: String(exchange.user_message_id),
+      isEphemeral
+    });
+
+    console.log("subject-mdall-exchange:context-built", {
+      subject_id: exchange.subject_id,
+      project_id: exchange.project_id,
+      messages_count: context.recent_messages.length
+    });
+
+    const prompt = buildSubjectMdallPrompt({
+      context,
+      userMessage: bodyMarkdown,
+      isEphemeral
+    });
+
+    console.log("subject-mdall-exchange:openai-request", {
+      model: MODEL,
+      subject_id: exchange.subject_id,
+      prompt_chars: prompt.input.length
+    });
+
+    const openAiReply = await fetch("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${openAiApiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        instructions: prompt.system,
+        input: prompt.input
+      })
+    });
+
+    if (!openAiReply.ok) {
+      const errorText = await openAiReply.text();
+      throw new Error(`OpenAI request failed (${openAiReply.status}): ${errorText}`);
+    }
+
+    const openAiJson = await openAiReply.json();
+    const replyMarkdown = extractOpenAiText(openAiJson).trim();
+
+    if (!replyMarkdown) {
+      throw new Error("OpenAI returned an empty reply");
+    }
+
+    const { data: insertedReplyRaw, error: insertReplyError } = await userSupabase.rpc("insert_subject_mdall_reply", {
+      p_subject_id: String(exchange.subject_id),
+      p_body_markdown: replyMarkdown,
+      p_mdall_person_id: String(exchange.mdall_person_id),
+      p_is_ephemeral: isEphemeral,
+      p_parent_message_id: parentMessageId,
+      p_llm_request_id: normalizeUuid(exchange.client_request_id),
+      p_metadata: {
+        mdall_exchange: true,
+        client_request_id: exchange.client_request_id || null,
+        actor: "subject-mdall-exchange"
+      }
+    });
+
+    if (insertReplyError) {
+      throw new Error(`insert_subject_mdall_reply failed: ${insertReplyError.message}`);
+    }
+
+    const insertedReply = normalizeRpcJsonResult(insertedReplyRaw);
+
+    console.log("subject-mdall-exchange:reply-inserted", {
+      subject_id: exchange.subject_id,
+      user_message_id: exchange.user_message_id,
+      reply_message_id: insertedReply?.message_id || null,
+      is_ephemeral: isEphemeral
+    });
+
+    return json({
+      user_message_id: String(exchange.user_message_id),
+      reply_message_id: insertedReply?.message_id ? String(insertedReply.message_id) : null,
+      subject_id: String(exchange.subject_id),
+      project_id: String(exchange.project_id),
+      is_ephemeral: !!exchange.is_ephemeral,
+      visible_until: exchange.visible_until || null,
+      reply_markdown: replyMarkdown
+    });
+  } catch (error) {
+    console.error("subject-mdall-exchange:error", serializeError(error));
+    return json({ error: "Mdall est momentanément indisponible." }, 500);
+  }
+});
+
+async function buildSubjectMdallContext(
+  supabase: ReturnType<typeof createClient>,
+  {
+    subjectId,
+    projectId,
+    userMessageId,
+    isEphemeral
+  }: { subjectId: string; projectId: string; userMessageId: string; isEphemeral: boolean }
+): Promise<SubjectMdallContext> {
+  const { data: subjectRow, error: subjectError } = await supabase
+    .from("subjects")
+    .select("id, project_id, parent_subject_id, title, status, description, created_at, updated_at")
+    .eq("id", subjectId)
+    .eq("project_id", projectId)
+    .maybeSingle();
+
+  if (subjectError || !subjectRow) {
+    throw new Error(`Failed to load subject context: ${subjectError?.message || "subject not found"}`);
+  }
+
+  const [projectRes, childrenRes, labelsRes, assigneesRes, objectivesRes, messagesRes] = await Promise.all([
+    supabase.from("projects").select("id,name").eq("id", projectId).maybeSingle(),
+    supabase
+      .from("subjects")
+      .select("id,title,status")
+      .eq("project_id", projectId)
+      .eq("parent_subject_id", subjectId)
+      .order("updated_at", { ascending: false })
+      .limit(MAX_RELATIONS_ITEMS),
+    supabase
+      .from("subject_labels")
+      .select("label_id,project_labels!inner(id,name)")
+      .eq("project_id", projectId)
+      .eq("subject_id", subjectId)
+      .limit(MAX_RELATIONS_ITEMS),
+    supabase
+      .from("subject_assignees")
+      .select("person_id,directory_people!inner(id,first_name,last_name,email)")
+      .eq("project_id", projectId)
+      .eq("subject_id", subjectId)
+      .limit(MAX_RELATIONS_ITEMS),
+    supabase
+      .from("milestone_subjects")
+      .select("milestone_id,milestones!inner(id,title,status,due_date)")
+      .eq("subject_id", subjectId)
+      .limit(MAX_RELATIONS_ITEMS),
+    supabase
+      .from("subject_messages")
+      .select("id,created_at,deleted_at,origin,visibility,visible_until,body_markdown")
+      .eq("subject_id", subjectId)
+      .is("deleted_at", null)
+      .order("created_at", { ascending: false })
+      .limit(MAX_MESSAGE_HISTORY + 5)
+  ]);
+
+  const project = projectRes.data || { id: projectId, name: "" };
+
+  const parentSubject = subjectRow.parent_subject_id
+    ? await fetchParentSubject(supabase, projectId, String(subjectRow.parent_subject_id))
+    : null;
+
+  const now = Date.now();
+  const maxMessages = isEphemeral ? MAX_MESSAGE_HISTORY_EPHEMERAL : MAX_MESSAGE_HISTORY;
+  const recentMessages = (messagesRes.data || [])
+    .filter((row) => {
+      if (row.deleted_at) return false;
+      if (String(row.visibility || "normal") !== "ephemeral") return true;
+      const visibleUntil = Date.parse(String(row.visible_until || ""));
+      return Number.isFinite(visibleUntil) && visibleUntil > now;
+    })
+    .reverse()
+    .slice(-maxMessages)
+    .map((row) => ({
+      id: String(row.id),
+      created_at: String(row.created_at || ""),
+      origin: String(row.origin || "human"),
+      visibility: String(row.visibility || "normal"),
+      visible_until: row.visible_until ? String(row.visible_until) : null,
+      body_markdown: truncate(String(row.body_markdown || ""), MAX_MESSAGE_CHARS)
+    }));
+
+  if (!recentMessages.some((message) => message.id === userMessageId)) {
+    const { data: userMessageRow } = await supabase
+      .from("subject_messages")
+      .select("id,created_at,origin,visibility,visible_until,body_markdown")
+      .eq("id", userMessageId)
+      .maybeSingle();
+
+    if (userMessageRow) {
+      recentMessages.push({
+        id: String(userMessageRow.id),
+        created_at: String(userMessageRow.created_at || ""),
+        origin: String(userMessageRow.origin || "human"),
+        visibility: String(userMessageRow.visibility || "normal"),
+        visible_until: userMessageRow.visible_until ? String(userMessageRow.visible_until) : null,
+        body_markdown: truncate(String(userMessageRow.body_markdown || ""), MAX_MESSAGE_CHARS)
+      });
+    }
+  }
+
+  const normalizedMessages = [...recentMessages]
+    .sort((a, b) => Date.parse(a.created_at || "") - Date.parse(b.created_at || ""))
+    .slice(-maxMessages);
+
+  return {
+    project: {
+      id: String(project.id || projectId),
+      name: String(project.name || "")
+    },
+    subject: {
+      id: String(subjectRow.id),
+      title: String(subjectRow.title || ""),
+      status: String(subjectRow.status || ""),
+      description: truncate(String(subjectRow.description || ""), MAX_SUBJECT_DESCRIPTION_CHARS),
+      created_at: subjectRow.created_at ? String(subjectRow.created_at) : null,
+      updated_at: subjectRow.updated_at ? String(subjectRow.updated_at) : null
+    },
+    relations: {
+      parent_subject: parentSubject,
+      children_subjects: (childrenRes.data || []).map((row) => ({
+        id: String(row.id),
+        title: String(row.title || ""),
+        status: String(row.status || "")
+      })),
+      labels: normalizeLabels(labelsRes.data || []),
+      assignees: normalizeAssignees(assigneesRes.data || []),
+      objectives: normalizeObjectives(objectivesRes.data || [])
+    },
+    recent_messages: normalizedMessages
+  };
+}
+
+function buildSubjectMdallPrompt({
+  context,
+  userMessage,
+  isEphemeral
+}: {
+  context: SubjectMdallContext;
+  userMessage: string;
+  isEphemeral: boolean;
+}) {
+  const system = [
+    "Tu es Mdall, assistant intégré à l’application Mdall.",
+    "Tu aides dans le contexte précis du sujet.",
+    "Tu réponds en français.",
+    "Tu réponds en markdown.",
+    "Tu ne prétends pas avoir accès à des informations absentes du contexte.",
+    isEphemeral
+      ? "Le mode est éphémère : la réponse est une aide temporaire visible brièvement."
+      : "Le mode est normal : la réponse sera stockée durablement dans la discussion comme message Mdall.",
+    "Tu dois être utile, précis, synthétique, et orienté action."
+  ].join(" ");
+
+  const inputPayload = {
+    mode: isEphemeral ? "ephemeral" : "normal",
+    context,
+    user_message: truncate(userMessage, MAX_MESSAGE_CHARS)
+  };
+
+  return {
+    system,
+    input: truncate(JSON.stringify(inputPayload, null, 2), MAX_PROMPT_CHARS)
+  };
+}
+
+async function fetchParentSubject(supabase: ReturnType<typeof createClient>, projectId: string, parentId: string) {
+  const { data } = await supabase
+    .from("subjects")
+    .select("id,title,status")
+    .eq("project_id", projectId)
+    .eq("id", parentId)
+    .maybeSingle();
+
+  if (!data) return null;
+
+  return {
+    id: String(data.id),
+    title: String(data.title || ""),
+    status: String(data.status || "")
+  };
+}
+
+function normalizeAssignees(rows: any[]) {
+  return rows.map((row) => {
+    const person = Array.isArray(row.directory_people) ? row.directory_people[0] : row.directory_people;
+    const firstName = String(person?.first_name || "").trim();
+    const lastName = String(person?.last_name || "").trim();
+    const fallback = String(person?.email || "").trim();
+    return {
+      id: String(person?.id || row.person_id || ""),
+      display_name: `${firstName} ${lastName}`.trim() || fallback
+    };
+  });
+}
+
+function normalizeLabels(rows: any[]) {
+  return rows.map((row) => {
+    const label = Array.isArray(row.project_labels) ? row.project_labels[0] : row.project_labels;
+    return {
+      id: String(label?.id || row.label_id || ""),
+      name: String(label?.name || "")
+    };
+  });
+}
+
+function normalizeObjectives(rows: any[]) {
+  return rows.map((row) => {
+    const objective = Array.isArray(row.milestones) ? row.milestones[0] : row.milestones;
+    return {
+      id: String(objective?.id || row.milestone_id || ""),
+      title: String(objective?.title || ""),
+      status: String(objective?.status || ""),
+      due_date: objective?.due_date ? String(objective.due_date) : null
+    };
+  });
+}
+
+function extractOpenAiText(payload: any): string {
+  if (typeof payload?.output_text === "string" && payload.output_text.trim()) {
+    return payload.output_text;
+  }
+
+  const outputs = Array.isArray(payload?.output) ? payload.output : [];
+  const chunks: string[] = [];
+
+  for (const output of outputs) {
+    const content = Array.isArray(output?.content) ? output.content : [];
+    for (const item of content) {
+      if (item?.type === "output_text" && typeof item?.text === "string") {
+        chunks.push(item.text);
+      }
+    }
+  }
+
+  return chunks.join("\n").trim();
+}
+
+function normalizeUuid(value: unknown): string | null {
+  const raw = String(value || "").trim();
+  return raw || null;
+}
+
+function normalizeRpcJsonResult(value: any): any {
+  if (Array.isArray(value)) return value[0] || null;
+  return value || null;
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: jsonHeaders
+  });
+}
+
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack
+    };
+  }
+
+  return { message: String(error) };
+}


### PR DESCRIPTION
### Motivation

- Centralize the Mdall exchange orchestration server-side to avoid direct client RPCs and external webhook calls from the browser.
- Improve security and CORS handling by delegating LLM calls and DB writes to a Supabase Edge Function.
- Simplify client logic and surface clearer error handling when Mdall is unavailable.

### Description

- Replaced direct REST/RPC calls and in-browser LLM webhook interactions in `apps/web/js/services/subject-mdall-service.js` with a single `invokeSubjectMdallExchange` POST to a new Edge Function endpoint at `/functions/v1/subject-mdall-exchange`, and removed several helper functions (`restFetch`, `rpcCall`, `fetchSubjectContext`, `normalizeRpcJsonResult`, `isMessageVisible`).
- Updated client payload/response shape handling and improved error messages; adjusted `parseAssistantReply` to prioritize structured reply fields and return JSON if no textual reply is found.
- Added new Supabase Edge Function `supabase/functions/subject-mdall-exchange/index.ts` that: validates requests, calls the `create_subject_mdall_exchange` and `insert_subject_mdall_reply` RPCs, builds subject context from DB rows, constructs a prompt, invokes OpenAI Responses API (`model: gpt-4.1-mini`), and returns a normalized JSON response; it also applies CORS headers and logs/serializes errors.
- Implemented helper utilities in the function for context building, payload truncation, response extraction, normalization, and RPC result handling.

### Testing

- Type-checked and linted the Edge Function code locally with `deno check`/`deno lint` and resolved type issues (checks passed).
- Performed a local frontend build to verify the updated client code bundles without errors (build succeeded).
- No new automated unit tests were added in this change; integration was validated via the above automated build/type-check steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf1ffa35483298dec0e70b04af97d)