### PR TITLE
feat(trajectory): add bidirectional virtualizer window

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
@@ -1,3 +1,5 @@
+import { getTrajectoryVisibleWindow } from "./trajectory-virtualizer.js";
+
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
@@ -27,17 +29,18 @@ function normalizeOverscan(overscan) {
 }
 
 function getVisibleRowWindow({ rowCount, rowHeight, scrollTop, viewportHeight, overscanRows }) {
-  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
-  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
-  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
-
-  const start = clamp(Math.floor(safeScrollTop / safeRowHeight) - overscanRows, 0, Math.max(0, rowCount - 1));
-  const end = clamp(
-    Math.ceil((safeScrollTop + safeViewportHeight) / safeRowHeight) + overscanRows,
-    start,
-    Math.max(0, rowCount - 1)
-  );
-  return { rowStart: start, rowEnd: end };
+  const { rowStart, rowEnd } = getTrajectoryVisibleWindow({
+    rowCount,
+    rowHeight,
+    scrollTop,
+    viewportHeight,
+    overscanRows,
+    scrollLeft: 0,
+    viewportWidth: 0,
+    totalWidth: 0,
+    overscanPx: 0
+  });
+  return { rowStart, rowEnd };
 }
 
 function setupCanvas(canvas, viewportWidth, viewportHeight) {
@@ -197,18 +200,24 @@ export function renderTrajectoryCanvas({
 
   const safeRows = asArray(rows);
   const rowCount = safeRows.length;
-  const { rowStart, rowEnd } = getVisibleRowWindow({
+  const visibleWindow = getTrajectoryVisibleWindow({
     rowCount,
     rowHeight,
     scrollTop,
-    viewportHeight: height,
-    overscanRows: overscanConfig.rows
-  });
-
-  const visibleTimeRange = timeScale.getVisibleTimeRange({
     scrollLeft,
     viewportWidth: width,
+    viewportHeight: height,
+    totalWidth: timeScale.totalWidth,
+    overscanRows: overscanConfig.rows,
     overscanPx: overscanConfig.px
+  });
+
+  const { rowStart, rowEnd, timeScrollLeft, timeViewportWidth } = visibleWindow;
+
+  const visibleTimeRange = timeScale.getVisibleTimeRange({
+    scrollLeft: timeScrollLeft,
+    viewportWidth: timeViewportWidth,
+    overscanPx: 0
   });
 
   const visibleStartTs = toTimestamp(visibleTimeRange.start);

--- a/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.js
@@ -1,0 +1,83 @@
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toInteger(value, fallback = 0) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) return fallback;
+  return Math.floor(numberValue);
+}
+
+export function getTrajectoryVisibleWindow({
+  rowCount = 0,
+  rowHeight = 32,
+  scrollTop = 0,
+  scrollLeft = 0,
+  viewportWidth = 0,
+  viewportHeight = 0,
+  totalWidth = 0,
+  overscanRows = 4,
+  overscanPx = 160
+} = {}) {
+  const safeRowCount = Math.max(0, toInteger(rowCount));
+  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
+
+  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
+  const safeScrollLeft = Math.max(0, Number(scrollLeft) || 0);
+  const safeViewportWidth = Math.max(0, Number(viewportWidth) || 0);
+  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
+  const safeTotalWidth = Math.max(0, Number(totalWidth) || 0);
+
+  const safeOverscanRows = Math.max(0, toInteger(overscanRows));
+  const safeOverscanPx = Math.max(0, Number(overscanPx) || 0);
+
+  let rowStart = 0;
+  let rowEnd = -1;
+
+  if (safeRowCount > 0) {
+    const maxRowIndex = safeRowCount - 1;
+    rowStart = clamp(Math.floor(safeScrollTop / safeRowHeight) - safeOverscanRows, 0, maxRowIndex);
+    rowEnd = clamp(
+      Math.ceil((safeScrollTop + safeViewportHeight) / safeRowHeight) + safeOverscanRows,
+      rowStart,
+      maxRowIndex
+    );
+  }
+
+  const visibleRowCount = rowEnd >= rowStart ? (rowEnd - rowStart + 1) : 0;
+  const maxScrollLeft = Math.max(0, safeTotalWidth - safeViewportWidth);
+
+  const timeScrollLeft = clamp(safeScrollLeft - safeOverscanPx, 0, maxScrollLeft);
+  const timeViewportWidth = Math.max(0, Math.min(
+    safeTotalWidth > 0 ? safeTotalWidth - timeScrollLeft : safeViewportWidth,
+    safeViewportWidth + (safeOverscanPx * 2)
+  ));
+
+  const isFastScrolling = safeViewportHeight > 0
+    ? Math.abs(safeScrollTop / safeViewportHeight) > 4
+    : false;
+
+  const window = {
+    rowStart,
+    rowEnd,
+    visibleRowCount,
+    timeScrollLeft,
+    timeViewportWidth,
+    isFastScrolling
+  };
+
+  console.info("[trajectory] virtualizer.window", {
+    rowStart,
+    rowEnd,
+    scrollLeft: safeScrollLeft
+  });
+
+  return window;
+}
+
+export function __trajectoryVirtualizerTestUtils() {
+  return {
+    clamp,
+    toInteger
+  };
+}

--- a/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getTrajectoryVisibleWindow, __trajectoryVirtualizerTestUtils } from "./trajectory-virtualizer.js";
+
+test("getTrajectoryVisibleWindow calcule la fenêtre verticale et horizontale avec overscan", () => {
+  const result = getTrajectoryVisibleWindow({
+    rowCount: 200,
+    rowHeight: 24,
+    scrollTop: 240,
+    scrollLeft: 320,
+    viewportWidth: 500,
+    viewportHeight: 300,
+    totalWidth: 5000,
+    overscanRows: 3,
+    overscanPx: 100
+  });
+
+  assert.deepEqual(result, {
+    rowStart: 7,
+    rowEnd: 26,
+    visibleRowCount: 20,
+    timeScrollLeft: 220,
+    timeViewportWidth: 700,
+    isFastScrolling: false
+  });
+});
+
+test("getTrajectoryVisibleWindow borne les valeurs pour éviter de sortir des limites", () => {
+  const result = getTrajectoryVisibleWindow({
+    rowCount: 2,
+    rowHeight: 32,
+    scrollTop: 999,
+    scrollLeft: 999,
+    viewportWidth: 400,
+    viewportHeight: 100,
+    totalWidth: 550,
+    overscanRows: 4,
+    overscanPx: 300
+  });
+
+  assert.equal(result.rowStart, 1);
+  assert.equal(result.rowEnd, 1);
+  assert.equal(result.visibleRowCount, 1);
+  assert.equal(result.timeScrollLeft, 150);
+  assert.equal(result.timeViewportWidth, 400);
+});
+
+test("__trajectoryVirtualizerTestUtils expose les utilitaires internes", () => {
+  const { clamp, toInteger } = __trajectoryVirtualizerTestUtils();
+  assert.equal(clamp(10, 0, 5), 5);
+  assert.equal(toInteger("12.9"), 12);
+});


### PR DESCRIPTION
### Motivation
- Provide bi-directional virtualization for the Trajectory view to limit rendering to the visible vertical rows and visible time range and protect UI performance for large numbers of subjects and events.
- Follow step 7 of the Trajectory implementation plan by isolating the windowing logic from canvas rendering so the renderer only draws what is necessary.

### Description
- Added a dedicated virtualizer module `apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.js` exposing `getTrajectoryVisibleWindow(...)` which returns `rowStart`, `rowEnd`, `visibleRowCount`, `timeScrollLeft`, `timeViewportWidth` and `isFastScrolling` and logs `[trajectory] virtualizer.window`.
- Integrated the virtualizer into the canvas renderer by importing it in `apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js` and using the returned window (`timeScrollLeft`/`timeViewportWidth`) to compute the visible time range and limit draw work to visible rows/time.
- Added unit tests `apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs` and adjusted canvas renderer test utilities to remain compatible, without changing routes or non-trajectory views.

### Testing
- Ran the trajectory unit tests with `node --test apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs` and all tests passed (5 tests, 0 failed).
- The canvas renderer test asserts that only the visible window is drawn and the virtualizer tests cover nominal and boundary cases for vertical and horizontal windowing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4b35bc788329b3b29813ad8de4be)