### PR TITLE
feat(trajectory): replace roadmap placeholder with shell layout

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -1,13 +1,78 @@
 import { escapeHtml } from "../../utils/escape-html.js";
 
+const TRAJECTORY_ZOOM_OPTIONS = [
+  { value: "hour", label: "Heure" },
+  { value: "half-day", label: "Demi-journée" },
+  { value: "day", label: "Jour" },
+  { value: "week", label: "Semaine" },
+  { value: "month", label: "Mois" }
+];
+
+function normalizeId(value) {
+  const normalized = String(value || "").trim();
+  return normalized || "";
+}
+
+function resolveProjectId(situation = {}) {
+  return normalizeId(situation?.project_id)
+    || normalizeId(situation?.projectId)
+    || normalizeId(situation?.project?.id)
+    || "";
+}
+
+function renderZoomOptions() {
+  return TRAJECTORY_ZOOM_OPTIONS
+    .map((option) => `<option value="${option.value}">${escapeHtml(option.label)}</option>`)
+    .join("");
+}
+
 export function renderSituationRoadmapView(situation, subjects = []) {
   const subjectCount = Array.isArray(subjects) ? subjects.length : 0;
   const title = String(situation?.title || "Situation");
+  const situationId = normalizeId(situation?.id);
+  const projectId = resolveProjectId(situation);
+
+  console.info("[trajectory] render.shell", { situationId, subjectCount });
+
+  const projectDataAttribute = projectId ? ` data-project-id="${escapeHtml(projectId)}"` : "";
+  const emptyState = subjectCount
+    ? ""
+    : `
+      <div class="settings-empty-state situation-trajectory__empty-state" role="status">
+        Aucun sujet n'est disponible pour la trajectoire de <strong>${escapeHtml(title)}</strong>.
+      </div>
+    `;
 
   return `
-    <section class="project-situation-alt-view project-situation-alt-view--roadmap" aria-label="Vue trajectoire">
-      <div class="settings-empty-state">
-        La vue trajectoire de <strong>${escapeHtml(title)}</strong> sera affichée ici (${subjectCount} sujet(s)).
+    <section
+      class="project-situation-alt-view project-situation-alt-view--roadmap"
+      aria-label="Vue trajectoire"
+    >
+      <div
+        class="situation-trajectory"
+        data-situation-trajectory
+        data-situation-id="${escapeHtml(situationId)}"${projectDataAttribute}
+      >
+        <header class="situation-trajectory__toolbar">
+          <div class="situation-trajectory__toolbar-title">Trajectoire · ${escapeHtml(title)}</div>
+          <label class="situation-trajectory__zoom" for="trajectoryZoomSelect">
+            <span>Zoom</span>
+            <select id="trajectoryZoomSelect" name="trajectoryZoom">
+              ${renderZoomOptions()}
+            </select>
+          </label>
+        </header>
+
+        <div class="situation-trajectory__timeline" role="presentation"></div>
+
+        <div class="situation-trajectory__body">
+          <aside class="situation-trajectory__left" aria-label="Sujets"></aside>
+
+          <div class="situation-trajectory__viewport" aria-label="Trajectoire des sujets">
+            <canvas class="situation-trajectory__canvas"></canvas>
+            ${emptyState}
+          </div>
+        </div>
       </div>
     </section>
   `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10129,6 +10129,77 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   overflow:auto;
 }
 
+.situation-trajectory{
+  display:flex;
+  flex-direction:column;
+  min-height:100%;
+  border:1px solid var(--borderColor-default, #30363d);
+  background:var(--bgColor-default, #0d1117);
+}
+
+.situation-trajectory__toolbar{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  padding:10px 12px;
+  border-bottom:1px solid var(--borderColor-default, #30363d);
+}
+
+.situation-trajectory__toolbar-title{
+  font-size:13px;
+  font-weight:600;
+  color:var(--fgColor-default, #e6edf3);
+}
+
+.situation-trajectory__zoom{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  font-size:12px;
+  color:var(--fgColor-muted, #8b949e);
+}
+
+.situation-trajectory__zoom select{
+  min-width:130px;
+}
+
+.situation-trajectory__timeline{
+  min-height:42px;
+  border-bottom:1px solid var(--borderColor-default, #30363d);
+  background:color-mix(in srgb, var(--bgColor-default, #0d1117) 82%, white 18%);
+}
+
+.situation-trajectory__body{
+  display:grid;
+  grid-template-columns:minmax(72px, 340px) minmax(0, 1fr);
+  min-height:0;
+  flex:1 1 auto;
+}
+
+.situation-trajectory__left{
+  min-width:0;
+  border-right:1px solid var(--borderColor-default, #30363d);
+}
+
+.situation-trajectory__viewport{
+  position:relative;
+  min-height:360px;
+  overflow:auto;
+}
+
+.situation-trajectory__canvas{
+  display:block;
+  width:100%;
+  min-height:360px;
+}
+
+.situation-trajectory__empty-state{
+  position:absolute;
+  inset:12px;
+  pointer-events:none;
+}
+
 .project-situation-grid,
 .situation-grid{
   --situation-grid-col-title:420px;


### PR DESCRIPTION
### Motivation
- Fournir la base HTML/CSS de la vue “Trajectoire” (remplacer le placeholder existant) pour pouvoir implémenter ensuite la timeline, le canvas et la logique métier sans créer de nouvelle route.
- Conserver la vue fonctionnelle même sans données historiques dédiées et exposer les attributs nécessaires pour les chargeurs/logiciels futurs (`data-situation-trajectory`, `data-situation-id`, `data-project-id`).
- Respecter la contrainte de DOM léger en préparant une zone centrale prévue pour du `canvas` et une colonne gauche réutilisable par la suite.

### Description
- Remplacement complet de la sortie de `renderSituationRoadmapView` pour retourner un shell `section.project-situation-alt-view--roadmap` contenant la structure demandée (`.situation-trajectory`, toolbar, timeline, `.situation-trajectory__body`, `.situation-trajectory__left`, `.situation-trajectory__viewport` et `<canvas class="situation-trajectory__canvas">`).
- Ajout d’un sélecteur de zoom avec les valeurs `hour`, `half-day`, `day`, `week`, `month` et rendu des options via `TRAJECTORY_ZOOM_OPTIONS`.
- Ajout des attributs `data-situation-trajectory`, `data-situation-id` et conditionnel `data-project-id`, d’un état vide convivial si aucun sujet, et d’une instrumentation console `console.info("[trajectory] render.shell", { situationId, subjectCount })`.
- Ajout de règles CSS de base (`.situation-trajectory*`) pour le toolbar, timeline, layout gauche/viewport, canvas et empty state afin de rendre la vue immédiatement exploitable visuellement.

### Testing
- Exécution de la vérification de syntaxe Node sur le fichier modifié avec `node --check apps/web/js/views/project-situations/project-situations-view-roadmap.js`, qui a réussi.
- Validation automatique basique via contrôle d’état Git (`git status`) et commit réalisé; aucun test d’intégration ou visuel automatisé n’a été exécuté dans ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3142231c8329bb3eaec322ce89ef)