### PR TITLE
Show project creation date and improve trajectory timeline (sync, offsets, icons)

### DIFF
--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -393,19 +393,31 @@ export async function resolveCurrentBackendProjectId(options = {}) {
   return backendProjectId;
 }
 
-function applyProjectIdentityLocally({ frontendProjectId = getFrontendProjectKey(), backendProjectId = "", name = "" } = {}) {
+function applyProjectIdentityLocally({
+  frontendProjectId = getFrontendProjectKey(),
+  backendProjectId = "",
+  name = "",
+  createdAt = null
+} = {}) {
   const nextName = safeString(name);
   const frontendKey = safeString(frontendProjectId);
+  const nextCreatedAt = safeString(createdAt);
 
   let changed = false;
 
-  if (nextName && frontendKey) {
+  if ((nextName || nextCreatedAt) && frontendKey) {
     const currentList = Array.isArray(store.projects) ? store.projects : [];
     const nextProjects = currentList.map((project) => {
       if (safeString(project?.id) !== frontendKey) return project;
-      if (safeString(project?.name) === nextName) return project;
+      const sameName = !nextName || safeString(project?.name) === nextName;
+      const sameCreatedAt = !nextCreatedAt || safeString(project?.createdAt || project?.created_at) === nextCreatedAt;
+      if (sameName && sameCreatedAt) return project;
       changed = true;
-      return { ...project, name: nextName };
+      return {
+        ...project,
+        ...(nextName ? { name: nextName } : {}),
+        ...(nextCreatedAt ? { createdAt: nextCreatedAt, created_at: nextCreatedAt } : {})
+      };
     });
     store.projects = nextProjects;
   }
@@ -415,8 +427,14 @@ function applyProjectIdentityLocally({ frontendProjectId = getFrontendProjectKey
       ? store.currentProject
       : { id: frontendKey };
 
-    if (nextName && safeString(currentProject.name) !== nextName) {
-      store.currentProject = { ...currentProject, name: nextName };
+    const currentProjectCreatedAt = safeString(currentProject?.created_at || currentProject?.createdAt);
+    if ((nextName && safeString(currentProject.name) !== nextName)
+      || (nextCreatedAt && currentProjectCreatedAt !== nextCreatedAt)) {
+      store.currentProject = {
+        ...currentProject,
+        ...(nextName ? { name: nextName } : {}),
+        ...(nextCreatedAt ? { created_at: nextCreatedAt, createdAt: nextCreatedAt } : {})
+      };
       changed = true;
     } else if (!store.currentProject) {
       store.currentProject = currentProject;
@@ -425,6 +443,15 @@ function applyProjectIdentityLocally({ frontendProjectId = getFrontendProjectKey
     if (nextName && safeString(store.projectForm?.projectName) !== nextName) {
       store.projectForm.projectName = nextName;
       changed = true;
+    }
+    if (nextCreatedAt) {
+      if (!store.projectForm.project || typeof store.projectForm.project !== "object") {
+        store.projectForm.project = {};
+      }
+      if (safeString(store.projectForm.project.created_at) !== nextCreatedAt) {
+        store.projectForm.project.created_at = nextCreatedAt;
+        changed = true;
+      }
     }
   }
 
@@ -575,7 +602,7 @@ export async function syncCurrentProjectIdentityFromSupabase(options = {}) {
   if (!backendProjectId) return null;
 
   const params = new URLSearchParams();
-  params.set("select", "id,name");
+  params.set("select", "id,name,created_at");
   params.set("id", `eq.${backendProjectId}`);
   params.set("limit", "1");
 
@@ -586,14 +613,16 @@ export async function syncCurrentProjectIdentityFromSupabase(options = {}) {
   const changed = applyProjectIdentityLocally({
     frontendProjectId: getFrontendProjectKey(),
     backendProjectId,
-    name: row.name
+    name: row.name,
+    createdAt: row.created_at || null
   });
 
   if (changed) {
     dispatchProjectIdentityUpdated({
       section: "project",
       backendProjectId,
-      projectName: safeString(row.name)
+      projectName: safeString(row.name),
+      createdAt: row.created_at || null
     });
   }
 

--- a/apps/web/js/views/project-parametres/project-parametres-general.js
+++ b/apps/web/js/views/project-parametres/project-parametres-general.js
@@ -2,7 +2,10 @@ import { store } from "../../store.js";
 import { PROJECT_TAB_IDS } from "../../constants.js";
 import { escapeHtml } from "../../utils/escape-html.js";
 import { bindGhEditableFields } from "../ui/gh-input.js";
-import { persistCurrentProjectNameToSupabase } from "../../services/project-supabase-sync.js";
+import {
+  persistCurrentProjectNameToSupabase,
+  syncCurrentProjectIdentityFromSupabase
+} from "../../services/project-supabase-sync.js";
 import {
   renderSettingsBlock,
   renderSectionCard,
@@ -53,8 +56,29 @@ function renderProjectTabsFeatureCard(projectTabs) {
   `;
 }
 
+function resolveProjectCreatedAt() {
+  return store?.currentProject?.created_at
+    || store?.projectForm?.project?.created_at
+    || store?.projectForm?.created_at
+    || null;
+}
+
+function formatProjectCreatedAt(createdAtValue) {
+  const createdAt = new Date(createdAtValue || "");
+  if (Number.isNaN(createdAt.getTime())) return "Date inconnue";
+  return createdAt.toLocaleString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC"
+  }).replace(",", " ·");
+}
+
 export function renderGeneralParametresContent() {
   const form = store.projectForm;
+  const projectCreatedAt = formatProjectCreatedAt(resolveProjectCreatedAt());
 
   return `${renderSettingsBlock({
     id: "parametres-general",
@@ -68,6 +92,10 @@ export function renderGeneralParametresContent() {
         description: "Description",
         body: `<div class="settings-form-grid settings-form-grid--thirds">
           ${renderInputField({ id: "projectName", label: "Nom de projet", value: form.projectName || "", placeholder: "Projet demo" })}
+          <div class="project-general-created-at">
+            <div class="gh-editable-field__label">Date de création du projet</div>
+            <div class="project-general-created-at__value">${escapeHtml(projectCreatedAt)}</div>
+          </div>
         </div>`
       }),
       renderSectionCard({
@@ -81,6 +109,12 @@ export function renderGeneralParametresContent() {
 
 export function bindGeneralParametresSection(root) {
   bindBaseParametresUi();
+
+  if (!resolveProjectCreatedAt()) {
+    syncCurrentProjectIdentityFromSupabase().catch((error) => {
+      console.warn("syncCurrentProjectIdentityFromSupabase failed", error);
+    });
+  }
 
   bindGhEditableFields(document, {
     onValidate: async (id, value) => {

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -556,6 +556,15 @@ export function createProjectSituationsEvents({
     trajectoryNode.style.setProperty("--situation-trajectory-left-width", `${normalizeTrajectoryColumnWidth(width)}px`);
   }
 
+  function syncTrajectoryHorizontalOffset(trajectoryNode) {
+    if (!trajectoryNode) return;
+    const viewportNode = trajectoryNode.querySelector("[data-situation-trajectory-viewport]")
+      || trajectoryNode.querySelector(".situation-trajectory__viewport");
+    const timelineContentNode = trajectoryNode.querySelector("[data-situation-trajectory-timeline-content]");
+    if (!viewportNode || !timelineContentNode) return;
+    timelineContentNode.style.transform = `translate3d(${-Math.max(0, Number(viewportNode.scrollLeft) || 0)}px,0,0)`;
+  }
+
   function hydrateTrajectoryColumnWidth(root) {
     root.querySelectorAll("[data-situation-trajectory][data-situation-id]").forEach((trajectoryNode) => {
       const situationId = String(trajectoryNode.getAttribute("data-situation-id") || "").trim();
@@ -566,6 +575,7 @@ export function createProjectSituationsEvents({
       const nextWidth = normalizeTrajectoryColumnWidth(fromStore ?? fromStorage);
       widthsBySituationId[situationId] = nextWidth;
       applyTrajectoryColumnWidth(trajectoryNode, nextWidth);
+      syncTrajectoryHorizontalOffset(trajectoryNode);
     });
   }
 
@@ -592,6 +602,7 @@ export function createProjectSituationsEvents({
           const nextWidth = normalizeTrajectoryColumnWidth(initialWidth + (pointerX - startX));
           widthsBySituationId[situationId] = nextWidth;
           applyTrajectoryColumnWidth(trajectoryNode, nextWidth);
+          syncTrajectoryHorizontalOffset(trajectoryNode);
         };
 
         const onPointerUp = () => {
@@ -600,6 +611,7 @@ export function createProjectSituationsEvents({
           window.removeEventListener("pointercancel", onPointerUp);
           trajectoryNode.classList.remove("is-resizing-left");
           persistTrajectoryColumnWidth(situationId, widthsBySituationId[situationId]);
+          syncTrajectoryHorizontalOffset(trajectoryNode);
         };
 
         event.preventDefault();
@@ -644,6 +656,14 @@ export function createProjectSituationsEvents({
     return Object.values(eventsBySubjectId)
       .flatMap((events) => (Array.isArray(events) ? events : []))
       .filter((event) => relationTypes.has(String(event?.event_type || "").trim().toLowerCase()));
+  }
+
+  function resolveTrajectorySituationStartDate(situationId = "") {
+    const normalizedSituationId = String(situationId || "").trim();
+    if (!normalizedSituationId) return null;
+    const situations = Array.isArray(store?.situationsView?.data) ? store.situationsView.data : [];
+    const currentSituation = situations.find((entry) => String(entry?.id || "").trim() === normalizedSituationId) || null;
+    return currentSituation?.created_at || null;
   }
 
   function resolveTrajectoryProjectStartDate() {
@@ -759,8 +779,10 @@ export function createProjectSituationsEvents({
           const objectivesById = rawSubjectsResult.objectivesById || {};
           const historyBySubjectId = resolveTrajectoryHistoryBySubjectId(situationId);
           const relationEvents = resolveTrajectoryRelationEvents(situationId);
+          const situationStartDate = resolveTrajectorySituationStartDate(situationId);
 
-          const projectStartDate = resolveTrajectoryProjectStartDate()
+          const effectiveTimelineAnchorDate = situationStartDate
+            || resolveTrajectoryProjectStartDate()
             || subjects.reduce((acc, subject) => {
               const createdAt = subject?.created_at ? new Date(subject.created_at) : null;
               if (!createdAt || Number.isNaN(createdAt.getTime())) return acc;
@@ -769,8 +791,11 @@ export function createProjectSituationsEvents({
             }, null)
             || new Date();
 
+          const timelineStartDate = new Date(effectiveTimelineAnchorDate);
+          timelineStartDate.setUTCMonth(timelineStartDate.getUTCMonth() - 1);
+
           const timeScale = createTrajectoryTimeScale({
-            startDate: projectStartDate,
+            startDate: timelineStartDate,
             endDate: resolveTrajectoryTimelineEndDate(),
             zoom: "day"
           });
@@ -780,7 +805,7 @@ export function createProjectSituationsEvents({
             subjectHistoryEvents: historyBySubjectId,
             objectivesById,
             objectiveIdsBySubjectId,
-            projectStartDate,
+            projectStartDate: effectiveTimelineAnchorDate,
             today: new Date()
           });
 
@@ -848,6 +873,13 @@ export function createProjectSituationsEvents({
           if (!viewportNode.dataset.trajectoryDomBound) {
             viewportNode.dataset.trajectoryDomBound = "true";
             viewportNode.addEventListener("scroll", scheduleRender, { passive: true });
+          }
+
+          const initialAnchorDate = new Date(effectiveTimelineAnchorDate);
+          if (Number.isFinite(initialAnchorDate.getTime()) && !viewportNode.dataset.trajectoryInitialAnchorApplied) {
+            const initialScrollLeft = Math.max(0, Math.round(timeScale.timeToX(initialAnchorDate)));
+            viewportNode.scrollLeft = initialScrollLeft;
+            viewportNode.dataset.trajectoryInitialAnchorApplied = "true";
           }
 
           scheduleRender();

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -1,4 +1,5 @@
 import { getTrajectoryVisibleWindow } from "./trajectory-virtualizer.js";
+import { svgIcon } from "../../../ui/icons.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 const HIERARCHY_EVENT_TYPES = new Set([
@@ -63,6 +64,12 @@ function resolvePointIcon(point = {}, previousPoint = null) {
   if (["closed", "closed_duplicate", "duplicate"].includes(status)) return "close";
   if (previousPoint && String(previousPoint?.status || "").trim().toLowerCase() !== "open") return "reopen";
   return "open";
+}
+
+function resolvePointSymbol(pointType = "open") {
+  if (pointType === "close") return "check-circle";
+  if (pointType === "reject") return "skip";
+  return "issue-opened";
 }
 
 function normalizeId(value) {
@@ -318,6 +325,7 @@ export function renderTrajectoryDom({
       const pointType = resolvePointIcon(point, statusPoints[pointIndex - 1] || null);
       pointNode.classList.add(`situation-trajectory__point--${pointType}`);
       pointNode.dataset.trajectoryPointType = pointType;
+      pointNode.innerHTML = `<span class="situation-trajectory__point-icon" aria-hidden="true">${svgIcon(resolvePointSymbol(pointType), { className: "octicon", width: 16, height: 16 })}</span>`;
       if (subjectId) {
         pointNode.dataset.trajectorySubjectId = subjectId;
         pointNode.dataset.openSituationSubject = subjectId;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10174,11 +10174,15 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   position:relative;
   min-height:64px;
   overflow:hidden;
+  padding-left:var(--situation-trajectory-left-width);
 }
 
 .situation-trajectory__timeline-content{
   position:absolute;
-  inset:0;
+  top:0;
+  right:0;
+  bottom:0;
+  left:var(--situation-trajectory-left-width);
   will-change:transform;
   pointer-events:none;
 }
@@ -10348,8 +10352,8 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__point,
 .situation-trajectory__marker{
-  width:14px;
-  height:14px;
+  width:20px;
+  height:20px;
   appearance:none;
   border:none;
   padding:0;
@@ -10360,19 +10364,28 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   pointer-events:auto;
 }
 
-.situation-trajectory__point::before,
 .situation-trajectory__marker::before,
-.situation-trajectory__point::after,
 .situation-trajectory__marker::after{
   content:"";
   position:absolute;
   inset:0;
 }
 
-.situation-trajectory__point::before{
-  inset:2px;
+.situation-trajectory__point{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.situation-trajectory__point-icon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:20px;
+  height:20px;
   border-radius:999px;
-  background:rgb(139, 148, 158);
+  background:rgb(21, 27, 35);
+  color:var(--fgColor-muted, #8b949e);
 }
 
 .situation-trajectory__marker::before,
@@ -10394,42 +10407,34 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   outline:none;
 }
 
-.situation-trajectory__point--open::before{
-  inset:2px;
-  border-radius:999px;
-  background:rgb(35, 134, 54);
+.situation-trajectory__point--open .situation-trajectory__point-icon{
+  color:var(--fgColor-open, rgb(63, 185, 80));
 }
 
-.situation-trajectory__point--close::before{
-  inset:2px;
-  border-radius:999px;
-  border:2px solid rgb(139, 148, 158);
-  background:rgb(22, 27, 34);
+.situation-trajectory__point--close .situation-trajectory__point-icon{
+  color:var(----fgColor-closed, var(--fgColor-closed, rgb(139, 148, 158)));
 }
 
-.situation-trajectory__point--reopen::before{
-  inset:1px;
-  border-radius:999px;
-  border:2px solid rgb(63, 185, 80);
-  border-right-color:transparent;
-  transform:rotate(30deg);
+.situation-trajectory__point--reopen .situation-trajectory__point-icon{
+  color:rgb(63, 185, 80);
 }
 
-.situation-trajectory__point--reject::before,
+.situation-trajectory__point--reject .situation-trajectory__point-icon{
+  color:var(--project-tabs-icon-color, rgb(248, 81, 73));
+}
+
 .situation-trajectory__marker--cross::before,
 .situation-trajectory__marker--cross::after{
   inset:2px;
   background:transparent;
 }
 
-.situation-trajectory__point--reject::before,
 .situation-trajectory__marker--cross::before{
   border-top:2px solid rgb(248, 81, 73);
   transform:rotate(45deg);
   top:6px;
 }
 
-.situation-trajectory__point--reject::after,
 .situation-trajectory__marker--cross::after{
   border-top:2px solid rgb(248, 81, 73);
   transform:rotate(-45deg);
@@ -12530,6 +12535,16 @@ circle.situation-trajectory__hierarchy-link{
 }
 
 .gh-editable-field__label{font-size:13px;color:var(--muted);font-weight:600;}
+.project-general-created-at{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.project-general-created-at__value{
+  font-size:14px;
+  font-weight:600;
+  color:var(--muted);
+}
 
 .arkolia-result-layout{
   display:grid;


### PR DESCRIPTION
### Motivation
- Surface the project's `created_at` timestamp in the General settings and ensure the frontend store stays in sync with Supabase for that field.
- Improve the situation trajectory timeline UX by anchoring the timeline around meaningful start dates and keeping the timeline content horizontally aligned with the left column when column width changes.
- Add visual point icons to trajectory status points and make the timeline layout more robust to resizing and initial anchoring.

### Description
- Update `applyProjectIdentityLocally` in `project-supabase-sync.js` to accept a `createdAt` argument and propagate `created_at`/`createdAt` into `store.projects`, `store.currentProject` and `store.projectForm.project`, and persist frontend-to-backend id mappings where applicable.
- Change `syncCurrentProjectIdentityFromSupabase` to select `created_at` from Supabase and pass it through to `applyProjectIdentityLocally` and the dispatched `PROJECT_IDENTITY_UPDATED_EVENT` detail.
- In `project-parametres-general.js` add `resolveProjectCreatedAt` and `formatProjectCreatedAt`, render the creation date in the General settings UI, and trigger `syncCurrentProjectIdentityFromSupabase` when the creation date is not yet available in the store.
- In scenario/trajectory code (`project-situations`): add `resolveTrajectorySituationStartDate`, compute an `effectiveTimelineAnchorDate` (preferring situation start date, then project start, then subject dates), set `timelineStartDate` one month earlier, apply initial scroll-left based on the time scale, and keep timeline content transformed when the left column width changes by adding `syncTrajectoryHorizontalOffset` calls on hydrate, during resize and after resize end.
- In `trajectory-dom-renderer.js` render an SVG icon for each status point using `svgIcon(resolvePointSymbol(...))`, add a small symbol resolver `resolvePointSymbol`, and wire new markup to allow CSS styling.
- Update `style.css` to introduce `--situation-trajectory-left-width` usage, increase point/marker hit sizes, add `.situation-trajectory__point-icon` styling and color classes, and layout adjustments for the timeline content offset.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef706f6f80832998bb704e8e5bcfb4)