### PR TITLE
Ajuste la vue trajectoire pour supprimer le flou des objectifs et récupérer de la hauteur canvas

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -712,6 +712,11 @@ export function createProjectSituationsEvents({
       <div role="row" class="situation-trajectory__timeline-row situation-trajectory__timeline-row--months">${monthTicksHtml}${objectiveLabelsHtml}</div>
       <div role="row" class="situation-trajectory__timeline-row situation-trajectory__timeline-row--days">${dayTicksHtml}</div>
     `;
+
+    timelineContentNode.querySelectorAll(".situation-trajectory__timeline-objective").forEach((objectiveNode) => {
+      const halfWidth = Math.round((objectiveNode.offsetWidth || 0) / 2);
+      objectiveNode.style.marginLeft = `${-halfWidth}px`;
+    });
   }
 
   function bindTrajectoryCanvas(root) {

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -161,18 +161,14 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
         data-situation-id="${escapeHtml(situationId)}"${projectDataAttribute}
         style="--situation-trajectory-left-width:${leftColumnWidth}px;"
       >
-        <header class="situation-trajectory__toolbar">
-          <div class="situation-trajectory__toolbar-title">Trajectoire · ${escapeHtml(title)}</div>
-          <label class="situation-trajectory__zoom" for="trajectoryZoomSelect">
-            <span>Zoom</span>
-            <select id="trajectoryZoomSelect" name="trajectoryZoom">
-              ${renderZoomOptions()}
-            </select>
-          </label>
-        </header>
-
         <div class="situation-trajectory__timeline" role="presentation">
           <div class="situation-trajectory__timeline-track" data-situation-trajectory-timeline-track>
+            <label class="situation-trajectory__zoom" for="trajectoryZoomSelect">
+              <span>Zoom</span>
+              <select id="trajectoryZoomSelect" name="trajectoryZoom">
+                ${renderZoomOptions()}
+              </select>
+            </label>
             <div class="situation-trajectory__timeline-content" data-situation-trajectory-timeline-content></div>
             <button
               type="button"

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10138,27 +10138,22 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   background:var(--bgColor-default, #0d1117);
 }
 
-.situation-trajectory__toolbar{
+.situation-trajectory__zoom{
+  position:absolute;
+  top:6px;
+  right:12px;
+  z-index:6;
   display:flex;
   align-items:center;
-  justify-content:space-between;
-  gap:12px;
-  padding:10px 12px;
-  border-bottom:1px solid var(--borderColor-default, #30363d);
-}
-
-.situation-trajectory__toolbar-title{
-  font-size:13px;
-  font-weight:600;
-  color:var(--fgColor-default, #e6edf3);
-}
-
-.situation-trajectory__zoom{
-  display:inline-flex;
-  align-items:center;
   gap:8px;
+  height:20px;
+  padding:2px 8px;
+  border-radius:999px;
+  background:color-mix(in srgb, var(--bgColor-default, #0d1117) 88%, transparent);
+  backdrop-filter:blur(2px);
   font-size:12px;
   color:var(--fgColor-muted, #8b949e);
+  pointer-events:auto;
 }
 
 .situation-trajectory__zoom select{
@@ -10230,7 +10225,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__timeline-objective{
   position:absolute;
   top:10px;
-  transform:translateX(-50%);
+  margin-left:-80px;
   max-width:160px;
   padding:1px 6px;
   border-radius:999px;


### PR DESCRIPTION
### Motivation
- Les labels d’objectif étaient centrés via `transform: translateX(-50%)` ce qui peut rendre le texte flou à l’écran, il faut un centrage sans transform pour améliorer la netteté.
- La toolbar occupe une ligne verticale utile pour le canvas, donc il faut superposer le contrôle de zoom sur la timeline pour gagner de la hauteur affichable.
- Le positionnement des labels d’objectif doit rester centré de façon précise après rendu sans dépendre d’un transform CSS.

### Description
- Supprime le bloc `header.situation-trajectory__toolbar` et déplace le contrôle de zoom dans la zone timeline en l’ajoutant avant le conteneur `.situation-trajectory__timeline-content` (fichier modifié: `apps/web/js/views/project-situations/project-situations-view-roadmap.js`).
- Remplace le centrage CSS `transform: translateX(-50%)` par un centrage via `margin-left` dans le CSS et ajoute une valeur par défaut `margin-left:-80px` comme fallback (fichier modifié: `apps/web/style.css`).
- Calcule dynamiquement après rendu la moitié de la largeur réelle de chaque label d’objectif et applique `margin-left: -halfWidth` pour centrer précisément sans transform (implémentation ajoutée dans `renderTrajectoryTimelineTicks` de `apps/web/js/views/project-situations/project-situations-events.js`).
- Ajoute des styles pour afficher le contrôle de zoom en overlay sur la timeline (`position:absolute`, `z-index`, léger fond brouillé et `pointer-events:auto`) afin de conserver l’interaction et la lisibilité tout en libérant de l’espace vertical (`apps/web/style.css`).

### Testing
- Lancement des tests unitaires via `npm test` a été exécuté et a réussi sans échec; résultat global: `211` tests exécutés, `0` échecs et `5` tests ignorés.
- Aucun test automatisé d’interface navigateur n’a été exécuté dans cet environnement (visual/regression manuelle recommandée en navigateur réel après déploiement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef60620c648329bfd7f4dcbb063bf1)