### PR TITLE
Trajectory: add today blue line, simplify timeline layout, and normalize status icons

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -172,7 +172,6 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
         </header>
 
         <div class="situation-trajectory__timeline" role="presentation">
-          <div class="situation-trajectory__timeline-left"></div>
           <div class="situation-trajectory__timeline-track" data-situation-trajectory-timeline-track>
             <div class="situation-trajectory__timeline-content" data-situation-trajectory-timeline-content></div>
             <button

--- a/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js
@@ -70,15 +70,23 @@ function setupCanvas(canvas, viewportWidth, viewportHeight) {
   return { ctx, width, height, dpr };
 }
 
-function drawVerticalLine(ctx, { x, height, color = "#cf222e", alpha = 1, dashed = false }) {
+function drawVerticalLine(ctx, {
+  x,
+  height,
+  color = "#cf222e",
+  alpha = 1,
+  dashed = false,
+  lineWidth = 1
+}) {
   ctx.save();
   ctx.strokeStyle = color;
   ctx.globalAlpha = alpha;
-  ctx.lineWidth = 1;
+  ctx.lineWidth = lineWidth;
   if (dashed) ctx.setLineDash([4, 4]);
+  const alignX = lineWidth % 2 === 1 ? x + 0.5 : x;
   ctx.beginPath();
-  ctx.moveTo(x + 0.5, 0);
-  ctx.lineTo(x + 0.5, height);
+  ctx.moveTo(alignX, 0);
+  ctx.lineTo(alignX, height);
   ctx.stroke();
   ctx.restore();
 }
@@ -107,7 +115,7 @@ function drawStatusIcon(ctx, { x, y, icon = "open" }) {
     ctx.beginPath();
     ctx.arc(x, y, 4, 0, Math.PI * 2);
     ctx.fill();
-  } else if (icon === "rejected") {
+  } else if (icon === "rejected" || icon === "reject") {
     ctx.strokeStyle = "#cf222e";
     ctx.lineWidth = 2;
     ctx.beginPath();
@@ -177,7 +185,7 @@ function resolvePointIcon(point = {}, previousPoint = null) {
   if (source === "subject_reopened") return "reopen";
   if (source === "subject_closed") return "close";
   const status = String(point?.status || "").trim().toLowerCase();
-  if (["closed_invalid", "invalid", "rejected"].includes(status)) return "rejected";
+  if (["closed_invalid", "invalid", "rejected"].includes(status)) return "reject";
   if (["closed", "closed_duplicate", "duplicate"].includes(status)) return "close";
   if (previousPoint && String(previousPoint?.status || "").trim().toLowerCase() !== "open") return "reopen";
   return "open";
@@ -315,7 +323,7 @@ export function renderTrajectoryCanvas({
   const todayTs = resolveTodayTimestamp(timeScale);
   if (todayTs >= visibleStartTs && todayTs <= visibleEndTs) {
     const x = timeScale.timeToX(todayTs) - scrollLeft;
-    drawVerticalLine(ctx, { x, height, color: "#cf222e", alpha: 1 });
+    drawVerticalLine(ctx, { x, height, color: "rgb(31, 11, 235)", alpha: 1, lineWidth: 2 });
   }
 
   const objectiveTimestamps = collectObjectiveVerticalTimestamps(safeRows);

--- a/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs
@@ -88,7 +88,7 @@ test("test utils: row window + icon resolution", () => {
   );
 
   assert.equal(resolvePointIcon({ source: "subject_reopened", status: "open" }, { status: "closed" }), "reopen");
-  assert.equal(resolvePointIcon({ status: "closed_invalid" }), "rejected");
+  assert.equal(resolvePointIcon({ status: "closed_invalid" }), "reject");
   assert.equal(resolvePointIcon({ status: "closed" }), "close");
 
   const timestamps = collectObjectiveVerticalTimestamps([

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -122,8 +122,8 @@ function resolveStatusAtTimestamp(statusPoints = [], targetTs, fallback = "open"
 
 function toStatusIcon(status = "open") {
   const normalized = normalizeStatus(status);
-  if (normalized === "closed_invalid") return "rejected";
-  if (normalized === "closed_duplicate") return "close-duplicate";
+  if (normalized === "closed_invalid") return "reject";
+  if (normalized === "closed_duplicate") return "close";
   if (normalized.startsWith("closed")) return "close";
   return "open";
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10169,34 +10169,26 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   position:sticky;
   top:0;
   z-index:5;
-  display:grid;
-  grid-template-columns:minmax(72px, var(--situation-trajectory-left-width)) minmax(0, 1fr);
+  display:block;
   min-height:64px;
   border-bottom:1px solid var(--borderColor-default, #30363d);
   background:rgb(13, 17, 23);
 }
 
-.situation-trajectory__timeline-left{
-  border-right:1px solid var(--borderColor-default, #30363d);
-  background:rgb(13, 17, 23);
-  position:relative;
-}
-
-.situation-trajectory__timeline-left::before,
-.situation-trajectory__timeline-left::after{
+.situation-trajectory__timeline::before{
   content:"";
   position:absolute;
-  left:0;
-  right:0;
-  height:32px;
-  border-bottom:1px solid color-mix(in srgb, var(--borderColor-default, #30363d) 70%, transparent 30%);
+  top:0;
+  bottom:0;
+  left:var(--situation-trajectory-left-width);
+  width:1px;
+  background:var(--borderColor-default, #30363d);
 }
-
-.situation-trajectory__timeline-left::before{ top:0; }
-.situation-trajectory__timeline-left::after{ top:32px; }
 
 .situation-trajectory__timeline-track{
   position:relative;
+  margin-left:var(--situation-trajectory-left-width);
+  min-height:64px;
   overflow:hidden;
 }
 
@@ -10213,11 +10205,11 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__timeline-row--months{
-  border-bottom:1px solid color-mix(in srgb, var(--borderColor-default, #30363d) 70%, transparent 30%);
+  border-bottom:none;
 }
 
 .situation-trajectory__timeline-row--days{
-  border-bottom:1px solid color-mix(in srgb, var(--borderColor-default, #30363d) 70%, transparent 30%);
+  border-bottom:none;
 }
 
 .situation-trajectory__timeline-day{
@@ -10229,7 +10221,6 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   justify-content:center;
   font-size:12px;
   color:rgb(145, 152, 161);
-  border-left:1px solid color-mix(in srgb, var(--borderColor-default, #30363d) 70%, transparent 30%);
 }
 
 .situation-trajectory__timeline-day.is-today{
@@ -10264,7 +10255,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__splitter{
   position:absolute;
-  top:50%;
+  top:100%;
   left:0;
   transform:translate(-50%, -50%) rotate(90deg);
   width:20px;


### PR DESCRIPTION
### Motivation
- Simplifier la structure visuelle/DOM de la timeline et garantir que la date « aujourd’hui » soit affichée clairement sur la trajectoire. 
- Harmoniser le rendu des icônes de statut pour couvrir `open`, `reopen`, `close` et `reject` de façon stable.

### Description
- Supprime le conteneur DOM `situation-trajectory__timeline-left` dans la vue `renderSituationRoadmapView` (`apps/web/js/views/project-situations/project-situations-view-roadmap.js`).
- Remplace le layout grille de la timeline par un layout centré et ajoute un séparateur vertical via pseudo-élément CSS; décale le contenu de la timeline avec `margin-left: var(--situation-trajectory-left-width)` et retire les bordures de grille (`apps/web/style.css`).
- Repositionne le bouton `situation-trajectory__splitter` pour rester aligné après la simplification (`apps/web/style.css`).
- Dans le renderer canvas, ajoute un paramètre `lineWidth` pour les lignes verticales et trace la ligne « aujourd’hui » en bleu `rgb(31, 11, 235)` avec `lineWidth: 2` (`apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js`).
- Normalise les icônes de fermeture côté modèle: mappe `closed_invalid` → `reject` et `closed_duplicate` → `close` (`apps/web/js/views/project-situations/trajectory/trajectory-model.js`).
- Adapte la résolution/rendu des icônes dans le canvas pour accepter la variante `reject` en plus de `rejected` et ajuste la logique de résolution d’icône (`apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.js`).
- Mets à jour le test unitaire correspondant pour attendre `reject` au lieu de `rejected` (`apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs`).

### Testing
- Exécuté les tests unitaires via `node --test apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs apps/web/js/views/project-situations/trajectory/trajectory-canvas-renderer.test.mjs` et tous les tests sont passés (`6` tests, `0` failures).
- Les tests vérifient le rendu canvas, la résolution des icônes et la construction du modèle de trajectoire et ont tous réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef58711fc883298ff035e2bc287e88)