### PR TITLE
Replace canvas trajectory renderer with DOM+SVG renderer and add trajectory history caching

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -27,6 +27,7 @@ import {
   setSituationSubjectKanbanStatus,
   loadSituationKanbanStatusMap
 } from "../services/project-situations-supabase.js";
+import { loadProjectSituationsTrajectoryHistory } from "../services/project-situations-trajectory-service.js";
 import { createProjectSituationsState, getDefaultCreateForm, getSituationEditForm } from "./project-situations/project-situations-state.js";
 import { createProjectSituationsSelectors } from "./project-situations/project-situations-selectors.js";
 import { createProjectSituationsSelection } from "./project-situations/project-situations-selection.js";
@@ -77,6 +78,100 @@ const {
   setSelectedSituationId
 } = createProjectSituationsSelection({ store, ensureSituationsViewState });
 
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function normalizeSubjectIdsFromSelection(subjects = []) {
+  return [...new Set((Array.isArray(subjects) ? subjects : [])
+    .map((subject) => normalizeId(subject?.id))
+    .filter(Boolean))]
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {}) {
+  const normalizedSituationId = normalizeId(situationId);
+  const subjectIds = normalizeSubjectIdsFromSelection(subjects);
+  const subjectIdsSignature = subjectIds.join(",");
+
+  if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") {
+    store.projectSubjectsView = {};
+  }
+  const cacheBySituationId = store.projectSubjectsView.trajectoryHistoryBySituationId && typeof store.projectSubjectsView.trajectoryHistoryBySituationId === "object"
+    ? store.projectSubjectsView.trajectoryHistoryBySituationId
+    : {};
+  store.projectSubjectsView.trajectoryHistoryBySituationId = cacheBySituationId;
+
+  const cached = cacheBySituationId[normalizedSituationId];
+  const cachedSignature = String(cached?.subjectIdsSignature || "").trim();
+  const hasUsableCachedPayload = cached
+    && typeof cached === "object"
+    && cached.eventsBySubjectId
+    && cached.statusEventsBySubjectId
+    && Array.isArray(cached.relationEvents);
+
+  console.info("[trajectory] history.ensure.start", {
+    situationId: normalizedSituationId,
+    subjectCount: subjectIds.length
+  });
+
+  if (hasUsableCachedPayload && cachedSignature === subjectIdsSignature) {
+    console.info("[trajectory] history.ensure.cache-hit", {
+      situationId: normalizedSituationId,
+      subjectCount: subjectIds.length
+    });
+    return cached;
+  }
+
+  if (!normalizedSituationId || !subjectIds.length) {
+    const emptyPayload = {
+      eventsBySubjectId: {},
+      relationEvents: [],
+      statusEventsBySubjectId: {},
+      subjectIdsSignature
+    };
+    cacheBySituationId[normalizedSituationId] = emptyPayload;
+    console.info("[trajectory] history.ensure.done", {
+      situationId: normalizedSituationId,
+      subjectCount: subjectIds.length,
+      eventCount: 0
+    });
+    return emptyPayload;
+  }
+
+  try {
+    const history = await loadProjectSituationsTrajectoryHistory({
+      projectId: normalizeId(store?.currentProjectId || store?.projectForm?.projectId || ""),
+      subjectIds
+    });
+    const payload = {
+      eventsBySubjectId: history?.eventsBySubjectId && typeof history.eventsBySubjectId === "object" ? history.eventsBySubjectId : {},
+      relationEvents: Array.isArray(history?.relationEvents) ? history.relationEvents : [],
+      statusEventsBySubjectId: history?.statusEventsBySubjectId && typeof history.statusEventsBySubjectId === "object" ? history.statusEventsBySubjectId : {},
+      subjectIdsSignature
+    };
+    cacheBySituationId[normalizedSituationId] = payload;
+    console.info("[trajectory] history.ensure.done", {
+      situationId: normalizedSituationId,
+      subjectCount: subjectIds.length,
+      eventCount: Object.values(payload.eventsBySubjectId).flat().length
+    });
+    return payload;
+  } catch (error) {
+    console.error("[trajectory] history.ensure.error", error);
+    const fallbackPayload = hasUsableCachedPayload
+      ? cached
+      : {
+          eventsBySubjectId: {},
+          relationEvents: [],
+          statusEventsBySubjectId: {},
+          subjectIdsSignature
+        };
+    cacheBySituationId[normalizedSituationId] = fallbackPayload;
+    return fallbackPayload;
+  }
+}
+
 const {
   getSituationById,
   loadSituationSelection,
@@ -90,6 +185,7 @@ const {
   loadFlatSubjectsForCurrentProject,
   loadSituationsForCurrentProject,
   loadSubjectsForSituation,
+  ensureTrajectoryHistory,
   loadSituationKanbanStatusMap,
   createSituation,
   updateSituation
@@ -444,6 +540,7 @@ const { bindEvents } = createProjectSituationsEvents({
   loadSituationSelection,
   loadSituationInsightsData,
   openSituationDrilldownFromSelection,
+  openSubjectDrilldown: (...args) => openSubjectDrilldownFromSituation(...args),
   openSharedSubjectMetaDropdown: (...args) => openSharedSubjectMetaDropdown(...args),
   openSharedSubjectKanbanDropdown: (...args) => openSharedSubjectKanbanDropdown(...args),
   closeSharedSubjectDropdowns: (...args) => closeSharedSubjectDropdowns(...args),

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -53,6 +53,7 @@ export function createProjectSituationsEvents({
   loadSituationSelection,
   loadSituationInsightsData,
   openSituationDrilldownFromSelection,
+  openSubjectDrilldown,
   openSharedSubjectMetaDropdown,
   openSharedSubjectKanbanDropdown,
   closeSharedSubjectDropdowns,
@@ -74,7 +75,7 @@ export function createProjectSituationsEvents({
       trajectoryRuntimeModulesPromise = Promise.all([
         import("./trajectory/trajectory-time-scale.js"),
         import("./trajectory/trajectory-model.js"),
-        import("./trajectory/trajectory-canvas-renderer.js"),
+        import("./trajectory/trajectory-dom-renderer.js"),
         import("./trajectory/trajectory-virtualizer.js")
       ]);
     }
@@ -719,7 +720,7 @@ export function createProjectSituationsEvents({
     });
   }
 
-  function bindTrajectoryCanvas(root) {
+  function bindTrajectoryDom(root) {
     const trajectoryNodes = [...root.querySelectorAll("[data-situation-trajectory][data-situation-id]")];
     if (!trajectoryNodes.length) return;
 
@@ -727,14 +728,14 @@ export function createProjectSituationsEvents({
     if (layout !== "roadmap") return;
 
     loadTrajectoryRuntimeModules()
-      .then(([timeScaleModule, modelModule, canvasRendererModule, virtualizerModule]) => {
+      .then(([timeScaleModule, modelModule, domRendererModule, virtualizerModule]) => {
         const { createTrajectoryTimeScale } = timeScaleModule || {};
         const { buildTrajectoryModel } = modelModule || {};
-        const { renderTrajectoryCanvas } = canvasRendererModule || {};
+        const { renderTrajectoryDom } = domRendererModule || {};
         const { getTrajectoryVisibleWindow } = virtualizerModule || {};
         if (typeof createTrajectoryTimeScale !== "function"
           || typeof buildTrajectoryModel !== "function"
-          || typeof renderTrajectoryCanvas !== "function"
+          || typeof renderTrajectoryDom !== "function"
           || typeof getTrajectoryVisibleWindow !== "function") {
           return;
         }
@@ -743,12 +744,14 @@ export function createProjectSituationsEvents({
           const situationId = String(trajectoryNode.getAttribute("data-situation-id") || "").trim();
           const viewportNode = trajectoryNode.querySelector("[data-situation-trajectory-viewport]")
             || trajectoryNode.querySelector(".situation-trajectory__viewport");
-          const canvasNode = trajectoryNode.querySelector(".situation-trajectory__canvas");
+          const sceneNode = trajectoryNode.querySelector("[data-situation-trajectory-scene]");
+          const svgNode = trajectoryNode.querySelector("[data-situation-trajectory-svg]");
+          const itemsRootNode = trajectoryNode.querySelector("[data-situation-trajectory-items]");
           const leftContentNode = trajectoryNode.querySelector("[data-situation-trajectory-left-content]");
           const timelineContentNode = trajectoryNode.querySelector("[data-situation-trajectory-timeline-content]");
           const scrollSizerNode = trajectoryNode.querySelector("[data-situation-trajectory-scroll-sizer]");
           const spinnerNode = trajectoryNode.querySelector("[data-situation-trajectory-spinner]");
-          if (!viewportNode || !canvasNode) return;
+          if (!viewportNode || !sceneNode || !svgNode || !itemsRootNode) return;
 
           const subjects = resolveTrajectorySubjects(situationId);
           const rawSubjectsResult = store?.projectSubjectsView?.rawSubjectsResult || {};
@@ -781,15 +784,23 @@ export function createProjectSituationsEvents({
             today: new Date()
           });
 
-          const contentHeight = Math.max(viewportNode.clientHeight || 0, rows.length * TRAJECTORY_ROW_HEIGHT);
+          const totalWidth = Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth);
+          const contentHeight = Math.max(360, rows.length * TRAJECTORY_ROW_HEIGHT);
           if (scrollSizerNode) {
-            scrollSizerNode.style.width = `${Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth)}px`;
-            scrollSizerNode.style.height = `${Math.max(360, contentHeight)}px`;
+            scrollSizerNode.style.width = `${totalWidth}px`;
+            scrollSizerNode.style.height = `${contentHeight}px`;
           }
           if (timelineContentNode) {
-            timelineContentNode.style.width = `${Math.max(viewportNode.clientWidth || 0, timeScale.totalWidth)}px`;
+            timelineContentNode.style.width = `${totalWidth}px`;
             renderTrajectoryTimelineTicks(timelineContentNode, timeScale, { objectivesById });
           }
+
+          sceneNode.style.width = `${totalWidth}px`;
+          sceneNode.style.height = `${contentHeight}px`;
+          sceneNode.style.setProperty("--situation-trajectory-scene-width", `${totalWidth}px`);
+          sceneNode.style.setProperty("--situation-trajectory-scene-height", `${contentHeight}px`);
+
+          console.info("[trajectory] dom.bind", { situationId, rowCount: rows.length, totalWidth, contentHeight });
 
           let rafId = 0;
           const renderFrame = () => {
@@ -815,8 +826,10 @@ export function createProjectSituationsEvents({
             if (leftContentNode) leftContentNode.style.transform = `translateY(${-scrollTop}px)`;
             if (timelineContentNode) timelineContentNode.style.transform = `translate3d(${-scrollLeft}px,0,0)`;
 
-            renderTrajectoryCanvas({
-              canvas: canvasNode,
+            renderTrajectoryDom({
+              scene: sceneNode,
+              svg: svgNode,
+              itemsRoot: itemsRootNode,
               rows,
               relationEvents,
               timeScale,
@@ -834,8 +847,8 @@ export function createProjectSituationsEvents({
             rafId = window.requestAnimationFrame(renderFrame);
           };
 
-          if (!viewportNode.dataset.trajectoryCanvasBound) {
-            viewportNode.dataset.trajectoryCanvasBound = "true";
+          if (!viewportNode.dataset.trajectoryDomBound) {
+            viewportNode.dataset.trajectoryDomBound = "true";
             viewportNode.addEventListener("scroll", scheduleRender, { passive: true });
           }
 
@@ -1679,6 +1692,27 @@ export function createProjectSituationsEvents({
       });
     });
 
+    if (!root.dataset.situationSubjectOpenBound) {
+      root.dataset.situationSubjectOpenBound = "true";
+      root.addEventListener("click", (event) => {
+        const trigger = event.target?.closest?.("[data-open-situation-subject]");
+        if (!trigger || !root.contains(trigger)) return;
+        const subjectId = String(trigger.getAttribute("data-open-situation-subject") || "").trim();
+        if (!subjectId) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const source = trigger.closest(".situation-trajectory__items, .situation-trajectory__scene, .situation-trajectory")
+          ? "trajectory-dom"
+          : "situations-view";
+        if (source === "trajectory-dom") {
+          console.info("[trajectory] subject.open", { subjectId, source: "trajectory-dom" });
+        }
+        if (typeof openSubjectDrilldown === "function") {
+          openSubjectDrilldown(subjectId);
+        }
+      });
+    }
+
     root.querySelectorAll("[data-situations-status-filter]").forEach((node) => {
       node.addEventListener("click", (event) => {
         event.preventDefault();
@@ -1732,7 +1766,7 @@ export function createProjectSituationsEvents({
 
     bindSituationGridColumnResize(root);
     bindTrajectoryColumnResize(root);
-    bindTrajectoryCanvas(root);
+    bindTrajectoryDom(root);
     bindSituationGridEditableCells(root);
     bindSituationGridDnd(root);
 

--- a/apps/web/js/views/project-situations/project-situations-persistence.js
+++ b/apps/web/js/views/project-situations/project-situations-persistence.js
@@ -5,6 +5,7 @@ export function createProjectSituationsPersistence({
   loadFlatSubjectsForCurrentProject,
   loadSituationsForCurrentProject,
   loadSubjectsForSituation,
+  ensureTrajectoryHistory,
   loadSituationKanbanStatusMap,
   createSituation,
   updateSituation
@@ -31,6 +32,13 @@ export function createProjectSituationsPersistence({
     try {
       const subjects = await loadSubjectsForSituation(selectedSituation, store.projectSubjectsView);
       uiState.selectedSituationSubjects = safeArray(subjects);
+      const selectedLayout = String(store?.situationsView?.selectedSituationLayout || "").trim().toLowerCase();
+      if (selectedLayout === "roadmap" && typeof ensureTrajectoryHistory === "function") {
+        await ensureTrajectoryHistory({
+          situationId: normalizedId,
+          subjects: uiState.selectedSituationSubjects
+        });
+      }
       return uiState.selectedSituationSubjects;
     } catch (error) {
       console.error("loadSituationSelection failed", error);

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -74,7 +74,7 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
     : {};
   const leftColumnWidth = normalizeLeftColumnWidth(options?.store?.situationsView?.trajectoryLeftColumnWidthBySituationId?.[situationId]);
 
-  console.info("[trajectory] render.shell", { situationId, subjectCount });
+  console.info("[trajectory] render.shell.dom-svg", { situationId });
 
   const projectDataAttribute = projectId ? ` data-project-id="${escapeHtml(projectId)}"` : "";
   let leftColumnHtml = "";
@@ -200,7 +200,10 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
 
           <div class="situation-trajectory__viewport" aria-label="Trajectoire des sujets" data-situation-trajectory-viewport>
             <div class="situation-trajectory__scroll-sizer" data-situation-trajectory-scroll-sizer aria-hidden="true"></div>
-            <canvas class="situation-trajectory__canvas"></canvas>
+            <div class="situation-trajectory__scene" data-situation-trajectory-scene>
+              <svg class="situation-trajectory__svg" data-situation-trajectory-svg aria-hidden="true"></svg>
+              <div class="situation-trajectory__items" data-situation-trajectory-items></div>
+            </div>
             <div class="situation-trajectory__spinner" data-situation-trajectory-spinner hidden>
               <span class="ui-spinner ui-spinner--sm" aria-hidden="true"><span class="ui-spinner__ring"></span></span>
               <span>Chargement de la trajectoire…</span>

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -1,0 +1,433 @@
+import { getTrajectoryVisibleWindow } from "./trajectory-virtualizer.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const HIERARCHY_EVENT_TYPES = new Set([
+  "subject_parent_added",
+  "subject_parent_removed",
+  "subject_child_added",
+  "subject_child_removed"
+]);
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function toTimestamp(value, fallback = Date.now()) {
+  const date = value instanceof Date ? value : new Date(value);
+  const ts = date.getTime();
+  return Number.isFinite(ts) ? ts : fallback;
+}
+
+function intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs) {
+  return endTs >= visibleStartTs && startTs <= visibleEndTs;
+}
+
+function normalizeOverscan(overscan) {
+  if (typeof overscan === "number") {
+    return { rows: Math.max(0, Math.floor(overscan)), px: 160 };
+  }
+  return {
+    rows: Math.max(0, Math.floor(Number(overscan?.rows) || 4)),
+    px: Math.max(0, Number(overscan?.px) || 160)
+  };
+}
+
+function resolveTodayTimestamp(timeScale) {
+  const startTs = toTimestamp(timeScale?.startDate, Date.now());
+  const endTs = toTimestamp(timeScale?.endDate, startTs + 1);
+  return clamp(Date.now(), startTs, endTs);
+}
+
+function collectObjectiveVerticalTimestamps(rows = []) {
+  const values = new Set();
+  for (const row of rows) {
+    for (const marker of asArray(row?.objectiveMarkers)) {
+      values.add(toTimestamp(marker?.at));
+    }
+  }
+  return [...values].sort((a, b) => a - b);
+}
+
+function resolvePointIcon(point = {}, previousPoint = null) {
+  const explicit = String(point?.icon || "").trim();
+  if (explicit) return explicit;
+  const source = String(point?.source || "").trim().toLowerCase();
+  if (source === "subject_reopened") return "reopen";
+  if (source === "subject_closed") return "close";
+  const status = String(point?.status || "").trim().toLowerCase();
+  if (["closed_invalid", "invalid", "rejected"].includes(status)) return "reject";
+  if (["closed", "closed_duplicate", "duplicate"].includes(status)) return "close";
+  if (previousPoint && String(previousPoint?.status || "").trim().toLowerCase() !== "open") return "reopen";
+  return "open";
+}
+
+function normalizeId(value) {
+  return String(value || "").trim();
+}
+
+function formatDateLabel(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "date inconnue";
+  return date.toISOString().replace("T", " ").replace(".000Z", "Z");
+}
+
+function formatPointEventLabel(point = {}) {
+  const source = String(point?.source || "").trim().toLowerCase();
+  if (source === "subject_created") return "création";
+  if (source === "subject_closed") return "fermeture";
+  if (source === "subject_reopened") return "réouverture";
+  return source || "mise à jour";
+}
+
+function buildHierarchyLinks(relationEvents = []) {
+  const dedupe = new Map();
+  for (const event of asArray(relationEvents)) {
+    const type = String(event?.event_type || "").trim().toLowerCase();
+    if (!HIERARCHY_EVENT_TYPES.has(type)) continue;
+
+    const subjectId = normalizeId(event?.subject_id);
+    const counterpartId = normalizeId(event?.payload?.counterpart_subject_id || event?.counterpart_subject_id);
+    if (!subjectId || !counterpartId) continue;
+
+    const at = new Date(event?.created_at || event?.at || Date.now());
+    if (Number.isNaN(at.getTime())) continue;
+
+    const isParentEvent = type.startsWith("subject_parent_");
+    const parentId = isParentEvent ? counterpartId : subjectId;
+    const childId = isParentEvent ? subjectId : counterpartId;
+    const action = type.endsWith("_removed") ? "removed" : "added";
+    const key = `${parentId}|${childId}|${at.toISOString()}|${action}`;
+
+    if (!dedupe.has(key) || isParentEvent) {
+      dedupe.set(key, {
+        parentId,
+        childId,
+        action,
+        at
+      });
+    }
+  }
+  return [...dedupe.values()].sort((a, b) => a.at.getTime() - b.at.getTime());
+}
+
+function clearChildren(node) {
+  if (!node) return;
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function createSvgLine({ x, y1, y2, classNames = [] } = {}) {
+  const line = document.createElementNS(SVG_NS, "line");
+  line.setAttribute("x1", String(x));
+  line.setAttribute("x2", String(x));
+  line.setAttribute("y1", String(y1));
+  line.setAttribute("y2", String(y2));
+  line.setAttribute("class", ["situation-trajectory__svg-line", ...classNames].join(" "));
+  return line;
+}
+
+function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse = false } = {}) {
+  const startY = isReverse ? childY : parentY;
+  const endY = isReverse ? parentY : childY;
+  const direction = endY >= startY ? 1 : -1;
+
+  const laneStartX = x + 2;
+  const laneMidX = x + 10;
+  const laneEndX = x + 18;
+  const curvePad = direction * 6;
+
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute(
+    "d",
+    [
+      `M ${laneStartX} ${startY}`,
+      `L ${laneMidX - 3} ${startY}`,
+      `Q ${laneMidX} ${startY} ${laneMidX} ${startY + curvePad}`,
+      `L ${laneMidX} ${endY - curvePad}`,
+      `Q ${laneMidX} ${endY} ${laneEndX} ${endY}`
+    ].join(" ")
+  );
+  path.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+
+  const markerCircle = !isRemoved
+    ? (() => {
+      const circle = document.createElementNS(SVG_NS, "circle");
+      circle.setAttribute("cx", String(laneStartX));
+      circle.setAttribute("cy", String(startY));
+      circle.setAttribute("r", "2.5");
+      circle.setAttribute("class", "situation-trajectory__hierarchy-link");
+      return circle;
+    })()
+    : null;
+
+  const arrow = document.createElementNS(SVG_NS, "polygon");
+  const arrowSize = 4;
+  arrow.setAttribute(
+    "points",
+    [
+      `${laneEndX},${endY}`,
+      `${laneEndX - arrowSize},${endY - (direction * arrowSize)}`,
+      `${laneEndX - arrowSize},${endY + (direction * arrowSize)}`
+    ].join(" ")
+  );
+  arrow.setAttribute("class", "situation-trajectory__hierarchy-link");
+
+  return { path, markerCircle, arrow };
+}
+
+export function renderTrajectoryDom({
+  scene,
+  svg,
+  itemsRoot,
+  rows = [],
+  relationEvents = [],
+  timeScale,
+  scrollLeft = 0,
+  scrollTop = 0,
+  viewportWidth = 0,
+  viewportHeight = 0,
+  rowHeight = 32,
+  overscan = { rows: 4, px: 160 }
+} = {}) {
+  if (!scene || !svg || !itemsRoot || !timeScale || typeof timeScale.timeToX !== "function") {
+    return {
+      visibleRows: 0,
+      visibleStart: null,
+      visibleEnd: null
+    };
+  }
+
+  const safeRows = asArray(rows);
+  const rowCount = safeRows.length;
+  const safeRowHeight = Math.max(1, Number(rowHeight) || 32);
+  const safeViewportWidth = Math.max(0, Number(viewportWidth) || 0);
+  const safeViewportHeight = Math.max(0, Number(viewportHeight) || 0);
+  const safeScrollLeft = Math.max(0, Number(scrollLeft) || 0);
+  const safeScrollTop = Math.max(0, Number(scrollTop) || 0);
+
+  const overscanConfig = normalizeOverscan(overscan);
+  const visibleWindow = getTrajectoryVisibleWindow({
+    rowCount,
+    rowHeight: safeRowHeight,
+    scrollTop: safeScrollTop,
+    scrollLeft: safeScrollLeft,
+    viewportWidth: safeViewportWidth,
+    viewportHeight: safeViewportHeight,
+    totalWidth: timeScale.totalWidth,
+    overscanRows: overscanConfig.rows,
+    overscanPx: overscanConfig.px
+  });
+
+  const { rowStart, rowEnd, timeScrollLeft, timeViewportWidth } = visibleWindow;
+
+  const visibleTimeRange = timeScale.getVisibleTimeRange({
+    scrollLeft: timeScrollLeft,
+    viewportWidth: timeViewportWidth,
+    overscanPx: 0
+  });
+
+  const visibleStartTs = toTimestamp(visibleTimeRange.start);
+  const visibleEndTs = toTimestamp(visibleTimeRange.end);
+
+  const contentWidth = Math.max(safeViewportWidth, Number(timeScale.totalWidth) || 0);
+  const contentHeight = Math.max(360, rowCount * safeRowHeight, Number(scene.clientHeight) || 0);
+
+  svg.setAttribute("viewBox", `0 0 ${contentWidth} ${contentHeight}`);
+  svg.setAttribute("width", String(contentWidth));
+  svg.setAttribute("height", String(contentHeight));
+
+  clearChildren(svg);
+  clearChildren(itemsRoot);
+
+  const fragmentSvg = document.createDocumentFragment();
+  const fragmentItems = document.createDocumentFragment();
+
+  const todayTs = resolveTodayTimestamp(timeScale);
+  if (todayTs >= visibleStartTs && todayTs <= visibleEndTs) {
+    const todayLine = createSvgLine({
+      x: timeScale.timeToX(todayTs),
+      y1: 0,
+      y2: contentHeight,
+      classNames: ["situation-trajectory__svg-line--today"]
+    });
+    fragmentSvg.appendChild(todayLine);
+  }
+
+  const objectiveTimestamps = collectObjectiveVerticalTimestamps(safeRows);
+  for (const ts of objectiveTimestamps) {
+    if (ts < visibleStartTs || ts > visibleEndTs) continue;
+    const objectiveLine = createSvgLine({
+      x: timeScale.timeToX(ts),
+      y1: 0,
+      y2: contentHeight,
+      classNames: ["situation-trajectory__svg-line--objective"]
+    });
+    fragmentSvg.appendChild(objectiveLine);
+  }
+
+  let segmentCount = 0;
+  let pointCount = 0;
+  let markerCount = 0;
+
+  for (let index = rowStart; index <= rowEnd; index += 1) {
+    const row = safeRows[index];
+    if (!row) continue;
+    const y = (index * safeRowHeight) + (safeRowHeight / 2);
+    const subjectId = normalizeId(row?.subjectId);
+
+    for (const segment of asArray(row.lifecycleSegments)) {
+      const startTs = toTimestamp(segment.startAt);
+      const endTs = toTimestamp(segment.endAt);
+      if (!intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs)) continue;
+
+      const segmentNode = document.createElement("div");
+      const segmentColor = String(segment?.lineColor || "").trim().toLowerCase();
+      const segmentStyle = String(segment?.lineStyle || "").trim().toLowerCase();
+      segmentNode.className = [
+        "situation-trajectory__segment",
+        segmentColor ? `situation-trajectory__segment--${segmentColor}` : "",
+        segmentStyle === "dashed" ? "situation-trajectory__segment--dashed" : ""
+      ].filter(Boolean).join(" ");
+      segmentNode.style.left = `${timeScale.timeToX(startTs)}px`;
+      segmentNode.style.top = `${y}px`;
+      segmentNode.style.width = `${Math.max(0, timeScale.timeToX(endTs) - timeScale.timeToX(startTs))}px`;
+      if (subjectId) {
+        segmentNode.dataset.trajectorySubjectId = subjectId;
+        segmentNode.dataset.openSituationSubject = subjectId;
+      }
+      segmentNode.title = `Sujet ${subjectId || "inconnu"} · ${formatDateLabel(segment.startAt)} → ${formatDateLabel(segment.endAt)} · statut ${String(segment?.status || "open").trim().toLowerCase() || "open"}`;
+      fragmentItems.appendChild(segmentNode);
+      segmentCount += 1;
+    }
+
+    const statusPoints = asArray(row.statusPoints);
+    for (let pointIndex = 0; pointIndex < statusPoints.length; pointIndex += 1) {
+      const point = statusPoints[pointIndex];
+      const ts = toTimestamp(point.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+
+      const pointNode = document.createElement("button");
+      pointNode.type = "button";
+      pointNode.className = "situation-trajectory__point";
+      pointNode.style.left = `${timeScale.timeToX(ts)}px`;
+      pointNode.style.top = `${y}px`;
+
+      const pointType = resolvePointIcon(point, statusPoints[pointIndex - 1] || null);
+      pointNode.classList.add(`situation-trajectory__point--${pointType}`);
+      pointNode.dataset.trajectoryPointType = pointType;
+      if (subjectId) {
+        pointNode.dataset.trajectorySubjectId = subjectId;
+        pointNode.dataset.openSituationSubject = subjectId;
+      }
+      pointNode.setAttribute("tabindex", "0");
+      pointNode.setAttribute("role", "button");
+      pointNode.title = `Sujet ${subjectId || "inconnu"} · ${formatDateLabel(point.at)} · ${formatPointEventLabel(point)}`;
+      fragmentItems.appendChild(pointNode);
+      pointCount += 1;
+    }
+
+    for (const marker of asArray(row.objectiveMarkers)) {
+      const ts = toTimestamp(marker.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+
+      const markerNode = document.createElement("button");
+      markerNode.type = "button";
+      const markerType = String(marker?.markerType || "").trim().toLowerCase() || "cross";
+      markerNode.className = `situation-trajectory__marker situation-trajectory__marker--${markerType}`;
+      markerNode.style.left = `${timeScale.timeToX(ts)}px`;
+      markerNode.style.top = `${y}px`;
+
+      if (subjectId) {
+        markerNode.dataset.trajectorySubjectId = subjectId;
+        markerNode.dataset.openSituationSubject = subjectId;
+      }
+      const objectiveId = normalizeId(marker?.objectiveId);
+      if (objectiveId) markerNode.dataset.trajectoryObjectiveId = objectiveId;
+      markerNode.setAttribute("tabindex", "0");
+      markerNode.setAttribute("role", "button");
+      markerNode.title = `Objectif ${objectiveId || "inconnu"} · ${formatDateLabel(marker.at)} · ${markerType === "check" ? "check" : "cross"}`;
+      fragmentItems.appendChild(markerNode);
+      markerCount += 1;
+    }
+  }
+
+  const rowIndexBySubjectId = new Map();
+  safeRows.forEach((row, index) => {
+    const subjectId = normalizeId(row?.subjectId);
+    if (subjectId) rowIndexBySubjectId.set(subjectId, index);
+  });
+
+  const hierarchyLinks = buildHierarchyLinks(relationEvents);
+  const linkRowMin = Math.max(0, rowStart - 2);
+  const linkRowMax = Math.min(Math.max(0, rowCount - 1), rowEnd + 2);
+  let linkCount = 0;
+
+  for (const link of hierarchyLinks) {
+    const parentIndex = rowIndexBySubjectId.get(link.parentId);
+    const childIndex = rowIndexBySubjectId.get(link.childId);
+    if (!Number.isInteger(parentIndex) || !Number.isInteger(childIndex)) continue;
+
+    if ((parentIndex < linkRowMin || parentIndex > linkRowMax)
+      && (childIndex < linkRowMin || childIndex > linkRowMax)) {
+      continue;
+    }
+
+    const ts = toTimestamp(link.at);
+    if (ts < visibleStartTs || ts > visibleEndTs) continue;
+
+    const x = timeScale.timeToX(ts);
+    const parentY = (parentIndex * safeRowHeight) + (safeRowHeight / 2);
+    const childY = (childIndex * safeRowHeight) + (safeRowHeight / 2);
+
+    const { path, markerCircle, arrow } = createHierarchyPath({
+      x,
+      parentY,
+      childY,
+      isRemoved: link.action === "removed",
+      isReverse: link.action === "removed"
+    });
+
+    fragmentSvg.appendChild(path);
+    if (markerCircle) fragmentSvg.appendChild(markerCircle);
+    fragmentSvg.appendChild(arrow);
+    linkCount += 1;
+  }
+
+  svg.appendChild(fragmentSvg);
+  itemsRoot.appendChild(fragmentItems);
+
+  const visibleRows = rowCount ? (rowEnd - rowStart + 1) : 0;
+  const visibleStart = new Date(visibleStartTs).toISOString();
+  const visibleEnd = new Date(visibleEndTs).toISOString();
+
+  console.info("[trajectory] dom.render", {
+    visibleRows,
+    visibleStart,
+    visibleEnd,
+    segmentCount,
+    pointCount,
+    markerCount,
+    linkCount
+  });
+
+  return {
+    visibleRows,
+    visibleStart,
+    visibleEnd,
+    rowStart,
+    rowEnd
+  };
+}
+
+export function __trajectoryDomRendererTestUtils() {
+  return {
+    normalizeOverscan,
+    collectObjectiveVerticalTimestamps,
+    resolvePointIcon,
+    intersectsRange,
+    buildHierarchyLinks
+  };
+}

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
@@ -1,0 +1,241 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createTrajectoryTimeScale } from "./trajectory-time-scale.js";
+import { renderTrajectoryDom, __trajectoryDomRendererTestUtils } from "./trajectory-dom-renderer.js";
+
+class MockNode {
+  constructor(tagName = "div") {
+    this.tagName = String(tagName || "div").toUpperCase();
+    this.childNodes = [];
+    this.parentNode = null;
+    this.attributes = {};
+    this.dataset = {};
+    this.style = {};
+    this.className = "";
+    this.clientHeight = 0;
+    this.clientWidth = 0;
+    this.type = "";
+    this.title = "";
+    this.classList = {
+      add: (...tokens) => {
+        const current = new Set(String(this.className || "").split(/\s+/).filter(Boolean));
+        tokens.map((token) => String(token || "").trim()).filter(Boolean).forEach((token) => current.add(token));
+        this.className = [...current].join(" ");
+      }
+    };
+  }
+
+  get firstChild() {
+    return this.childNodes[0] || null;
+  }
+
+  appendChild(node) {
+    if (!node) return null;
+    if (node.isFragment) {
+      for (const child of [...node.childNodes]) this.appendChild(child);
+      node.childNodes = [];
+      return node;
+    }
+    node.parentNode = this;
+    this.childNodes.push(node);
+    return node;
+  }
+
+  removeChild(node) {
+    const index = this.childNodes.indexOf(node);
+    if (index >= 0) {
+      this.childNodes.splice(index, 1);
+      node.parentNode = null;
+    }
+    return node;
+  }
+
+  setAttribute(name, value) {
+    const key = String(name || "");
+    const safeValue = String(value ?? "");
+    this.attributes[key] = safeValue;
+    if (key === "class") this.className = safeValue;
+    if (key.startsWith("data-")) {
+      const datasetKey = key
+        .slice(5)
+        .split("-")
+        .map((part, index) => (index === 0 ? part : (part.charAt(0).toUpperCase() + part.slice(1))))
+        .join("");
+      this.dataset[datasetKey] = safeValue;
+    }
+  }
+
+  getAttribute(name) {
+    return this.attributes[String(name || "")] || null;
+  }
+
+  set innerHTML(_) {
+    this.childNodes = [];
+  }
+}
+
+class MockFragment extends MockNode {
+  constructor() {
+    super("#fragment");
+    this.isFragment = true;
+  }
+}
+
+function createMockDocument() {
+  return {
+    createElement: (tagName) => new MockNode(tagName),
+    createElementNS: (_ns, tagName) => new MockNode(tagName),
+    createDocumentFragment: () => new MockFragment()
+  };
+}
+
+function walk(node, visit) {
+  if (!node) return;
+  visit(node);
+  for (const child of node.childNodes || []) walk(child, visit);
+}
+
+function queryByClass(root, className) {
+  const matches = [];
+  walk(root, (node) => {
+    const classes = String(node.className || "").split(/\s+/).filter(Boolean);
+    if (classes.includes(className)) matches.push(node);
+  });
+  return matches;
+}
+
+function createRows(count) {
+  return Array.from({ length: count }, (_unused, index) => ({
+    subjectId: `subject-${index}`,
+    lifecycleSegments: [
+      {
+        subjectId: `subject-${index}`,
+        status: "open",
+        startAt: new Date("2026-01-02T00:00:00.000Z"),
+        endAt: new Date("2026-01-04T00:00:00.000Z"),
+        lineColor: "green",
+        lineStyle: "solid"
+      }
+    ],
+    statusPoints: [
+      {
+        at: new Date("2026-01-03T00:00:00.000Z"),
+        status: "open",
+        source: "subject_created"
+      }
+    ],
+    objectiveMarkers: [
+      {
+        objectiveId: `obj-${index}`,
+        at: new Date("2026-01-05T00:00:00.000Z"),
+        markerType: "check",
+        markerColor: "green"
+      }
+    ]
+  }));
+}
+
+test("renderTrajectoryDom rend uniquement les lignes visibles et les éléments attendus", () => {
+  const originalDocument = globalThis.document;
+  const originalNow = Date.now;
+  globalThis.document = createMockDocument();
+  Date.now = () => new Date("2026-01-03T00:00:00.000Z").getTime();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 600;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = createRows(5);
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-01-01T00:00:00.000Z",
+    endDate: "2026-01-10T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 12
+  });
+
+  const result = renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [
+      {
+        event_type: "subject_parent_added",
+        subject_id: "subject-2",
+        created_at: "2026-01-03T00:00:00.000Z",
+        payload: { counterpart_subject_id: "subject-3" }
+      }
+    ],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 40,
+    viewportWidth: 300,
+    viewportHeight: 20,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  assert.equal(result.rowStart, 2);
+  assert.equal(result.rowEnd, 3);
+  assert.equal(result.visibleRows, 2);
+
+  const segments = queryByClass(itemsRoot, "situation-trajectory__segment");
+  assert.equal(segments.length, 2);
+  assert.deepEqual(
+    [...new Set(segments.map((node) => node.dataset.trajectorySubjectId))].sort(),
+    ["subject-2", "subject-3"]
+  );
+
+  const points = queryByClass(itemsRoot, "situation-trajectory__point");
+  assert.equal(points.length, 2);
+  assert.ok(points.every((node) => !!node.dataset.openSituationSubject));
+
+  const markers = queryByClass(itemsRoot, "situation-trajectory__marker");
+  assert.equal(markers.length, 2);
+
+  const todayLines = queryByClass(svg, "situation-trajectory__svg-line--today");
+  assert.equal(todayLines.length, 1);
+
+  const hierarchyLinks = queryByClass(svg, "situation-trajectory__hierarchy-link");
+  assert.ok(hierarchyLinks.length >= 1);
+
+  globalThis.document = originalDocument;
+  Date.now = originalNow;
+});
+
+test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
+  const {
+    buildHierarchyLinks,
+    resolvePointIcon,
+    collectObjectiveVerticalTimestamps
+  } = __trajectoryDomRendererTestUtils();
+
+  assert.equal(typeof buildHierarchyLinks, "function");
+  assert.equal(typeof resolvePointIcon, "function");
+  assert.equal(typeof collectObjectiveVerticalTimestamps, "function");
+
+  assert.equal(resolvePointIcon({ source: "subject_reopened", status: "open" }, { status: "closed" }), "reopen");
+
+  const timestamps = collectObjectiveVerticalTimestamps([
+    { objectiveMarkers: [{ at: "2026-01-05T00:00:00.000Z" }, { at: "2026-01-05T00:00:00.000Z" }] },
+    { objectiveMarkers: [{ at: "2026-01-07T00:00:00.000Z" }] }
+  ]);
+  assert.equal(timestamps.length, 2);
+
+  const links = buildHierarchyLinks([
+    {
+      event_type: "subject_parent_added",
+      subject_id: "child-1",
+      created_at: "2026-01-03T00:00:00.000Z",
+      payload: { counterpart_subject_id: "parent-1" }
+    },
+    {
+      event_type: "subject_child_added",
+      subject_id: "parent-1",
+      created_at: "2026-01-03T00:00:00.000Z",
+      payload: { counterpart_subject_id: "child-1" }
+    }
+  ]);
+  assert.equal(links.length, 1);
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10289,14 +10289,196 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   min-height:360px;
 }
 
-.situation-trajectory__canvas{
-  display:block;
+.situation-trajectory__scene{
   position:absolute;
   top:0;
   left:0;
-  width:100%;
+  width:var(--situation-trajectory-scene-width, 100%);
+  height:var(--situation-trajectory-scene-height, 360px);
   min-height:360px;
+}
+
+.situation-trajectory__svg{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
   pointer-events:none;
+}
+
+.situation-trajectory__items{
+  position:absolute;
+  inset:0;
+}
+
+.situation-trajectory__segment,
+.situation-trajectory__point,
+.situation-trajectory__marker{
+  position:absolute;
+  transform:translate(-50%, -50%);
+}
+
+.situation-trajectory__segment{
+  height:4px;
+  border-radius:999px;
+  background:var(--fgColor-muted, #8b949e);
+  opacity:.95;
+  pointer-events:auto;
+  cursor:pointer;
+}
+
+.situation-trajectory__segment--green{
+  background:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--red{
+  background:rgb(207, 34, 46);
+}
+
+.situation-trajectory__segment--gray{
+  background:rgb(99, 110, 123);
+}
+
+.situation-trajectory__segment--dashed{
+  background:transparent;
+  border-top:2px dashed rgb(99, 110, 123);
+  border-radius:0;
+  height:0;
+}
+
+.situation-trajectory__point,
+.situation-trajectory__marker{
+  width:14px;
+  height:14px;
+  appearance:none;
+  border:none;
+  padding:0;
+  border-radius:999px;
+  background:transparent;
+  color:var(--fgColor-muted, #8b949e);
+  cursor:pointer;
+  pointer-events:auto;
+}
+
+.situation-trajectory__point::before,
+.situation-trajectory__marker::before,
+.situation-trajectory__point::after,
+.situation-trajectory__marker::after{
+  content:"";
+  position:absolute;
+  inset:0;
+}
+
+.situation-trajectory__point::before{
+  inset:2px;
+  border-radius:999px;
+  background:rgb(139, 148, 158);
+}
+
+.situation-trajectory__marker::before,
+.situation-trajectory__marker::after{
+  border-top:2px solid rgb(248, 81, 73);
+  top:6px;
+}
+
+.situation-trajectory__marker::before{ transform:rotate(45deg); }
+.situation-trajectory__marker::after{ transform:rotate(-45deg); }
+
+.situation-trajectory__point:hover,
+.situation-trajectory__point:focus-visible,
+.situation-trajectory__marker:hover,
+.situation-trajectory__marker:focus-visible,
+.situation-trajectory__segment:hover,
+.situation-trajectory__segment:focus-visible{
+  filter:brightness(1.15);
+  outline:none;
+}
+
+.situation-trajectory__point--open::before{
+  inset:2px;
+  border-radius:999px;
+  background:rgb(35, 134, 54);
+}
+
+.situation-trajectory__point--close::before{
+  inset:2px;
+  border-radius:999px;
+  border:2px solid rgb(139, 148, 158);
+  background:rgb(22, 27, 34);
+}
+
+.situation-trajectory__point--reopen::before{
+  inset:1px;
+  border-radius:999px;
+  border:2px solid rgb(63, 185, 80);
+  border-right-color:transparent;
+  transform:rotate(30deg);
+}
+
+.situation-trajectory__point--reject::before,
+.situation-trajectory__marker--cross::before,
+.situation-trajectory__marker--cross::after{
+  inset:2px;
+  background:transparent;
+}
+
+.situation-trajectory__point--reject::before,
+.situation-trajectory__marker--cross::before{
+  border-top:2px solid rgb(248, 81, 73);
+  transform:rotate(45deg);
+  top:6px;
+}
+
+.situation-trajectory__point--reject::after,
+.situation-trajectory__marker--cross::after{
+  border-top:2px solid rgb(248, 81, 73);
+  transform:rotate(-45deg);
+  top:6px;
+}
+
+.situation-trajectory__marker--check::before{
+  width:4px;
+  height:8px;
+  border-right:2px solid rgb(63, 185, 80);
+  border-bottom:2px solid rgb(63, 185, 80);
+  transform:rotate(45deg);
+  left:4px;
+  top:1px;
+}
+
+.situation-trajectory__svg-line{
+  stroke:rgb(99, 110, 123);
+  stroke-width:1;
+  vector-effect:non-scaling-stroke;
+}
+
+.situation-trajectory__svg-line--today{
+  stroke:rgb(31, 111, 235);
+  stroke-width:2;
+}
+
+.situation-trajectory__svg-line--objective{
+  stroke:rgb(248, 81, 73);
+  stroke-dasharray:4 4;
+  opacity:.7;
+}
+
+.situation-trajectory__hierarchy-link{
+  fill:none;
+  stroke:rgb(139, 148, 158);
+  stroke-width:1.5;
+  vector-effect:non-scaling-stroke;
+}
+
+.situation-trajectory__hierarchy-link.is-removed{
+  stroke-dasharray:4 4;
+}
+
+.situation-trajectory__hierarchy-link[points],
+polygon.situation-trajectory__hierarchy-link,
+circle.situation-trajectory__hierarchy-link{
+  fill:rgb(139, 148, 158);
+  stroke:none;
 }
 
 .situation-trajectory__spinner{
@@ -10371,6 +10553,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   right:-4px;
   bottom:0;
   width:8px;
+  appearance:none;
   border:none;
   padding:0;
   margin:0;
@@ -10446,6 +10629,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   right:-5px;
   width:10px;
   height:100%;
+  appearance:none;
   border:none;
   padding:0;
   margin:0;
@@ -10484,6 +10668,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   right:-6px;
   width:10px;
   height:100%;
+  appearance:none;
   border:none;
   padding:0;
   margin:0;
@@ -12218,6 +12403,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .arkolia-identity-preview__textarea{
   min-height:120px;
   resize:vertical;
+  appearance:none;
   border:none;
   padding:0;
   background:transparent;


### PR DESCRIPTION
### Motivation

- Replace the previous canvas-based trajectory renderer with a DOM+SVG implementation to improve interactivity, accessibility, and easier composition of timeline visuals. 
- Cache and ensure trajectory history per situation to avoid redundant network requests when rendering roadmap views and subject selections.

### Description

- Add a new DOM+SVG trajectory renderer in `trajectory/trajectory-dom-renderer.js` that draws timeline lines, points, markers, and hierarchy links into an SVG layer and places interactive items into a DOM layer. 
- Swap the runtime import to load `trajectory-dom-renderer.js` instead of the canvas renderer and update binding logic from `bindTrajectoryCanvas` to `bindTrajectoryDom` in `project-situations` event bindings. 
- Update the roadmap view markup in `project-situations-view-roadmap.js` to replace the `<canvas>` with a scene container including an SVG (`data-situation-trajectory-svg`) and an items root (`data-situation-trajectory-items`), and adapt sizing attributes. 
- Introduce UI/CSS rules in `style.css` to support the scene, SVG, item positioning, segment/point/marker styles, and hierarchy link visuals. 
- Add `ensureTrajectoryHistory`, `normalizeId`, and `normalizeSubjectIdsFromSelection` helpers in `project-situations.js` and wire `ensureTrajectoryHistory` into persistence so roadmap layout loads cached or fetched history via `loadProjectSituationsTrajectoryHistory`. 
- Add a click handler to open subject drilldowns from trajectory DOM elements by listening for `data-open-situation-subject` triggers. 
- Provide small layout/virtualization adjustments such as computing `totalWidth`, `contentHeight`, and scene CSS variables so the virtualizer and renderer share consistent sizes. 

### Testing

- Added unit tests `apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs` that exercise rendering logic, utilities, and a mock DOM to verify visible rows, segments, points, markers, today line and hierarchy links. 
- Ran the new test with `node --test apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs` and the test passed. 
- No existing automated tests related to situations/trajectory were reported failing after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef640b8bdc83299c6cc32955ddc1fc)