### PR TITLE
Hide empty handwriting overlay error message block

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -14255,7 +14255,7 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 
 .handwriting-composer-overlay__error {
   margin: 0;
-  min-height: 18px;
+  display: none;
   color: #fca5a5;
   font-size: 13px;
   opacity: 0;
@@ -14263,6 +14263,7 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 }
 
 .handwriting-composer-overlay__error.is-visible {
+  display: block;
   opacity: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the handwriting composer from reserving visual space for the error paragraph when there is no error message.

### Description
- Update `apps/web/style.css` to hide `p.handwriting-composer-overlay__error` by default with `display: none` and restore `display: block` when the `.is-visible` modifier is present, replacing the previous `min-height: 18px` behavior.

### Testing
- Ran the full JS test suite with `npm test` and observed `202` tests total with `197` passing, `5` skipped and `0` failing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3d400c74832984926f99b7c4eaa0)