### PR TITLE
Trajectory: robust subject history lookup and lifecycle segment reconstruction

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -106,12 +106,35 @@ function resolveObjectiveMilestonePoints(event = {}, ts, currentStatus = "open")
   return points;
 }
 
-function collectEventsForSubject(subjectId, subjectHistoryEvents) {
+function resolveSubjectHistoryKeys(subject = {}) {
+  const keys = new Set([
+    normalizeId(subject?.id),
+    normalizeId(subject?.subject_id),
+    normalizeId(subject?.subjectId),
+    normalizeId(subject?.subject_number),
+    normalizeId(subject?.subjectNumber),
+    normalizeId(subject?.raw?.id),
+    normalizeId(subject?.raw?.subject_id),
+    normalizeId(subject?.raw?.subjectId),
+    normalizeId(subject?.raw?.subject_number),
+    normalizeId(subject?.raw?.subjectNumber)
+  ]);
+  keys.delete("");
+  return [...keys];
+}
+
+function collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys = []) {
+  const keysSet = new Set(asArray(subjectHistoryKeys).map((value) => normalizeId(value)).filter(Boolean));
+  if (!keysSet.size) return [];
   if (Array.isArray(subjectHistoryEvents)) {
-    return subjectHistoryEvents.filter((event) => normalizeId(event?.subject_id) === subjectId);
+    return subjectHistoryEvents.filter((event) => keysSet.has(normalizeId(event?.subject_id)));
   }
   if (subjectHistoryEvents && typeof subjectHistoryEvents === "object") {
-    return asArray(subjectHistoryEvents[subjectId]);
+    const collected = [];
+    for (const key of keysSet) {
+      collected.push(...asArray(subjectHistoryEvents[key]));
+    }
+    return collected;
   }
   return [];
 }
@@ -194,6 +217,76 @@ function toStatusIcon(status = "open") {
   return "open";
 }
 
+function resolveLifecycleStatusFromEvent(event = {}, fallbackStatus = "closed") {
+  const eventType = normalizeId(event?.event_type).toLowerCase();
+  if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+    return "closed_invalid";
+  }
+  if (eventType === "subject_closed") {
+    return normalizeCloseStatus(event, fallbackStatus);
+  }
+  return "open";
+}
+
+function buildLifecycleSegments({
+  subjectId = "",
+  subjectCreatedTs,
+  lifecycleEvents = [],
+  endTs,
+  fallbackClosedStatus = "closed"
+} = {}) {
+  const safeEndTs = Math.max(endTs, subjectCreatedTs);
+  let state = "open";
+  let currentStart = subjectCreatedTs;
+  const segments = [];
+
+  for (const event of lifecycleEvents) {
+    const eventType = normalizeId(event?.event_type).toLowerCase();
+    const eventTs = toTimestamp(event?.created_at, currentStart);
+    const safeEventTs = Math.min(Math.max(eventTs, subjectCreatedTs), safeEndTs);
+
+    if (eventType === "subject_reopened") {
+      if (state !== "open" && safeEventTs > currentStart) {
+        segments.push({
+          subjectId,
+          status: state,
+          startAt: new Date(currentStart),
+          endAt: new Date(safeEventTs)
+        });
+        state = "open";
+        currentStart = safeEventTs;
+      }
+      continue;
+    }
+
+    if (!["subject_closed", "subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+      continue;
+    }
+
+    if (state === "open" && safeEventTs > currentStart) {
+      segments.push({
+        subjectId,
+        status: "open",
+        startAt: new Date(currentStart),
+        endAt: new Date(safeEventTs)
+      });
+      state = resolveLifecycleStatusFromEvent(event, fallbackClosedStatus);
+      currentStart = safeEventTs;
+    }
+  }
+
+  if (safeEndTs > currentStart) {
+    segments.push({
+      subjectId,
+      status: state,
+      startAt: new Date(currentStart),
+      endAt: new Date(safeEndTs)
+    });
+  }
+
+  return segments;
+}
+
 export function buildTrajectoryModel({
   subjects = [],
   subjectHistoryEvents = {},
@@ -212,7 +305,8 @@ export function buildTrajectoryModel({
     const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
     const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
 
-    const events = collectEventsForSubject(subjectId, subjectHistoryEvents)
+    const subjectHistoryKeys = resolveSubjectHistoryKeys(subject);
+    const events = collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys)
       .map((event = {}) => ({
         ...event,
         event_type: normalizeId(event.event_type).toLowerCase(),
@@ -283,24 +377,16 @@ export function buildTrajectoryModel({
 
     statusPoints.sort((a, b) => a.at.getTime() - b.at.getTime());
 
-    const rawSegments = [];
-    for (let index = 0; index < statusPoints.length; index += 1) {
-      const point = statusPoints[index];
-      if (point.contributesToLifecycle === false) continue;
-      const nextPoint = statusPoints[index + 1];
-      const segmentStartTs = point.at.getTime();
-      const nextLifecyclePoint = nextPoint && nextPoint.contributesToLifecycle !== false
-        ? nextPoint
-        : statusPoints.slice(index + 1).find((entry) => entry.contributesToLifecycle !== false);
-      const segmentEndTs = nextLifecyclePoint ? nextLifecyclePoint.at.getTime() : endTs;
-      if (segmentEndTs <= segmentStartTs) continue;
-      rawSegments.push({
-        subjectId,
-        status: point.status,
-        startAt: new Date(segmentStartTs),
-        endAt: new Date(segmentEndTs)
-      });
-    }
+    const lifecycleEvents = events.filter((event) => (
+      ["subject_closed", "subject_reopened", "subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)
+    ));
+    const rawSegments = buildLifecycleSegments({
+      subjectId,
+      subjectCreatedTs,
+      lifecycleEvents,
+      endTs,
+      fallbackClosedStatus: subject.status
+    });
 
     const lifecycleSegments = rawSegments
       .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
@@ -312,6 +398,8 @@ export function buildTrajectoryModel({
           objectiveDates
         })
       }));
+
+    console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments);
 
     const objectiveMarkers = objectiveDates.map((entry) => {
       const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
@@ -342,8 +430,12 @@ export function buildTrajectoryModel({
 
 export function __trajectoryModelTestUtils() {
   return {
+    buildLifecycleSegments,
+    collectEventsForSubject,
     normalizeStatus,
     normalizeCloseStatus,
+    resolveSubjectHistoryKeys,
+    resolveLifecycleStatusFromEvent,
     resolveObjectiveDates,
     resolveStatusAtTimestamp,
     splitSegmentByObjectiveBoundaries,

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -309,6 +309,68 @@ test("buildTrajectoryModel conserve un point à chaque évènement de cycle de v
   );
 });
 
+test("buildTrajectoryModel reconstruit 4 segments pour open → close → reopen → close", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "s-reopen-close", created_at: "2026-04-11T00:00:00.000Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "s-reopen-close": [
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-reopen-close", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T00:00:00.000Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T00:00:00.000Z" }
+    ]
+  );
+});
+
+test("buildTrajectoryModel récupère l'historique même si les événements sont indexés par subject_number", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "29d78a78-d219-45de-9d3f-8d3a7fd1b915", subject_number: 18, created_at: "2026-04-11T09:28:07.836Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "18": [
+        { subject_id: "18", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "18", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "18", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T06:58:22.818Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T09:28:07.836Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T06:58:22.818Z" }
+    ]
+  );
+});
+
 test("buildTrajectoryModel rend plusieurs blocages entrants à des dates différentes sans casser le cycle de vie", () => {
   const result = buildTrajectoryModel({
     subjects: [{ id: "s-blocked", created_at: "2026-01-01T00:00:00.000Z", status: "open" }],


### PR DESCRIPTION
### Motivation

- Ensure subject history is correctly collected when events are keyed by different identifiers (id, subject_id, subjectId, subject_number, subjectNumber or nested in `raw`).
- Accurately reconstruct lifecycle segments for open/close/reopen sequences instead of deriving them indirectly from status points.

### Description

- Add `resolveSubjectHistoryKeys` to derive all possible history keys for a subject and update `collectEventsForSubject` to accept `subjectHistoryEvents` and a list of keys to aggregate events from multiple indexes. 
- Introduce `resolveLifecycleStatusFromEvent` and `buildLifecycleSegments` to compute lifecycle segments from lifecycle events (`subject_closed`, `subject_reopened`, `subject_rejected`, `review_rejected`, `subject_invalidated`) with clamping to subject creation and end timestamps. 
- Replace previous raw segment construction (based on filtering `statusPoints`) with `buildLifecycleSegments` and keep existing objective-splitting and styling logic via `splitSegmentByObjectiveBoundaries` and `resolveSegmentStyle`. 
- Export new utilities in `__trajectoryModelTestUtils`: `buildLifecycleSegments`, `collectEventsForSubject`, and `resolveSubjectHistoryKeys` for testing, and add a debug `console.log` for lifecycle segments. 
- Add tests covering reopen→close→reopen→close segment reconstruction and history lookup when events are keyed by `subject_number`.

### Testing

- Ran the trajectory model unit tests including the updated `trajectory-model.test.mjs` suite; all tests, including the new cases for reopen/close segment reconstruction and `subject_number`-keyed history, passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0569f7d788329a32725a9793c9b32)