### PR TITLE
feat(trajectory): replace roadmap canvas shell with DOM+SVG scene

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -74,7 +74,7 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
     : {};
   const leftColumnWidth = normalizeLeftColumnWidth(options?.store?.situationsView?.trajectoryLeftColumnWidthBySituationId?.[situationId]);
 
-  console.info("[trajectory] render.shell", { situationId, subjectCount });
+  console.info("[trajectory] render.shell.dom-svg", { situationId });
 
   const projectDataAttribute = projectId ? ` data-project-id="${escapeHtml(projectId)}"` : "";
   let leftColumnHtml = "";
@@ -200,7 +200,10 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
 
           <div class="situation-trajectory__viewport" aria-label="Trajectoire des sujets" data-situation-trajectory-viewport>
             <div class="situation-trajectory__scroll-sizer" data-situation-trajectory-scroll-sizer aria-hidden="true"></div>
-            <canvas class="situation-trajectory__canvas"></canvas>
+            <div class="situation-trajectory__scene" data-situation-trajectory-scene>
+              <svg class="situation-trajectory__svg" data-situation-trajectory-svg aria-hidden="true"></svg>
+              <div class="situation-trajectory__items" data-situation-trajectory-items></div>
+            </div>
             <div class="situation-trajectory__spinner" data-situation-trajectory-spinner hidden>
               <span class="ui-spinner ui-spinner--sm" aria-hidden="true"><span class="ui-spinner__ring"></span></span>
               <span>Chargement de la trajectoire…</span>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10289,14 +10289,26 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:360px;
 }
 
-.situation-trajectory__canvas{
-  display:block;
+.situation-trajectory__scene{
   position:absolute;
   top:0;
   left:0;
-  width:100%;
+  width:var(--situation-trajectory-scene-width, 100%);
+  height:var(--situation-trajectory-scene-height, 360px);
   min-height:360px;
+}
+
+.situation-trajectory__svg{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
   pointer-events:none;
+}
+
+.situation-trajectory__items{
+  position:absolute;
+  inset:0;
 }
 
 .situation-trajectory__spinner{


### PR DESCRIPTION
### Motivation
- Préparer la migration du renderer canvas vers un renderer DOM+SVG en remplaçant le shell `<canvas>` par une scène DOM qui permettra ensuite des éléments interactifs et une superposition SVG pour les lignes.

### Description
- Remplacement du `<canvas class="situation-trajectory__canvas">` par la structure DOM+SVG : `<div class="situation-trajectory__scene" data-situation-trajectory-scene>`, `<svg class="situation-trajectory__svg" data-situation-trajectory-svg aria-hidden="true"></svg>` et `<div class="situation-trajectory__items" data-situation-trajectory-items></div>` dans `apps/web/js/views/project-situations/project-situations-view-roadmap.js`, tout en conservant `scroll-sizer`, le spinner, l’empty state, le viewport et les data-attributes existants.
- Mise à jour de l’instrumentation pour indiquer la nouvelle étape : `console.info("[trajectory] render.shell.dom-svg", { situationId })`.
- Neutralisation des styles spécifiques au canvas et ajout d’un scaffolding CSS minimal pour la scène, le SVG (`pointer-events:none`) et la zone d’items dans `apps/web/style.css` (positionnement absolute, width/height pilotés par variables CSS). Le comportement scrollable du viewport est conservé.
- Aucun changement de runtime : le binding et les renderers existants restent inchangés (le nouveau renderer DOM+SVG n’est pas encore branché).

### Testing
- Exécuté `git diff --check` et `git status --short` pour valider l’état du dépôt et il n’y a pas d’erreur de diff; commit créé avec succès (`feat(trajectory): replace roadmap canvas shell with dom+svg scene`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef640b8bdc83299c6cc32955ddc1fc)