### PR TITLE
Refactor help/assist UI styles and add composer focus outlines

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2568,6 +2568,14 @@ body.is-resizing{
 .comment-composer{display:flex;gap:12px;align-items:flex-start;margin-top:30px;}
 .comment-composer__main{flex:1 1 auto;min-width:0;}
 .comment-composer__box{width:100%;}
+.comment-composer .comment-composer__box:not(.gh-comment-box--help):has(.comment-composer__editor:not(.hidden) .comment-composer__textarea:focus){
+  outline:2px solid rgb(31, 111, 235);
+  outline-offset:-1px;
+}
+.comment-composer .comment-composer__box.gh-comment-box--help:has(.comment-composer__editor:not(.hidden) .comment-composer__textarea:focus){
+  outline:2px dashed rgb(31, 111, 235);
+  outline-offset:-1px;
+}
 .comment-composer__actions{padding-bottom:100px;}
 .comment-composer__actions-right{width:100%;}
 .comment-composer__hint{margin-right:auto;}
@@ -4245,15 +4253,16 @@ body.drilldown-open .drilldown__inner,
   height:30px;
   padding:0 10px;
   border-radius:999px;
-  border:1px solid rgba(46,160,67,.28);
-  background: rgba(46,160,67,.06);
+  border:1px solid rgba(56,139,253,.28);
+  background: rgba(56,139,253,.06);
   color: rgba(240,246,252,.92);
 }
 .gh-btn--help-mode .gh-btn__icon{ display:inline-flex; }
-.gh-btn--help-mode:hover{ background: rgba(46,160,67,.10); }
+.gh-btn--help-mode:hover{ background: rgba(56,139,253,.10); }
 .gh-btn--help-mode.is-on{
-  border-color: rgba(46,160,67,.60);
-  background: rgba(46,160,67,.16);
+  border-color: rgba(31,111,235,.70);
+  border-style:dashed;
+  background: rgba(56,139,253,.16);
 }
 
 .help-ephemeral{
@@ -4265,14 +4274,22 @@ body.drilldown-open .drilldown__inner,
 
 
 .gh-comment-box--help{
-  border-color: rgba(46,160,67,.35);
-  background: rgba(46,160,67,.04);
+  border:1px dashed rgba(31,111,235,.65);
+  background: var(--bg);
 }
 .gh-comment-header--help{
-  background: rgba(46,160,67,.10);
-  border-bottom:1px solid rgba(46,160,67,.22);
+  background: rgba(56,139,253,.10);
   font-family: var(--font);
   font-size:14px;
+}
+.comment-composer__tabs.light-tabs.gh-comment-header--help::before{
+  border-bottom:1px dashed rgba(31, 111, 235, .65);
+}
+.comment-composer__tabs.light-tabs.gh-comment-header--help .light-tabs__item.is-active{
+  border:1px dashed rgba(31,111,235,.70);
+  border-top:none;
+  border-bottom:1px solid var(--bg);
+  background:var(--bg);
 }
 .gh-comment-body--help{
   background: transparent;


### PR DESCRIPTION
### Motivation

- Standardize the help/assist visual language by switching the assist/help accent from green to a blue palette for better consistency with other UI elements.
- Improve focus visibility and accessibility for the comment composer textarea.
- Make help-state containers visually distinct using dashed borders and adjusted backgrounds.

### Description

- Replaced green `rgba(46,160,67,...)` assist/help color tokens with blue tones `rgba(56,139,253,...)` and `rgba(31,111,235,...)` across helper button, assist messages, and help-mode styles.
- Added focus outlines for the comment composer textarea with selectors: `.comment-composer .comment-composer__box:not(.gh-comment-box--help):has(.comment-composer__editor:not(.hidden) .comment-composer__textarea:focus)` and a dashed variant for `.gh-comment-box--help`.
- Introduced dashed borders and adjusted background styles for `.gh-comment-box--help`, `.gh-btn--help-mode.is-on`, and related `.gh-comment-header--help` and tab styles to emphasize help/ephemeral state.
- Touched various `.comment-composer__tabs` and `.light-tabs__item` styles to ensure active tab visuals match the new help styling.

### Testing

- Ran `stylelint` against the stylesheet and it passed without errors.
- Performed a local CSS build (`npm run build`) to ensure the stylesheet compiles and the app loads the updated styles successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee075e09488329992033f5f1b70dba)