### PR TITLE
Virtualize trajectory roadmap rendering: add virtualizer, integrate with canvas renderer and UI

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -74,7 +74,8 @@ export function createProjectSituationsEvents({
       trajectoryRuntimeModulesPromise = Promise.all([
         import("./trajectory/trajectory-time-scale.js"),
         import("./trajectory/trajectory-model.js"),
-        import("./trajectory/trajectory-canvas-renderer.js")
+        import("./trajectory/trajectory-canvas-renderer.js"),
+        import("./trajectory/trajectory-virtualizer.js")
       ]);
     }
     return trajectoryRuntimeModulesPromise;
@@ -644,20 +645,27 @@ export function createProjectSituationsEvents({
     if (layout !== "roadmap") return;
 
     loadTrajectoryRuntimeModules()
-      .then(([timeScaleModule, modelModule, canvasRendererModule]) => {
+      .then(([timeScaleModule, modelModule, canvasRendererModule, virtualizerModule]) => {
         const { createTrajectoryTimeScale } = timeScaleModule || {};
         const { buildTrajectoryModel } = modelModule || {};
         const { renderTrajectoryCanvas } = canvasRendererModule || {};
+        const { getTrajectoryVisibleWindow } = virtualizerModule || {};
         if (typeof createTrajectoryTimeScale !== "function"
           || typeof buildTrajectoryModel !== "function"
-          || typeof renderTrajectoryCanvas !== "function") {
+          || typeof renderTrajectoryCanvas !== "function"
+          || typeof getTrajectoryVisibleWindow !== "function") {
           return;
         }
 
         trajectoryNodes.forEach((trajectoryNode) => {
           const situationId = String(trajectoryNode.getAttribute("data-situation-id") || "").trim();
-          const viewportNode = trajectoryNode.querySelector(".situation-trajectory__viewport");
+          const viewportNode = trajectoryNode.querySelector("[data-situation-trajectory-viewport]")
+            || trajectoryNode.querySelector(".situation-trajectory__viewport");
           const canvasNode = trajectoryNode.querySelector(".situation-trajectory__canvas");
+          const leftContentNode = trajectoryNode.querySelector("[data-situation-trajectory-left-content]");
+          const timelineContentNode = trajectoryNode.querySelector("[data-situation-trajectory-timeline-content]");
+          const scrollSizerNode = trajectoryNode.querySelector("[data-situation-trajectory-scroll-sizer]");
+          const spinnerNode = trajectoryNode.querySelector("[data-situation-trajectory-spinner]");
           if (!viewportNode || !canvasNode) return;
 
           const subjects = resolveTrajectorySubjects(situationId);
@@ -690,23 +698,55 @@ export function createProjectSituationsEvents({
             today: new Date()
           });
 
+          const contentHeight = Math.max(viewportNode.clientHeight || 0, rows.length * TRAJECTORY_ROW_HEIGHT);
+          if (scrollSizerNode) {
+            scrollSizerNode.style.width = `${Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth)}px`;
+            scrollSizerNode.style.height = `${Math.max(360, contentHeight)}px`;
+          }
+          if (timelineContentNode) {
+            timelineContentNode.style.width = `${Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth)}px`;
+          }
+
           let rafId = 0;
+          const renderFrame = () => {
+            rafId = 0;
+            const scrollTop = viewportNode.scrollTop;
+            const scrollLeft = viewportNode.scrollLeft;
+
+            console.info("[trajectory] scroll", { scrollTop, scrollLeft });
+
+            const windowState = getTrajectoryVisibleWindow({
+              rowCount: rows.length,
+              rowHeight: TRAJECTORY_ROW_HEIGHT,
+              scrollTop,
+              scrollLeft,
+              viewportWidth: viewportNode.clientWidth,
+              viewportHeight: viewportNode.clientHeight,
+              totalWidth: timeScale.totalWidth,
+              overscanRows: 4,
+              overscanPx: 160
+            });
+
+            if (spinnerNode) spinnerNode.hidden = !windowState.isFastScrolling;
+            if (leftContentNode) leftContentNode.style.transform = `translateY(${-scrollTop}px)`;
+            if (timelineContentNode) timelineContentNode.style.transform = `translateX(${-scrollLeft}px)`;
+
+            renderTrajectoryCanvas({
+              canvas: canvasNode,
+              rows,
+              timeScale,
+              scrollLeft,
+              scrollTop,
+              viewportWidth: viewportNode.clientWidth,
+              viewportHeight: viewportNode.clientHeight,
+              rowHeight: TRAJECTORY_ROW_HEIGHT,
+              overscan: { rows: 4, px: 160 }
+            });
+          };
+
           const scheduleRender = () => {
             if (rafId) return;
-            rafId = window.requestAnimationFrame(() => {
-              rafId = 0;
-              renderTrajectoryCanvas({
-                canvas: canvasNode,
-                rows,
-                timeScale,
-                scrollLeft: viewportNode.scrollLeft,
-                scrollTop: viewportNode.scrollTop,
-                viewportWidth: viewportNode.clientWidth,
-                viewportHeight: viewportNode.clientHeight,
-                rowHeight: TRAJECTORY_ROW_HEIGHT,
-                overscan: { rows: 4, px: 160 }
-              });
-            });
+            rafId = window.requestAnimationFrame(renderFrame);
           };
 
           if (!viewportNode.dataset.trajectoryCanvasBound) {

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -173,7 +173,8 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
 
         <div class="situation-trajectory__timeline" role="presentation">
           <div class="situation-trajectory__timeline-left"></div>
-          <div class="situation-trajectory__timeline-track">
+          <div class="situation-trajectory__timeline-track" data-situation-trajectory-timeline-track>
+            <div class="situation-trajectory__timeline-content" data-situation-trajectory-timeline-content></div>
             <button
               type="button"
               class="situation-trajectory__splitter"
@@ -189,7 +190,9 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
 
         <div class="situation-trajectory__body">
           <aside class="situation-trajectory__left" aria-label="Sujets">
-            ${leftColumnHtml}
+            <div class="situation-trajectory__left-content" data-situation-trajectory-left-content>
+              ${leftColumnHtml}
+            </div>
             <button
               type="button"
               class="situation-trajectory__left-resize-handle"
@@ -200,8 +203,13 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
             ></button>
           </aside>
 
-          <div class="situation-trajectory__viewport" aria-label="Trajectoire des sujets">
+          <div class="situation-trajectory__viewport" aria-label="Trajectoire des sujets" data-situation-trajectory-viewport>
+            <div class="situation-trajectory__scroll-sizer" data-situation-trajectory-scroll-sizer aria-hidden="true"></div>
             <canvas class="situation-trajectory__canvas"></canvas>
+            <div class="situation-trajectory__spinner" data-situation-trajectory-spinner hidden>
+              <span class="ui-spinner ui-spinner--sm" aria-hidden="true"><span class="ui-spinner__ring"></span></span>
+              <span>Chargement de la trajectoire…</span>
+            </div>
             ${emptyState}
           </div>
         </div>

--- a/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
@@ -1,3 +1,5 @@
+import { getTrajectoryVisibleWindow } from "./trajectory-virtualizer.js";
+
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
@@ -27,17 +29,18 @@ function normalizeOverscan(overscan) {
 }
 
 function getVisibleRowWindow({ rowCount, rowHeight, scrollTop, viewportHeight, overscanRows }) {
-  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
-  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
-  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
-
-  const start = clamp(Math.floor(safeScrollTop / safeRowHeight) - overscanRows, 0, Math.max(0, rowCount - 1));
-  const end = clamp(
-    Math.ceil((safeScrollTop + safeViewportHeight) / safeRowHeight) + overscanRows,
-    start,
-    Math.max(0, rowCount - 1)
-  );
-  return { rowStart: start, rowEnd: end };
+  const { rowStart, rowEnd } = getTrajectoryVisibleWindow({
+    rowCount,
+    rowHeight,
+    scrollTop,
+    viewportHeight,
+    overscanRows,
+    scrollLeft: 0,
+    viewportWidth: 0,
+    totalWidth: 0,
+    overscanPx: 0
+  });
+  return { rowStart, rowEnd };
 }
 
 function setupCanvas(canvas, viewportWidth, viewportHeight) {
@@ -197,18 +200,24 @@ export function renderTrajectoryCanvas({
 
   const safeRows = asArray(rows);
   const rowCount = safeRows.length;
-  const { rowStart, rowEnd } = getVisibleRowWindow({
+  const visibleWindow = getTrajectoryVisibleWindow({
     rowCount,
     rowHeight,
     scrollTop,
-    viewportHeight: height,
-    overscanRows: overscanConfig.rows
-  });
-
-  const visibleTimeRange = timeScale.getVisibleTimeRange({
     scrollLeft,
     viewportWidth: width,
+    viewportHeight: height,
+    totalWidth: timeScale.totalWidth,
+    overscanRows: overscanConfig.rows,
     overscanPx: overscanConfig.px
+  });
+
+  const { rowStart, rowEnd, timeScrollLeft, timeViewportWidth } = visibleWindow;
+
+  const visibleTimeRange = timeScale.getVisibleTimeRange({
+    scrollLeft: timeScrollLeft,
+    viewportWidth: timeViewportWidth,
+    overscanPx: 0
   });
 
   const visibleStartTs = toTimestamp(visibleTimeRange.start);

--- a/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.js
@@ -1,0 +1,83 @@
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toInteger(value, fallback = 0) {
+  const numberValue = Number(value);
+  if (!Number.isFinite(numberValue)) return fallback;
+  return Math.floor(numberValue);
+}
+
+export function getTrajectoryVisibleWindow({
+  rowCount = 0,
+  rowHeight = 32,
+  scrollTop = 0,
+  scrollLeft = 0,
+  viewportWidth = 0,
+  viewportHeight = 0,
+  totalWidth = 0,
+  overscanRows = 4,
+  overscanPx = 160
+} = {}) {
+  const safeRowCount = Math.max(0, toInteger(rowCount));
+  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
+
+  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
+  const safeScrollLeft = Math.max(0, Number(scrollLeft) || 0);
+  const safeViewportWidth = Math.max(0, Number(viewportWidth) || 0);
+  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
+  const safeTotalWidth = Math.max(0, Number(totalWidth) || 0);
+
+  const safeOverscanRows = Math.max(0, toInteger(overscanRows));
+  const safeOverscanPx = Math.max(0, Number(overscanPx) || 0);
+
+  let rowStart = 0;
+  let rowEnd = -1;
+
+  if (safeRowCount > 0) {
+    const maxRowIndex = safeRowCount - 1;
+    rowStart = clamp(Math.floor(safeScrollTop / safeRowHeight) - safeOverscanRows, 0, maxRowIndex);
+    rowEnd = clamp(
+      Math.ceil((safeScrollTop + safeViewportHeight) / safeRowHeight) + safeOverscanRows,
+      rowStart,
+      maxRowIndex
+    );
+  }
+
+  const visibleRowCount = rowEnd >= rowStart ? (rowEnd - rowStart + 1) : 0;
+  const maxScrollLeft = Math.max(0, safeTotalWidth - safeViewportWidth);
+
+  const timeScrollLeft = clamp(safeScrollLeft - safeOverscanPx, 0, maxScrollLeft);
+  const timeViewportWidth = Math.max(0, Math.min(
+    safeTotalWidth > 0 ? safeTotalWidth - timeScrollLeft : safeViewportWidth,
+    safeViewportWidth + (safeOverscanPx * 2)
+  ));
+
+  const isFastScrolling = safeViewportHeight > 0
+    ? Math.abs(safeScrollTop / safeViewportHeight) > 4
+    : false;
+
+  const window = {
+    rowStart,
+    rowEnd,
+    visibleRowCount,
+    timeScrollLeft,
+    timeViewportWidth,
+    isFastScrolling
+  };
+
+  console.info("[trajectory] virtualizer.window", {
+    rowStart,
+    rowEnd,
+    scrollLeft: safeScrollLeft
+  });
+
+  return window;
+}
+
+export function __trajectoryVirtualizerTestUtils() {
+  return {
+    clamp,
+    toInteger
+  };
+}

--- a/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getTrajectoryVisibleWindow, __trajectoryVirtualizerTestUtils } from "./trajectory-virtualizer.js";
+
+test("getTrajectoryVisibleWindow calcule la fenêtre verticale et horizontale avec overscan", () => {
+  const result = getTrajectoryVisibleWindow({
+    rowCount: 200,
+    rowHeight: 24,
+    scrollTop: 240,
+    scrollLeft: 320,
+    viewportWidth: 500,
+    viewportHeight: 300,
+    totalWidth: 5000,
+    overscanRows: 3,
+    overscanPx: 100
+  });
+
+  assert.deepEqual(result, {
+    rowStart: 7,
+    rowEnd: 26,
+    visibleRowCount: 20,
+    timeScrollLeft: 220,
+    timeViewportWidth: 700,
+    isFastScrolling: false
+  });
+});
+
+test("getTrajectoryVisibleWindow borne les valeurs pour éviter de sortir des limites", () => {
+  const result = getTrajectoryVisibleWindow({
+    rowCount: 2,
+    rowHeight: 32,
+    scrollTop: 999,
+    scrollLeft: 999,
+    viewportWidth: 400,
+    viewportHeight: 100,
+    totalWidth: 550,
+    overscanRows: 4,
+    overscanPx: 300
+  });
+
+  assert.equal(result.rowStart, 1);
+  assert.equal(result.rowEnd, 1);
+  assert.equal(result.visibleRowCount, 1);
+  assert.equal(result.timeScrollLeft, 150);
+  assert.equal(result.timeViewportWidth, 400);
+});
+
+test("__trajectoryVirtualizerTestUtils expose les utilitaires internes", () => {
+  const { clamp, toInteger } = __trajectoryVirtualizerTestUtils();
+  assert.equal(clamp(10, 0, 5), 5);
+  assert.equal(toInteger("12.9"), 12);
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10180,6 +10180,14 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__timeline-track{
   position:relative;
+  overflow:hidden;
+}
+
+.situation-trajectory__timeline-content{
+  position:absolute;
+  inset:0;
+  will-change:transform;
+  pointer-events:none;
 }
 
 .situation-trajectory__splitter{
@@ -10211,7 +10219,12 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   position:relative;
   min-width:0;
   border-right:1px solid var(--borderColor-default, #30363d);
-  overflow:auto;
+  overflow:hidden;
+}
+
+.situation-trajectory__left-content{
+  min-width:100%;
+  will-change:transform;
 }
 
 .situation-trajectory.is-resizing-left .situation-trajectory__left{
@@ -10224,10 +10237,34 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   overflow:auto;
 }
 
+.situation-trajectory__scroll-sizer{
+  min-height:360px;
+}
+
 .situation-trajectory__canvas{
   display:block;
+  position:sticky;
+  top:0;
+  left:0;
   width:100%;
   min-height:360px;
+  pointer-events:none;
+}
+
+.situation-trajectory__spinner{
+  position:sticky;
+  left:16px;
+  bottom:16px;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 10px;
+  border:1px solid var(--borderColor-default, #30363d);
+  border-radius:999px;
+  background:color-mix(in srgb, var(--bgColor-default, #0d1117) 88%, white 12%);
+  color:var(--fgColor-muted, #8b949e);
+  font-size:12px;
+  z-index:2;
 }
 
 .situation-trajectory__empty-state{


### PR DESCRIPTION
### Motivation

- Improve performance and responsiveness of the roadmap/trajectory view when rendering many subject rows by virtualizing vertical and horizontal windows and reducing unnecessary drawing work.
- Provide smoother scrolling by adding overscan, a fast-scroll spinner, and left/timeline content transforms to avoid reflow while scrolling.

### Description

- Add `trajectory-virtualizer.js` which exports `getTrajectoryVisibleWindow` (and `__trajectoryVirtualizerTestUtils`) to compute visible row range, time scroll window, overscan, and a fast-scrolling flag.
- Update runtime loading in `project-situations-events.js` to import the virtualizer, compute visible windows with `getTrajectoryVisibleWindow`, size the scroll sizer/timeline, expose left/timeline transforms, toggle a spinner during fast scrolling, and run a single `requestAnimationFrame` render loop via `renderFrame`/`scheduleRender`.
- Modify `trajectory-canvas-renderer.js` to import the virtualizer utilities and use the computed visible window/time window to restrict drawing to visible rows/time ranges and respect overscan settings.
- Update the roadmap view template `project-situations-view-roadmap.js` to add DOM hooks (`data-situation-trajectory-viewport`, `data-situation-trajectory-scroll-sizer`, `data-situation-trajectory-left-content`, `data-situation-trajectory-timeline-content`, spinner markup) and adjust structure for virtualization.
- Add CSS rules in `apps/web/style.css` to style the timeline content, left content, scroll sizer, spinner, and to make the canvas sticky and pointer-events safe for virtualization.

### Testing

- Added `trajectory-virtualizer.test.mjs` and executed it with `node --test apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs`, which ran the included unit tests and they passed (3 assertions covering window calculation, bounds clamping, and utility exposure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4b35bc788329b3b29813ad8de4be)