### PR TITLE
Add trajectory lifecycle model from subject history events

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -1,0 +1,264 @@
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function toDate(value) {
+  if (value instanceof Date) return new Date(value.getTime());
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function toTimestamp(value, fallbackTs = Date.now()) {
+  const date = toDate(value);
+  if (date) return date.getTime();
+  return fallbackTs;
+}
+
+function normalizeStatus(status = "") {
+  const value = String(status || "").trim().toLowerCase();
+  if (["rejected", "invalid"].includes(value)) return "closed_invalid";
+  if (["duplicate"].includes(value)) return "closed_duplicate";
+  if (["closed", "closed_invalid", "closed_duplicate"].includes(value)) return value;
+  return "open";
+}
+
+function normalizeCloseStatus(event = {}, fallbackStatus = "closed") {
+  const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
+  const payloadStatus = normalizeStatus(
+    payload.closed_status
+      || payload.closedStatus
+      || payload.status
+      || payload.reason
+      || payload.close_reason
+      || fallbackStatus
+  );
+  if (payloadStatus === "open") return "closed";
+  return payloadStatus;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectEventsForSubject(subjectId, subjectHistoryEvents) {
+  if (Array.isArray(subjectHistoryEvents)) {
+    return subjectHistoryEvents.filter((event) => normalizeId(event?.subject_id) === subjectId);
+  }
+  if (subjectHistoryEvents && typeof subjectHistoryEvents === "object") {
+    return asArray(subjectHistoryEvents[subjectId]);
+  }
+  return [];
+}
+
+function resolveObjectiveDates({ subjectId, objectivesById = {}, objectiveIdsBySubjectId = {} } = {}) {
+  return asArray(objectiveIdsBySubjectId[subjectId])
+    .map((objectiveId) => objectivesById?.[objectiveId])
+    .map((objective = {}) => ({
+      objectiveId: normalizeId(objective.id),
+      dueDate: toDate(objective.due_date || objective.dueDate)
+    }))
+    .filter((entry) => !!entry.objectiveId && !!entry.dueDate)
+    .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+}
+
+function splitSegmentByObjectiveBoundaries(segment, objectiveDates = []) {
+  const boundaries = objectiveDates
+    .map((entry) => entry.dueDate.getTime())
+    .filter((ts) => ts > segment.startAt.getTime() && ts < segment.endAt.getTime());
+
+  if (!boundaries.length) return [segment];
+
+  const splits = [];
+  let startTs = segment.startAt.getTime();
+  for (const boundaryTs of boundaries) {
+    splits.push({
+      ...segment,
+      startAt: new Date(startTs),
+      endAt: new Date(boundaryTs)
+    });
+    startTs = boundaryTs;
+  }
+  splits.push({
+    ...segment,
+    startAt: new Date(startTs),
+    endAt: new Date(segment.endAt.getTime())
+  });
+  return splits;
+}
+
+function resolveSegmentStyle({ status, endAt, objectiveDates }) {
+  const statusKey = normalizeStatus(status);
+  const endTs = endAt.getTime();
+  const hasObjectivePassed = objectiveDates.some((entry) => endTs > entry.dueDate.getTime());
+
+  if (hasObjectivePassed) {
+    return {
+      lineStyle: statusKey === "open" ? "solid" : "dashed",
+      lineColor: "red"
+    };
+  }
+
+  if (statusKey === "open") {
+    return {
+      lineStyle: "solid",
+      lineColor: "green"
+    };
+  }
+
+  return {
+    lineStyle: "dashed",
+    lineColor: "gray"
+  };
+}
+
+function resolveStatusAtTimestamp(statusPoints = [], targetTs, fallback = "open") {
+  let resolved = normalizeStatus(fallback);
+  for (const point of statusPoints) {
+    if (point.at.getTime() > targetTs) break;
+    resolved = normalizeStatus(point.status);
+  }
+  return resolved;
+}
+
+function toStatusIcon(status = "open") {
+  const normalized = normalizeStatus(status);
+  if (normalized === "closed_invalid") return "rejected";
+  if (normalized === "closed_duplicate") return "close-duplicate";
+  if (normalized.startsWith("closed")) return "close";
+  return "open";
+}
+
+export function buildTrajectoryModel({
+  subjects = [],
+  subjectHistoryEvents = {},
+  objectivesById = {},
+  objectiveIdsBySubjectId = {},
+  projectStartDate,
+  today = new Date()
+} = {}) {
+  const todayTs = toTimestamp(today);
+  const fallbackProjectStartTs = toTimestamp(projectStartDate, todayTs);
+
+  const rows = asArray(subjects).map((subject = {}) => {
+    const subjectId = normalizeId(subject.id);
+    const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
+    const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
+
+    const events = collectEventsForSubject(subjectId, subjectHistoryEvents)
+      .map((event = {}) => ({
+        ...event,
+        event_type: normalizeId(event.event_type).toLowerCase(),
+        created_at: toDate(event.created_at)
+      }))
+      .filter((event) => !!event.created_at)
+      .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+
+    const createdEvent = events.find((event) => event.event_type === "subject_created");
+    const subjectCreatedTs = toTimestamp(
+      createdEvent?.created_at || subject.created_at,
+      fallbackProjectStartTs
+    );
+
+    const endTs = Math.max(todayTs, latestObjectiveTs || 0, subjectCreatedTs);
+    const fallbackStartStatus = normalizeStatus(subject.status);
+
+    const statusPoints = [];
+    const upsertStatusPoint = (ts, status, source) => {
+      const safeTs = Math.max(subjectCreatedTs, ts);
+      const safeStatus = normalizeStatus(status);
+      const existing = statusPoints.find((point) => point.at.getTime() === safeTs);
+      if (existing) {
+        existing.status = safeStatus;
+        existing.icon = toStatusIcon(safeStatus);
+        existing.source = source;
+        return;
+      }
+      statusPoints.push({
+        at: new Date(safeTs),
+        status: safeStatus,
+        icon: toStatusIcon(safeStatus),
+        source
+      });
+    };
+
+    upsertStatusPoint(subjectCreatedTs, createdEvent ? "open" : fallbackStartStatus, createdEvent ? "subject_created" : "subject_fallback_created_at");
+
+    for (const event of events) {
+      const ts = event.created_at.getTime();
+      if (event.event_type === "subject_created") {
+        upsertStatusPoint(ts, "open", event.event_type);
+      } else if (event.event_type === "subject_closed") {
+        upsertStatusPoint(ts, normalizeCloseStatus(event, subject.status), event.event_type);
+      } else if (event.event_type === "subject_reopened") {
+        upsertStatusPoint(ts, "open", event.event_type);
+      }
+    }
+
+    statusPoints.sort((a, b) => a.at.getTime() - b.at.getTime());
+
+    const rawSegments = [];
+    for (let index = 0; index < statusPoints.length; index += 1) {
+      const point = statusPoints[index];
+      const nextPoint = statusPoints[index + 1];
+      const segmentStartTs = point.at.getTime();
+      const segmentEndTs = nextPoint ? nextPoint.at.getTime() : endTs;
+      if (segmentEndTs <= segmentStartTs) continue;
+      rawSegments.push({
+        subjectId,
+        status: point.status,
+        startAt: new Date(segmentStartTs),
+        endAt: new Date(segmentEndTs)
+      });
+    }
+
+    const lifecycleSegments = rawSegments
+      .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
+      .map((segment) => ({
+        ...segment,
+        ...resolveSegmentStyle({
+          status: segment.status,
+          endAt: segment.endAt,
+          objectiveDates
+        })
+      }));
+
+    const objectiveMarkers = objectiveDates.map((entry) => {
+      const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
+      const isClosedAtDueDate = normalizeStatus(statusAtDueDate) !== "open";
+      return {
+        subjectId,
+        objectiveId: entry.objectiveId,
+        at: new Date(entry.dueDate.getTime()),
+        markerType: isClosedAtDueDate ? "check" : "cross",
+        markerColor: isClosedAtDueDate ? "green" : "red",
+        statusAtDueDate
+      };
+    });
+
+    console.info("[trajectory] model.subject", {
+      subjectId,
+      segmentCount: lifecycleSegments.length,
+      markerCount: objectiveMarkers.length
+    });
+
+    return {
+      subjectId,
+      statusPoints,
+      lifecycleSegments,
+      objectiveMarkers
+    };
+  });
+
+  return { rows };
+}
+
+export function __trajectoryModelTestUtils() {
+  return {
+    normalizeStatus,
+    normalizeCloseStatus,
+    resolveObjectiveDates,
+    resolveStatusAtTimestamp,
+    splitSegmentByObjectiveBoundaries,
+    resolveSegmentStyle
+  };
+}

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTrajectoryModel, __trajectoryModelTestUtils } from "./trajectory-model.js";
+
+test("buildTrajectoryModel construit les segments open/closed avant et après objectif", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-1",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-1": [
+        { subject_id: "s-1", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-1", event_type: "subject_closed", created_at: "2026-01-03T00:00:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-1", event_type: "subject_reopened", created_at: "2026-01-07T00:00:00.000Z" }
+      ]
+    },
+    objectivesById: {
+      "o-1": { id: "o-1", due_date: "2026-01-05T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-1": ["o-1"]
+    },
+    projectStartDate: "2025-12-01T00:00:00.000Z",
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  assert.equal(result.rows.length, 1);
+  const [row] = result.rows;
+  assert.equal(row.subjectId, "s-1");
+
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString(),
+      color: segment.lineColor,
+      style: segment.lineStyle
+    })),
+    [
+      {
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2026-01-03T00:00:00.000Z",
+        color: "green",
+        style: "solid"
+      },
+      {
+        start: "2026-01-03T00:00:00.000Z",
+        end: "2026-01-05T00:00:00.000Z",
+        color: "gray",
+        style: "dashed"
+      },
+      {
+        start: "2026-01-05T00:00:00.000Z",
+        end: "2026-01-07T00:00:00.000Z",
+        color: "red",
+        style: "dashed"
+      },
+      {
+        start: "2026-01-07T00:00:00.000Z",
+        end: "2026-01-10T00:00:00.000Z",
+        color: "red",
+        style: "solid"
+      }
+    ]
+  );
+
+  assert.deepEqual(
+    row.objectiveMarkers.map((marker) => ({
+      at: marker.at.toISOString(),
+      type: marker.markerType,
+      color: marker.markerColor
+    })),
+    [
+      {
+        at: "2026-01-05T00:00:00.000Z",
+        type: "check",
+        color: "green"
+      }
+    ]
+  );
+});
+
+test("buildTrajectoryModel utilise subject.created_at si subject_created absent et prolonge jusqu'à objectif futur", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-2",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-2": []
+    },
+    objectivesById: {
+      "o-future": { id: "o-future", due_date: "2026-03-01T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-2": ["o-future"]
+    },
+    today: "2026-01-15T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.equal(row.lifecycleSegments.length, 1);
+  assert.equal(row.lifecycleSegments[0].lineColor, "green");
+  assert.equal(row.lifecycleSegments[0].lineStyle, "solid");
+  assert.equal(row.lifecycleSegments[0].endAt.toISOString(), "2026-03-01T00:00:00.000Z");
+
+  assert.equal(row.objectiveMarkers[0].markerType, "cross");
+  assert.equal(row.objectiveMarkers[0].markerColor, "red");
+});
+
+test("normalizeCloseStatus remonte closed_invalid et closed_duplicate depuis le payload", () => {
+  const { normalizeCloseStatus } = __trajectoryModelTestUtils();
+  assert.equal(normalizeCloseStatus({ payload: { closed_status: "invalid" } }), "closed_invalid");
+  assert.equal(normalizeCloseStatus({ payload: { status: "closed_duplicate" } }), "closed_duplicate");
+  assert.equal(normalizeCloseStatus({ payload: {} }), "closed");
+});


### PR DESCRIPTION
### Motivation
- Provide a pure business model to convert `subject_history` events and objectives into time-based lifecycle segments for the Trajectoire view without coupling to DOM or canvas.
- Ensure the trajectory engine is testable in isolation and can be used by subsequent steps (canvas renderer, virtualizer, scroll sync) while keeping the DOM light.

### Description
- Add `apps/web/js/views/project-situations/trajectory/trajectory-model.js` exporting `buildTrajectoryModel(...)` which transforms subjects + history + objectives into rows containing `statusPoints`, `lifecycleSegments`, and `objectiveMarkers` following the specified rules (open/closed/reopened, objective boundaries, color/style before/after objective, no invented close dates, fallback to `subject.created_at`).
- Implement status normalization (including `closed_invalid` / `closed_duplicate`) and close-status extraction from event payloads, objective-date resolution, segment splitting at objective boundaries, and style resolution for segments.
- Export `__trajectoryModelTestUtils()` with focused helpers to aid unit tests.
- Add unit tests in `apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` covering event→segments conversion, fallback start-date behavior, future-objective extension, and payload close-status normalization.
- Add lightweight instrumentation calls `console.info("[trajectory] model.subject", ...)` per subject for debugging/telemetry.

### Testing
- Ran the unit suite: `node --test apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` which executed the model tests; all tests passed (3/3).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef44577078832985dd5b73023e8503)