### PR TITLE
Improve handwriting overlay palm rejection, selection blocking and drawing smoothness

### DIFF
--- a/apps/web/js/views/ui/handwriting-composer-overlay.js
+++ b/apps/web/js/views/ui/handwriting-composer-overlay.js
@@ -149,12 +149,24 @@ export function mountHandwritingComposerOverlay({
   const canvasWrap = overlay.querySelector(".handwriting-composer-overlay__canvas-wrap");
   const drawing = {
     strokes: initialDraft.strokes.map(cloneStroke),
+    hasSeenPenInput: false,
     activePointerId: null,
+    activePointerType: null,
     activeStroke: null,
+    pendingPoints: [],
+    rafId: 0,
+    ignoreTouchUntil: 0,
     width: 1,
     height: 1,
     dpr: Math.max(1, toNumber(window?.devicePixelRatio, 1))
   };
+  const debugEnabled = (() => {
+    try {
+      return window?.localStorage?.getItem("mdall:debug-handwriting-composer") === "1";
+    } catch {
+      return false;
+    }
+  })();
 
   const previousBodyOverflow = document.body.style.overflow;
   document.body.style.overflow = "hidden";
@@ -175,10 +187,37 @@ export function mountHandwritingComposerOverlay({
   }
 
   function computeWidth(pointerType = "mouse", pressure = 0.5) {
-    const safePressure = Math.min(1, Math.max(0, toNumber(pressure, 0.5)));
-    if (pointerType === "pen") return 1.2 + safePressure * 2.8;
-    if (pointerType === "touch") return 2.6 + safePressure * 2.4;
-    return 1.8 + safePressure * 1.4;
+    const rawPressure = toNumber(pressure, 0.5);
+    const normalizedPressure = rawPressure <= 0 ? 0.5 : rawPressure;
+    const safePressure = Math.min(1, Math.max(0.2, normalizedPressure));
+    if (pointerType === "pen") return Math.min(4, Math.max(2, 2 + safePressure * 2));
+    if (pointerType === "touch") return Math.min(5, Math.max(3, 2.8 + safePressure * 2.2));
+    return Math.min(3.8, Math.max(2.2, 2 + safePressure * 1.8));
+  }
+
+  function debugLog(message, payload = undefined) {
+    if (!debugEnabled) return;
+    if (payload === undefined) {
+      console.debug("[handwriting-composer]", message);
+      return;
+    }
+    console.debug("[handwriting-composer]", message, payload);
+  }
+
+  function drawStrokeSegment(ctx, previousPoint, point, stroke) {
+    if (!ctx || !previousPoint || !point || !stroke) return;
+    const prevX = previousPoint.x * drawing.width;
+    const prevY = previousPoint.y * drawing.height;
+    const x = point.x * drawing.width;
+    const y = point.y * drawing.height;
+    const midX = (prevX + x) / 2;
+    const midY = (prevY + y) / 2;
+    ctx.strokeStyle = stroke.color;
+    ctx.lineWidth = stroke.width;
+    ctx.beginPath();
+    ctx.moveTo(prevX, prevY);
+    ctx.quadraticCurveTo(prevX, prevY, midX, midY);
+    ctx.stroke();
   }
 
   function redraw() {
@@ -209,8 +248,17 @@ export function mountHandwritingComposerOverlay({
         const x = point.x * drawing.width;
         const y = point.y * drawing.height;
         if (index === 0) ctx.moveTo(x, y);
-        else ctx.lineTo(x, y);
+        else {
+          const previous = points[index - 1];
+          const prevX = previous.x * drawing.width;
+          const prevY = previous.y * drawing.height;
+          const midX = (prevX + x) / 2;
+          const midY = (prevY + y) / 2;
+          ctx.quadraticCurveTo(prevX, prevY, midX, midY);
+        }
       });
+      const lastPoint = points[points.length - 1];
+      ctx.lineTo(lastPoint.x * drawing.width, lastPoint.y * drawing.height);
       ctx.stroke();
     });
 
@@ -246,6 +294,51 @@ export function mountHandwritingComposerOverlay({
     });
   }
 
+  function flushDraw() {
+    drawing.rafId = 0;
+    if (!canvas || !drawing.activeStroke || drawing.pendingPoints.length < 2) {
+      drawing.pendingPoints = drawing.pendingPoints.slice(-1);
+      return;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    for (let index = 1; index < drawing.pendingPoints.length; index += 1) {
+      drawStrokeSegment(ctx, drawing.pendingPoints[index - 1], drawing.pendingPoints[index], drawing.activeStroke);
+    }
+    drawing.pendingPoints = drawing.pendingPoints.slice(-1);
+  }
+
+  function scheduleDraw() {
+    if (drawing.rafId) return;
+    drawing.rafId = requestAnimationFrame(flushDraw);
+  }
+
+  function shouldAcceptPointerStart(event) {
+    const pointerType = String(event?.pointerType || "mouse").toLowerCase();
+    const now = Date.now();
+    if (!["pen", "touch", "mouse"].includes(pointerType)) {
+      return { accepted: false, reason: "unsupported-pointer", pointerType };
+    }
+    if (drawing.activePointerId !== null && drawing.activePointerId !== event.pointerId) {
+      return { accepted: false, reason: "active-pointer", pointerType };
+    }
+    if (pointerType === "pen") {
+      drawing.hasSeenPenInput = true;
+      drawing.ignoreTouchUntil = now + 1500;
+      return { accepted: true, pointerType };
+    }
+    if (pointerType === "touch") {
+      if (drawing.hasSeenPenInput) return { accepted: false, reason: "palm-touch-after-pen", pointerType };
+      if (now < drawing.ignoreTouchUntil) return { accepted: false, reason: "touch-cooldown", pointerType };
+      if (drawing.activePointerType === "pen") return { accepted: false, reason: "active-pen", pointerType };
+      return { accepted: true, pointerType };
+    }
+    if (drawing.activePointerType && drawing.activePointerType !== "mouse") {
+      return { accepted: false, reason: "active-pointer", pointerType };
+    }
+    return { accepted: true, pointerType };
+  }
+
   function endCurrentStroke() {
     if (!drawing.activeStroke) return;
     if (drawing.activeStroke.points.length > 0) {
@@ -253,16 +346,27 @@ export function mountHandwritingComposerOverlay({
       saveDraft();
     }
     drawing.activePointerId = null;
+    drawing.activePointerType = null;
     drawing.activeStroke = null;
+    drawing.pendingPoints = [];
+    if (drawing.rafId) {
+      cancelAnimationFrame(drawing.rafId);
+      drawing.rafId = 0;
+    }
     redraw();
   }
 
   function onPointerDown(event) {
     if (!canvas) return;
-    const pointerType = String(event.pointerType || "mouse").toLowerCase();
-    if (!["pen", "touch", "mouse"].includes(pointerType)) return;
+    const decision = shouldAcceptPointerStart(event);
+    if (!decision.accepted) {
+      debugLog(`pointer rejected: ${decision.reason}`, { pointerType: decision.pointerType, pointerId: event.pointerId });
+      return;
+    }
+    const pointerType = decision.pointerType;
     event.preventDefault();
     drawing.activePointerId = event.pointerId;
+    drawing.activePointerType = pointerType;
     drawing.activeStroke = cloneStroke({
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       pointerType,
@@ -270,6 +374,7 @@ export function mountHandwritingComposerOverlay({
       width: computeWidth(pointerType, event.pressure),
       points: [toNormalizedPoint(event)]
     });
+    drawing.pendingPoints = drawing.activeStroke.points.slice(-1);
     if (typeof canvas.setPointerCapture === "function") {
       try {
         canvas.setPointerCapture(event.pointerId);
@@ -283,8 +388,13 @@ export function mountHandwritingComposerOverlay({
   function onPointerMove(event) {
     if (!drawing.activeStroke || drawing.activePointerId !== event.pointerId) return;
     event.preventDefault();
-    drawing.activeStroke.points.push(toNormalizedPoint(event));
-    redraw();
+    const events = typeof event.getCoalescedEvents === "function" ? event.getCoalescedEvents() : [event];
+    events.forEach((entry) => {
+      const point = toNormalizedPoint(entry);
+      drawing.activeStroke.points.push(point);
+      drawing.pendingPoints.push(point);
+    });
+    scheduleDraw();
   }
 
   function onPointerUp(event) {
@@ -309,6 +419,9 @@ export function mountHandwritingComposerOverlay({
     canvas?.removeEventListener("pointermove", onPointerMove);
     canvas?.removeEventListener("pointerup", onPointerUp);
     canvas?.removeEventListener("pointercancel", onPointerCancel);
+    canvas?.removeEventListener("touchstart", preventOverlayTouch, { passive: false });
+    overlay?.removeEventListener("touchmove", preventOverlayTouch, { passive: false });
+    overlay?.removeEventListener("touchstart", preventOverlayTouch, { passive: false });
     document.body.style.overflow = previousBodyOverflow;
     if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
     if (typeof onClose === "function") onClose({ trigger, draft: { ...initialDraft, strokes: drawing.strokes.map(cloneStroke) } });
@@ -325,6 +438,8 @@ export function mountHandwritingComposerOverlay({
     drawing.strokes = [];
     drawing.activeStroke = null;
     drawing.activePointerId = null;
+    drawing.activePointerType = null;
+    drawing.pendingPoints = [];
     saveDraft();
     redraw();
   });
@@ -399,6 +514,14 @@ export function mountHandwritingComposerOverlay({
   canvas?.addEventListener("pointermove", onPointerMove);
   canvas?.addEventListener("pointerup", onPointerUp);
   canvas?.addEventListener("pointercancel", onPointerCancel);
+  function preventOverlayTouch(event) {
+    const target = event.target;
+    if (target && target.closest?.("button, input, textarea, select, label, a")) return;
+    event.preventDefault();
+  }
+  canvas?.addEventListener("touchstart", preventOverlayTouch, { passive: false });
+  overlay?.addEventListener("touchstart", preventOverlayTouch, { passive: false });
+  overlay?.addEventListener("touchmove", preventOverlayTouch, { passive: false });
   window.addEventListener("resize", resizeCanvas);
   window.addEventListener("keydown", onWindowKeydown);
 
@@ -417,5 +540,40 @@ export function mountHandwritingComposerOverlay({
 
 
 export const __handwritingComposerOverlayInternals = {
-  exportRecognitionImageDataUrl
+  exportRecognitionImageDataUrl,
+  createPointerStartGate() {
+    const state = {
+      hasSeenPenInput: false,
+      activePointerId: null,
+      activePointerType: null,
+      ignoreTouchUntil: 0
+    };
+    return {
+      state,
+      shouldAcceptPointerStart(event, now = Date.now()) {
+        const pointerType = String(event?.pointerType || "mouse").toLowerCase();
+        if (!["pen", "touch", "mouse"].includes(pointerType)) {
+          return { accepted: false, reason: "unsupported-pointer", pointerType };
+        }
+        if (state.activePointerId !== null && state.activePointerId !== event.pointerId) {
+          return { accepted: false, reason: "active-pointer", pointerType };
+        }
+        if (pointerType === "pen") {
+          state.hasSeenPenInput = true;
+          state.ignoreTouchUntil = now + 1500;
+          return { accepted: true, pointerType };
+        }
+        if (pointerType === "touch") {
+          if (state.hasSeenPenInput) return { accepted: false, reason: "palm-touch-after-pen", pointerType };
+          if (now < state.ignoreTouchUntil) return { accepted: false, reason: "touch-cooldown", pointerType };
+          if (state.activePointerType === "pen") return { accepted: false, reason: "active-pen", pointerType };
+          return { accepted: true, pointerType };
+        }
+        if (state.activePointerType && state.activePointerType !== "mouse") {
+          return { accepted: false, reason: "active-pointer", pointerType };
+        }
+        return { accepted: true, pointerType };
+      }
+    };
+  }
 };

--- a/apps/web/js/views/ui/handwriting-composer-overlay.test.mjs
+++ b/apps/web/js/views/ui/handwriting-composer-overlay.test.mjs
@@ -66,3 +66,30 @@ test("exportRecognitionImageDataUrl génère une image data URL exploitable", ()
   assert.ok(operations.includes("fillRect"));
   assert.ok(operations.includes("stroke"));
 });
+
+test("shouldAcceptPointerStart accepte pen puis refuse touch après détection stylet", () => {
+  const gate = __handwritingComposerOverlayInternals.createPointerStartGate();
+  const now = 1000;
+  const penDecision = gate.shouldAcceptPointerStart({ pointerType: "pen", pointerId: 1 }, now);
+  assert.equal(penDecision.accepted, true);
+  assert.equal(gate.state.hasSeenPenInput, true);
+
+  const touchDecision = gate.shouldAcceptPointerStart({ pointerType: "touch", pointerId: 2 }, now + 10);
+  assert.equal(touchDecision.accepted, false);
+  assert.equal(touchDecision.reason, "palm-touch-after-pen");
+});
+
+test("shouldAcceptPointerStart garde mouse pour debug sans pointeur actif", () => {
+  const gate = __handwritingComposerOverlayInternals.createPointerStartGate();
+  const mouseDecision = gate.shouldAcceptPointerStart({ pointerType: "mouse", pointerId: 3 }, 500);
+  assert.equal(mouseDecision.accepted, true);
+});
+
+test("shouldAcceptPointerStart refuse un pointer concurrent", () => {
+  const gate = __handwritingComposerOverlayInternals.createPointerStartGate();
+  gate.state.activePointerId = 7;
+  gate.state.activePointerType = "pen";
+  const otherPointer = gate.shouldAcceptPointerStart({ pointerType: "touch", pointerId: 8 }, 500);
+  assert.equal(otherPointer.accepted, false);
+  assert.equal(otherPointer.reason, "active-pointer");
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -14207,7 +14207,16 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   flex-direction: column;
   gap: 12px;
   padding: 16px;
-  overscroll-behavior: contain;
+  overscroll-behavior: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+
+.handwriting-composer-overlay * {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .handwriting-composer-overlay__header {
@@ -14233,6 +14242,11 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   margin: 6px 0 0;
   color: #b8c0cc;
   font-size: 13px;
+}
+
+.handwriting-composer-overlay__hint,
+.handwriting-composer-overlay__title {
+  pointer-events: none;
 }
 
 .handwriting-composer-overlay__actions {
@@ -14262,6 +14276,8 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   border-radius: 12px;
   background: #111821;
   overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
 }
 
 .handwriting-composer-overlay__canvas {
@@ -14269,5 +14285,6 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   height: 100%;
   display: block;
   touch-action: none;
+  overscroll-behavior: none;
   cursor: crosshair;
 }


### PR DESCRIPTION
### Motivation
- Fix palm/poignet touches being recorded as strokes on touch devices while prioritizing stylus input for iPad/pen workflows.
- Prevent accidental selection of overlay text and page gestures while writing in fullscreen handwriting composer.
- Reduce latency and jitter by avoiding full redraw on every `pointermove` and smoothing stroke rendering.

### Description
- Add pointer-start gating state and logic (`hasSeenPenInput`, `activePointerId`, `activePointerType`, `ignoreTouchUntil`) and `shouldAcceptPointerStart(event)` to prioritize `pen` and reject `touch` after pen detection; keep `mouse` for desktop debugging (`apps/web/js/views/ui/handwriting-composer-overlay.js`).
- Replace immediate full redraw on every `pointermove` with a coalesced-events + `requestAnimationFrame` pipeline using `pendingPoints`, `scheduleDraw()`, and `flushDraw()` to draw current segments incrementally and reduce jitter (`apps/web/js/views/ui/handwriting-composer-overlay.js`).
- Improve stroke smoothing using quadratic curves and stabilize stroke width with pressure fallback/clamping per pointer type (`computeWidth`, `drawStrokeSegment`) while preserving normalized storage/export behavior (`exportRecognitionImageDataUrl` unchanged) (`apps/web/js/views/ui/handwriting-composer-overlay.js`).
- Strengthen CSS protections to disable text selection/touch callouts on the overlay and disable scrolling/gesture actions on canvas while keeping controls clickable; add `user-select: none`, `-webkit-touch-callout: none`, `overscroll-behavior: none`, and `touch-action: none` on appropriate selectors and make titles/hints `pointer-events: none` so they are not selectable (`apps/web/style.css`).
- Add non-passive `touchstart`/`touchmove` listeners on overlay/canvas to `preventDefault()` for non-interactive targets while preserving button/input interactivity and remove listeners on close (`apps/web/js/views/ui/handwriting-composer-overlay.js`).
- Add lightweight debug logging gated by `localStorage["mdall:debug-handwriting-composer"] === "1"` and expose a small test utility `createPointerStartGate()` for unit testing (`apps/web/js/views/ui/handwriting-composer-overlay.js`).
- Add unit tests for pointer gating behavior (`shouldAcceptPointerStart` scenarios) and keep existing image-export test coverage (`apps/web/js/views/ui/handwriting-composer-overlay.test.mjs`).

### Testing
- Ran unit test suite with `npm test` and all tests passed (`ok`, `1..202`, including new pointer-gate tests).
- Attempted `npm run build:web` which failed in this environment due to a missing local dependency (`node_modules/katex/dist/katex.min.css`), unrelated to the changes in the handwriting overlay and reproducible in CI without KaTeX installed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2d2a6ab88329ba4dfadced8c5c79)