### PR TITLE
Fix Trajectoire row/title sync and stabilize day/date timeline mapping

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -10,6 +10,7 @@ import {
   normalizeSituationGridColumnWidths
 } from "./project-situations-view-grid.js";
 import { buildSubjectHierarchyIndexes } from "../../services/subject-hierarchy.js";
+import { getExpandedSubjectIdsSet, resolveSituationTreeData } from "./project-situations-tree-data.js";
 
 function syncSubmitButtonState(button, { submitting = false, title = "" } = {}) {
   if (!button) return;
@@ -36,6 +37,39 @@ const TRAJECTORY_LEFT_COLUMN_WIDTH = {
   default: 320
 };
 const TRAJECTORY_ROW_HEIGHT = 40;
+
+function parseLocalDate(value) {
+  if (value instanceof Date) return new Date(value.getTime());
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+      const [, yyyy, mm, dd] = dateOnlyMatch;
+      return new Date(Number(yyyy), Number(mm) - 1, Number(dd));
+    }
+  }
+  return new Date(value);
+}
+
+function flattenVisibleSubjectIds({
+  rootSubjectIds = [],
+  childrenBySubjectId = {},
+  expandedSubjectIds = new Set()
+} = {}) {
+  const visibleIds = [];
+  const visit = (subjectId) => {
+    const normalizedId = String(subjectId || "").trim();
+    if (!normalizedId) return;
+    visibleIds.push(normalizedId);
+    if (!expandedSubjectIds.has(normalizedId)) return;
+    const children = Array.isArray(childrenBySubjectId?.[normalizedId])
+      ? childrenBySubjectId[normalizedId]
+      : [];
+    children.forEach(visit);
+  };
+  (Array.isArray(rootSubjectIds) ? rootSubjectIds : []).forEach(visit);
+  return visibleIds;
+}
 
 export function createProjectSituationsEvents({
   store,
@@ -627,7 +661,30 @@ export function createProjectSituationsEvents({
   function resolveTrajectorySubjects(situationId = "") {
     const selectedSituationId = String(store?.situationsView?.selectedSituationId || "").trim();
     if (situationId && selectedSituationId && situationId !== selectedSituationId) return [];
-    return Array.isArray(uiState?.selectedSituationSubjects) ? uiState.selectedSituationSubjects : [];
+    const selectedSituationSubjects = Array.isArray(uiState?.selectedSituationSubjects)
+      ? uiState.selectedSituationSubjects
+      : [];
+    const rawSubjectsResult = store?.projectSubjectsView?.rawSubjectsResult || {};
+    const {
+      subjectsById,
+      childrenBySubjectId,
+      rootSubjectIds,
+      selectedSubjectIds
+    } = resolveSituationTreeData(selectedSituationSubjects, rawSubjectsResult);
+    const expandedSubjectIds = getExpandedSubjectIdsSet({
+      store,
+      situationId: selectedSituationId || situationId,
+      rootSubjectIds,
+      fallbackExpandedIds: [...selectedSubjectIds]
+    });
+    const orderedVisibleSubjectIds = flattenVisibleSubjectIds({
+      rootSubjectIds,
+      childrenBySubjectId,
+      expandedSubjectIds
+    });
+    return orderedVisibleSubjectIds
+      .map((subjectId) => subjectsById?.[subjectId])
+      .filter(Boolean);
   }
 
   function resolveTrajectoryHistoryBySubjectId(situationId = "") {
@@ -728,7 +785,7 @@ export function createProjectSituationsEvents({
     const objectiveLabelsHtml = Object.values(objectivesById || {})
       .filter((objective) => objective && objective.due_date && objective.title)
       .map((objective) => {
-        const dueDate = new Date(objective.due_date);
+        const dueDate = parseLocalDate(objective.due_date);
         if (Number.isNaN(dueDate.getTime())) return "";
         const x = timeScale.timeToX(dueDate);
         const safeTitle = escapeHtml(String(objective.title));

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -15,6 +15,15 @@ function resolveSubjectDisplayIdentifier(subject = {}, subjectId = "") {
 
 function toDate(value) {
   if (value instanceof Date) return new Date(value.getTime());
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+      const [, yyyy, mm, dd] = dateOnlyMatch;
+      const localDate = new Date(Number(yyyy), Number(mm) - 1, Number(dd));
+      return Number.isFinite(localDate.getTime()) ? localDate : null;
+    }
+  }
   const date = new Date(value);
   return Number.isFinite(date.getTime()) ? date : null;
 }

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -200,6 +200,31 @@ test("buildTrajectoryModel mappe les événements de rejet vers closed_invalid/r
   assert.equal(rejectPoint.icon, "reject");
 });
 
+test("buildTrajectoryModel conserve la date calendaire des objectifs en format YYYY-MM-DD", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-date-only",
+        created_at: "2026-04-01T00:00:00.000Z",
+        status: "open"
+      }
+    ],
+    objectivesById: {
+      "o-date-only": { id: "o-date-only", due_date: "2026-04-19" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-date-only": ["o-date-only"]
+    },
+    today: "2026-04-18T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  const objectiveDate = row.objectiveMarkers[0].at;
+  assert.equal(objectiveDate.getFullYear(), 2026);
+  assert.equal(objectiveDate.getMonth(), 3);
+  assert.equal(objectiveDate.getDate(), 19);
+});
+
 test("buildTrajectoryModel conserve un point par évènement de statut et ajoute un point bloqué sans casser le cycle de vie", () => {
   const result = buildTrajectoryModel({
     subjects: [

--- a/apps/web/js/views/project-situations/trajectory/trajectory-time-scale.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-time-scale.js
@@ -19,12 +19,47 @@ function normalizeZoom(zoom = "day") {
   return ZOOM_UNIT_MS[value] ? value : "day";
 }
 
+function parseDateLike(value) {
+  if (value instanceof Date) return new Date(value.getTime());
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+      const [, yyyy, mm, dd] = dateOnlyMatch;
+      return new Date(Number(yyyy), Number(mm) - 1, Number(dd));
+    }
+  }
+  return new Date(value);
+}
+
 function toTimestamp(value, { fallback = null } = {}) {
-  const date = value instanceof Date ? value : new Date(value);
+  const date = parseDateLike(value);
   const ts = date.getTime();
   if (Number.isFinite(ts)) return ts;
   if (fallback === null) return Date.now();
   return toTimestamp(fallback);
+}
+
+function alignTimestampToUnitStart(timestamp, zoom) {
+  const date = new Date(timestamp);
+  if (zoom === "month") {
+    return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+  }
+  if (zoom === "week") {
+    const aligned = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const day = aligned.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    aligned.setDate(aligned.getDate() + diff);
+    return aligned.getTime();
+  }
+  if (zoom === "day") {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  }
+  if (zoom === "half-day") {
+    const hour = date.getHours() >= 12 ? 12 : 0;
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate(), hour).getTime();
+  }
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours()).getTime();
 }
 
 function formatTickLabel(timestamp, zoom) {
@@ -50,7 +85,8 @@ export function createTrajectoryTimeScale({
   const unitMs = ZOOM_UNIT_MS[normalizedZoom];
   const pxPerUnitValue = Math.max(1, Number(pxPerUnit) || DEFAULT_PX_PER_UNIT[normalizedZoom]);
 
-  const startTs = toTimestamp(startDate);
+  const rawStartTs = toTimestamp(startDate);
+  const startTs = alignTimestampToUnitStart(rawStartTs, normalizedZoom);
   const rawEndTs = toTimestamp(endDate, { fallback: startTs + unitMs });
   const endTs = Math.max(startTs + 1, rawEndTs);
   const durationMs = Math.max(1, endTs - startTs);

--- a/apps/web/js/views/project-situations/trajectory/trajectory-time-scale.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-time-scale.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createTrajectoryTimeScale } from "./trajectory-time-scale.js";
+
+test("createTrajectoryTimeScale aligne le zoom day sur minuit local", () => {
+  const scale = createTrajectoryTimeScale({
+    startDate: "2026-04-27T15:42:11.000Z",
+    endDate: "2026-04-30T00:00:00.000Z",
+    zoom: "day"
+  });
+
+  const startDate = scale.startDate;
+  assert.equal(startDate.getHours(), 0);
+  assert.equal(startDate.getMinutes(), 0);
+  assert.equal(startDate.getSeconds(), 0);
+  assert.equal(startDate.getMilliseconds(), 0);
+});
+
+test("createTrajectoryTimeScale interprète les dates YYYY-MM-DD en date locale", () => {
+  const scale = createTrajectoryTimeScale({
+    startDate: "2026-04-01",
+    endDate: "2026-04-20",
+    zoom: "day"
+  });
+
+  const x = scale.timeToX("2026-04-19");
+  const date = scale.xToTime(x);
+  assert.equal(date.getFullYear(), 2026);
+  assert.equal(date.getMonth(), 3);
+  assert.equal(date.getDate(), 19);
+});


### PR DESCRIPTION
### Motivation
- Fix a mismatch between subject titles shown on timeline cards and the left column by ensuring the trajectory rows use the same visible tree ordering and expansion state. 
- Eliminate day-shift artifacts caused by interpreting `YYYY-MM-DD` strings as UTC instead of local calendar dates. 
- Improve coherence between viewport, timeline ticks and vertical markers by anchoring day-scale start to a unit boundary (midnight local for `day` zoom).

### Description
- Recompute trajectory rows from the same tree used by the left column by calling `resolveSituationTreeData` + `getExpandedSubjectIdsSet` and flattening the visible tree into an ordered list (`flattenVisibleSubjectIds`) in `project-situations-events.js` so card labels align with their left-column rows. (modified `resolveTrajectorySubjects`)
- Normalize date-only strings (`YYYY-MM-DD`) to local calendar `Date` objects by adding `parseDateLike` / `parseLocalDate` helpers and updating `toDate` in `trajectory-model.js` and objective rendering in `project-situations-events.js`.
- Align the timeline start anchor to unit boundaries by adding `alignTimestampToUnitStart` and using it when computing `startTs` in `trajectory-time-scale.js`, so the `day` zoom begins at local midnight and ticks/viewport mapping are stable.
- Add unit tests: `apps/web/js/views/project-situations/trajectory/trajectory-time-scale.test.mjs` and a model regression asserting `YYYY-MM-DD` objective handling (`trajectory-model.test.mjs` updated).

### Testing
- Ran `node --test apps/web/js/views/project-situations/trajectory/trajectory-time-scale.test.mjs apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` and all tests passed (`13/13` tests ok).
- Added targeted assertions covering day-scale alignment and calendar date parsing which succeed under local-date semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8d5a6840832998fa912ab831aa72)