### PR TITLE
Fix trajectory lifecycle segmentation after reopen/close transitions

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -194,6 +194,76 @@ function toStatusIcon(status = "open") {
   return "open";
 }
 
+function resolveLifecycleStatusFromEvent(event = {}, fallbackStatus = "closed") {
+  const eventType = normalizeId(event?.event_type).toLowerCase();
+  if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+    return "closed_invalid";
+  }
+  if (eventType === "subject_closed") {
+    return normalizeCloseStatus(event, fallbackStatus);
+  }
+  return "open";
+}
+
+function buildLifecycleSegments({
+  subjectId = "",
+  subjectCreatedTs,
+  lifecycleEvents = [],
+  endTs,
+  fallbackClosedStatus = "closed"
+} = {}) {
+  const safeEndTs = Math.max(endTs, subjectCreatedTs);
+  let state = "open";
+  let currentStart = subjectCreatedTs;
+  const segments = [];
+
+  for (const event of lifecycleEvents) {
+    const eventType = normalizeId(event?.event_type).toLowerCase();
+    const eventTs = toTimestamp(event?.created_at, currentStart);
+    const safeEventTs = Math.min(Math.max(eventTs, subjectCreatedTs), safeEndTs);
+
+    if (eventType === "subject_reopened") {
+      if (state !== "open" && safeEventTs > currentStart) {
+        segments.push({
+          subjectId,
+          status: state,
+          startAt: new Date(currentStart),
+          endAt: new Date(safeEventTs)
+        });
+        state = "open";
+        currentStart = safeEventTs;
+      }
+      continue;
+    }
+
+    if (!["subject_closed", "subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+      continue;
+    }
+
+    if (state === "open" && safeEventTs > currentStart) {
+      segments.push({
+        subjectId,
+        status: "open",
+        startAt: new Date(currentStart),
+        endAt: new Date(safeEventTs)
+      });
+      state = resolveLifecycleStatusFromEvent(event, fallbackClosedStatus);
+      currentStart = safeEventTs;
+    }
+  }
+
+  if (safeEndTs > currentStart) {
+    segments.push({
+      subjectId,
+      status: state,
+      startAt: new Date(currentStart),
+      endAt: new Date(safeEndTs)
+    });
+  }
+
+  return segments;
+}
+
 export function buildTrajectoryModel({
   subjects = [],
   subjectHistoryEvents = {},
@@ -283,24 +353,16 @@ export function buildTrajectoryModel({
 
     statusPoints.sort((a, b) => a.at.getTime() - b.at.getTime());
 
-    const rawSegments = [];
-    for (let index = 0; index < statusPoints.length; index += 1) {
-      const point = statusPoints[index];
-      if (point.contributesToLifecycle === false) continue;
-      const nextPoint = statusPoints[index + 1];
-      const segmentStartTs = point.at.getTime();
-      const nextLifecyclePoint = nextPoint && nextPoint.contributesToLifecycle !== false
-        ? nextPoint
-        : statusPoints.slice(index + 1).find((entry) => entry.contributesToLifecycle !== false);
-      const segmentEndTs = nextLifecyclePoint ? nextLifecyclePoint.at.getTime() : endTs;
-      if (segmentEndTs <= segmentStartTs) continue;
-      rawSegments.push({
-        subjectId,
-        status: point.status,
-        startAt: new Date(segmentStartTs),
-        endAt: new Date(segmentEndTs)
-      });
-    }
+    const lifecycleEvents = events.filter((event) => (
+      ["subject_closed", "subject_reopened", "subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)
+    ));
+    const rawSegments = buildLifecycleSegments({
+      subjectId,
+      subjectCreatedTs,
+      lifecycleEvents,
+      endTs,
+      fallbackClosedStatus: subject.status
+    });
 
     const lifecycleSegments = rawSegments
       .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
@@ -312,6 +374,8 @@ export function buildTrajectoryModel({
           objectiveDates
         })
       }));
+
+    console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments);
 
     const objectiveMarkers = objectiveDates.map((entry) => {
       const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
@@ -342,8 +406,10 @@ export function buildTrajectoryModel({
 
 export function __trajectoryModelTestUtils() {
   return {
+    buildLifecycleSegments,
     normalizeStatus,
     normalizeCloseStatus,
+    resolveLifecycleStatusFromEvent,
     resolveObjectiveDates,
     resolveStatusAtTimestamp,
     splitSegmentByObjectiveBoundaries,

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -309,6 +309,37 @@ test("buildTrajectoryModel conserve un point à chaque évènement de cycle de v
   );
 });
 
+test("buildTrajectoryModel reconstruit 4 segments pour open → close → reopen → close", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "s-reopen-close", created_at: "2026-04-11T00:00:00.000Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "s-reopen-close": [
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-reopen-close", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T00:00:00.000Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T00:00:00.000Z" }
+    ]
+  );
+});
+
 test("buildTrajectoryModel rend plusieurs blocages entrants à des dates différentes sans casser le cycle de vie", () => {
   const result = buildTrajectoryModel({
     subjects: [{ id: "s-blocked", created_at: "2026-01-01T00:00:00.000Z", status: "open" }],


### PR DESCRIPTION
### Motivation
- The trajectory view collapsed lifecycle into a single segment because `lifecycleSegments` were derived indirectly from status points instead of reconstructing state changes from chronological events, causing missing open/close transitions (e.g. close → reopen → close).

### Description
- Modified `apps/web/js/views/project-situations/trajectory/trajectory-model.js` to replace the previous segment derivation with a chronological state-machine implementation via `resolveLifecycleStatusFromEvent` and `buildLifecycleSegments` that walk lifecycle events (`subject_closed`, `subject_reopened`, rejection/invalid events) in order and emit explicit segments from `subject.created_at` to `now` (or objective boundary).
- Replaced the old `rawSegments` construction with a call to `buildLifecycleSegments`, then kept existing objective-boundary splitting and `resolveSegmentStyle` unchanged, and exposed `buildLifecycleSegments`/`resolveLifecycleStatusFromEvent` in `__trajectoryModelTestUtils` for tests.
- Added a temporary runtime instrumentation `console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments)` and added one focused unit test in `apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` that asserts the `open → close → reopen → close` sequence produces four segments with exact timestamps.
- No CSS or time-scale changes were made and the DOM renderer already iterates `row.lifecycleSegments` so no changes were required in `trajectory-dom-renderer.js`.

### Testing
- Ran `node --test apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` and all tests passed (12/12), including the new `open → close → reopen → close` scenario.
- Ran `node --test apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs` and all tests passed (7/7).
- Test output includes the `console.log` lifecycle segments per subject confirming multiple segments are emitted when transitions exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0569f7d788329a32725a9793c9b32)