### PR TITLE
Handwriting composer: UI overlay, mock recognition service, input-capability utils, and store integration

### DIFF
--- a/apps/web/js/services/handwriting-document-recognition.js
+++ b/apps/web/js/services/handwriting-document-recognition.js
@@ -1,0 +1,68 @@
+const HANDWRITING_MOCK_STORAGE_KEY = "mdall:debug-handwriting-document-mock";
+
+const MOCK_MARKDOWN = `### Résolution
+
+On cherche à calculer :
+
+$$
+I = \\int_0^1 x^2 \\, dx
+$$
+
+On utilise :
+
+$$
+\\int x^n dx = \\frac{x^{n+1}}{n+1}
+$$
+
+Donc :
+
+$$
+I = \\left[ \\frac{x^3}{3} \\right]_0^1 = \\frac{1}{3}
+$$
+
+Conclusion : \\( I = \\frac{1}{3} \\).`;
+
+function isHandwritingMockEnabled(env = globalThis) {
+  try {
+    const raw = String(env?.localStorage?.getItem?.(HANDWRITING_MOCK_STORAGE_KEY) || "").trim();
+    return raw === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Architecture note:
+ * - Real handwriting recognition MUST be executed by a backend / Edge Function.
+ * - Provider secrets (Mathpix/MyScript/etc.) must never be exposed in frontend code.
+ * - This service is expected to return Markdown + LaTeX content compatible with existing KaTeX rendering.
+ */
+export async function recognizeHandwrittenDocument({ strokes = [], canvasSize = null, subjectContext = null } = {}) {
+  const safeStrokes = Array.isArray(strokes) ? strokes : [];
+  const safeCanvasSize = canvasSize && typeof canvasSize === "object" ? canvasSize : null;
+  const safeSubjectContext = subjectContext && typeof subjectContext === "object" ? subjectContext : null;
+
+  if (isHandwritingMockEnabled()) {
+    return {
+      markdown: MOCK_MARKDOWN,
+      provider: "mock-local",
+      confidence: 0.93,
+      warnings: []
+    };
+  }
+
+  const error = new Error("Reconnaissance manuscrite non configurée");
+  error.code = "HANDWRITING_RECOGNITION_NOT_CONFIGURED";
+  error.meta = {
+    strokeCount: safeStrokes.length,
+    hasCanvasSize: !!safeCanvasSize,
+    hasSubjectContext: !!safeSubjectContext
+  };
+  throw error;
+}
+
+export const __handwritingRecognitionMock = {
+  HANDWRITING_MOCK_STORAGE_KEY,
+  MOCK_MARKDOWN,
+  isHandwritingMockEnabled
+};

--- a/apps/web/js/services/handwriting-document-recognition.test.mjs
+++ b/apps/web/js/services/handwriting-document-recognition.test.mjs
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  recognizeHandwrittenDocument,
+  __handwritingRecognitionMock
+} from "./handwriting-document-recognition.js";
+
+const { HANDWRITING_MOCK_STORAGE_KEY } = __handwritingRecognitionMock;
+
+function withLocalStorage(initialValue = "") {
+  const data = new Map([[HANDWRITING_MOCK_STORAGE_KEY, initialValue]]);
+  globalThis.localStorage = {
+    getItem(key) {
+      return data.has(key) ? data.get(key) : null;
+    },
+    setItem(key, value) {
+      data.set(key, String(value));
+    },
+    removeItem(key) {
+      data.delete(key);
+    }
+  };
+}
+
+test("recognizeHandwrittenDocument retourne Markdown + LaTeX en mode mock", async () => {
+  withLocalStorage("1");
+
+  const result = await recognizeHandwrittenDocument({
+    strokes: [{ id: "s1", points: [{ x: 0.1, y: 0.2, t: 1, pressure: 0.5 }] }],
+    canvasSize: { width: 1024, height: 768 },
+    subjectContext: { subjectId: "subject-1" }
+  });
+
+  assert.equal(typeof result.markdown, "string");
+  assert.equal(result.provider, "mock-local");
+  assert.match(result.markdown, /\$\$/);
+  assert.match(result.markdown, /\\int_0\^1/);
+});
+
+test("recognizeHandwrittenDocument échoue proprement hors mode mock", async () => {
+  withLocalStorage("0");
+
+  await assert.rejects(
+    () => recognizeHandwrittenDocument({ strokes: [] }),
+    (error) => {
+      assert.equal(error?.message, "Reconnaissance manuscrite non configurée");
+      assert.equal(error?.code, "HANDWRITING_RECOGNITION_NOT_CONFIGURED");
+      return true;
+    }
+  );
+});
+
+test("le markdown mock contient des blocs mathématiques $$...$$", async () => {
+  withLocalStorage("1");
+
+  const { markdown } = await recognizeHandwrittenDocument();
+  const blockCount = (markdown.match(/\$\$/g) || []).length;
+
+  assert.ok(blockCount >= 2);
+});

--- a/apps/web/js/store.js
+++ b/apps/web/js/store.js
@@ -76,7 +76,8 @@ function createSituationsViewState() {
     displayDepth: "situations",
     page: 1,
     pageSize: 80,
-    detailsModalOpen: false
+    detailsModalOpen: false,
+    handwritingComposerDraftBySubjectId: {}
   };
 }
 

--- a/apps/web/js/utils/input-capabilities.js
+++ b/apps/web/js/utils/input-capabilities.js
@@ -1,0 +1,23 @@
+export function hasCoarsePointer(env = globalThis) {
+  const matchMedia = env?.window?.matchMedia || env?.matchMedia;
+  if (typeof matchMedia !== "function") return false;
+  try {
+    const coarse = matchMedia("(pointer: coarse)");
+    if (coarse?.matches) return true;
+    const anyCoarse = matchMedia("(any-pointer: coarse)");
+    return !!anyCoarse?.matches;
+  } catch {
+    return false;
+  }
+}
+
+export function supportsPointerEvents(env = globalThis) {
+  const PointerEventCtor = env?.window?.PointerEvent || env?.PointerEvent;
+  return typeof PointerEventCtor === "function";
+}
+
+export function shouldShowHandwritingButton(env = globalThis) {
+  const maxTouchPoints = Number(env?.navigator?.maxTouchPoints || env?.window?.navigator?.maxTouchPoints || 0);
+  const touchCapable = Number.isFinite(maxTouchPoints) && maxTouchPoints > 0;
+  return hasCoarsePointer(env) || (touchCapable && supportsPointerEvents(env));
+}

--- a/apps/web/js/utils/input-capabilities.test.mjs
+++ b/apps/web/js/utils/input-capabilities.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  hasCoarsePointer,
+  supportsPointerEvents,
+  shouldShowHandwritingButton
+} from "./input-capabilities.js";
+
+test("hasCoarsePointer retourne true quand any-pointer coarse est actif", () => {
+  const env = {
+    matchMedia(query) {
+      return { matches: query === "(any-pointer: coarse)" };
+    }
+  };
+
+  assert.equal(hasCoarsePointer(env), true);
+});
+
+test("shouldShowHandwritingButton retourne false sans fenêtre", () => {
+  assert.equal(shouldShowHandwritingButton({}), false);
+});
+
+test("shouldShowHandwritingButton retourne false sur desktop non tactile", () => {
+  const env = {
+    matchMedia() {
+      return { matches: false };
+    },
+    PointerEvent() {},
+    navigator: { maxTouchPoints: 0 }
+  };
+
+  assert.equal(supportsPointerEvents(env), true);
+  assert.equal(shouldShowHandwritingButton(env), false);
+});
+
+test("shouldShowHandwritingButton retourne true sur device tactile avec PointerEvent", () => {
+  const env = {
+    matchMedia() {
+      return { matches: false };
+    },
+    PointerEvent() {},
+    navigator: { maxTouchPoints: 5 }
+  };
+
+  assert.equal(shouldShowHandwritingButton(env), true);
+});

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -18,6 +18,7 @@ import { computeTextareaCaretRect } from "../../utils/textarea-caret-position.js
 import { autosizeTextarea } from "../../utils/textarea-autosize.js";
 import { renderSubjectAttachmentTile, renderSubjectAttachmentsPreviewList } from "./project-subjects-attachments-ui.js";
 import { isMetaDropdownOpenForAnchor } from "../ui/select-dropdown-controller.js";
+import { mountHandwritingComposerOverlay } from "../ui/handwriting-composer-overlay.js";
 
 export function createProjectSubjectsEvents(config) {
   const EMOJI_GRID_COLUMNS = 6;
@@ -118,6 +119,40 @@ export function createProjectSubjectsEvents(config) {
   let descriptionVersionsPositionBound = false;
   let isCreateSubjectSubmitHandling = false;
   const interactiveBindingEpochByRoot = new WeakMap();
+  const HANDWRITING_DEBUG_STORAGE_KEY = "mdall:debug-handwriting-composer";
+
+  function isHandwritingComposerDebugEnabled() {
+    try {
+      return String(window?.localStorage?.getItem?.(HANDWRITING_DEBUG_STORAGE_KEY) || "").trim() === "1";
+    } catch {
+      return false;
+    }
+  }
+
+  function debugHandwritingComposer(eventName, payload = {}) {
+    if (!isHandwritingComposerDebugEnabled()) return;
+    console.debug("[handwriting-composer]", eventName, payload);
+  }
+
+  function ensureHandwritingDraftForSubject(subjectId = "") {
+    const normalizedSubjectId = String(subjectId || "").trim();
+    if (!normalizedSubjectId) return null;
+    if (!store.situationsView.handwritingComposerDraftBySubjectId
+      || typeof store.situationsView.handwritingComposerDraftBySubjectId !== "object") {
+      store.situationsView.handwritingComposerDraftBySubjectId = {};
+    }
+    const drafts = store.situationsView.handwritingComposerDraftBySubjectId;
+    const existingDraft = drafts[normalizedSubjectId];
+    if (!existingDraft || typeof existingDraft !== "object") {
+      drafts[normalizedSubjectId] = {
+        strokes: [],
+        recognizedMarkdown: "",
+        updatedAt: Date.now()
+      };
+      debugHandwritingComposer("draft-created", { subjectId: normalizedSubjectId });
+    }
+    return drafts[normalizedSubjectId];
+  }
 
   function getTextareaAutosizeMeta(textarea) {
     const type = textarea?.matches?.("#humanCommentBox")
@@ -3453,6 +3488,40 @@ export function createProjectSubjectsEvents(config) {
       btn.onclick = () => {
         store.situationsView.helpMode = !store.situationsView.helpMode;
         rerenderDiscussionComposerScope(btn);
+      };
+    });
+    root.querySelectorAll("[data-action='open-handwriting-composer']").forEach((btn) => {
+      btn.onclick = () => {
+        const selection = getScopedSelection(btn) || getScopedSelection(root);
+        const subjectId = String(selection?.type === "sujet" ? selection?.item?.id || "" : "").trim();
+        if (!subjectId) {
+          debugHandwritingComposer("open-click-ignored-no-subject", {});
+          return;
+        }
+        const existingDraft = ensureHandwritingDraftForSubject(subjectId);
+        mountHandwritingComposerOverlay({
+          root: document.body,
+          subjectId,
+          draft: existingDraft,
+          onSaveDraft: (nextDraft = {}) => {
+            const normalized = ensureHandwritingDraftForSubject(subjectId);
+            if (!normalized) return;
+            normalized.strokes = Array.isArray(nextDraft.strokes) ? nextDraft.strokes : [];
+            normalized.recognizedMarkdown = String(nextDraft.recognizedMarkdown || normalized.recognizedMarkdown || "");
+            normalized.updatedAt = Number.isFinite(Number(nextDraft.updatedAt)) ? Number(nextDraft.updatedAt) : Date.now();
+            debugHandwritingComposer("draft-saved", {
+              subjectId,
+              strokeCount: normalized.strokes.length
+            });
+          },
+          onClose: ({ trigger } = {}) => {
+            debugHandwritingComposer("overlay-closed", { subjectId, trigger: String(trigger || "") });
+          },
+          onRecognizeAndInsert: () => {
+            debugHandwritingComposer("recognize-click-ignored-step2", { subjectId });
+          }
+        });
+        debugHandwritingComposer("open-click", { subjectId });
       };
     });
 

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -46,6 +46,9 @@ export function createProjectSubjectsState({ store }) {
     if (typeof v.commentPreviewMode !== "boolean") v.commentPreviewMode = false;
     if (typeof v.commentDraft !== "string") v.commentDraft = "";
     if (typeof v.helpMode !== "boolean") v.helpMode = false;
+    if (!v.handwritingComposerDraftBySubjectId || typeof v.handwritingComposerDraftBySubjectId !== "object") {
+      v.handwritingComposerDraftBySubjectId = {};
+    }
     if (!v.replyContext || typeof v.replyContext !== "object") {
       v.replyContext = {
         subjectId: "",

--- a/apps/web/js/views/project-subjects/project-subjects-thread.js
+++ b/apps/web/js/views/project-subjects/project-subjects-thread.js
@@ -1,5 +1,6 @@
 import { getAuthorIdentity } from "../ui/author-identity.js";
 import { renderSubjectMarkdownToolbar } from "../ui/subject-rich-editor.js";
+import { shouldShowHandwritingButton } from "../../utils/input-capabilities.js";
 import { renderSubjectAttachmentTile } from "./project-subjects-attachments-ui.js";
 import {
   buildBusinessActivitySummary,
@@ -1904,11 +1905,20 @@ priority=${firstNonEmpty(subject.priority, "")}`
     const pendingAttachments = normalizedSubjectId && normalizeId(attachmentState.subjectId) === normalizedSubjectId
       ? attachmentState.items
       : [];
+    const showHandwritingButton = shouldShowHandwritingButton();
+    const handwritingActionHtml = showHandwritingButton
+      ? `
+      <button class="gh-btn gh-btn--handwriting" data-action="open-handwriting-composer" type="button" title="Écrire à la main">
+        <span>Formules</span>
+      </button>
+    `
+      : "";
     const actionsHtml = `
       <button class="gh-btn gh-btn--help-mode ${helpMode ? "is-on" : ""}" data-action="toggle-help" type="button">
         <span class="gh-btn__icon" aria-hidden="true">${svgIcon("stopwatch", { className: "octicon octicon-stopwatch" })}</span>
         <span>Mode éphémère</span>
       </button>
+      ${handwritingActionHtml}
 
       ${issueStatusActionHtml}
 

--- a/apps/web/js/views/ui/handwriting-composer-overlay.js
+++ b/apps/web/js/views/ui/handwriting-composer-overlay.js
@@ -1,0 +1,301 @@
+function toNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function clonePoint(point = {}) {
+  return {
+    x: Math.min(1, Math.max(0, toNumber(point.x, 0))),
+    y: Math.min(1, Math.max(0, toNumber(point.y, 0))),
+    t: toNumber(point.t, Date.now()),
+    pressure: Math.min(1, Math.max(0, toNumber(point.pressure, 0.5)))
+  };
+}
+
+function cloneStroke(stroke = {}) {
+  return {
+    id: String(stroke.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`),
+    pointerType: String(stroke.pointerType || "mouse"),
+    color: String(stroke.color || "#f8fafc"),
+    width: Math.max(0.5, toNumber(stroke.width, 2.2)),
+    points: Array.isArray(stroke.points) ? stroke.points.map(clonePoint) : []
+  };
+}
+
+function cloneDraft(draft = {}) {
+  return {
+    strokes: Array.isArray(draft.strokes) ? draft.strokes.map(cloneStroke) : [],
+    recognizedMarkdown: String(draft.recognizedMarkdown || ""),
+    updatedAt: toNumber(draft.updatedAt, Date.now())
+  };
+}
+
+export function renderHandwritingComposerOverlay({ subjectId = "", draft = {} } = {}) {
+  const safeSubjectId = String(subjectId || "");
+  const strokeCount = Array.isArray(draft?.strokes) ? draft.strokes.length : 0;
+  return `
+    <div class="handwriting-composer-overlay" data-role="handwriting-composer-overlay" data-subject-id="${safeSubjectId}">
+      <div class="handwriting-composer-overlay__header">
+        <div class="handwriting-composer-overlay__title-wrap">
+          <h2 class="handwriting-composer-overlay__title">Rédaction manuscrite</h2>
+          <p class="handwriting-composer-overlay__hint">
+            Écrivez votre réponse complète : texte, titres, formules, flèches. La conversion produira du Markdown + LaTeX.
+          </p>
+        </div>
+        <div class="handwriting-composer-overlay__actions">
+          <button type="button" class="gh-btn gh-btn--sm" data-action="handwriting-clear">Effacer</button>
+          <button type="button" class="gh-btn gh-btn--sm" data-action="handwriting-undo">Annuler dernier trait</button>
+          <button type="button" class="gh-btn gh-btn--sm gh-btn--primary" data-action="handwriting-recognize-insert">Convertir et insérer</button>
+          <button type="button" class="gh-btn gh-btn--sm" data-action="handwriting-close">Fermer</button>
+        </div>
+      </div>
+      <div class="handwriting-composer-overlay__canvas-wrap" data-stroke-count="${strokeCount}">
+        <canvas class="handwriting-composer-overlay__canvas" data-role="handwriting-canvas"></canvas>
+      </div>
+    </div>
+  `;
+}
+
+export function mountHandwritingComposerOverlay({
+  root,
+  subjectId = "",
+  draft = {},
+  onClose,
+  onSaveDraft,
+  onRecognizeAndInsert
+} = {}) {
+  const host = root || document?.body;
+  if (!host) {
+    return { close() {} };
+  }
+
+  const initialDraft = cloneDraft(draft);
+  const overlayRoot = document.createElement("div");
+  overlayRoot.innerHTML = renderHandwritingComposerOverlay({ subjectId, draft: initialDraft });
+  const overlay = overlayRoot.firstElementChild;
+  if (!overlay) return { close() {} };
+
+  const existing = document.querySelector("[data-role='handwriting-composer-overlay']");
+  if (existing?.parentNode) existing.parentNode.removeChild(existing);
+
+  host.appendChild(overlay);
+
+  const canvas = overlay.querySelector("[data-role='handwriting-canvas']");
+  const clearBtn = overlay.querySelector("[data-action='handwriting-clear']");
+  const undoBtn = overlay.querySelector("[data-action='handwriting-undo']");
+  const closeBtn = overlay.querySelector("[data-action='handwriting-close']");
+  const recognizeBtn = overlay.querySelector("[data-action='handwriting-recognize-insert']");
+  const canvasWrap = overlay.querySelector(".handwriting-composer-overlay__canvas-wrap");
+  const drawing = {
+    strokes: initialDraft.strokes.map(cloneStroke),
+    activePointerId: null,
+    activeStroke: null,
+    width: 1,
+    height: 1,
+    dpr: Math.max(1, toNumber(window?.devicePixelRatio, 1))
+  };
+
+  const previousBodyOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+
+  function saveDraft() {
+    if (typeof onSaveDraft !== "function") return;
+    onSaveDraft({
+      strokes: drawing.strokes.map(cloneStroke),
+      recognizedMarkdown: String(initialDraft.recognizedMarkdown || ""),
+      updatedAt: Date.now()
+    });
+  }
+
+  function computeWidth(pointerType = "mouse", pressure = 0.5) {
+    const safePressure = Math.min(1, Math.max(0, toNumber(pressure, 0.5)));
+    if (pointerType === "pen") return 1.2 + safePressure * 2.8;
+    if (pointerType === "touch") return 2.6 + safePressure * 2.4;
+    return 1.8 + safePressure * 1.4;
+  }
+
+  function redraw() {
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, drawing.width, drawing.height);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+
+    drawing.strokes.forEach((stroke) => {
+      const points = Array.isArray(stroke.points) ? stroke.points : [];
+      if (!points.length) return;
+      if (points.length === 1) {
+        const p = points[0];
+        const x = p.x * drawing.width;
+        const y = p.y * drawing.height;
+        ctx.fillStyle = stroke.color;
+        ctx.beginPath();
+        ctx.arc(x, y, Math.max(1, stroke.width / 2), 0, Math.PI * 2);
+        ctx.fill();
+        return;
+      }
+      ctx.strokeStyle = stroke.color;
+      ctx.lineWidth = stroke.width;
+      ctx.beginPath();
+      points.forEach((point, index) => {
+        const x = point.x * drawing.width;
+        const y = point.y * drawing.height;
+        if (index === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    });
+
+    if (canvasWrap) {
+      canvasWrap.dataset.strokeCount = String(drawing.strokes.length);
+    }
+  }
+
+  function resizeCanvas() {
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    drawing.dpr = Math.max(1, toNumber(window?.devicePixelRatio, 1));
+    drawing.width = Math.max(1, Math.floor(rect.width));
+    drawing.height = Math.max(1, Math.floor(rect.height));
+    canvas.width = Math.max(1, Math.floor(drawing.width * drawing.dpr));
+    canvas.height = Math.max(1, Math.floor(drawing.height * drawing.dpr));
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.setTransform(drawing.dpr, 0, 0, drawing.dpr, 0, 0);
+    }
+    redraw();
+  }
+
+  function toNormalizedPoint(event) {
+    const rect = canvas.getBoundingClientRect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    return clonePoint({
+      x: (toNumber(event.clientX, 0) - rect.left) / width,
+      y: (toNumber(event.clientY, 0) - rect.top) / height,
+      t: toNumber(event.timeStamp, Date.now()),
+      pressure: toNumber(event.pressure, 0.5)
+    });
+  }
+
+  function endCurrentStroke() {
+    if (!drawing.activeStroke) return;
+    if (drawing.activeStroke.points.length > 0) {
+      drawing.strokes.push(cloneStroke(drawing.activeStroke));
+      saveDraft();
+    }
+    drawing.activePointerId = null;
+    drawing.activeStroke = null;
+    redraw();
+  }
+
+  function onPointerDown(event) {
+    if (!canvas) return;
+    const pointerType = String(event.pointerType || "mouse").toLowerCase();
+    if (!["pen", "touch", "mouse"].includes(pointerType)) return;
+    event.preventDefault();
+    drawing.activePointerId = event.pointerId;
+    drawing.activeStroke = cloneStroke({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      pointerType,
+      color: "#f8fafc",
+      width: computeWidth(pointerType, event.pressure),
+      points: [toNormalizedPoint(event)]
+    });
+    if (typeof canvas.setPointerCapture === "function") {
+      try {
+        canvas.setPointerCapture(event.pointerId);
+      } catch {
+        // no-op
+      }
+    }
+    redraw();
+  }
+
+  function onPointerMove(event) {
+    if (!drawing.activeStroke || drawing.activePointerId !== event.pointerId) return;
+    event.preventDefault();
+    drawing.activeStroke.points.push(toNormalizedPoint(event));
+    redraw();
+  }
+
+  function onPointerUp(event) {
+    if (drawing.activePointerId !== event.pointerId) return;
+    event.preventDefault();
+    if (drawing.activeStroke) {
+      drawing.activeStroke.points.push(toNormalizedPoint(event));
+    }
+    endCurrentStroke();
+  }
+
+  function onPointerCancel(event) {
+    if (drawing.activePointerId !== event.pointerId) return;
+    event.preventDefault();
+    endCurrentStroke();
+  }
+
+  function closeOverlay(trigger = "close") {
+    window.removeEventListener("resize", resizeCanvas);
+    window.removeEventListener("keydown", onWindowKeydown);
+    canvas?.removeEventListener("pointerdown", onPointerDown);
+    canvas?.removeEventListener("pointermove", onPointerMove);
+    canvas?.removeEventListener("pointerup", onPointerUp);
+    canvas?.removeEventListener("pointercancel", onPointerCancel);
+    document.body.style.overflow = previousBodyOverflow;
+    if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    if (typeof onClose === "function") onClose({ trigger, draft: { ...initialDraft, strokes: drawing.strokes.map(cloneStroke) } });
+  }
+
+  function onWindowKeydown(event) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeOverlay("escape");
+    }
+  }
+
+  clearBtn?.addEventListener("click", () => {
+    drawing.strokes = [];
+    drawing.activeStroke = null;
+    drawing.activePointerId = null;
+    saveDraft();
+    redraw();
+  });
+
+  undoBtn?.addEventListener("click", () => {
+    if (!drawing.strokes.length) return;
+    drawing.strokes.pop();
+    saveDraft();
+    redraw();
+  });
+
+  closeBtn?.addEventListener("click", () => {
+    saveDraft();
+    closeOverlay("close-button");
+  });
+
+  recognizeBtn?.addEventListener("click", async () => {
+    if (typeof onRecognizeAndInsert === "function") {
+      await onRecognizeAndInsert({ subjectId: String(subjectId || ""), draft: { ...initialDraft, strokes: drawing.strokes.map(cloneStroke) } });
+    }
+  });
+
+  canvas?.addEventListener("pointerdown", onPointerDown);
+  canvas?.addEventListener("pointermove", onPointerMove);
+  canvas?.addEventListener("pointerup", onPointerUp);
+  canvas?.addEventListener("pointercancel", onPointerCancel);
+  window.addEventListener("resize", resizeCanvas);
+  window.addEventListener("keydown", onWindowKeydown);
+
+  requestAnimationFrame(() => {
+    resizeCanvas();
+    redraw();
+  });
+
+  return {
+    close() {
+      saveDraft();
+      closeOverlay("api-close");
+    }
+  };
+}

--- a/apps/web/js/views/ui/handwriting-composer-overlay.test.mjs
+++ b/apps/web/js/views/ui/handwriting-composer-overlay.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderHandwritingComposerOverlay } from "./handwriting-composer-overlay.js";
+
+test("renderHandwritingComposerOverlay expose les actions attendues", () => {
+  const html = renderHandwritingComposerOverlay({
+    subjectId: "subject-123",
+    draft: { strokes: [{ id: "s1", points: [{ x: 0.1, y: 0.1 }] }] }
+  });
+
+  assert.match(html, /Rédaction manuscrite/);
+  assert.match(html, /data-action="handwriting-clear"/);
+  assert.match(html, /data-action="handwriting-undo"/);
+  assert.match(html, /data-action="handwriting-recognize-insert"/);
+  assert.match(html, /data-action="handwriting-close"/);
+  assert.match(html, /data-subject-id="subject-123"/);
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -14197,3 +14197,64 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   width:14px;
   height:14px;
 }
+
+.handwriting-composer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  background: rgba(10, 14, 22, 0.96);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  overscroll-behavior: contain;
+}
+
+.handwriting-composer-overlay__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.handwriting-composer-overlay__title-wrap {
+  min-width: 260px;
+  flex: 1;
+}
+
+.handwriting-composer-overlay__title {
+  margin: 0;
+  font-size: 20px;
+  color: #f8fafc;
+}
+
+.handwriting-composer-overlay__hint {
+  margin: 6px 0 0;
+  color: #b8c0cc;
+  font-size: 13px;
+}
+
+.handwriting-composer-overlay__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.handwriting-composer-overlay__canvas-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 300px;
+  border: 1px solid rgba(248, 250, 252, 0.2);
+  border-radius: 12px;
+  background: #111821;
+  overflow: hidden;
+}
+
+.handwriting-composer-overlay__canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  touch-action: none;
+  cursor: crosshair;
+}


### PR DESCRIPTION
### Motivation

- Provide a first-class handwriting composer so users on touch/pen devices can write formulas and have them converted to Markdown+LaTeX. 
- Allow safe local testing of recognition via a mock service while real backend/Edge recognition is not configured. 
- Detect input capabilities to surface the handwriting action only on appropriate devices and persist per-subject drafts in the existing UI state.

### Description

- Added a handwriting recognition service `recognizeHandwrittenDocument` with a local mock mode controlled by the `mdall:debug-handwriting-document-mock` localStorage key and exported `__handwritingRecognitionMock` helpers. 
- Implemented a `handwriting-composer-overlay` UI with `renderHandwritingComposerOverlay` and `mountHandwritingComposerOverlay` that provides a canvas-based pointer drawing surface (pointer capture, normalized points, stroke/undo/clear/save hooks) and event callbacks for `onSaveDraft`, `onClose`, and `onRecognizeAndInsert`.
- Introduced `input-capabilities` utilities: `hasCoarsePointer`, `supportsPointerEvents`, and `shouldShowHandwritingButton` to decide when to show the handwriting action. 
- Integrated the handwriting button into the subject composer toolbar (conditional via `shouldShowHandwritingButton`) and wired an open handler that mounts the overlay and persists per-subject drafts via `store.situationsView.handwritingComposerDraftBySubjectId` with helper functions and debug logging controlled by `mdall:debug-handwriting-composer` localStorage key. 
- Ensured view state defaults and store initialization by adding `handwritingComposerDraftBySubjectId` to `createSituationsViewState` and `createProjectSubjectsState`. 
- Added styles for the overlay in `style.css`. 
- Added unit tests for the new modules: `handwriting-document-recognition.test.mjs`, `input-capabilities.test.mjs`, and `handwriting-composer-overlay.test.mjs`.

### Testing

- Ran `node:test` unit tests for `handwriting-document-recognition.test.mjs`, `input-capabilities.test.mjs`, and `handwriting-composer-overlay.test.mjs`, and they passed. 
- New UI rendering tests validate `renderHandwritingComposerOverlay` output and presence of expected actions, and recognition service tests validate mock-returned Markdown/LaTeX and proper error when mock is disabled. 
- Basic input-capabilities tests verify detection behavior for coarse pointers and touch+PointerEvent combinations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1d2adba083298f4b10eae6a31db8)