### PR TITLE
Trajectoire : point de création toujours open, prise en charge des rejets, couleurs pointillées et rendu liens supprimés

### DIFF
--- a/apps/web/js/services/project-situations-trajectory-service.js
+++ b/apps/web/js/services/project-situations-trajectory-service.js
@@ -7,6 +7,9 @@ const TRAJECTORY_EVENT_TYPES = [
   "subject_created",
   "subject_closed",
   "subject_reopened",
+  "subject_rejected",
+  "review_rejected",
+  "subject_invalidated",
   "subject_parent_added",
   "subject_parent_removed",
   "subject_child_added",
@@ -32,7 +35,10 @@ const RELATION_EVENT_TYPES = new Set([
 const STATUS_EVENT_TYPES = new Set([
   "subject_created",
   "subject_closed",
-  "subject_reopened"
+  "subject_reopened",
+  "subject_rejected",
+  "review_rejected",
+  "subject_invalidated"
 ]);
 
 function normalizeId(value) {

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -159,16 +159,14 @@ function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse 
   );
   path.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
 
-  const markerCircle = !isRemoved
-    ? (() => {
-      const circle = document.createElementNS(SVG_NS, "circle");
-      circle.setAttribute("cx", String(laneStartX));
-      circle.setAttribute("cy", String(startY));
-      circle.setAttribute("r", "2.5");
-      circle.setAttribute("class", "situation-trajectory__hierarchy-link");
-      return circle;
-    })()
-    : null;
+  const markerCircle = (() => {
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("cx", String(laneStartX));
+    circle.setAttribute("cy", String(startY));
+    circle.setAttribute("r", "2.5");
+    circle.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+    return circle;
+  })();
 
   const arrow = document.createElementNS(SVG_NS, "polygon");
   const arrowSize = 4;
@@ -180,7 +178,7 @@ function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse 
       `${laneEndX - arrowSize},${endY + (direction * arrowSize)}`
     ].join(" ")
   );
-  arrow.setAttribute("class", "situation-trajectory__hierarchy-link");
+  arrow.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
 
   return { path, markerCircle, arrow };
 }

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
@@ -239,3 +239,87 @@ test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
   ]);
   assert.equal(links.length, 1);
 });
+
+test("renderTrajectoryDom applique les classes red+dashed et dessine un lien removed enfant -> parent avec circle+arrow", () => {
+  const originalDocument = globalThis.document;
+  const originalNow = Date.now;
+  globalThis.document = createMockDocument();
+  Date.now = () => new Date("2026-01-06T00:00:00.000Z").getTime();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 600;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = [
+    {
+      subjectId: "parent-1",
+      lifecycleSegments: [],
+      statusPoints: [],
+      objectiveMarkers: []
+    },
+    {
+      subjectId: "child-1",
+      lifecycleSegments: [
+        {
+          subjectId: "child-1",
+          status: "closed",
+          startAt: new Date("2026-01-05T00:00:00.000Z"),
+          endAt: new Date("2026-01-07T00:00:00.000Z"),
+          lineColor: "red",
+          lineStyle: "dashed"
+        }
+      ],
+      statusPoints: [],
+      objectiveMarkers: []
+    }
+  ];
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-01-01T00:00:00.000Z",
+    endDate: "2026-01-10T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 12
+  });
+
+  renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [
+      {
+        event_type: "subject_parent_removed",
+        subject_id: "child-1",
+        created_at: "2026-01-06T00:00:00.000Z",
+        payload: { counterpart_subject_id: "parent-1" }
+      }
+    ],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 600,
+    viewportHeight: 200,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  const [redDashedSegment] = queryByClass(itemsRoot, "situation-trajectory__segment--dashed");
+  assert.ok(redDashedSegment);
+  assert.ok(String(redDashedSegment.className).includes("situation-trajectory__segment--red"));
+
+  const removedPaths = queryByClass(svg, "situation-trajectory__hierarchy-link")
+    .filter((node) => node.tagName === "PATH" && String(node.className).includes("is-removed"));
+  const removedCircles = queryByClass(svg, "situation-trajectory__hierarchy-link")
+    .filter((node) => node.tagName === "CIRCLE" && String(node.className).includes("is-removed"));
+  const removedArrows = queryByClass(svg, "situation-trajectory__hierarchy-link")
+    .filter((node) => node.tagName === "POLYGON" && String(node.className).includes("is-removed"));
+
+  assert.equal(removedPaths.length, 1);
+  assert.equal(removedCircles.length, 1);
+  assert.equal(removedArrows.length, 1);
+  assert.equal(removedCircles[0].getAttribute("cy"), "30");
+
+  globalThis.document = originalDocument;
+  Date.now = originalNow;
+});

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -181,7 +181,7 @@ export function buildTrajectoryModel({
       });
     };
 
-    upsertStatusPoint(subjectCreatedTs, createdEvent ? "open" : fallbackStartStatus, createdEvent ? "subject_created" : "subject_fallback_created_at");
+    upsertStatusPoint(subjectCreatedTs, "open", createdEvent ? "subject_created" : "subject_fallback_created_at");
 
     for (const event of events) {
       const ts = event.created_at.getTime();
@@ -191,6 +191,8 @@ export function buildTrajectoryModel({
         upsertStatusPoint(ts, normalizeCloseStatus(event, subject.status), event.event_type);
       } else if (event.event_type === "subject_reopened") {
         upsertStatusPoint(ts, "open", event.event_type);
+      } else if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)) {
+        upsertStatusPoint(ts, "closed_invalid", event.event_type);
       }
     }
 

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -120,3 +120,82 @@ test("normalizeCloseStatus remonte closed_invalid et closed_duplicate depuis le 
   assert.equal(normalizeCloseStatus({ payload: { status: "closed_duplicate" } }), "closed_duplicate");
   assert.equal(normalizeCloseStatus({ payload: {} }), "closed");
 });
+
+test("buildTrajectoryModel crée toujours un premier point open depuis subject.created_at sans subject_created", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-no-created-event",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "closed"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-no-created-event": []
+    },
+    today: "2026-01-02T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.equal(row.statusPoints[0].status, "open");
+  assert.equal(row.statusPoints[0].icon, "open");
+  assert.equal(row.statusPoints[0].source, "subject_fallback_created_at");
+  assert.equal(row.statusPoints[0].at.toISOString(), "2026-01-01T00:00:00.000Z");
+});
+
+test("buildTrajectoryModel rend un segment red dashed après objectif quand le sujet est fermé après objectif", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-after-objective-close",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "closed"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-after-objective-close": [
+        { subject_id: "s-after-objective-close", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-after-objective-close", event_type: "subject_reopened", created_at: "2026-01-07T00:00:00.000Z" },
+        { subject_id: "s-after-objective-close", event_type: "subject_closed", created_at: "2026-01-08T00:00:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    objectivesById: {
+      "o-1": { id: "o-1", due_date: "2026-01-05T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-after-objective-close": ["o-1"]
+    },
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const redDashedSegment = row.lifecycleSegments.find((segment) => segment.startAt.toISOString() === "2026-01-08T00:00:00.000Z");
+  assert.ok(redDashedSegment);
+  assert.equal(redDashedSegment.lineColor, "red");
+  assert.equal(redDashedSegment.lineStyle, "dashed");
+});
+
+test("buildTrajectoryModel mappe les événements de rejet vers closed_invalid/reject", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-reject-event",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-reject-event": [
+        { subject_id: "s-reject-event", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-reject-event", event_type: "subject_rejected", created_at: "2026-01-03T00:00:00.000Z" }
+      ]
+    },
+    today: "2026-01-05T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const rejectPoint = row.statusPoints.find((point) => point.source === "subject_rejected");
+  assert.ok(rejectPoint);
+  assert.equal(rejectPoint.status, "closed_invalid");
+  assert.equal(rejectPoint.icon, "reject");
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10345,9 +10345,21 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__segment--dashed{
   background:transparent;
-  border-top:2px dashed rgb(99, 110, 123);
+  border-top:2px dashed currentColor;
   border-radius:0;
   height:0;
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--green{
+  border-top-color:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--red{
+  border-top-color:rgb(207, 34, 46);
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
+  border-top-color:rgb(99, 110, 123);
 }
 
 .situation-trajectory__point,


### PR DESCRIPTION
### Motivation
- Faire respecter les règles de représentation temporelle: afficher systématiquement une icône `open` à la date de création et ne pas convertir ce point initial en `close`/`reject` via `subject.status`.
- Prendre en charge de façon défensive les événements de rejet pour qu'ils rendent un point `closed_invalid`/icône `reject`.
- Permettre aux segments pointillés de conserver la couleur fournie par le modèle (red/gray/green) au lieu d’imposer toujours du gris.
- Dessiner les liaisons hiérarchiques supprimées avec un cercle de départ et une flèche orientée enfant → parent tout en marquant les éléments concernés pour le style CSS.

### Description
- Dans `apps/web/js/views/project-situations/trajectory/trajectory-model.js` le premier `statusPoint` est forcé à `open` à `subject.created_at` (source `subject_fallback_created_at`) et des événements `subject_rejected`, `review_rejected`, `subject_invalidated` sont mappés vers `closed_invalid`.
- Dans `apps/web/js/services/project-situations-trajectory-service.js` les types d’événements de rejet ont été ajoutés à `TRAJECTORY_EVENT_TYPES` et `STATUS_EVENT_TYPES` pour qu'ils soient récupérés et groupés.
- Dans `apps/web/style.css` la règle `.situation-trajectory__segment--dashed` utilise maintenant `currentColor` et des sélecteurs composés (`.situation-trajectory__segment--dashed.situation-trajectory__segment--red` / `--gray` / `--green`) pour appliquer la bonne couleur pointillée.
- Dans `apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js` la fonction `createHierarchyPath` crée désormais systématiquement un `circle` de départ et applique la classe `is-removed` sur `path`, `circle` et `polygon` lorsque `isRemoved=true` afin de dessiner correctement la liaison supprimée (départ sur l’enfant, flèche vers le parent) sans casser le rendu des liens ajoutés.
- Tests étendus/modifiés dans `apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` et `trajectory-dom-renderer.test.mjs` pour couvrir le fallback `open` initial, segments `red+dashed` post-objectif, mapping des événements de rejet, classes `segment--red segment--dashed` et rendu du lien `removed` avec `path+circle+arrow`.

### Testing
- Exécution des tests unitaires ciblés avec `node --test apps/web/js/views/project-situations/trajectory/*.test.mjs` a été réalisée.
- Tous les tests locaux relatifs à la trajectoire sont passés avec succès (tous les sous-tests verts dans la suite exécutée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef79c014308329a2992ffa05369e18)