### PR TITLE
Add trajectory roadmap model & canvas renderer and wire into situations view

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -35,6 +35,7 @@ const TRAJECTORY_LEFT_COLUMN_WIDTH = {
   max: 640,
   default: 320
 };
+const TRAJECTORY_ROW_HEIGHT = 36;
 
 export function createProjectSituationsEvents({
   store,
@@ -66,6 +67,18 @@ export function createProjectSituationsEvents({
   reorderSituationGridRootSubjects
 }) {
   let insightsRequestId = 0;
+  let trajectoryRuntimeModulesPromise = null;
+
+  function loadTrajectoryRuntimeModules() {
+    if (!trajectoryRuntimeModulesPromise) {
+      trajectoryRuntimeModulesPromise = Promise.all([
+        import("./trajectory/trajectory-time-scale.js"),
+        import("./trajectory/trajectory-model.js"),
+        import("./trajectory/trajectory-canvas-renderer.js")
+      ]);
+    }
+    return trajectoryRuntimeModulesPromise;
+  }
 
   function isSituationInsightsDebugEnabled() {
     try {
@@ -595,6 +608,118 @@ export function createProjectSituationsEvents({
         window.addEventListener("pointercancel", onPointerUp);
       });
     });
+  }
+
+  function resolveTrajectorySubjects(situationId = "") {
+    const selectedSituationId = String(store?.situationsView?.selectedSituationId || "").trim();
+    if (situationId && selectedSituationId && situationId !== selectedSituationId) return [];
+    return Array.isArray(uiState?.selectedSituationSubjects) ? uiState.selectedSituationSubjects : [];
+  }
+
+  function resolveTrajectoryHistoryBySubjectId(situationId = "") {
+    const bySituationId = store?.projectSubjectsView?.trajectoryHistoryBySituationId;
+    if (!bySituationId || typeof bySituationId !== "object") return {};
+    const scoped = bySituationId[situationId];
+    if (!scoped || typeof scoped !== "object") return {};
+    return scoped.statusEventsBySubjectId || scoped.eventsBySubjectId || {};
+  }
+
+  function resolveTrajectoryProjectStartDate() {
+    return store?.projectForm?.project?.created_at
+      || store?.project?.created_at
+      || null;
+  }
+
+  function resolveTrajectoryTimelineEndDate() {
+    const endDate = new Date();
+    endDate.setUTCMonth(endDate.getUTCMonth() + 6);
+    return endDate;
+  }
+
+  function bindTrajectoryCanvas(root) {
+    const trajectoryNodes = [...root.querySelectorAll("[data-situation-trajectory][data-situation-id]")];
+    if (!trajectoryNodes.length) return;
+
+    const layout = String(store?.situationsView?.selectedSituationLayout || "").trim().toLowerCase();
+    if (layout !== "roadmap") return;
+
+    loadTrajectoryRuntimeModules()
+      .then(([timeScaleModule, modelModule, canvasRendererModule]) => {
+        const { createTrajectoryTimeScale } = timeScaleModule || {};
+        const { buildTrajectoryModel } = modelModule || {};
+        const { renderTrajectoryCanvas } = canvasRendererModule || {};
+        if (typeof createTrajectoryTimeScale !== "function"
+          || typeof buildTrajectoryModel !== "function"
+          || typeof renderTrajectoryCanvas !== "function") {
+          return;
+        }
+
+        trajectoryNodes.forEach((trajectoryNode) => {
+          const situationId = String(trajectoryNode.getAttribute("data-situation-id") || "").trim();
+          const viewportNode = trajectoryNode.querySelector(".situation-trajectory__viewport");
+          const canvasNode = trajectoryNode.querySelector(".situation-trajectory__canvas");
+          if (!viewportNode || !canvasNode) return;
+
+          const subjects = resolveTrajectorySubjects(situationId);
+          const rawSubjectsResult = store?.projectSubjectsView?.rawSubjectsResult || {};
+          const objectiveIdsBySubjectId = rawSubjectsResult.objectiveIdsBySubjectId || {};
+          const objectivesById = rawSubjectsResult.objectivesById || {};
+          const historyBySubjectId = resolveTrajectoryHistoryBySubjectId(situationId);
+
+          const projectStartDate = resolveTrajectoryProjectStartDate()
+            || subjects.reduce((acc, subject) => {
+              const createdAt = subject?.created_at ? new Date(subject.created_at) : null;
+              if (!createdAt || Number.isNaN(createdAt.getTime())) return acc;
+              if (!acc) return createdAt;
+              return createdAt.getTime() < acc.getTime() ? createdAt : acc;
+            }, null)
+            || new Date();
+
+          const timeScale = createTrajectoryTimeScale({
+            startDate: projectStartDate,
+            endDate: resolveTrajectoryTimelineEndDate(),
+            zoom: "day"
+          });
+
+          const { rows } = buildTrajectoryModel({
+            subjects,
+            subjectHistoryEvents: historyBySubjectId,
+            objectivesById,
+            objectiveIdsBySubjectId,
+            projectStartDate,
+            today: new Date()
+          });
+
+          let rafId = 0;
+          const scheduleRender = () => {
+            if (rafId) return;
+            rafId = window.requestAnimationFrame(() => {
+              rafId = 0;
+              renderTrajectoryCanvas({
+                canvas: canvasNode,
+                rows,
+                timeScale,
+                scrollLeft: viewportNode.scrollLeft,
+                scrollTop: viewportNode.scrollTop,
+                viewportWidth: viewportNode.clientWidth,
+                viewportHeight: viewportNode.clientHeight,
+                rowHeight: TRAJECTORY_ROW_HEIGHT,
+                overscan: { rows: 4, px: 160 }
+              });
+            });
+          };
+
+          if (!viewportNode.dataset.trajectoryCanvasBound) {
+            viewportNode.dataset.trajectoryCanvasBound = "true";
+            viewportNode.addEventListener("scroll", scheduleRender, { passive: true });
+          }
+
+          scheduleRender();
+        });
+      })
+      .catch((error) => {
+        console.error("[trajectory] runtime.load.error", error);
+      });
   }
 
   async function handleSituationGridKanbanAction(root, actionNode, event = null) {
@@ -1482,6 +1607,7 @@ export function createProjectSituationsEvents({
 
     bindSituationGridColumnResize(root);
     bindTrajectoryColumnResize(root);
+    bindTrajectoryCanvas(root);
     bindSituationGridEditableCells(root);
     bindSituationGridDnd(root);
 

--- a/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
@@ -1,0 +1,302 @@
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function toTimestamp(value, fallback = Date.now()) {
+  const date = value instanceof Date ? value : new Date(value);
+  const ts = date.getTime();
+  return Number.isFinite(ts) ? ts : fallback;
+}
+
+function intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs) {
+  return endTs >= visibleStartTs && startTs <= visibleEndTs;
+}
+
+function normalizeOverscan(overscan) {
+  if (typeof overscan === "number") {
+    return { rows: Math.max(0, Math.floor(overscan)), px: 160 };
+  }
+  return {
+    rows: Math.max(0, Math.floor(Number(overscan?.rows) || 4)),
+    px: Math.max(0, Number(overscan?.px) || 160)
+  };
+}
+
+function getVisibleRowWindow({ rowCount, rowHeight, scrollTop, viewportHeight, overscanRows }) {
+  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
+  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
+  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
+
+  const start = clamp(Math.floor(safeScrollTop / safeRowHeight) - overscanRows, 0, Math.max(0, rowCount - 1));
+  const end = clamp(
+    Math.ceil((safeScrollTop + safeViewportHeight) / safeRowHeight) + overscanRows,
+    start,
+    Math.max(0, rowCount - 1)
+  );
+  return { rowStart: start, rowEnd: end };
+}
+
+function setupCanvas(canvas, viewportWidth, viewportHeight) {
+  const width = Math.max(1, Math.floor(Number(viewportWidth) || 0));
+  const height = Math.max(1, Math.floor(Number(viewportHeight) || 0));
+  const dpr = Math.max(1, Number(globalThis.devicePixelRatio) || 1);
+
+  const displayWidth = Math.max(1, Math.round(width * dpr));
+  const displayHeight = Math.max(1, Math.round(height * dpr));
+  if (canvas.width !== displayWidth) canvas.width = displayWidth;
+  if (canvas.height !== displayHeight) canvas.height = displayHeight;
+
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+
+  const ctx = canvas.getContext("2d");
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+
+  return { ctx, width, height, dpr };
+}
+
+function drawVerticalLine(ctx, { x, height, color = "#cf222e", alpha = 1, dashed = false }) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.globalAlpha = alpha;
+  ctx.lineWidth = 1;
+  if (dashed) ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(x + 0.5, 0);
+  ctx.lineTo(x + 0.5, height);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawSegment(ctx, { x1, x2, y, lineColor, lineStyle }) {
+  if (x2 <= x1) return;
+  ctx.save();
+  ctx.strokeStyle = lineColor === "red"
+    ? "#cf222e"
+    : lineColor === "green"
+      ? "#1a7f37"
+      : "#8c959f";
+  ctx.lineWidth = 2;
+  if (lineStyle === "dashed") ctx.setLineDash([6, 4]);
+  ctx.beginPath();
+  ctx.moveTo(x1, y);
+  ctx.lineTo(x2, y);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawStatusIcon(ctx, { x, y, icon = "open" }) {
+  ctx.save();
+  if (icon === "open") {
+    ctx.fillStyle = "#1a7f37";
+    ctx.beginPath();
+    ctx.arc(x, y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  } else if (icon === "rejected") {
+    ctx.strokeStyle = "#cf222e";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(x - 4, y - 4);
+    ctx.lineTo(x + 4, y + 4);
+    ctx.moveTo(x + 4, y - 4);
+    ctx.lineTo(x - 4, y + 4);
+    ctx.stroke();
+  } else if (icon === "reopen") {
+    ctx.strokeStyle = "#1a7f37";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(x, y, 4, Math.PI * 0.15, Math.PI * 1.75);
+    ctx.stroke();
+  } else {
+    ctx.fillStyle = "#8c959f";
+    ctx.beginPath();
+    ctx.rect(x - 4, y - 4, 8, 8);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawObjectiveMarker(ctx, { x, y, markerType, markerColor }) {
+  ctx.save();
+  const color = markerColor === "green" ? "#1a7f37" : "#cf222e";
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = 2;
+  if (markerType === "check") {
+    ctx.beginPath();
+    ctx.moveTo(x - 4, y);
+    ctx.lineTo(x - 1, y + 4);
+    ctx.lineTo(x + 5, y - 4);
+    ctx.stroke();
+  } else {
+    ctx.beginPath();
+    ctx.moveTo(x - 4, y - 4);
+    ctx.lineTo(x + 4, y + 4);
+    ctx.moveTo(x + 4, y - 4);
+    ctx.lineTo(x - 4, y + 4);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function resolveTodayTimestamp(timeScale) {
+  const startTs = toTimestamp(timeScale?.startDate, Date.now());
+  const endTs = toTimestamp(timeScale?.endDate, startTs + 1);
+  return clamp(Date.now(), startTs, endTs);
+}
+
+function collectObjectiveVerticalTimestamps(rows = []) {
+  const values = new Set();
+  for (const row of rows) {
+    for (const marker of asArray(row?.objectiveMarkers)) {
+      values.add(toTimestamp(marker?.at));
+    }
+  }
+  return [...values].sort((a, b) => a - b);
+}
+
+function resolvePointIcon(point = {}, previousPoint = null) {
+  const explicit = String(point?.icon || "").trim();
+  if (explicit) return explicit;
+  const source = String(point?.source || "").trim().toLowerCase();
+  if (source === "subject_reopened") return "reopen";
+  if (source === "subject_closed") return "close";
+  const status = String(point?.status || "").trim().toLowerCase();
+  if (["closed_invalid", "invalid", "rejected"].includes(status)) return "rejected";
+  if (["closed", "closed_duplicate", "duplicate"].includes(status)) return "close";
+  if (previousPoint && String(previousPoint?.status || "").trim().toLowerCase() !== "open") return "reopen";
+  return "open";
+}
+
+export function renderTrajectoryCanvas({
+  canvas,
+  rows = [],
+  timeScale,
+  scrollLeft = 0,
+  scrollTop = 0,
+  viewportWidth = 0,
+  viewportHeight = 0,
+  rowHeight = 32,
+  overscan = { rows: 4, px: 160 }
+} = {}) {
+  if (!canvas || typeof canvas.getContext !== "function" || !timeScale || typeof timeScale.timeToX !== "function") {
+    return {
+      visibleRows: 0,
+      visibleStart: null,
+      visibleEnd: null
+    };
+  }
+
+  const overscanConfig = normalizeOverscan(overscan);
+  const { ctx, width, height } = setupCanvas(canvas, viewportWidth, viewportHeight);
+
+  const safeRows = asArray(rows);
+  const rowCount = safeRows.length;
+  const { rowStart, rowEnd } = getVisibleRowWindow({
+    rowCount,
+    rowHeight,
+    scrollTop,
+    viewportHeight: height,
+    overscanRows: overscanConfig.rows
+  });
+
+  const visibleTimeRange = timeScale.getVisibleTimeRange({
+    scrollLeft,
+    viewportWidth: width,
+    overscanPx: overscanConfig.px
+  });
+
+  const visibleStartTs = toTimestamp(visibleTimeRange.start);
+  const visibleEndTs = toTimestamp(visibleTimeRange.end);
+
+  const todayTs = resolveTodayTimestamp(timeScale);
+  if (todayTs >= visibleStartTs && todayTs <= visibleEndTs) {
+    const x = timeScale.timeToX(todayTs) - scrollLeft;
+    drawVerticalLine(ctx, { x, height, color: "#cf222e", alpha: 1 });
+  }
+
+  const objectiveTimestamps = collectObjectiveVerticalTimestamps(safeRows);
+  for (const ts of objectiveTimestamps) {
+    if (ts < visibleStartTs || ts > visibleEndTs) continue;
+    const x = timeScale.timeToX(ts) - scrollLeft;
+    drawVerticalLine(ctx, { x, height, color: "#cf222e", alpha: 0.5, dashed: true });
+  }
+
+  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
+  for (let index = rowStart; index <= rowEnd; index += 1) {
+    const row = safeRows[index];
+    if (!row) continue;
+    const y = (index * safeRowHeight) - scrollTop + (safeRowHeight / 2);
+    if (y < -safeRowHeight || y > height + safeRowHeight) continue;
+
+    for (const segment of asArray(row.lifecycleSegments)) {
+      const startTs = toTimestamp(segment.startAt);
+      const endTs = toTimestamp(segment.endAt);
+      if (!intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs)) continue;
+
+      const segmentX1 = timeScale.timeToX(startTs) - scrollLeft;
+      const segmentX2 = timeScale.timeToX(endTs) - scrollLeft;
+      drawSegment(ctx, {
+        x1: segmentX1,
+        x2: segmentX2,
+        y,
+        lineColor: segment.lineColor,
+        lineStyle: segment.lineStyle
+      });
+    }
+
+    const statusPoints = asArray(row.statusPoints);
+    for (let pointIndex = 0; pointIndex < statusPoints.length; pointIndex += 1) {
+      const point = statusPoints[pointIndex];
+      const ts = toTimestamp(point.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+      const x = timeScale.timeToX(ts) - scrollLeft;
+      drawStatusIcon(ctx, {
+        x,
+        y,
+        icon: resolvePointIcon(point, statusPoints[pointIndex - 1] || null)
+      });
+    }
+
+    for (const marker of asArray(row.objectiveMarkers)) {
+      const ts = toTimestamp(marker.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+      const x = timeScale.timeToX(ts) - scrollLeft;
+      drawObjectiveMarker(ctx, {
+        x,
+        y,
+        markerType: marker.markerType,
+        markerColor: marker.markerColor
+      });
+    }
+  }
+
+  const visibleRows = rowCount ? (rowEnd - rowStart + 1) : 0;
+  const visibleStart = new Date(visibleStartTs).toISOString();
+  const visibleEnd = new Date(visibleEndTs).toISOString();
+
+  console.info("[trajectory] canvas.render", { visibleRows, visibleStart, visibleEnd });
+
+  return {
+    visibleRows,
+    visibleStart,
+    visibleEnd,
+    rowStart,
+    rowEnd
+  };
+}
+
+export function __trajectoryCanvasRendererTestUtils() {
+  return {
+    normalizeOverscan,
+    getVisibleRowWindow,
+    collectObjectiveVerticalTimestamps,
+    resolvePointIcon,
+    intersectsRange
+  };
+}

--- a/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createTrajectoryTimeScale } from "./trajectory-time-scale.js";
+import { renderTrajectoryCanvas, __trajectoryCanvasRendererTestUtils } from "./trajectory-canvas-renderer.js";
+
+function createMockCanvas() {
+  const operations = [];
+  const ctx = {
+    save: () => operations.push(["save"]),
+    restore: () => operations.push(["restore"]),
+    setTransform: (...args) => operations.push(["setTransform", ...args]),
+    clearRect: (...args) => operations.push(["clearRect", ...args]),
+    setLineDash: (...args) => operations.push(["setLineDash", ...args]),
+    beginPath: () => operations.push(["beginPath"]),
+    moveTo: (...args) => operations.push(["moveTo", ...args]),
+    lineTo: (...args) => operations.push(["lineTo", ...args]),
+    stroke: () => operations.push(["stroke"]),
+    fill: () => operations.push(["fill"]),
+    arc: (...args) => operations.push(["arc", ...args]),
+    rect: (...args) => operations.push(["rect", ...args]),
+    fillText: (...args) => operations.push(["fillText", ...args])
+  };
+
+  return {
+    width: 0,
+    height: 0,
+    style: {},
+    getContext: () => ctx,
+    operations
+  };
+}
+
+test("renderTrajectoryCanvas dessine uniquement la fenêtre visible + instrumentation", () => {
+  const originalDpr = globalThis.devicePixelRatio;
+  globalThis.devicePixelRatio = 2;
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-01-01T00:00:00.000Z",
+    endDate: "2026-01-10T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 10
+  });
+
+  const canvas = createMockCanvas();
+  const result = renderTrajectoryCanvas({
+    canvas,
+    timeScale,
+    rows: [
+      {
+        statusPoints: [{ at: "2026-01-02T00:00:00.000Z", status: "open", source: "subject_created" }],
+        lifecycleSegments: [{ startAt: "2026-01-02T00:00:00.000Z", endAt: "2026-01-05T00:00:00.000Z", lineColor: "green", lineStyle: "solid" }],
+        objectiveMarkers: [{ at: "2026-01-04T00:00:00.000Z", markerType: "cross", markerColor: "red" }]
+      },
+      {
+        statusPoints: [{ at: "2026-01-09T00:00:00.000Z", status: "open", source: "subject_created" }],
+        lifecycleSegments: [{ startAt: "2026-01-09T00:00:00.000Z", endAt: "2026-01-10T00:00:00.000Z", lineColor: "green", lineStyle: "solid" }],
+        objectiveMarkers: []
+      }
+    ],
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 60,
+    viewportHeight: 40,
+    rowHeight: 20,
+    overscan: { rows: 0, px: 0 }
+  });
+
+  assert.equal(canvas.width, 120);
+  assert.equal(canvas.height, 80);
+  assert.equal(result.visibleRows, 2);
+  assert.equal(result.rowStart, 0);
+  assert.equal(result.rowEnd, 1);
+
+  const strokeCalls = canvas.operations.filter((op) => op[0] === "stroke").length;
+  assert.ok(strokeCalls >= 3);
+
+  globalThis.devicePixelRatio = originalDpr;
+});
+
+test("test utils: row window + icon resolution", () => {
+  const { getVisibleRowWindow, resolvePointIcon, collectObjectiveVerticalTimestamps } = __trajectoryCanvasRendererTestUtils();
+
+  assert.deepEqual(
+    getVisibleRowWindow({ rowCount: 100, rowHeight: 20, scrollTop: 200, viewportHeight: 60, overscanRows: 2 }),
+    { rowStart: 8, rowEnd: 15 }
+  );
+
+  assert.equal(resolvePointIcon({ source: "subject_reopened", status: "open" }, { status: "closed" }), "reopen");
+  assert.equal(resolvePointIcon({ status: "closed_invalid" }), "rejected");
+  assert.equal(resolvePointIcon({ status: "closed" }), "close");
+
+  const timestamps = collectObjectiveVerticalTimestamps([
+    { objectiveMarkers: [{ at: "2026-01-05T00:00:00.000Z" }, { at: "2026-01-05T00:00:00.000Z" }] },
+    { objectiveMarkers: [{ at: "2026-01-07T00:00:00.000Z" }] }
+  ]);
+  assert.equal(timestamps.length, 2);
+});

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -1,0 +1,264 @@
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function toDate(value) {
+  if (value instanceof Date) return new Date(value.getTime());
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function toTimestamp(value, fallbackTs = Date.now()) {
+  const date = toDate(value);
+  if (date) return date.getTime();
+  return fallbackTs;
+}
+
+function normalizeStatus(status = "") {
+  const value = String(status || "").trim().toLowerCase();
+  if (["rejected", "invalid"].includes(value)) return "closed_invalid";
+  if (["duplicate"].includes(value)) return "closed_duplicate";
+  if (["closed", "closed_invalid", "closed_duplicate"].includes(value)) return value;
+  return "open";
+}
+
+function normalizeCloseStatus(event = {}, fallbackStatus = "closed") {
+  const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
+  const payloadStatus = normalizeStatus(
+    payload.closed_status
+      || payload.closedStatus
+      || payload.status
+      || payload.reason
+      || payload.close_reason
+      || fallbackStatus
+  );
+  if (payloadStatus === "open") return "closed";
+  return payloadStatus;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectEventsForSubject(subjectId, subjectHistoryEvents) {
+  if (Array.isArray(subjectHistoryEvents)) {
+    return subjectHistoryEvents.filter((event) => normalizeId(event?.subject_id) === subjectId);
+  }
+  if (subjectHistoryEvents && typeof subjectHistoryEvents === "object") {
+    return asArray(subjectHistoryEvents[subjectId]);
+  }
+  return [];
+}
+
+function resolveObjectiveDates({ subjectId, objectivesById = {}, objectiveIdsBySubjectId = {} } = {}) {
+  return asArray(objectiveIdsBySubjectId[subjectId])
+    .map((objectiveId) => objectivesById?.[objectiveId])
+    .map((objective = {}) => ({
+      objectiveId: normalizeId(objective.id),
+      dueDate: toDate(objective.due_date || objective.dueDate)
+    }))
+    .filter((entry) => !!entry.objectiveId && !!entry.dueDate)
+    .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
+}
+
+function splitSegmentByObjectiveBoundaries(segment, objectiveDates = []) {
+  const boundaries = objectiveDates
+    .map((entry) => entry.dueDate.getTime())
+    .filter((ts) => ts > segment.startAt.getTime() && ts < segment.endAt.getTime());
+
+  if (!boundaries.length) return [segment];
+
+  const splits = [];
+  let startTs = segment.startAt.getTime();
+  for (const boundaryTs of boundaries) {
+    splits.push({
+      ...segment,
+      startAt: new Date(startTs),
+      endAt: new Date(boundaryTs)
+    });
+    startTs = boundaryTs;
+  }
+  splits.push({
+    ...segment,
+    startAt: new Date(startTs),
+    endAt: new Date(segment.endAt.getTime())
+  });
+  return splits;
+}
+
+function resolveSegmentStyle({ status, endAt, objectiveDates }) {
+  const statusKey = normalizeStatus(status);
+  const endTs = endAt.getTime();
+  const hasObjectivePassed = objectiveDates.some((entry) => endTs > entry.dueDate.getTime());
+
+  if (hasObjectivePassed) {
+    return {
+      lineStyle: statusKey === "open" ? "solid" : "dashed",
+      lineColor: "red"
+    };
+  }
+
+  if (statusKey === "open") {
+    return {
+      lineStyle: "solid",
+      lineColor: "green"
+    };
+  }
+
+  return {
+    lineStyle: "dashed",
+    lineColor: "gray"
+  };
+}
+
+function resolveStatusAtTimestamp(statusPoints = [], targetTs, fallback = "open") {
+  let resolved = normalizeStatus(fallback);
+  for (const point of statusPoints) {
+    if (point.at.getTime() > targetTs) break;
+    resolved = normalizeStatus(point.status);
+  }
+  return resolved;
+}
+
+function toStatusIcon(status = "open") {
+  const normalized = normalizeStatus(status);
+  if (normalized === "closed_invalid") return "rejected";
+  if (normalized === "closed_duplicate") return "close-duplicate";
+  if (normalized.startsWith("closed")) return "close";
+  return "open";
+}
+
+export function buildTrajectoryModel({
+  subjects = [],
+  subjectHistoryEvents = {},
+  objectivesById = {},
+  objectiveIdsBySubjectId = {},
+  projectStartDate,
+  today = new Date()
+} = {}) {
+  const todayTs = toTimestamp(today);
+  const fallbackProjectStartTs = toTimestamp(projectStartDate, todayTs);
+
+  const rows = asArray(subjects).map((subject = {}) => {
+    const subjectId = normalizeId(subject.id);
+    const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
+    const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
+
+    const events = collectEventsForSubject(subjectId, subjectHistoryEvents)
+      .map((event = {}) => ({
+        ...event,
+        event_type: normalizeId(event.event_type).toLowerCase(),
+        created_at: toDate(event.created_at)
+      }))
+      .filter((event) => !!event.created_at)
+      .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+
+    const createdEvent = events.find((event) => event.event_type === "subject_created");
+    const subjectCreatedTs = toTimestamp(
+      createdEvent?.created_at || subject.created_at,
+      fallbackProjectStartTs
+    );
+
+    const endTs = Math.max(todayTs, latestObjectiveTs || 0, subjectCreatedTs);
+    const fallbackStartStatus = normalizeStatus(subject.status);
+
+    const statusPoints = [];
+    const upsertStatusPoint = (ts, status, source) => {
+      const safeTs = Math.max(subjectCreatedTs, ts);
+      const safeStatus = normalizeStatus(status);
+      const existing = statusPoints.find((point) => point.at.getTime() === safeTs);
+      if (existing) {
+        existing.status = safeStatus;
+        existing.icon = toStatusIcon(safeStatus);
+        existing.source = source;
+        return;
+      }
+      statusPoints.push({
+        at: new Date(safeTs),
+        status: safeStatus,
+        icon: toStatusIcon(safeStatus),
+        source
+      });
+    };
+
+    upsertStatusPoint(subjectCreatedTs, createdEvent ? "open" : fallbackStartStatus, createdEvent ? "subject_created" : "subject_fallback_created_at");
+
+    for (const event of events) {
+      const ts = event.created_at.getTime();
+      if (event.event_type === "subject_created") {
+        upsertStatusPoint(ts, "open", event.event_type);
+      } else if (event.event_type === "subject_closed") {
+        upsertStatusPoint(ts, normalizeCloseStatus(event, subject.status), event.event_type);
+      } else if (event.event_type === "subject_reopened") {
+        upsertStatusPoint(ts, "open", event.event_type);
+      }
+    }
+
+    statusPoints.sort((a, b) => a.at.getTime() - b.at.getTime());
+
+    const rawSegments = [];
+    for (let index = 0; index < statusPoints.length; index += 1) {
+      const point = statusPoints[index];
+      const nextPoint = statusPoints[index + 1];
+      const segmentStartTs = point.at.getTime();
+      const segmentEndTs = nextPoint ? nextPoint.at.getTime() : endTs;
+      if (segmentEndTs <= segmentStartTs) continue;
+      rawSegments.push({
+        subjectId,
+        status: point.status,
+        startAt: new Date(segmentStartTs),
+        endAt: new Date(segmentEndTs)
+      });
+    }
+
+    const lifecycleSegments = rawSegments
+      .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
+      .map((segment) => ({
+        ...segment,
+        ...resolveSegmentStyle({
+          status: segment.status,
+          endAt: segment.endAt,
+          objectiveDates
+        })
+      }));
+
+    const objectiveMarkers = objectiveDates.map((entry) => {
+      const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
+      const isClosedAtDueDate = normalizeStatus(statusAtDueDate) !== "open";
+      return {
+        subjectId,
+        objectiveId: entry.objectiveId,
+        at: new Date(entry.dueDate.getTime()),
+        markerType: isClosedAtDueDate ? "check" : "cross",
+        markerColor: isClosedAtDueDate ? "green" : "red",
+        statusAtDueDate
+      };
+    });
+
+    console.info("[trajectory] model.subject", {
+      subjectId,
+      segmentCount: lifecycleSegments.length,
+      markerCount: objectiveMarkers.length
+    });
+
+    return {
+      subjectId,
+      statusPoints,
+      lifecycleSegments,
+      objectiveMarkers
+    };
+  });
+
+  return { rows };
+}
+
+export function __trajectoryModelTestUtils() {
+  return {
+    normalizeStatus,
+    normalizeCloseStatus,
+    resolveObjectiveDates,
+    resolveStatusAtTimestamp,
+    splitSegmentByObjectiveBoundaries,
+    resolveSegmentStyle
+  };
+}

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTrajectoryModel, __trajectoryModelTestUtils } from "./trajectory-model.js";
+
+test("buildTrajectoryModel construit les segments open/closed avant et après objectif", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-1",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-1": [
+        { subject_id: "s-1", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-1", event_type: "subject_closed", created_at: "2026-01-03T00:00:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-1", event_type: "subject_reopened", created_at: "2026-01-07T00:00:00.000Z" }
+      ]
+    },
+    objectivesById: {
+      "o-1": { id: "o-1", due_date: "2026-01-05T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-1": ["o-1"]
+    },
+    projectStartDate: "2025-12-01T00:00:00.000Z",
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  assert.equal(result.rows.length, 1);
+  const [row] = result.rows;
+  assert.equal(row.subjectId, "s-1");
+
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString(),
+      color: segment.lineColor,
+      style: segment.lineStyle
+    })),
+    [
+      {
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2026-01-03T00:00:00.000Z",
+        color: "green",
+        style: "solid"
+      },
+      {
+        start: "2026-01-03T00:00:00.000Z",
+        end: "2026-01-05T00:00:00.000Z",
+        color: "gray",
+        style: "dashed"
+      },
+      {
+        start: "2026-01-05T00:00:00.000Z",
+        end: "2026-01-07T00:00:00.000Z",
+        color: "red",
+        style: "dashed"
+      },
+      {
+        start: "2026-01-07T00:00:00.000Z",
+        end: "2026-01-10T00:00:00.000Z",
+        color: "red",
+        style: "solid"
+      }
+    ]
+  );
+
+  assert.deepEqual(
+    row.objectiveMarkers.map((marker) => ({
+      at: marker.at.toISOString(),
+      type: marker.markerType,
+      color: marker.markerColor
+    })),
+    [
+      {
+        at: "2026-01-05T00:00:00.000Z",
+        type: "check",
+        color: "green"
+      }
+    ]
+  );
+});
+
+test("buildTrajectoryModel utilise subject.created_at si subject_created absent et prolonge jusqu'à objectif futur", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-2",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-2": []
+    },
+    objectivesById: {
+      "o-future": { id: "o-future", due_date: "2026-03-01T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-2": ["o-future"]
+    },
+    today: "2026-01-15T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.equal(row.lifecycleSegments.length, 1);
+  assert.equal(row.lifecycleSegments[0].lineColor, "green");
+  assert.equal(row.lifecycleSegments[0].lineStyle, "solid");
+  assert.equal(row.lifecycleSegments[0].endAt.toISOString(), "2026-03-01T00:00:00.000Z");
+
+  assert.equal(row.objectiveMarkers[0].markerType, "cross");
+  assert.equal(row.objectiveMarkers[0].markerColor, "red");
+});
+
+test("normalizeCloseStatus remonte closed_invalid et closed_duplicate depuis le payload", () => {
+  const { normalizeCloseStatus } = __trajectoryModelTestUtils();
+  assert.equal(normalizeCloseStatus({ payload: { closed_status: "invalid" } }), "closed_invalid");
+  assert.equal(normalizeCloseStatus({ payload: { status: "closed_duplicate" } }), "closed_duplicate");
+  assert.equal(normalizeCloseStatus({ payload: {} }), "closed");
+});


### PR DESCRIPTION
### Motivation

- Render an interactive roadmap (trajectory) view for situation subjects by building a model and drawing it efficiently on a canvas.

### Description

- Introduces a runtime loader and lazy imports for trajectory modules and a new `TRAJECTORY_ROW_HEIGHT` constant, plus helper resolvers (`resolveTrajectorySubjects`, `resolveTrajectoryHistoryBySubjectId`, `resolveTrajectoryProjectStartDate`, `resolveTrajectoryTimelineEndDate`) to scope data for the selected situation.
- Adds `bindTrajectoryCanvas` and integrates it into the situations view lifecycle so the roadmap canvas is bound when the layout is `roadmap` and the DOM contains trajectory nodes.
- Adds `trajectory-model.js` which builds a structured model (`rows`) from subjects, history events and objectives and splits lifecycle segments by objective boundaries and styles them based on status/objective logic.
- Adds `trajectory-canvas-renderer.js` which implements high-DPR canvas setup, visibility/overscan calculation, rendering of segments, status icons, objective markers and vertical markers (today and objectives), and exports test utilities.
- Adds unit tests `trajectory-model.test.mjs` and `trajectory-canvas-renderer.test.mjs` covering model segmentation, objective handling, and canvas rendering behavior.

### Testing

- Ran the new model tests with Node's test runner via `node --test apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` and they passed.
- Ran the new renderer tests with Node's test runner via `node --test apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef44577078832985dd5b73023e8503)