### PR TITLE
Switch trajectory renderer from canvas to DOM/SVG implementation

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -74,7 +74,7 @@ export function createProjectSituationsEvents({
       trajectoryRuntimeModulesPromise = Promise.all([
         import("./trajectory/trajectory-time-scale.js"),
         import("./trajectory/trajectory-model.js"),
-        import("./trajectory/trajectory-canvas-renderer.js"),
+        import("./trajectory/trajectory-dom-renderer.js"),
         import("./trajectory/trajectory-virtualizer.js")
       ]);
     }
@@ -719,7 +719,7 @@ export function createProjectSituationsEvents({
     });
   }
 
-  function bindTrajectoryCanvas(root) {
+  function bindTrajectoryDom(root) {
     const trajectoryNodes = [...root.querySelectorAll("[data-situation-trajectory][data-situation-id]")];
     if (!trajectoryNodes.length) return;
 
@@ -727,14 +727,14 @@ export function createProjectSituationsEvents({
     if (layout !== "roadmap") return;
 
     loadTrajectoryRuntimeModules()
-      .then(([timeScaleModule, modelModule, canvasRendererModule, virtualizerModule]) => {
+      .then(([timeScaleModule, modelModule, domRendererModule, virtualizerModule]) => {
         const { createTrajectoryTimeScale } = timeScaleModule || {};
         const { buildTrajectoryModel } = modelModule || {};
-        const { renderTrajectoryCanvas } = canvasRendererModule || {};
+        const { renderTrajectoryDom } = domRendererModule || {};
         const { getTrajectoryVisibleWindow } = virtualizerModule || {};
         if (typeof createTrajectoryTimeScale !== "function"
           || typeof buildTrajectoryModel !== "function"
-          || typeof renderTrajectoryCanvas !== "function"
+          || typeof renderTrajectoryDom !== "function"
           || typeof getTrajectoryVisibleWindow !== "function") {
           return;
         }
@@ -743,12 +743,14 @@ export function createProjectSituationsEvents({
           const situationId = String(trajectoryNode.getAttribute("data-situation-id") || "").trim();
           const viewportNode = trajectoryNode.querySelector("[data-situation-trajectory-viewport]")
             || trajectoryNode.querySelector(".situation-trajectory__viewport");
-          const canvasNode = trajectoryNode.querySelector(".situation-trajectory__canvas");
+          const sceneNode = trajectoryNode.querySelector("[data-situation-trajectory-scene]");
+          const svgNode = trajectoryNode.querySelector("[data-situation-trajectory-svg]");
+          const itemsRootNode = trajectoryNode.querySelector("[data-situation-trajectory-items]");
           const leftContentNode = trajectoryNode.querySelector("[data-situation-trajectory-left-content]");
           const timelineContentNode = trajectoryNode.querySelector("[data-situation-trajectory-timeline-content]");
           const scrollSizerNode = trajectoryNode.querySelector("[data-situation-trajectory-scroll-sizer]");
           const spinnerNode = trajectoryNode.querySelector("[data-situation-trajectory-spinner]");
-          if (!viewportNode || !canvasNode) return;
+          if (!viewportNode || !sceneNode || !svgNode || !itemsRootNode) return;
 
           const subjects = resolveTrajectorySubjects(situationId);
           const rawSubjectsResult = store?.projectSubjectsView?.rawSubjectsResult || {};
@@ -781,15 +783,23 @@ export function createProjectSituationsEvents({
             today: new Date()
           });
 
-          const contentHeight = Math.max(viewportNode.clientHeight || 0, rows.length * TRAJECTORY_ROW_HEIGHT);
+          const totalWidth = Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth);
+          const contentHeight = Math.max(360, rows.length * TRAJECTORY_ROW_HEIGHT);
           if (scrollSizerNode) {
-            scrollSizerNode.style.width = `${Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth)}px`;
-            scrollSizerNode.style.height = `${Math.max(360, contentHeight)}px`;
+            scrollSizerNode.style.width = `${totalWidth}px`;
+            scrollSizerNode.style.height = `${contentHeight}px`;
           }
           if (timelineContentNode) {
-            timelineContentNode.style.width = `${Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth)}px`;
+            timelineContentNode.style.width = `${totalWidth}px`;
             renderTrajectoryTimelineTicks(timelineContentNode, timeScale, { objectivesById });
           }
+
+          sceneNode.style.width = `${totalWidth}px`;
+          sceneNode.style.height = `${contentHeight}px`;
+          sceneNode.style.setProperty("--situation-trajectory-scene-width", `${totalWidth}px`);
+          sceneNode.style.setProperty("--situation-trajectory-scene-height", `${contentHeight}px`);
+
+          console.info("[trajectory] dom.bind", { situationId, rowCount: rows.length, totalWidth, contentHeight });
 
           let rafId = 0;
           const renderFrame = () => {
@@ -815,8 +825,10 @@ export function createProjectSituationsEvents({
             if (leftContentNode) leftContentNode.style.transform = `translateY(${-scrollTop}px)`;
             if (timelineContentNode) timelineContentNode.style.transform = `translate3d(${-scrollLeft}px,0,0)`;
 
-            renderTrajectoryCanvas({
-              canvas: canvasNode,
+            renderTrajectoryDom({
+              scene: sceneNode,
+              svg: svgNode,
+              itemsRoot: itemsRootNode,
               rows,
               relationEvents,
               timeScale,
@@ -834,8 +846,8 @@ export function createProjectSituationsEvents({
             rafId = window.requestAnimationFrame(renderFrame);
           };
 
-          if (!viewportNode.dataset.trajectoryCanvasBound) {
-            viewportNode.dataset.trajectoryCanvasBound = "true";
+          if (!viewportNode.dataset.trajectoryDomBound) {
+            viewportNode.dataset.trajectoryDomBound = "true";
             viewportNode.addEventListener("scroll", scheduleRender, { passive: true });
           }
 
@@ -1732,7 +1744,7 @@ export function createProjectSituationsEvents({
 
     bindSituationGridColumnResize(root);
     bindTrajectoryColumnResize(root);
-    bindTrajectoryCanvas(root);
+    bindTrajectoryDom(root);
     bindSituationGridEditableCells(root);
     bindSituationGridDnd(root);
 

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -74,7 +74,7 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
     : {};
   const leftColumnWidth = normalizeLeftColumnWidth(options?.store?.situationsView?.trajectoryLeftColumnWidthBySituationId?.[situationId]);
 
-  console.info("[trajectory] render.shell", { situationId, subjectCount });
+  console.info("[trajectory] render.shell.dom-svg", { situationId });
 
   const projectDataAttribute = projectId ? ` data-project-id="${escapeHtml(projectId)}"` : "";
   let leftColumnHtml = "";
@@ -200,7 +200,10 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
 
           <div class="situation-trajectory__viewport" aria-label="Trajectoire des sujets" data-situation-trajectory-viewport>
             <div class="situation-trajectory__scroll-sizer" data-situation-trajectory-scroll-sizer aria-hidden="true"></div>
-            <canvas class="situation-trajectory__canvas"></canvas>
+            <div class="situation-trajectory__scene" data-situation-trajectory-scene>
+              <svg class="situation-trajectory__svg" data-situation-trajectory-svg aria-hidden="true"></svg>
+              <div class="situation-trajectory__items" data-situation-trajectory-items></div>
+            </div>
             <div class="situation-trajectory__spinner" data-situation-trajectory-spinner hidden>
               <span class="ui-spinner ui-spinner--sm" aria-hidden="true"><span class="ui-spinner__ring"></span></span>
               <span>Chargement de la trajectoire…</span>

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -1,0 +1,404 @@
+import { getTrajectoryVisibleWindow } from "./trajectory-virtualizer.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const HIERARCHY_EVENT_TYPES = new Set([
+  "subject_parent_added",
+  "subject_parent_removed",
+  "subject_child_added",
+  "subject_child_removed"
+]);
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function toTimestamp(value, fallback = Date.now()) {
+  const date = value instanceof Date ? value : new Date(value);
+  const ts = date.getTime();
+  return Number.isFinite(ts) ? ts : fallback;
+}
+
+function intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs) {
+  return endTs >= visibleStartTs && startTs <= visibleEndTs;
+}
+
+function normalizeOverscan(overscan) {
+  if (typeof overscan === "number") {
+    return { rows: Math.max(0, Math.floor(overscan)), px: 160 };
+  }
+  return {
+    rows: Math.max(0, Math.floor(Number(overscan?.rows) || 4)),
+    px: Math.max(0, Number(overscan?.px) || 160)
+  };
+}
+
+function resolveTodayTimestamp(timeScale) {
+  const startTs = toTimestamp(timeScale?.startDate, Date.now());
+  const endTs = toTimestamp(timeScale?.endDate, startTs + 1);
+  return clamp(Date.now(), startTs, endTs);
+}
+
+function collectObjectiveVerticalTimestamps(rows = []) {
+  const values = new Set();
+  for (const row of rows) {
+    for (const marker of asArray(row?.objectiveMarkers)) {
+      values.add(toTimestamp(marker?.at));
+    }
+  }
+  return [...values].sort((a, b) => a - b);
+}
+
+function resolvePointIcon(point = {}, previousPoint = null) {
+  const explicit = String(point?.icon || "").trim();
+  if (explicit) return explicit;
+  const source = String(point?.source || "").trim().toLowerCase();
+  if (source === "subject_reopened") return "reopen";
+  if (source === "subject_closed") return "close";
+  const status = String(point?.status || "").trim().toLowerCase();
+  if (["closed_invalid", "invalid", "rejected"].includes(status)) return "reject";
+  if (["closed", "closed_duplicate", "duplicate"].includes(status)) return "close";
+  if (previousPoint && String(previousPoint?.status || "").trim().toLowerCase() !== "open") return "reopen";
+  return "open";
+}
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function buildHierarchyLinks(relationEvents = []) {
+  const dedupe = new Map();
+  for (const event of asArray(relationEvents)) {
+    const type = String(event?.event_type || "").trim().toLowerCase();
+    if (!HIERARCHY_EVENT_TYPES.has(type)) continue;
+
+    const subjectId = normalizeId(event?.subject_id);
+    const counterpartId = normalizeId(event?.payload?.counterpart_subject_id || event?.counterpart_subject_id);
+    if (!subjectId || !counterpartId) continue;
+
+    const at = new Date(event?.created_at || event?.at || Date.now());
+    if (Number.isNaN(at.getTime())) continue;
+
+    const isParentEvent = type.startsWith("subject_parent_");
+    const parentId = isParentEvent ? counterpartId : subjectId;
+    const childId = isParentEvent ? subjectId : counterpartId;
+    const action = type.endsWith("_removed") ? "removed" : "added";
+    const key = `${parentId}|${childId}|${at.toISOString()}|${action}`;
+
+    if (!dedupe.has(key) || isParentEvent) {
+      dedupe.set(key, {
+        parentId,
+        childId,
+        action,
+        at
+      });
+    }
+  }
+  return [...dedupe.values()].sort((a, b) => a.at.getTime() - b.at.getTime());
+}
+
+function clearChildren(node) {
+  if (!node) return;
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function createSvgLine({ x, y1, y2, classNames = [] } = {}) {
+  const line = document.createElementNS(SVG_NS, "line");
+  line.setAttribute("x1", String(x));
+  line.setAttribute("x2", String(x));
+  line.setAttribute("y1", String(y1));
+  line.setAttribute("y2", String(y2));
+  line.setAttribute("class", ["situation-trajectory__svg-line", ...classNames].join(" "));
+  return line;
+}
+
+function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse = false } = {}) {
+  const startY = isReverse ? childY : parentY;
+  const endY = isReverse ? parentY : childY;
+  const direction = endY >= startY ? 1 : -1;
+
+  const laneStartX = x + 2;
+  const laneMidX = x + 10;
+  const laneEndX = x + 18;
+  const curvePad = direction * 6;
+
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute(
+    "d",
+    [
+      `M ${laneStartX} ${startY}`,
+      `L ${laneMidX - 3} ${startY}`,
+      `Q ${laneMidX} ${startY} ${laneMidX} ${startY + curvePad}`,
+      `L ${laneMidX} ${endY - curvePad}`,
+      `Q ${laneMidX} ${endY} ${laneEndX} ${endY}`
+    ].join(" ")
+  );
+  path.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+
+  const markerCircle = !isRemoved
+    ? (() => {
+      const circle = document.createElementNS(SVG_NS, "circle");
+      circle.setAttribute("cx", String(laneStartX));
+      circle.setAttribute("cy", String(startY));
+      circle.setAttribute("r", "2.5");
+      circle.setAttribute("class", "situation-trajectory__hierarchy-link");
+      return circle;
+    })()
+    : null;
+
+  const arrow = document.createElementNS(SVG_NS, "polygon");
+  const arrowSize = 4;
+  arrow.setAttribute(
+    "points",
+    [
+      `${laneEndX},${endY}`,
+      `${laneEndX - arrowSize},${endY - (direction * arrowSize)}`,
+      `${laneEndX - arrowSize},${endY + (direction * arrowSize)}`
+    ].join(" ")
+  );
+  arrow.setAttribute("class", "situation-trajectory__hierarchy-link");
+
+  return { path, markerCircle, arrow };
+}
+
+export function renderTrajectoryDom({
+  scene,
+  svg,
+  itemsRoot,
+  rows = [],
+  relationEvents = [],
+  timeScale,
+  scrollLeft = 0,
+  scrollTop = 0,
+  viewportWidth = 0,
+  viewportHeight = 0,
+  rowHeight = 32,
+  overscan = { rows: 4, px: 160 }
+} = {}) {
+  if (!scene || !svg || !itemsRoot || !timeScale || typeof timeScale.timeToX !== "function") {
+    return {
+      visibleRows: 0,
+      visibleStart: null,
+      visibleEnd: null
+    };
+  }
+
+  const safeRows = asArray(rows);
+  const rowCount = safeRows.length;
+  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
+  const safeViewportWidth = Math.max(0, Number(viewportWidth) || 0);
+  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
+  const safeScrollLeft = Math.max(0, Number(scrollLeft) || 0);
+  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
+
+  const overscanConfig = normalizeOverscan(overscan);
+  const visibleWindow = getTrajectoryVisibleWindow({
+    rowCount,
+    rowHeight: safeRowHeight,
+    scrollTop: safeScrollTop,
+    scrollLeft: safeScrollLeft,
+    viewportWidth: safeViewportWidth,
+    viewportHeight: safeViewportHeight,
+    totalWidth: timeScale.totalWidth,
+    overscanRows: overscanConfig.rows,
+    overscanPx: overscanConfig.px
+  });
+
+  const { rowStart, rowEnd, timeScrollLeft, timeViewportWidth } = visibleWindow;
+
+  const visibleTimeRange = timeScale.getVisibleTimeRange({
+    scrollLeft: timeScrollLeft,
+    viewportWidth: timeViewportWidth,
+    overscanPx: 0
+  });
+
+  const visibleStartTs = toTimestamp(visibleTimeRange.start);
+  const visibleEndTs = toTimestamp(visibleTimeRange.end);
+
+  const contentWidth = Math.max(safeViewportWidth, Number(timeScale.totalWidth) || 0);
+  const contentHeight = Math.max(360, rowCount * safeRowHeight, Number(scene.clientHeight) || 0);
+
+  svg.setAttribute("viewBox", `0 0 ${contentWidth} ${contentHeight}`);
+  svg.setAttribute("width", String(contentWidth));
+  svg.setAttribute("height", String(contentHeight));
+
+  clearChildren(svg);
+  clearChildren(itemsRoot);
+
+  const fragmentSvg = document.createDocumentFragment();
+  const fragmentItems = document.createDocumentFragment();
+
+  const todayTs = resolveTodayTimestamp(timeScale);
+  if (todayTs >= visibleStartTs && todayTs <= visibleEndTs) {
+    const todayLine = createSvgLine({
+      x: timeScale.timeToX(todayTs),
+      y1: 0,
+      y2: contentHeight,
+      classNames: ["situation-trajectory__svg-line--today"]
+    });
+    fragmentSvg.appendChild(todayLine);
+  }
+
+  const objectiveTimestamps = collectObjectiveVerticalTimestamps(safeRows);
+  for (const ts of objectiveTimestamps) {
+    if (ts < visibleStartTs || ts > visibleEndTs) continue;
+    const objectiveLine = createSvgLine({
+      x: timeScale.timeToX(ts),
+      y1: 0,
+      y2: contentHeight,
+      classNames: ["situation-trajectory__svg-line--objective"]
+    });
+    fragmentSvg.appendChild(objectiveLine);
+  }
+
+  let segmentCount = 0;
+  let pointCount = 0;
+  let markerCount = 0;
+
+  for (let index = rowStart; index <= rowEnd; index += 1) {
+    const row = safeRows[index];
+    if (!row) continue;
+    const y = (index * safeRowHeight) + (safeRowHeight / 2);
+    const subjectId = normalizeId(row?.subjectId);
+
+    for (const segment of asArray(row.lifecycleSegments)) {
+      const startTs = toTimestamp(segment.startAt);
+      const endTs = toTimestamp(segment.endAt);
+      if (!intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs)) continue;
+
+      const segmentNode = document.createElement("div");
+      segmentNode.className = "situation-trajectory__segment";
+      segmentNode.style.left = `${timeScale.timeToX(startTs)}px`;
+      segmentNode.style.top = `${y}px`;
+      segmentNode.style.width = `${Math.max(0, timeScale.timeToX(endTs) - timeScale.timeToX(startTs))}px`;
+      if (subjectId) {
+        segmentNode.dataset.trajectorySubjectId = subjectId;
+        segmentNode.dataset.openSituationSubject = subjectId;
+      }
+      fragmentItems.appendChild(segmentNode);
+      segmentCount += 1;
+    }
+
+    const statusPoints = asArray(row.statusPoints);
+    for (let pointIndex = 0; pointIndex < statusPoints.length; pointIndex += 1) {
+      const point = statusPoints[pointIndex];
+      const ts = toTimestamp(point.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+
+      const pointNode = document.createElement("button");
+      pointNode.type = "button";
+      pointNode.className = "situation-trajectory__point";
+      pointNode.style.left = `${timeScale.timeToX(ts)}px`;
+      pointNode.style.top = `${y}px`;
+
+      const pointType = resolvePointIcon(point, statusPoints[pointIndex - 1] || null);
+      pointNode.dataset.trajectoryPointType = pointType;
+      if (subjectId) {
+        pointNode.dataset.trajectorySubjectId = subjectId;
+        pointNode.dataset.openSituationSubject = subjectId;
+      }
+      fragmentItems.appendChild(pointNode);
+      pointCount += 1;
+    }
+
+    for (const marker of asArray(row.objectiveMarkers)) {
+      const ts = toTimestamp(marker.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+
+      const markerNode = document.createElement("button");
+      markerNode.type = "button";
+      markerNode.className = "situation-trajectory__marker";
+      markerNode.style.left = `${timeScale.timeToX(ts)}px`;
+      markerNode.style.top = `${y}px`;
+
+      if (subjectId) {
+        markerNode.dataset.trajectorySubjectId = subjectId;
+        markerNode.dataset.openSituationSubject = subjectId;
+      }
+      const objectiveId = normalizeId(marker?.objectiveId);
+      if (objectiveId) markerNode.dataset.trajectoryObjectiveId = objectiveId;
+      fragmentItems.appendChild(markerNode);
+      markerCount += 1;
+    }
+  }
+
+  const rowIndexBySubjectId = new Map();
+  safeRows.forEach((row, index) => {
+    const subjectId = normalizeId(row?.subjectId);
+    if (subjectId) rowIndexBySubjectId.set(subjectId, index);
+  });
+
+  const hierarchyLinks = buildHierarchyLinks(relationEvents);
+  const linkRowMin = Math.max(0, rowStart - 2);
+  const linkRowMax = Math.min(Math.max(0, rowCount - 1), rowEnd + 2);
+  let linkCount = 0;
+
+  for (const link of hierarchyLinks) {
+    const parentIndex = rowIndexBySubjectId.get(link.parentId);
+    const childIndex = rowIndexBySubjectId.get(link.childId);
+    if (!Number.isInteger(parentIndex) || !Number.isInteger(childIndex)) continue;
+
+    if ((parentIndex < linkRowMin || parentIndex > linkRowMax)
+      && (childIndex < linkRowMin || childIndex > linkRowMax)) {
+      continue;
+    }
+
+    const ts = toTimestamp(link.at);
+    if (ts < visibleStartTs || ts > visibleEndTs) continue;
+
+    const x = timeScale.timeToX(ts);
+    const parentY = (parentIndex * safeRowHeight) + (safeRowHeight / 2);
+    const childY = (childIndex * safeRowHeight) + (safeRowHeight / 2);
+
+    const { path, markerCircle, arrow } = createHierarchyPath({
+      x,
+      parentY,
+      childY,
+      isRemoved: link.action === "removed",
+      isReverse: link.action === "removed"
+    });
+
+    fragmentSvg.appendChild(path);
+    if (markerCircle) fragmentSvg.appendChild(markerCircle);
+    fragmentSvg.appendChild(arrow);
+    linkCount += 1;
+  }
+
+  svg.appendChild(fragmentSvg);
+  itemsRoot.appendChild(fragmentItems);
+
+  const visibleRows = rowCount ? (rowEnd - rowStart + 1) : 0;
+  const visibleStart = new Date(visibleStartTs).toISOString();
+  const visibleEnd = new Date(visibleEndTs).toISOString();
+
+  console.info("[trajectory] dom.render", {
+    visibleRows,
+    visibleStart,
+    visibleEnd,
+    segmentCount,
+    pointCount,
+    markerCount,
+    linkCount
+  });
+
+  return {
+    visibleRows,
+    visibleStart,
+    visibleEnd,
+    rowStart,
+    rowEnd
+  };
+}
+
+export function __trajectoryDomRendererTestUtils() {
+  return {
+    normalizeOverscan,
+    collectObjectiveVerticalTimestamps,
+    resolvePointIcon,
+    intersectsRange,
+    buildHierarchyLinks
+  };
+}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10289,14 +10289,26 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:360px;
 }
 
-.situation-trajectory__canvas{
-  display:block;
+.situation-trajectory__scene{
   position:absolute;
   top:0;
   left:0;
-  width:100%;
+  width:var(--situation-trajectory-scene-width, 100%);
+  height:var(--situation-trajectory-scene-height, 360px);
   min-height:360px;
+}
+
+.situation-trajectory__svg{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
   pointer-events:none;
+}
+
+.situation-trajectory__items{
+  position:absolute;
+  inset:0;
 }
 
 .situation-trajectory__spinner{


### PR DESCRIPTION
### Motivation
- Replace the canvas-based trajectory renderer with a DOM/SVG renderer to improve DOM-level interactivity and make trajectory elements addressable for events and styling.
- Move toward a scene/svg/items structure that better supports virtualization and positional styling using CSS variables for scene dimensions.

### Description
- Added a new DOM renderer `renderTrajectoryDom` in `apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js` which draws timeline lines, segments, points, markers, and hierarchy links into an SVG and DOM items container and exports small test utilities.
- Replaced the canvas renderer import and usage in `apps/web/js/views/project-situations/project-situations-events.js`, renaming `bindTrajectoryCanvas` to `bindTrajectoryDom`, updating module imports, dataset binding flag (`data-trajectory-dom-bound`) and the render call to `renderTrajectoryDom` with `scene`, `svg`, and `itemsRoot` nodes.
- Updated the roadmap view `apps/web/js/views/project-situations/project-situations-view-roadmap.js` to emit the new scene markup (`.situation-trajectory__scene` with `svg` and `.items`) instead of a `<canvas>` element and adjusted a console log message.
- Updated styles in `apps/web/style.css` to add `.situation-trajectory__scene`, `.situation-trajectory__svg`, and `.situation-trajectory__items` rules and wire scene sizing to CSS variables set by the binding logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef640b8bdc83299c6cc32955ddc1fc)