### PR TITLE
Add milestone support for objective changes, fix local date rendering, avoid overlapping points and update styles

### DIFF
--- a/apps/web/js/services/project-situations-trajectory-service.js
+++ b/apps/web/js/services/project-situations-trajectory-service.js
@@ -32,14 +32,15 @@ const RELATION_EVENT_TYPES = new Set([
   "subject_blocking_for_removed"
 ]);
 
-const STATUS_EVENT_TYPES = new Set([
+const ACTIVITY_EVENT_TYPES = new Set([
   "subject_created",
   "subject_closed",
   "subject_reopened",
   "subject_rejected",
   "review_rejected",
   "subject_invalidated",
-  "subject_blocked_by_added"
+  "subject_blocked_by_added",
+  "subject_objectives_changed"
 ]);
 
 function normalizeId(value) {
@@ -131,7 +132,7 @@ export async function loadProjectSituationsTrajectoryHistory({
   const eventsBySubjectId = groupEventsBySubjectId(normalizedEvents);
   const relationEvents = normalizedEvents.filter((event) => RELATION_EVENT_TYPES.has(event.event_type));
   const statusEventsBySubjectId = groupEventsBySubjectId(
-    normalizedEvents.filter((event) => STATUS_EVENT_TYPES.has(event.event_type))
+    normalizedEvents.filter((event) => ACTIVITY_EVENT_TYPES.has(event.event_type))
   );
 
 

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -690,14 +690,23 @@ export function createProjectSituationsEvents({
       return;
     }
 
-    const todayIsoDate = new Date().toISOString().slice(0, 10);
+    const toLocalIsoDate = (value) => {
+      const date = value instanceof Date ? value : new Date(value);
+      if (Number.isNaN(date.getTime())) return "";
+      const yyyy = date.getFullYear();
+      const mm = String(date.getMonth() + 1).padStart(2, "0");
+      const dd = String(date.getDate()).padStart(2, "0");
+      return `${yyyy}-${mm}-${dd}`;
+    };
+
+    const todayIsoDate = toLocalIsoDate(new Date());
 
     const dayTicksHtml = ticks.map((tick, index) => {
       const nextTick = ticks[index + 1];
       const tickWidth = Math.max(24, (nextTick?.x ?? timeScale.totalWidth) - tick.x);
       const date = tick.date instanceof Date ? tick.date : new Date(tick.timestamp);
-      const dayLabel = String(date.getUTCDate());
-      const isoDate = date.toISOString().slice(0, 10);
+      const dayLabel = String(date.getDate());
+      const isoDate = toLocalIsoDate(date);
       const isToday = isoDate === todayIsoDate;
       return `<time role="columnheader" data-index="${index}" datetime="${isoDate}" class="situation-trajectory__timeline-day${isToday ? " is-today" : ""}" style="left:${tick.x}px;width:${tickWidth}px;">${dayLabel}</time>`;
     }).join("");
@@ -705,16 +714,15 @@ export function createProjectSituationsEvents({
     const monthTicksHtml = ticks
       .filter((tick, index) => {
         const date = tick.date instanceof Date ? tick.date : new Date(tick.timestamp);
-        return index === 0 || date.getUTCDate() === 1;
+        return index === 0 || date.getDate() === 1;
       })
       .map((tick) => {
         const date = tick.date instanceof Date ? tick.date : new Date(tick.timestamp);
         const label = date.toLocaleDateString("fr-FR", {
           month: "long",
-          year: "numeric",
-          timeZone: "UTC"
+          year: "numeric"
         });
-        return `<time datetime="${date.toISOString().slice(0, 10)}" class="situation-trajectory__timeline-month" style="left:${tick.x}px;">${label}</time>`;
+        return `<time datetime="${toLocalIsoDate(date)}" class="situation-trajectory__timeline-month" style="left:${tick.x}px;">${label}</time>`;
       }).join("");
 
     const objectiveLabelsHtml = Object.values(objectivesById || {})

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -67,6 +67,7 @@ function resolvePointIcon(point = {}, previousPoint = null) {
 }
 
 function resolvePointSymbol(pointType = "open") {
+  if (pointType === "milestone") return "milestone";
   if (pointType === "close") return "check-circle";
   if (pointType === "reject") return "skip";
   return "issue-opened";
@@ -89,18 +90,25 @@ function formatPointEventLabel(point = {}) {
   if (source === "subject_reopened") return "réouverture";
   if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(source)) return "rejet";
   if (source === "subject_blocked_by_added") return "blocage entrant";
+  if (source === "subject_objectives_changed") {
+    if (point?.milestoneAction === "added") return "objectif ajouté";
+    if (point?.milestoneAction === "removed") return "objectif supprimé";
+    return "objectifs mis à jour";
+  }
   return source || "mise à jour";
 }
 
 function renderPointIconHtml(pointType = "open", point = {}) {
   const symbol = resolvePointSymbol(pointType);
-  const colorStyle = pointType === "close"
+  const colorStyle = pointType === "milestone"
+    ? (point?.markerColor || "var(--muted)")
+    : pointType === "close"
     ? "var(--fgColor-done)"
     : (pointType === "reject" ? "var(--project-tabs-icon-color, rgb(248, 81, 73))" : "var(--fgColor-open)");
   const blockedIconHtml = point?.hasBlockedIndicator
     ? `<span class="subject-status-blocked-indicator situation-trajectory__status-blocked-indicator" aria-hidden="true">${svgIcon("blocked", { className: "octicon octicon-blocked", width: 12, height: 12 })}</span>`
     : "";
-  return `<span class="issue-status-icon situation-trajectory__status-icon" aria-hidden="true">${
+  return `<span class="issue-status-icon situation-trajectory__point-icon situation-trajectory__status-icon" aria-hidden="true">${
     svgIcon(symbol, { className: "ui-icon", width: 16, height: 16, style: `color: ${colorStyle}` })
   }${blockedIconHtml}</span>`;
 }
@@ -324,19 +332,36 @@ export function renderTrajectoryDom({
     }
 
     const statusPoints = asArray(row.statusPoints);
+    const statusPointTotalsByTs = new Map();
+    for (const point of statusPoints) {
+      const ts = toTimestamp(point.at);
+      statusPointTotalsByTs.set(ts, (statusPointTotalsByTs.get(ts) || 0) + 1);
+    }
+    const statusPointUsedOffsetsByTs = new Map();
     for (let pointIndex = 0; pointIndex < statusPoints.length; pointIndex += 1) {
       const point = statusPoints[pointIndex];
       const ts = toTimestamp(point.at);
       if (ts < visibleStartTs || ts > visibleEndTs) continue;
 
+      const localOffset = statusPointUsedOffsetsByTs.get(ts) || 0;
+      statusPointUsedOffsetsByTs.set(ts, localOffset + 1);
+      const totalAtTimestamp = statusPointTotalsByTs.get(ts) || 1;
+      const pointOffsetIndex = Number.isInteger(point?.offsetIndex) ? point.offsetIndex : localOffset;
+      const pointOffsetPx = totalAtTimestamp > 1 ? (pointOffsetIndex - ((totalAtTimestamp - 1) / 2)) * 6 : 0;
+
       const pointNode = document.createElement("button");
       pointNode.type = "button";
       pointNode.className = "situation-trajectory__point";
-      pointNode.style.left = `${timeScale.timeToX(ts)}px`;
+      pointNode.style.left = `${timeScale.timeToX(ts) + pointOffsetPx}px`;
       pointNode.style.top = `${y}px`;
 
       const pointType = resolvePointIcon(point, statusPoints[pointIndex - 1] || null);
       pointNode.classList.add(`situation-trajectory__point--${pointType}`);
+      if (pointType === "milestone") {
+        pointNode.classList.add("situation-trajectory__point--milestone");
+        if (point?.milestoneAction === "added") pointNode.classList.add("situation-trajectory__point--milestone-added");
+        if (point?.milestoneAction === "removed") pointNode.classList.add("situation-trajectory__point--milestone-removed");
+      }
       pointNode.dataset.trajectoryPointType = pointType;
       pointNode.innerHTML = renderPointIconHtml(pointType, point);
       if (subjectId) {

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
@@ -393,3 +393,77 @@ test("renderTrajectoryDom affiche une icône par point de statut et ajoute l'ind
 
   globalThis.document = originalDocument;
 });
+
+test("renderTrajectoryDom affiche les milestones avec classes dédiées, icône milestone et décalage sur timestamp identique", () => {
+  const originalDocument = globalThis.document;
+  globalThis.document = createMockDocument();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 600;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = [
+    {
+      subjectId: "subject-ms",
+      lifecycleSegments: [],
+      statusPoints: [
+        {
+          at: new Date("2026-01-10T00:00:00.000Z"),
+          status: "open",
+          source: "subject_objectives_changed",
+          icon: "milestone",
+          milestoneAction: "removed",
+          markerColor: "var(--muted)",
+          contributesToLifecycle: false,
+          offsetIndex: 0
+        },
+        {
+          at: new Date("2026-01-10T00:00:00.000Z"),
+          status: "open",
+          source: "subject_objectives_changed",
+          icon: "milestone",
+          milestoneAction: "added",
+          markerColor: "#fff",
+          contributesToLifecycle: false,
+          offsetIndex: 1
+        }
+      ],
+      objectiveMarkers: []
+    }
+  ];
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-01-01T00:00:00.000Z",
+    endDate: "2026-01-20T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 10
+  });
+
+  renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 800,
+    viewportHeight: 200,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  const points = queryByClass(itemsRoot, "situation-trajectory__point");
+  assert.equal(points.length, 2);
+  assert.ok(points.every((node) => String(node.className).includes("situation-trajectory__point--milestone")));
+  assert.ok(points.some((node) => String(node.className).includes("situation-trajectory__point--milestone-added")));
+  assert.ok(points.some((node) => String(node.className).includes("situation-trajectory__point--milestone-removed")));
+  assert.ok(points.every((node) => String(node.innerHTML || "").includes("milestone")));
+
+  const leftPositions = points.map((node) => node.style.left);
+  assert.equal(new Set(leftPositions).size, 2);
+
+  globalThis.document = originalDocument;
+});

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -40,6 +40,52 @@ function asArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function toObjectiveDeltaArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === "object") return Object.keys(value);
+  return [];
+}
+
+function resolveObjectiveMilestonePoints(event = {}, ts, currentStatus = "open") {
+  const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
+  const action = normalizeId(payload.action).toLowerCase();
+  const delta = payload?.delta && typeof payload.delta === "object" ? payload.delta : {};
+  const added = toObjectiveDeltaArray(delta.added);
+  const removed = toObjectiveDeltaArray(delta.removed);
+
+  const hasAdded = action === "added" || action === "replaced" || added.length > 0;
+  const hasRemoved = action === "removed" || action === "replaced" || removed.length > 0;
+  const points = [];
+
+  if (hasRemoved) {
+    points.push({
+      at: new Date(ts),
+      status: normalizeStatus(currentStatus),
+      icon: "milestone",
+      source: "subject_objectives_changed",
+      contributesToLifecycle: false,
+      milestoneAction: "removed",
+      markerColor: "var(--muted)",
+      offsetIndex: 0
+    });
+  }
+
+  if (hasAdded) {
+    points.push({
+      at: new Date(ts),
+      status: normalizeStatus(currentStatus),
+      icon: "milestone",
+      source: "subject_objectives_changed",
+      contributesToLifecycle: false,
+      milestoneAction: "added",
+      markerColor: "#fff",
+      offsetIndex: hasRemoved ? 1 : 0
+    });
+  }
+
+  return points;
+}
+
 function collectEventsForSubject(subjectId, subjectHistoryEvents) {
   if (Array.isArray(subjectHistoryEvents)) {
     return subjectHistoryEvents.filter((event) => normalizeId(event?.subject_id) === subjectId);
@@ -172,7 +218,10 @@ export function buildTrajectoryModel({
         icon: extra.icon || toStatusIcon(safeStatus),
         source,
         contributesToLifecycle: extra.contributesToLifecycle !== false,
-        hasBlockedIndicator: extra.hasBlockedIndicator === true
+        hasBlockedIndicator: extra.hasBlockedIndicator === true,
+        milestoneAction: extra.milestoneAction || "",
+        markerColor: extra.markerColor || "",
+        offsetIndex: Number.isInteger(extra.offsetIndex) ? extra.offsetIndex : undefined
       });
     };
 
@@ -195,6 +244,18 @@ export function buildTrajectoryModel({
           contributesToLifecycle: false,
           hasBlockedIndicator: true
         });
+      } else if (event.event_type === "subject_objectives_changed") {
+        const currentStatus = resolveStatusAtTimestamp(statusPoints, ts, fallbackStartStatus);
+        const milestonePoints = resolveObjectiveMilestonePoints(event, ts, currentStatus);
+        for (const point of milestonePoints) {
+          pushStatusPoint(ts, point.status, point.source, {
+            icon: point.icon,
+            contributesToLifecycle: false,
+            milestoneAction: point.milestoneAction,
+            markerColor: point.markerColor,
+            offsetIndex: point.offsetIndex
+          });
+        }
       }
     }
 

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -251,3 +251,105 @@ test("buildTrajectoryModel conserve un point par évènement de statut et ajoute
     ]
   );
 });
+
+test("buildTrajectoryModel conserve un point à chaque évènement de cycle de vie avec les dates exactes", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "s-lifecycle", created_at: "2026-01-01T00:00:00.000Z", status: "open" }
+    ],
+    subjectHistoryEvents: {
+      "s-lifecycle": [
+        { subject_id: "s-lifecycle", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        { subject_id: "s-lifecycle", event_type: "subject_closed", created_at: "2026-01-05T00:00:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-lifecycle", event_type: "subject_reopened", created_at: "2026-01-07T00:00:00.000Z" },
+        { subject_id: "s-lifecycle", event_type: "subject_rejected", created_at: "2026-01-09T00:00:00.000Z" }
+      ]
+    },
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.statusPoints.map((point) => ({
+      at: point.at.toISOString(),
+      source: point.source,
+      icon: point.icon
+    })),
+    [
+      { at: "2026-01-01T00:00:00.000Z", source: "subject_created", icon: "open" },
+      { at: "2026-01-05T00:00:00.000Z", source: "subject_closed", icon: "close" },
+      { at: "2026-01-07T00:00:00.000Z", source: "subject_reopened", icon: "open" },
+      { at: "2026-01-09T00:00:00.000Z", source: "subject_rejected", icon: "reject" }
+    ]
+  );
+});
+
+test("buildTrajectoryModel rend plusieurs blocages entrants à des dates différentes sans casser le cycle de vie", () => {
+  const result = buildTrajectoryModel({
+    subjects: [{ id: "s-blocked", created_at: "2026-01-01T00:00:00.000Z", status: "open" }],
+    subjectHistoryEvents: {
+      "s-blocked": [
+        { subject_id: "s-blocked", event_type: "subject_blocked_by_added", created_at: "2026-01-03T00:00:00.000Z" },
+        { subject_id: "s-blocked", event_type: "subject_blocked_by_added", created_at: "2026-01-06T00:00:00.000Z" }
+      ]
+    },
+    today: "2026-01-07T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const blockedPoints = row.statusPoints.filter((point) => point.source === "subject_blocked_by_added");
+  assert.equal(blockedPoints.length, 2);
+  assert.ok(blockedPoints.every((point) => point.icon === "open"));
+  assert.ok(blockedPoints.every((point) => point.hasBlockedIndicator === true));
+  assert.ok(blockedPoints.every((point) => point.contributesToLifecycle === false));
+  assert.deepEqual(blockedPoints.map((point) => point.at.toISOString()), [
+    "2026-01-03T00:00:00.000Z",
+    "2026-01-06T00:00:00.000Z"
+  ]);
+});
+
+test("buildTrajectoryModel transforme subject_objectives_changed added/removed/replaced en milestones non lifecycle", () => {
+  const result = buildTrajectoryModel({
+    subjects: [{ id: "s-objective-events", created_at: "2026-01-01T00:00:00.000Z", status: "open" }],
+    subjectHistoryEvents: {
+      "s-objective-events": [
+        {
+          subject_id: "s-objective-events",
+          event_type: "subject_objectives_changed",
+          created_at: "2026-01-03T00:00:00.000Z",
+          payload: { action: "added", delta: { added: ["o1"], removed: [] } }
+        },
+        {
+          subject_id: "s-objective-events",
+          event_type: "subject_objectives_changed",
+          created_at: "2026-01-04T00:00:00.000Z",
+          payload: { action: "removed", delta: { added: [], removed: ["o1"] } }
+        },
+        {
+          subject_id: "s-objective-events",
+          event_type: "subject_objectives_changed",
+          created_at: "2026-01-05T00:00:00.000Z",
+          payload: { action: "replaced", delta: { added: ["o2"], removed: ["o1"] } }
+        }
+      ]
+    },
+    today: "2026-01-06T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const milestones = row.statusPoints.filter((point) => point.icon === "milestone");
+  assert.deepEqual(
+    milestones.map((point) => ({
+      at: point.at.toISOString(),
+      action: point.milestoneAction,
+      contributesToLifecycle: point.contributesToLifecycle,
+      markerColor: point.markerColor
+    })),
+    [
+      { at: "2026-01-03T00:00:00.000Z", action: "added", contributesToLifecycle: false, markerColor: "#fff" },
+      { at: "2026-01-04T00:00:00.000Z", action: "removed", contributesToLifecycle: false, markerColor: "var(--muted)" },
+      { at: "2026-01-05T00:00:00.000Z", action: "removed", contributesToLifecycle: false, markerColor: "var(--muted)" },
+      { at: "2026-01-05T00:00:00.000Z", action: "added", contributesToLifecycle: false, markerColor: "#fff" }
+    ]
+  );
+});

--- a/apps/web/js/views/project-situations/trajectory/trajectory-time-scale.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-time-scale.js
@@ -29,10 +29,10 @@ function toTimestamp(value, { fallback = null } = {}) {
 
 function formatTickLabel(timestamp, zoom) {
   const date = new Date(timestamp);
-  const yyyy = date.getUTCFullYear();
-  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(date.getUTCDate()).padStart(2, "0");
-  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
   if (zoom === "hour") return `${dd}/${mm} ${hh}:00`;
   if (zoom === "half-day") return `${dd}/${mm} ${Number(hh) < 12 ? "AM" : "PM"}`;
   if (zoom === "day") return `${dd}/${mm}`;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10323,43 +10323,45 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment{
-  height:4px;
-  border-radius:999px;
-  background:var(--fgColor-muted, #8b949e);
+  height:28px;
+  border-radius:var(--radius);
+  background:rgb(13, 17, 23);
+  border:solid 1px currentColor;
+  outline-color:rgb(240, 246, 252);
+  box-shadow:rgba(1, 4, 9, 0.4) 0px 1px 1px 0px, rgba(1, 4, 9, 0.8) 0px 3px 6px 0px;
+  color:var(--fgColor-muted, #8b949e);
   opacity:.95;
   pointer-events:auto;
   cursor:pointer;
+  z-index:1;
 }
 
 .situation-trajectory__segment--green{
-  background:rgb(35, 134, 54);
+  color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--red{
-  background:rgb(207, 34, 46);
+  color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--gray{
-  background:rgb(99, 110, 123);
+  color:rgb(99, 110, 123);
 }
 
 .situation-trajectory__segment--dashed{
-  background:transparent;
-  border-top:2px dashed currentColor;
-  border-radius:0;
-  height:0;
+  border-style:dashed;
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--green{
-  border-top-color:rgb(35, 134, 54);
+  border-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--red{
-  border-top-color:rgb(207, 34, 46);
+  border-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
-  border-top-color:rgb(99, 110, 123);
+  border-color:rgb(99, 110, 123);
 }
 
 .situation-trajectory__point,
@@ -10387,6 +10389,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   display:inline-flex;
   align-items:center;
   justify-content:center;
+  z-index:3;
 }
 
 .situation-trajectory__point-icon{
@@ -10398,6 +10401,12 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   border-radius:999px;
   background:rgb(21, 27, 35);
   color:var(--fgColor-muted, #8b949e);
+}
+
+.situation-trajectory__status-icon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
 }
 
 .situation-trajectory__marker::before,
@@ -10433,6 +10442,14 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__point--reject .situation-trajectory__point-icon{
   color:var(--project-tabs-icon-color, rgb(248, 81, 73));
+}
+
+.situation-trajectory__point--milestone-added .situation-trajectory__point-icon svg{
+  color:#fff;
+}
+
+.situation-trajectory__point--milestone-removed .situation-trajectory__point-icon svg{
+  color:var(--muted);
 }
 
 .situation-trajectory__marker--cross::before,


### PR DESCRIPTION
### Motivation

- Represent objective add/remove/replace events as non-lifecycle milestone points on the trajectory so objectives are visible on the timeline.
- Use local dates for timeline labels and ticks to avoid UTC-related date mismatches in the UI.
- Prevent visual overlap when multiple points share the same timestamp and improve point/segment visuals for clarity.

### Description

- Include `subject_objectives_changed` in activity event filtering and rename the set to `ACTIVITY_EVENT_TYPES` in `project-situations-trajectory-service.js`.
- Add `toObjectiveDeltaArray` and `resolveObjectiveMilestonePoints` in `trajectory-model.js`, and emit milestone `statusPoints` (with `milestoneAction`, `markerColor` and `offsetIndex`) when handling `subject_objectives_changed` events.
- Render milestone points in `trajectory-dom-renderer.js` by adding `milestone` as a `pointType`, mapping to a milestone icon, applying dedicated classes (`situation-trajectory__point--milestone`, `--milestone-added`, `--milestone-removed`), and compute horizontal offsets to deconflict points that share the same timestamp.
- Switch timeline/date formatting to local date functions in `project-situations-events.js` and `trajectory-time-scale.js` and update CSS in `style.css` to adjust segment/point appearance and milestone-specific styles.

### Testing

- Added unit tests in `trajectory-model.test.mjs` covering lifecycle points, multiple blocked events and `subject_objectives_changed` -> milestone transformation, and in `trajectory-dom-renderer.test.mjs` covering milestone rendering and offset behavior.
- Ran the trajectory unit test suite (`trajectory-model` and `trajectory-dom-renderer` tests) and the new/modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef81f3177883299d44270a55adea1f)