### PR TITLE
feat(web): add handwriting composer button gating and draft state (step 1)

### DIFF
--- a/apps/web/js/store.js
+++ b/apps/web/js/store.js
@@ -76,7 +76,8 @@ function createSituationsViewState() {
     displayDepth: "situations",
     page: 1,
     pageSize: 80,
-    detailsModalOpen: false
+    detailsModalOpen: false,
+    handwritingComposerDraftBySubjectId: {}
   };
 }
 

--- a/apps/web/js/utils/input-capabilities.js
+++ b/apps/web/js/utils/input-capabilities.js
@@ -1,0 +1,23 @@
+export function hasCoarsePointer(env = globalThis) {
+  const matchMedia = env?.window?.matchMedia || env?.matchMedia;
+  if (typeof matchMedia !== "function") return false;
+  try {
+    const coarse = matchMedia("(pointer: coarse)");
+    if (coarse?.matches) return true;
+    const anyCoarse = matchMedia("(any-pointer: coarse)");
+    return !!anyCoarse?.matches;
+  } catch {
+    return false;
+  }
+}
+
+export function supportsPointerEvents(env = globalThis) {
+  const PointerEventCtor = env?.window?.PointerEvent || env?.PointerEvent;
+  return typeof PointerEventCtor === "function";
+}
+
+export function shouldShowHandwritingButton(env = globalThis) {
+  const maxTouchPoints = Number(env?.navigator?.maxTouchPoints || env?.window?.navigator?.maxTouchPoints || 0);
+  const touchCapable = Number.isFinite(maxTouchPoints) && maxTouchPoints > 0;
+  return hasCoarsePointer(env) || (touchCapable && supportsPointerEvents(env));
+}

--- a/apps/web/js/utils/input-capabilities.test.mjs
+++ b/apps/web/js/utils/input-capabilities.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  hasCoarsePointer,
+  supportsPointerEvents,
+  shouldShowHandwritingButton
+} from "./input-capabilities.js";
+
+test("hasCoarsePointer retourne true quand any-pointer coarse est actif", () => {
+  const env = {
+    matchMedia(query) {
+      return { matches: query === "(any-pointer: coarse)" };
+    }
+  };
+
+  assert.equal(hasCoarsePointer(env), true);
+});
+
+test("shouldShowHandwritingButton retourne false sans fenêtre", () => {
+  assert.equal(shouldShowHandwritingButton({}), false);
+});
+
+test("shouldShowHandwritingButton retourne false sur desktop non tactile", () => {
+  const env = {
+    matchMedia() {
+      return { matches: false };
+    },
+    PointerEvent() {},
+    navigator: { maxTouchPoints: 0 }
+  };
+
+  assert.equal(supportsPointerEvents(env), true);
+  assert.equal(shouldShowHandwritingButton(env), false);
+});
+
+test("shouldShowHandwritingButton retourne true sur device tactile avec PointerEvent", () => {
+  const env = {
+    matchMedia() {
+      return { matches: false };
+    },
+    PointerEvent() {},
+    navigator: { maxTouchPoints: 5 }
+  };
+
+  assert.equal(shouldShowHandwritingButton(env), true);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -118,6 +118,40 @@ export function createProjectSubjectsEvents(config) {
   let descriptionVersionsPositionBound = false;
   let isCreateSubjectSubmitHandling = false;
   const interactiveBindingEpochByRoot = new WeakMap();
+  const HANDWRITING_DEBUG_STORAGE_KEY = "mdall:debug-handwriting-composer";
+
+  function isHandwritingComposerDebugEnabled() {
+    try {
+      return String(window?.localStorage?.getItem?.(HANDWRITING_DEBUG_STORAGE_KEY) || "").trim() === "1";
+    } catch {
+      return false;
+    }
+  }
+
+  function debugHandwritingComposer(eventName, payload = {}) {
+    if (!isHandwritingComposerDebugEnabled()) return;
+    console.debug("[handwriting-composer]", eventName, payload);
+  }
+
+  function ensureHandwritingDraftForSubject(subjectId = "") {
+    const normalizedSubjectId = String(subjectId || "").trim();
+    if (!normalizedSubjectId) return null;
+    if (!store.situationsView.handwritingComposerDraftBySubjectId
+      || typeof store.situationsView.handwritingComposerDraftBySubjectId !== "object") {
+      store.situationsView.handwritingComposerDraftBySubjectId = {};
+    }
+    const drafts = store.situationsView.handwritingComposerDraftBySubjectId;
+    const existingDraft = drafts[normalizedSubjectId];
+    if (!existingDraft || typeof existingDraft !== "object") {
+      drafts[normalizedSubjectId] = {
+        strokes: [],
+        recognizedMarkdown: "",
+        updatedAt: Date.now()
+      };
+      debugHandwritingComposer("draft-created", { subjectId: normalizedSubjectId });
+    }
+    return drafts[normalizedSubjectId];
+  }
 
   function getTextareaAutosizeMeta(textarea) {
     const type = textarea?.matches?.("#humanCommentBox")
@@ -3453,6 +3487,18 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = () => {
         store.situationsView.helpMode = !store.situationsView.helpMode;
         rerenderDiscussionComposerScope(btn);
+      };
+    });
+    root.querySelectorAll("[data-action='open-handwriting-composer']").forEach((btn) => {
+      btn.onclick = () => {
+        const selection = getScopedSelection(btn) || getScopedSelection(root);
+        const subjectId = String(selection?.type === "sujet" ? selection?.item?.id || "" : "").trim();
+        if (!subjectId) {
+          debugHandwritingComposer("open-click-ignored-no-subject", {});
+          return;
+        }
+        ensureHandwritingDraftForSubject(subjectId);
+        debugHandwritingComposer("open-click", { subjectId });
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -46,6 +46,9 @@ export function createProjectSubjectsState({ store }) {
     if (typeof v.commentPreviewMode !== "boolean") v.commentPreviewMode = false;
     if (typeof v.commentDraft !== "string") v.commentDraft = "";
     if (typeof v.helpMode !== "boolean") v.helpMode = false;
+    if (!v.handwritingComposerDraftBySubjectId || typeof v.handwritingComposerDraftBySubjectId !== "object") {
+      v.handwritingComposerDraftBySubjectId = {};
+    }
     if (!v.replyContext || typeof v.replyContext !== "object") {
       v.replyContext = {
         subjectId: "",

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1,5 +1,6 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+import { shouldShowHandwritingButton } from "../../utils/input-capabilities.js";
 import { renderSubjectAttachmentTile } from "./project-subjects-attachments-ui.js";
 import {
   buildBusinessActivitySummary,
@@ -1904,11 +1905,20 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const pendingAttachments = normalizedSubjectId && normalizeId(attachmentState.subjectId) === normalizedSubjectId
       ? attachmentState.items
       : [];
+    const showHandwritingButton = shouldShowHandwritingButton();
+    const handwritingActionHtml = showHandwritingButton
+      ? `
+      <button class="gh-btn gh-btn--handwriting" data-action="open-handwriting-composer" type="button" title="Écrire à la main">
+        <span>Formules</span>
+      </button>
+    `
+      : "";
     const actionsHtml = `
       <button class="gh-btn gh-btn--help-mode ${helpMode ? "is-on" : ""}" data-action="toggle-help" type="button">
         <span class="gh-btn__icon" aria-hidden="true">${svgIcon("stopwatch", { className: "octicon octicon-stopwatch" })}</span>
         <span>Mode éphémère</span>
       </button>
+      ${handwritingActionHtml}
 
       ${issueStatusActionHtml}
 


### PR DESCRIPTION
### Motivation
- Préparer la première brique UI du mode de rédaction manuscrite plein écran en ajoutant un bouton accessible uniquement sur devices tactiles/stylet et en réservant un état de brouillon par sujet pour réouverture ultérieure.

### Description
- Ajout d’un utilitaire `input-capabilities` avec `hasCoarsePointer()`, `supportsPointerEvents()` et `shouldShowHandwritingButton()` (fallbacks sûrs pour environnements sans `window`).
- Rendu d’un bouton `Formules` (`data-action="open-handwriting-composer"`, classe `gh-btn--handwriting`) immédiatement à droite de `Mode éphémère` et conditionné par `shouldShowHandwritingButton()`.
- Initialisation d’un bucket de brouillons côté UI `situationsView.handwritingComposerDraftBySubjectId` et ajout d’une fonction pour créer/normer un draft par `subjectId` contenant `strokes`, `recognizedMarkdown` et `updatedAt`.
- Wiring événementiel minimal pour `data-action="open-handwriting-composer"` qui résout le sujet actif et crée un draft stub sans lancer de reconnaissance backend, plus instrumentation debug activable via `localStorage["mdall:debug-handwriting-composer"] === "1"`.

Modifications clés (fichiers) :
- `apps/web/js/utils/input-capabilities.js` (+ tests `apps/web/js/utils/input-capabilities.test.mjs`)
- `apps/web/js/views/project-subjects/project-subjects-thread.js` (insertion bouton)
- `apps/web/js/views/project-subjects/project-subjects-events.js` (wiring click, draft creation, debug helper)
- `apps/web/js/views/project-subjects/project-subjects-state.js` et `apps/web/js/store.js` (initialisation/normalisation de `handwritingComposerDraftBySubjectId`).

### Testing
- Exécuté `npm test` (tous les tests unitaires dans `apps/web/js` ont passé) — réussite.
- Tentative `npm run build:web` bloquée dans cet environnement en raison d’un `katex` manquant (`node_modules/katex/dist/katex.min.css`) et d’un `npm install` empêché par une erreur `403 Forbidden`, donc build non validé ici.
- Ajouté tests unitaires pour le helper `input-capabilities` et ceux-ci ont été exécutés dans la suite `npm test` avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1d2adba083298f4b10eae6a31db8)