### PR TITLE
Support reject/blocked events in trajectory model and renderer; add blocked indicator and improve hierarchy SVG/segments

### DIFF
--- a/apps/web/js/services/project-situations-trajectory-service.js
+++ b/apps/web/js/services/project-situations-trajectory-service.js
@@ -7,6 +7,9 @@ const TRAJECTORY_EVENT_TYPES = [
   "subject_created",
   "subject_closed",
   "subject_reopened",
+  "subject_rejected",
+  "review_rejected",
+  "subject_invalidated",
   "subject_parent_added",
   "subject_parent_removed",
   "subject_child_added",
@@ -32,7 +35,11 @@ const RELATION_EVENT_TYPES = new Set([
 const STATUS_EVENT_TYPES = new Set([
   "subject_created",
   "subject_closed",
-  "subject_reopened"
+  "subject_reopened",
+  "subject_rejected",
+  "review_rejected",
+  "subject_invalidated",
+  "subject_blocked_by_added"
 ]);
 
 function normalizeId(value) {

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -87,7 +87,22 @@ function formatPointEventLabel(point = {}) {
   if (source === "subject_created") return "création";
   if (source === "subject_closed") return "fermeture";
   if (source === "subject_reopened") return "réouverture";
+  if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(source)) return "rejet";
+  if (source === "subject_blocked_by_added") return "blocage entrant";
   return source || "mise à jour";
+}
+
+function renderPointIconHtml(pointType = "open", point = {}) {
+  const symbol = resolvePointSymbol(pointType);
+  const colorStyle = pointType === "close"
+    ? "var(--fgColor-done)"
+    : (pointType === "reject" ? "var(--project-tabs-icon-color, rgb(248, 81, 73))" : "var(--fgColor-open)");
+  const blockedIconHtml = point?.hasBlockedIndicator
+    ? `<span class="subject-status-blocked-indicator situation-trajectory__status-blocked-indicator" aria-hidden="true">${svgIcon("blocked", { className: "octicon octicon-blocked", width: 12, height: 12 })}</span>`
+    : "";
+  return `<span class="issue-status-icon situation-trajectory__status-icon" aria-hidden="true">${
+    svgIcon(symbol, { className: "ui-icon", width: 16, height: 16, style: `color: ${colorStyle}` })
+  }${blockedIconHtml}</span>`;
 }
 
 function buildHierarchyLinks(relationEvents = []) {
@@ -159,16 +174,14 @@ function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse 
   );
   path.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
 
-  const markerCircle = !isRemoved
-    ? (() => {
-      const circle = document.createElementNS(SVG_NS, "circle");
-      circle.setAttribute("cx", String(laneStartX));
-      circle.setAttribute("cy", String(startY));
-      circle.setAttribute("r", "2.5");
-      circle.setAttribute("class", "situation-trajectory__hierarchy-link");
-      return circle;
-    })()
-    : null;
+  const markerCircle = (() => {
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("cx", String(laneStartX));
+    circle.setAttribute("cy", String(startY));
+    circle.setAttribute("r", "2.5");
+    circle.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+    return circle;
+  })();
 
   const arrow = document.createElementNS(SVG_NS, "polygon");
   const arrowSize = 4;
@@ -180,7 +193,7 @@ function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse 
       `${laneEndX - arrowSize},${endY + (direction * arrowSize)}`
     ].join(" ")
   );
-  arrow.setAttribute("class", "situation-trajectory__hierarchy-link");
+  arrow.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
 
   return { path, markerCircle, arrow };
 }
@@ -325,7 +338,7 @@ export function renderTrajectoryDom({
       const pointType = resolvePointIcon(point, statusPoints[pointIndex - 1] || null);
       pointNode.classList.add(`situation-trajectory__point--${pointType}`);
       pointNode.dataset.trajectoryPointType = pointType;
-      pointNode.innerHTML = `<span class="situation-trajectory__point-icon" aria-hidden="true">${svgIcon(resolvePointSymbol(pointType), { className: "octicon", width: 16, height: 16 })}</span>`;
+      pointNode.innerHTML = renderPointIconHtml(pointType, point);
       if (subjectId) {
         pointNode.dataset.trajectorySubjectId = subjectId;
         pointNode.dataset.openSituationSubject = subjectId;

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
@@ -16,6 +16,7 @@ class MockNode {
     this.clientWidth = 0;
     this.type = "";
     this.title = "";
+    this._innerHTML = "";
     this.classList = {
       add: (...tokens) => {
         const current = new Set(String(this.className || "").split(/\s+/).filter(Boolean));
@@ -70,7 +71,12 @@ class MockNode {
   }
 
   set innerHTML(_) {
+    this._innerHTML = String(_ || "");
     this.childNodes = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
   }
 }
 
@@ -238,4 +244,152 @@ test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
     }
   ]);
   assert.equal(links.length, 1);
+});
+
+test("renderTrajectoryDom applique les classes red+dashed et dessine un lien removed enfant -> parent avec circle+arrow", () => {
+  const originalDocument = globalThis.document;
+  const originalNow = Date.now;
+  globalThis.document = createMockDocument();
+  Date.now = () => new Date("2026-01-06T00:00:00.000Z").getTime();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 600;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = [
+    {
+      subjectId: "parent-1",
+      lifecycleSegments: [],
+      statusPoints: [],
+      objectiveMarkers: []
+    },
+    {
+      subjectId: "child-1",
+      lifecycleSegments: [
+        {
+          subjectId: "child-1",
+          status: "closed",
+          startAt: new Date("2026-01-05T00:00:00.000Z"),
+          endAt: new Date("2026-01-07T00:00:00.000Z"),
+          lineColor: "red",
+          lineStyle: "dashed"
+        }
+      ],
+      statusPoints: [],
+      objectiveMarkers: []
+    }
+  ];
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-01-01T00:00:00.000Z",
+    endDate: "2026-01-10T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 12
+  });
+
+  renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [
+      {
+        event_type: "subject_parent_removed",
+        subject_id: "child-1",
+        created_at: "2026-01-06T00:00:00.000Z",
+        payload: { counterpart_subject_id: "parent-1" }
+      }
+    ],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 600,
+    viewportHeight: 200,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  const [redDashedSegment] = queryByClass(itemsRoot, "situation-trajectory__segment--dashed");
+  assert.ok(redDashedSegment);
+  assert.ok(String(redDashedSegment.className).includes("situation-trajectory__segment--red"));
+
+  const removedPaths = queryByClass(svg, "situation-trajectory__hierarchy-link")
+    .filter((node) => node.tagName === "PATH" && String(node.className).includes("is-removed"));
+  const removedCircles = queryByClass(svg, "situation-trajectory__hierarchy-link")
+    .filter((node) => node.tagName === "CIRCLE" && String(node.className).includes("is-removed"));
+  const removedArrows = queryByClass(svg, "situation-trajectory__hierarchy-link")
+    .filter((node) => node.tagName === "POLYGON" && String(node.className).includes("is-removed"));
+
+  assert.equal(removedPaths.length, 1);
+  assert.equal(removedCircles.length, 1);
+  assert.equal(removedArrows.length, 1);
+  assert.equal(removedCircles[0].getAttribute("cy"), "30");
+
+  globalThis.document = originalDocument;
+  Date.now = originalNow;
+});
+
+test("renderTrajectoryDom affiche une icône par point de statut et ajoute l'indicateur bloqué", () => {
+  const originalDocument = globalThis.document;
+  globalThis.document = createMockDocument();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 600;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = [
+    {
+      subjectId: "subject-1",
+      lifecycleSegments: [
+        {
+          subjectId: "subject-1",
+          status: "open",
+          startAt: new Date("2026-01-01T00:00:00.000Z"),
+          endAt: new Date("2026-02-20T00:00:00.000Z"),
+          lineColor: "green",
+          lineStyle: "solid"
+        }
+      ],
+      statusPoints: [
+        { at: new Date("2026-01-01T00:00:00.000Z"), status: "open", source: "subject_created", icon: "open" },
+        { at: new Date("2026-01-20T00:00:00.000Z"), status: "closed", source: "subject_closed", icon: "close" },
+        { at: new Date("2026-02-04T00:00:00.000Z"), status: "open", source: "subject_reopened", icon: "open" },
+        { at: new Date("2026-02-10T00:00:00.000Z"), status: "open", source: "subject_blocked_by_added", icon: "open", hasBlockedIndicator: true },
+        { at: new Date("2026-02-18T00:00:00.000Z"), status: "closed_invalid", source: "subject_rejected", icon: "reject" }
+      ],
+      objectiveMarkers: []
+    }
+  ];
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2025-12-28T00:00:00.000Z",
+    endDate: "2026-02-25T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 8
+  });
+
+  renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 1200,
+    viewportHeight: 200,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  const points = queryByClass(itemsRoot, "situation-trajectory__point");
+  assert.equal(points.length, 5);
+  assert.ok(points.some((node) => String(node.className).includes("situation-trajectory__point--close")));
+  assert.ok(points.some((node) => String(node.className).includes("situation-trajectory__point--reject")));
+  assert.ok(points.some((node) => String(node.innerHTML || "").includes("situation-trajectory__status-blocked-indicator")));
+
+  globalThis.document = originalDocument;
 });

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -163,34 +163,38 @@ export function buildTrajectoryModel({
     const fallbackStartStatus = normalizeStatus(subject.status);
 
     const statusPoints = [];
-    const upsertStatusPoint = (ts, status, source) => {
+    const pushStatusPoint = (ts, status, source, extra = {}) => {
       const safeTs = Math.max(subjectCreatedTs, ts);
       const safeStatus = normalizeStatus(status);
-      const existing = statusPoints.find((point) => point.at.getTime() === safeTs);
-      if (existing) {
-        existing.status = safeStatus;
-        existing.icon = toStatusIcon(safeStatus);
-        existing.source = source;
-        return;
-      }
       statusPoints.push({
         at: new Date(safeTs),
         status: safeStatus,
-        icon: toStatusIcon(safeStatus),
-        source
+        icon: extra.icon || toStatusIcon(safeStatus),
+        source,
+        contributesToLifecycle: extra.contributesToLifecycle !== false,
+        hasBlockedIndicator: extra.hasBlockedIndicator === true
       });
     };
 
-    upsertStatusPoint(subjectCreatedTs, createdEvent ? "open" : fallbackStartStatus, createdEvent ? "subject_created" : "subject_fallback_created_at");
+    pushStatusPoint(subjectCreatedTs, "open", createdEvent ? "subject_created" : "subject_fallback_created_at");
 
     for (const event of events) {
       const ts = event.created_at.getTime();
       if (event.event_type === "subject_created") {
-        upsertStatusPoint(ts, "open", event.event_type);
+        continue;
       } else if (event.event_type === "subject_closed") {
-        upsertStatusPoint(ts, normalizeCloseStatus(event, subject.status), event.event_type);
+        pushStatusPoint(ts, normalizeCloseStatus(event, subject.status), event.event_type);
       } else if (event.event_type === "subject_reopened") {
-        upsertStatusPoint(ts, "open", event.event_type);
+        pushStatusPoint(ts, "open", event.event_type);
+      } else if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)) {
+        pushStatusPoint(ts, "closed_invalid", event.event_type);
+      } else if (event.event_type === "subject_blocked_by_added") {
+        const currentStatus = resolveStatusAtTimestamp(statusPoints, ts, fallbackStartStatus);
+        pushStatusPoint(ts, currentStatus, event.event_type, {
+          icon: "open",
+          contributesToLifecycle: false,
+          hasBlockedIndicator: true
+        });
       }
     }
 
@@ -199,9 +203,13 @@ export function buildTrajectoryModel({
     const rawSegments = [];
     for (let index = 0; index < statusPoints.length; index += 1) {
       const point = statusPoints[index];
+      if (point.contributesToLifecycle === false) continue;
       const nextPoint = statusPoints[index + 1];
       const segmentStartTs = point.at.getTime();
-      const segmentEndTs = nextPoint ? nextPoint.at.getTime() : endTs;
+      const nextLifecyclePoint = nextPoint && nextPoint.contributesToLifecycle !== false
+        ? nextPoint
+        : statusPoints.slice(index + 1).find((entry) => entry.contributesToLifecycle !== false);
+      const segmentEndTs = nextLifecyclePoint ? nextLifecyclePoint.at.getTime() : endTs;
       if (segmentEndTs <= segmentStartTs) continue;
       rawSegments.push({
         subjectId,

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -120,3 +120,134 @@ test("normalizeCloseStatus remonte closed_invalid et closed_duplicate depuis le 
   assert.equal(normalizeCloseStatus({ payload: { status: "closed_duplicate" } }), "closed_duplicate");
   assert.equal(normalizeCloseStatus({ payload: {} }), "closed");
 });
+
+test("buildTrajectoryModel crée toujours un premier point open depuis subject.created_at sans subject_created", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-no-created-event",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "closed"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-no-created-event": []
+    },
+    today: "2026-01-02T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.equal(row.statusPoints[0].status, "open");
+  assert.equal(row.statusPoints[0].icon, "open");
+  assert.equal(row.statusPoints[0].source, "subject_fallback_created_at");
+  assert.equal(row.statusPoints[0].at.toISOString(), "2026-01-01T00:00:00.000Z");
+});
+
+test("buildTrajectoryModel rend un segment red dashed après objectif quand le sujet est fermé après objectif", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-after-objective-close",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "closed"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-after-objective-close": [
+        { subject_id: "s-after-objective-close", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-after-objective-close", event_type: "subject_reopened", created_at: "2026-01-07T00:00:00.000Z" },
+        { subject_id: "s-after-objective-close", event_type: "subject_closed", created_at: "2026-01-08T00:00:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    objectivesById: {
+      "o-1": { id: "o-1", due_date: "2026-01-05T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-after-objective-close": ["o-1"]
+    },
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const redDashedSegment = row.lifecycleSegments.find((segment) => segment.startAt.toISOString() === "2026-01-08T00:00:00.000Z");
+  assert.ok(redDashedSegment);
+  assert.equal(redDashedSegment.lineColor, "red");
+  assert.equal(redDashedSegment.lineStyle, "dashed");
+});
+
+test("buildTrajectoryModel mappe les événements de rejet vers closed_invalid/reject", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-reject-event",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-reject-event": [
+        { subject_id: "s-reject-event", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-reject-event", event_type: "subject_rejected", created_at: "2026-01-03T00:00:00.000Z" }
+      ]
+    },
+    today: "2026-01-05T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const rejectPoint = row.statusPoints.find((point) => point.source === "subject_rejected");
+  assert.ok(rejectPoint);
+  assert.equal(rejectPoint.status, "closed_invalid");
+  assert.equal(rejectPoint.icon, "reject");
+});
+
+test("buildTrajectoryModel conserve un point par évènement de statut et ajoute un point bloqué sans casser le cycle de vie", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-many-events",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-many-events": [
+        { subject_id: "s-many-events", event_type: "subject_closed", created_at: "2026-01-20T00:00:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-many-events", event_type: "subject_reopened", created_at: "2026-02-04T00:00:00.000Z" },
+        { subject_id: "s-many-events", event_type: "subject_rejected", created_at: "2026-02-18T00:00:00.000Z" },
+        { subject_id: "s-many-events", event_type: "subject_blocked_by_added", created_at: "2026-02-10T00:00:00.000Z" }
+      ]
+    },
+    today: "2026-02-20T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.statusPoints.map((point) => ({
+      at: point.at.toISOString(),
+      source: point.source,
+      icon: point.icon,
+      lifecycle: point.contributesToLifecycle
+    })),
+    [
+      { at: "2026-01-01T00:00:00.000Z", source: "subject_fallback_created_at", icon: "open", lifecycle: true },
+      { at: "2026-01-20T00:00:00.000Z", source: "subject_closed", icon: "close", lifecycle: true },
+      { at: "2026-02-04T00:00:00.000Z", source: "subject_reopened", icon: "open", lifecycle: true },
+      { at: "2026-02-10T00:00:00.000Z", source: "subject_blocked_by_added", icon: "open", lifecycle: false },
+      { at: "2026-02-18T00:00:00.000Z", source: "subject_rejected", icon: "reject", lifecycle: true }
+    ]
+  );
+
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString(),
+      status: segment.status
+    })),
+    [
+      { start: "2026-01-01T00:00:00.000Z", end: "2026-01-20T00:00:00.000Z", status: "open" },
+      { start: "2026-01-20T00:00:00.000Z", end: "2026-02-04T00:00:00.000Z", status: "closed" },
+      { start: "2026-02-04T00:00:00.000Z", end: "2026-02-18T00:00:00.000Z", status: "open" },
+      { start: "2026-02-18T00:00:00.000Z", end: "2026-02-20T00:00:00.000Z", status: "closed_invalid" }
+    ]
+  );
+});

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10345,9 +10345,21 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__segment--dashed{
   background:transparent;
-  border-top:2px dashed rgb(99, 110, 123);
+  border-top:2px dashed currentColor;
   border-radius:0;
   height:0;
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--green{
+  border-top-color:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--red{
+  border-top-color:rgb(207, 34, 46);
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
+  border-top-color:rgb(99, 110, 123);
 }
 
 .situation-trajectory__point,


### PR DESCRIPTION
### Motivation
- Introduce handling for rejection and blocking events in the trajectory view so status points and segments correctly reflect `subject_rejected`, `review_rejected`, `subject_invalidated`, and `subject_blocked_by_added` events.
- Ensure visual representation for blocked state and removed hierarchy links is accurate in the DOM and styles.
- Simplify status point processing to preserve every event as a point while excluding non-lifecycle markers from segment computation.

### Description
- Extended event lists in `project-situations-trajectory-service.js` to include `subject_rejected`, `review_rejected`, and `subject_invalidated` and adjusted relation/status type sets.
- Reworked status point handling in `trajectory-model.js` by replacing the previous upsert logic with `pushStatusPoint`, adding `contributesToLifecycle` and `hasBlockedIndicator` flags, mapping reject events to `closed_invalid` with `reject` icon, and treating `subject_blocked_by_added` as a non-lifecycle point with a blocked indicator.
- Adjusted segment building to skip non-lifecycle points and to compute segment end times by finding the next lifecycle-contributing point.
- In `trajectory-dom-renderer.js` added `renderPointIconHtml` to render per-point icons and a blocked indicator, expanded `formatPointEventLabel` and `resolvePointSymbol` to handle reject/blocked sources, and ensured hierarchy SVG marker elements contain the `is-removed` class when appropriate.
- Updated CSS (`style.css`) to make dashed segments use `currentColor` and added color variants for dashed segments to keep segment color consistent with line color.
- Added and updated unit tests in `trajectory-dom-renderer.test.mjs` and `trajectory-model.test.mjs` covering blocked indicator rendering, removed hierarchy link shapes and classes, lifecycle behavior with non-lifecycle points, mapping of reject events, and dashed red segments after objectives.

### Testing
- Ran the project's unit tests (`node --test`) including the updated tests for the trajectory model and DOM renderer; all new and existing tests passed.
- Added DOM renderer tests that assert presence of blocked indicator, correct point icons, and SVG path/circle/polygon with `is-removed` classes, and they succeeded.
- Added model tests that assert mapping of reject events to `closed_invalid`, preservation of per-event points, non-lifecycle blocked points, and correct lifecycle segments after objectives, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef79c014308329a2992ffa05369e18)