### PR TITLE
Ajuste les bordures du composeur en mode normal et éphémère

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2568,6 +2568,14 @@ body.is-resizing{
 .comment-composer{display:flex;gap:12px;align-items:flex-start;margin-top:30px;}
 .comment-composer__main{flex:1 1 auto;min-width:0;}
 .comment-composer__box{width:100%;}
+.comment-composer .comment-composer__box:not(.gh-comment-box--help):has(.comment-composer__editor:not(.hidden) .comment-composer__textarea:focus){
+  outline:2px solid rgb(31, 111, 235);
+  outline-offset:-1px;
+}
+.comment-composer .comment-composer__box.gh-comment-box--help:has(.comment-composer__editor:not(.hidden) .comment-composer__textarea:focus){
+  outline:2px dashed rgb(31, 111, 235);
+  outline-offset:-1px;
+}
 .comment-composer__actions{padding-bottom:100px;}
 .comment-composer__actions-right{width:100%;}
 .comment-composer__hint{margin-right:auto;}
@@ -4245,15 +4253,16 @@ body.drilldown-open .drilldown__inner,
   height:30px;
   padding:0 10px;
   border-radius:999px;
-  border:1px solid rgba(46,160,67,.28);
-  background: rgba(46,160,67,.06);
+  border:1px solid rgba(56,139,253,.28);
+  background: rgba(56,139,253,.06);
   color: rgba(240,246,252,.92);
 }
 .gh-btn--help-mode .gh-btn__icon{ display:inline-flex; }
-.gh-btn--help-mode:hover{ background: rgba(46,160,67,.10); }
+.gh-btn--help-mode:hover{ background: rgba(56,139,253,.10); }
 .gh-btn--help-mode.is-on{
-  border-color: rgba(46,160,67,.60);
-  background: rgba(46,160,67,.16);
+  border-color: rgba(31,111,235,.70);
+  border-style:dashed;
+  background: rgba(56,139,253,.16);
 }
 
 .help-ephemeral{
@@ -4265,12 +4274,12 @@ body.drilldown-open .drilldown__inner,
 
 
 .gh-comment-box--help{
-  border-color: rgba(46,160,67,.35);
-  background: rgba(46,160,67,.04);
+  border:1px dashed rgba(31,111,235,.65);
+  background: rgba(56,139,253,.04);
 }
 .gh-comment-header--help{
-  background: rgba(46,160,67,.10);
-  border-bottom:1px solid rgba(46,160,67,.22);
+  background: rgba(56,139,253,.10);
+  border-bottom:1px dashed rgba(31,111,235,.45);
   font-family: var(--font);
   font-size:14px;
 }


### PR DESCRIPTION
### Motivation
- Harmoniser l’indicateur visuel quand l’utilisateur écrit un commentaire en centrant le focus sur la boîte du composeur et distinguer le mode éphémère par un style pointillé, et remplacer les accents verts actuels du mode éphémère par des accents bleus cohérents avec l’état diffusé.

### Description
- Ajout de règles CSS ciblant la boîte du composeur afin d’appliquer un `outline: 2px solid rgb(31, 111, 235)` avec `outline-offset: -1px` quand la `textarea` visible est en `:focus` en mode Écrire. (`.comment-composer .comment-composer__box:not(.gh-comment-box--help):has(.comment-composer__editor:not(.hidden) .comment-composer__textarea:focus)`).
- Ajout d’une variante pour le mode éphémère qui utilise un `outline: 2px dashed rgb(31, 111, 235)` dans les mêmes conditions. (`.comment-composer .comment-composer__box.gh-comment-box--help:has(...)`).
- Remplacement des accents verts du mode éphémère par des styles bleus pointillés sur le bouton `Mode éphémère` (couleurs et `border-style: dashed` quand actif), sur la boîte éphémère (`.gh-comment-box--help`) et sur l’en-tête éphémère (`.gh-comment-header--help`).
- Fichier modifié : `apps/web/style.css` (UI/CSS seulement, aucun changement JS/logiciel).

### Testing
- Exécution de recherches et d’inspections de fichier avec `rg` et `sed` pour localiser les sélecteurs et confirmer l’emplacement des modifications (réussite). 
- Application du patch sur `apps/web/style.css` puis vérification du diff avec `git diff` (réussite). 
- Ajout et commit du changement avec `git add` / `git commit` (réussite). 
- Note : aucun test visuel automatisé ni capture d’écran n’a été généré dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee075e09488329992033f5f1b70dba)