### PR TITLE
Corrige l'alignement horizontal des segments de la trajectoire

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
@@ -258,6 +258,82 @@ test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
   assert.equal(links.length, 1);
 });
 
+test("renderTrajectoryDom positionne les segments à partir de left (début) et conserve points/markers sur leur date", () => {
+  const originalDocument = globalThis.document;
+  globalThis.document = createMockDocument();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 300;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = [
+    {
+      subjectId: "subject-1",
+      lifecycleSegments: [
+        {
+          subjectId: "subject-1",
+          status: "open",
+          startAt: new Date("2026-04-11T00:00:00.000Z"),
+          endAt: new Date("2026-04-19T00:00:00.000Z"),
+          lineColor: "green",
+          lineStyle: "solid"
+        }
+      ],
+      statusPoints: [{ at: new Date("2026-04-13T00:00:00.000Z"), status: "open", source: "subject_created" }],
+      objectiveMarkers: [{ objectiveId: "obj-1", at: new Date("2026-04-17T00:00:00.000Z"), markerType: "check" }]
+    }
+  ];
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-04-01T00:00:00.000Z",
+    endDate: "2026-04-30T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 12
+  });
+
+  renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 2000,
+    viewportHeight: 200,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  const [segment] = queryByClass(itemsRoot, "situation-trajectory__segment");
+  const [point] = queryByClass(itemsRoot, "situation-trajectory__point");
+  const [marker] = queryByClass(itemsRoot, "situation-trajectory__marker");
+
+  assert.ok(segment);
+  assert.ok(point);
+  assert.ok(marker);
+
+  const { toRenderTimestamp } = __trajectoryDomRendererTestUtils();
+  const segmentStartTs = toRenderTimestamp("2026-04-11T00:00:00.000Z", timeScale);
+  const segmentEndTs = toRenderTimestamp("2026-04-19T00:00:00.000Z", timeScale);
+  const pointTs = toRenderTimestamp("2026-04-13T00:00:00.000Z", timeScale);
+  const markerTs = toRenderTimestamp("2026-04-17T00:00:00.000Z", timeScale);
+
+  const expectedSegmentLeft = `${timeScale.timeToX(segmentStartTs)}px`;
+  const expectedSegmentWidth = `${timeScale.timeToX(segmentEndTs) - timeScale.timeToX(segmentStartTs)}px`;
+  const expectedPointLeft = `${timeScale.timeToX(pointTs)}px`;
+  const expectedMarkerLeft = `${timeScale.timeToX(markerTs)}px`;
+
+  assert.equal(segment.style.left, expectedSegmentLeft);
+  assert.equal(segment.style.width, expectedSegmentWidth);
+  assert.equal(point.style.left, expectedPointLeft);
+  assert.equal(marker.style.left, expectedMarkerLeft);
+
+  globalThis.document = originalDocument;
+});
+
 test("renderTrajectoryDom applique les classes red+dashed et dessine un lien removed enfant -> parent avec circle+arrow", () => {
   const originalDocument = globalThis.document;
   const originalNow = Date.now;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10328,10 +10328,10 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__point,
 .situation-trajectory__marker{
   position:absolute;
-  transform:translate(-50%, -50%);
 }
 
 .situation-trajectory__segment{
+  transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
   background:rgb(13, 17, 23);
@@ -10403,6 +10403,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__point,
 .situation-trajectory__marker{
+  transform:translate(-50%, -50%);
   width:20px;
   height:20px;
   appearance:none;


### PR DESCRIPTION
### Motivation
- Les segments, points et markers partageaient `transform: translate(-50%, -50%)` alors que le renderer positionne les segments avec `left = début` et `width = fin - début`, provoquant un décalage visuel horizontal des segments. 

### Description
- Séparation minimale des règles CSS pour ne plus appliquer `translateX(-50%)` aux segments et conserver le centrage horizontal uniquement pour les points et markers. 
- Ajout de `transform: translateY(-50%)` sur `.situation-trajectory__segment` pour garder l'alignement vertical sans modifier `left`. 
- Aucun changement à la logique JS de `renderTrajectoryDom` (les calculs `left`/`width` restent inchangés). 
- Fichiers modifiés : `apps/web/style.css` et test DOM ajouté/ajusté `apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs`.

### Testing
- Exécution du test modulaire du renderer avec `node --test apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs` (tests passés). 
- Vérification des utilitaires de virtualisation/échelle avec `node --test apps/web/js/views/project-situations/trajectory/trajectory-virtualizer.test.mjs apps/web/js/views/project-situations/trajectory/trajectory-time-scale.test.mjs` (tests passés). 
- Tous les tests automatiques lancés pour cette portée sont verts après la correction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f046bf81fc8329a2a9649e877e4425)