### PR TITLE
Fix trajectory timeline alignment and viewport anchor behavior

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -556,6 +556,15 @@ export function createProjectSituationsEvents({
     trajectoryNode.style.setProperty("--situation-trajectory-left-width", `${normalizeTrajectoryColumnWidth(width)}px`);
   }
 
+  function syncTrajectoryHorizontalOffset(trajectoryNode) {
+    if (!trajectoryNode) return;
+    const viewportNode = trajectoryNode.querySelector("[data-situation-trajectory-viewport]")
+      || trajectoryNode.querySelector(".situation-trajectory__viewport");
+    const timelineContentNode = trajectoryNode.querySelector("[data-situation-trajectory-timeline-content]");
+    if (!viewportNode || !timelineContentNode) return;
+    timelineContentNode.style.transform = `translate3d(${-Math.max(0, Number(viewportNode.scrollLeft) || 0)}px,0,0)`;
+  }
+
   function hydrateTrajectoryColumnWidth(root) {
     root.querySelectorAll("[data-situation-trajectory][data-situation-id]").forEach((trajectoryNode) => {
       const situationId = String(trajectoryNode.getAttribute("data-situation-id") || "").trim();
@@ -566,6 +575,7 @@ export function createProjectSituationsEvents({
       const nextWidth = normalizeTrajectoryColumnWidth(fromStore ?? fromStorage);
       widthsBySituationId[situationId] = nextWidth;
       applyTrajectoryColumnWidth(trajectoryNode, nextWidth);
+      syncTrajectoryHorizontalOffset(trajectoryNode);
     });
   }
 
@@ -592,6 +602,7 @@ export function createProjectSituationsEvents({
           const nextWidth = normalizeTrajectoryColumnWidth(initialWidth + (pointerX - startX));
           widthsBySituationId[situationId] = nextWidth;
           applyTrajectoryColumnWidth(trajectoryNode, nextWidth);
+          syncTrajectoryHorizontalOffset(trajectoryNode);
         };
 
         const onPointerUp = () => {
@@ -600,6 +611,7 @@ export function createProjectSituationsEvents({
           window.removeEventListener("pointercancel", onPointerUp);
           trajectoryNode.classList.remove("is-resizing-left");
           persistTrajectoryColumnWidth(situationId, widthsBySituationId[situationId]);
+          syncTrajectoryHorizontalOffset(trajectoryNode);
         };
 
         event.preventDefault();
@@ -644,6 +656,14 @@ export function createProjectSituationsEvents({
     return Object.values(eventsBySubjectId)
       .flatMap((events) => (Array.isArray(events) ? events : []))
       .filter((event) => relationTypes.has(String(event?.event_type || "").trim().toLowerCase()));
+  }
+
+  function resolveTrajectorySituationStartDate(situationId = "") {
+    const normalizedSituationId = String(situationId || "").trim();
+    if (!normalizedSituationId) return null;
+    const situations = Array.isArray(store?.situationsView?.data) ? store.situationsView.data : [];
+    const currentSituation = situations.find((entry) => String(entry?.id || "").trim() === normalizedSituationId) || null;
+    return currentSituation?.created_at || null;
   }
 
   function resolveTrajectoryProjectStartDate() {
@@ -759,8 +779,10 @@ export function createProjectSituationsEvents({
           const objectivesById = rawSubjectsResult.objectivesById || {};
           const historyBySubjectId = resolveTrajectoryHistoryBySubjectId(situationId);
           const relationEvents = resolveTrajectoryRelationEvents(situationId);
+          const situationStartDate = resolveTrajectorySituationStartDate(situationId);
 
-          const projectStartDate = resolveTrajectoryProjectStartDate()
+          const effectiveTimelineAnchorDate = situationStartDate
+            || resolveTrajectoryProjectStartDate()
             || subjects.reduce((acc, subject) => {
               const createdAt = subject?.created_at ? new Date(subject.created_at) : null;
               if (!createdAt || Number.isNaN(createdAt.getTime())) return acc;
@@ -769,8 +791,11 @@ export function createProjectSituationsEvents({
             }, null)
             || new Date();
 
+          const timelineStartDate = new Date(effectiveTimelineAnchorDate);
+          timelineStartDate.setUTCMonth(timelineStartDate.getUTCMonth() - 1);
+
           const timeScale = createTrajectoryTimeScale({
-            startDate: projectStartDate,
+            startDate: timelineStartDate,
             endDate: resolveTrajectoryTimelineEndDate(),
             zoom: "day"
           });
@@ -780,7 +805,7 @@ export function createProjectSituationsEvents({
             subjectHistoryEvents: historyBySubjectId,
             objectivesById,
             objectiveIdsBySubjectId,
-            projectStartDate,
+            projectStartDate: effectiveTimelineAnchorDate,
             today: new Date()
           });
 
@@ -848,6 +873,13 @@ export function createProjectSituationsEvents({
           if (!viewportNode.dataset.trajectoryDomBound) {
             viewportNode.dataset.trajectoryDomBound = "true";
             viewportNode.addEventListener("scroll", scheduleRender, { passive: true });
+          }
+
+          const initialAnchorDate = new Date(effectiveTimelineAnchorDate);
+          if (Number.isFinite(initialAnchorDate.getTime()) && !viewportNode.dataset.trajectoryInitialAnchorApplied) {
+            const initialScrollLeft = Math.max(0, Math.round(timeScale.timeToX(initialAnchorDate)));
+            viewportNode.scrollLeft = initialScrollLeft;
+            viewportNode.dataset.trajectoryInitialAnchorApplied = "true";
           }
 
           scheduleRender();

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10174,11 +10174,15 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   position:relative;
   min-height:64px;
   overflow:hidden;
+  padding-left:var(--situation-trajectory-left-width);
 }
 
 .situation-trajectory__timeline-content{
   position:absolute;
-  inset:0;
+  top:0;
+  right:0;
+  bottom:0;
+  left:var(--situation-trajectory-left-width);
   will-change:transform;
   pointer-events:none;
 }


### PR DESCRIPTION
### Motivation
- Corriger le décalage visuel entre la colonne « sujets » et la timeline lors du chargement et après redimensionnement de la colonne, et permettre de scroller vers la gauche depuis la date de création de la situation plutôt que depuis le début du projet.

### Description
- Décalage CSS : la piste timeline commence après la largeur de la colonne sujets en utilisant `--situation-trajectory-left-width` pour aligner la timeline et le viewport (modification de `apps/web/style.css`).
- Synchronisation runtime : ajout de `syncTrajectoryHorizontalOffset` pour garder `timelineContent` transformé en accord avec `viewport.scrollLeft` lors de l'hydratation et pendant le drag du splitter (modification de `apps/web/js/views/project-situations/project-situations-events.js`).
- Ancrage temporel : nouvel utilitaire `resolveTrajectorySituationStartDate` et sélection d'une `effectiveTimelineAnchorDate` qui privilégie la `created_at` de la situation (fallbacks projet/sujets conservés), puis décalage d'1 mois en arrière pour le `timeScale` afin d'autoriser le scroll gauche.
- Initialisation du viewport : au premier rendu, le `scrollLeft` du viewport est positionné sur la date d'ancrage calculée pour que l'ouverture de la roadmap affiche la période autour de la situation sélectionnée.

### Testing
- Lancer les tests unitaires ciblés avec `node --test apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs` et tous les cas sont passés (`8` tests, `0` fails).
- Les changements visuels / comportementaux ont été conçus pour être no-op en l'absence d'éléments DOM concernés et conservent les anciens fallbacks si les dates manquent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef706f6f80832998bb704e8e5bcfb4)