### PR TITLE
Make trajectory history fetching resilient, add loading/error state, and improve lifecycle segmenting

### DIFF
--- a/apps/web/js/services/project-situations-trajectory-service.js
+++ b/apps/web/js/services/project-situations-trajectory-service.js
@@ -42,6 +42,11 @@ const ACTIVITY_EVENT_TYPES = new Set([
   "subject_blocked_by_added",
   "subject_objectives_changed"
 ]);
+const HISTORY_SELECT_CANDIDATES = [
+  "id,project_id,subject_id,event_type,event_payload,created_at,created_by",
+  "id,project_id,subject_id,event_type,payload,created_at,created_by",
+  "id,project_id,subject_id,event_type,created_at,created_by"
+];
 
 function normalizeId(value) {
   return String(value || "").trim();
@@ -71,12 +76,13 @@ function normalizeHistoryRow(row = {}) {
   const eventType = normalizeId(row.event_type || row.type).toLowerCase();
   const subjectId = normalizeId(row.subject_id || row.entity_id || row.subjectId);
   const createdAt = row.created_at || row.createdAt || "";
+  const payloadCandidate = row.event_payload ?? row.eventPayload ?? row.payload;
   return {
     ...row,
     event_type: eventType,
     subject_id: subjectId,
     created_at: createdAt,
-    payload: row.payload && typeof row.payload === "object" ? row.payload : {}
+    payload: payloadCandidate && typeof payloadCandidate === "object" ? payloadCandidate : {}
   };
 }
 
@@ -106,25 +112,42 @@ export async function loadProjectSituationsTrajectoryHistory({
     };
   }
 
-  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_history`);
-  url.searchParams.set("select", "id,project_id,subject_id,event_type,payload,created_at,created_by");
-  url.searchParams.set("project_id", `eq.${resolvedProjectId}`);
-  url.searchParams.set("subject_id", buildInFilterValue(scopedSubjectIds));
-  url.searchParams.set("event_type", `in.(${TRAJECTORY_EVENT_TYPES.join(",")})`);
-  url.searchParams.set("order", "created_at.asc");
+  const headers = await getSupabaseAuthHeaders({ Accept: "application/json" });
+  let rows = null;
+  let lastErrorText = "";
+  let lastStatus = 0;
+  for (const select of HISTORY_SELECT_CANDIDATES) {
+    const url = new URL(`${SUPABASE_URL}/rest/v1/subject_history`);
+    url.searchParams.set("select", select);
+    url.searchParams.set("project_id", `eq.${resolvedProjectId}`);
+    url.searchParams.set("subject_id", buildInFilterValue(scopedSubjectIds));
+    url.searchParams.set("event_type", `in.(${TRAJECTORY_EVENT_TYPES.join(",")})`);
+    url.searchParams.set("order", "created_at.asc");
 
-  const response = await fetch(url.toString(), {
-    method: "GET",
-    headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
-    cache: "no-store"
-  });
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers,
+      cache: "no-store"
+    });
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`trajectory history fetch failed (${response.status}): ${text}`);
+    if (response.ok) {
+      rows = safeArray(await response.json());
+      break;
+    }
+
+    lastStatus = response.status;
+    lastErrorText = await response.text().catch(() => "");
+    const isMissingColumnError = response.status === 400 && /column subject_history\.[a-z_]+ does not exist/i.test(lastErrorText);
+    if (!isMissingColumnError) {
+      throw new Error(`trajectory history fetch failed (${response.status}): ${lastErrorText}`);
+    }
   }
 
-  const normalizedEvents = safeArray(await response.json())
+  if (!rows) {
+    throw new Error(`trajectory history fetch failed (${lastStatus}): ${lastErrorText}`);
+  }
+
+  const normalizedEvents = safeArray(rows)
     .map(normalizeHistoryRow)
     .filter((event) => !!normalizeId(event.subject_id))
     .filter((event) => TRAJECTORY_EVENT_TYPES.includes(event.event_type));

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -108,7 +108,9 @@ async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {})
     && typeof cached === "object"
     && cached.eventsBySubjectId
     && cached.statusEventsBySubjectId
-    && Array.isArray(cached.relationEvents);
+    && Array.isArray(cached.relationEvents)
+    && cached.historyStatus === "ready"
+    && cached.isComplete === true;
 
 
   if (hasUsableCachedPayload && cachedSignature === subjectIdsSignature) {
@@ -120,11 +122,24 @@ async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {})
       eventsBySubjectId: {},
       relationEvents: [],
       statusEventsBySubjectId: {},
-      subjectIdsSignature
+      subjectIdsSignature,
+      historyStatus: "ready",
+      isComplete: true,
+      errorMessage: ""
     };
     cacheBySituationId[normalizedSituationId] = emptyPayload;
     return emptyPayload;
   }
+
+  cacheBySituationId[normalizedSituationId] = {
+    eventsBySubjectId: {},
+    relationEvents: [],
+    statusEventsBySubjectId: {},
+    subjectIdsSignature,
+    historyStatus: "loading",
+    isComplete: false,
+    errorMessage: ""
+  };
 
   try {
     const history = await loadProjectSituationsTrajectoryHistory({
@@ -135,22 +150,26 @@ async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {})
       eventsBySubjectId: history?.eventsBySubjectId && typeof history.eventsBySubjectId === "object" ? history.eventsBySubjectId : {},
       relationEvents: Array.isArray(history?.relationEvents) ? history.relationEvents : [],
       statusEventsBySubjectId: history?.statusEventsBySubjectId && typeof history.statusEventsBySubjectId === "object" ? history.statusEventsBySubjectId : {},
-      subjectIdsSignature
+      subjectIdsSignature,
+      historyStatus: "ready",
+      isComplete: true,
+      errorMessage: ""
     };
     cacheBySituationId[normalizedSituationId] = payload;
     return payload;
   } catch (error) {
     console.error("[trajectory] history.ensure.error", error);
-    const fallbackPayload = hasUsableCachedPayload
-      ? cached
-      : {
-          eventsBySubjectId: {},
-          relationEvents: [],
-          statusEventsBySubjectId: {},
-          subjectIdsSignature
-        };
-    cacheBySituationId[normalizedSituationId] = fallbackPayload;
-    return fallbackPayload;
+    const errorPayload = {
+      eventsBySubjectId: {},
+      relationEvents: [],
+      statusEventsBySubjectId: {},
+      subjectIdsSignature,
+      historyStatus: "error",
+      isComplete: false,
+      errorMessage: error instanceof Error ? error.message : "Impossible de charger l'historique de trajectoire."
+    };
+    cacheBySituationId[normalizedSituationId] = errorPayload;
+    return errorPayload;
   }
 }
 

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -704,6 +704,31 @@ export function createProjectSituationsEvents({
     return scoped.statusEventsBySubjectId || scoped.eventsBySubjectId || {};
   }
 
+  function resolveTrajectoryHistoryState(situationId = "", subjects = []) {
+    const bySituationId = store?.projectSubjectsView?.trajectoryHistoryBySituationId;
+    if (!bySituationId || typeof bySituationId !== "object") {
+      return { status: "loading", isComplete: false, errorMessage: "" };
+    }
+    const scoped = bySituationId[situationId];
+    if (!scoped || typeof scoped !== "object") {
+      return { status: "loading", isComplete: false, errorMessage: "" };
+    }
+    const subjectIdsSignature = [...new Set((Array.isArray(subjects) ? subjects : [])
+      .map((subject) => String(subject?.id || "").trim())
+      .filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b))
+      .join(",");
+    const scopedSignature = String(scoped?.subjectIdsSignature || "").trim();
+    if (subjectIdsSignature && scopedSignature && scopedSignature !== subjectIdsSignature) {
+      return { status: "loading", isComplete: false, errorMessage: "" };
+    }
+    return {
+      status: String(scoped?.historyStatus || "").trim().toLowerCase() || "ready",
+      isComplete: scoped?.isComplete === true,
+      errorMessage: String(scoped?.errorMessage || "").trim()
+    };
+  }
+
 
   function resolveTrajectoryRelationEvents(situationId = "") {
     const bySituationId = store?.projectSubjectsView?.trajectoryHistoryBySituationId;
@@ -852,6 +877,7 @@ export function createProjectSituationsEvents({
           const objectiveIdsBySubjectId = rawSubjectsResult.objectiveIdsBySubjectId || {};
           const objectivesById = rawSubjectsResult.objectivesById || {};
           const historyBySubjectId = resolveTrajectoryHistoryBySubjectId(situationId);
+          const historyState = resolveTrajectoryHistoryState(situationId, subjects);
           const relationEvents = resolveTrajectoryRelationEvents(situationId);
           const situationStartDate = resolveTrajectorySituationStartDate(situationId);
 
@@ -873,6 +899,27 @@ export function createProjectSituationsEvents({
             endDate: resolveTrajectoryTimelineEndDate(),
             zoom: "day"
           });
+
+          if (historyState.status !== "ready" || historyState.isComplete !== true) {
+            if (itemsRootNode) itemsRootNode.innerHTML = "";
+            if (svgNode) svgNode.innerHTML = "";
+            if (spinnerNode) {
+              spinnerNode.hidden = false;
+              const spinnerLabel = spinnerNode.querySelector("span:last-child");
+              if (spinnerLabel) {
+                spinnerLabel.textContent = historyState.status === "error"
+                  ? "Trajectoire indisponible : historique incomplet."
+                  : "Chargement de la trajectoire…";
+              }
+            }
+            console.warn("[trajectory] history.incomplete", {
+              situationId,
+              status: historyState.status,
+              isComplete: historyState.isComplete,
+              message: historyState.errorMessage || ""
+            });
+            return;
+          }
 
           const { rows } = buildTrajectoryModel({
             subjects,
@@ -1840,6 +1887,17 @@ export function createProjectSituationsEvents({
         if (store.situationsView.selectedSituationLayout === nextLayout) return;
         store.situationsView.selectedSituationLayout = nextLayout;
         rerender(root);
+        if (nextLayout === "roadmap" && typeof loadSituationSelection === "function") {
+          const selectedSituationId = String(store?.situationsView?.selectedSituationId || "").trim();
+          if (selectedSituationId) {
+            loadSituationSelection(selectedSituationId)
+              .then(() => rerender(root))
+              .catch((error) => {
+                console.error("[trajectory] history.load.on.layout.error", error);
+                rerender(root);
+              });
+          }
+        }
       }
     });
 

--- a/apps/web/js/views/project-situations/project-situations-persistence.js
+++ b/apps/web/js/views/project-situations/project-situations-persistence.js
@@ -32,8 +32,7 @@ export function createProjectSituationsPersistence({
     try {
       const subjects = await loadSubjectsForSituation(selectedSituation, store.projectSubjectsView);
       uiState.selectedSituationSubjects = safeArray(subjects);
-      const selectedLayout = String(store?.situationsView?.selectedSituationLayout || "").trim().toLowerCase();
-      if (selectedLayout === "roadmap" && typeof ensureTrajectoryHistory === "function") {
+      if (typeof ensureTrajectoryHistory === "function") {
         await ensureTrajectoryHistory({
           situationId: normalizedId,
           subjects: uiState.selectedSituationSubjects

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -106,12 +106,35 @@ function resolveObjectiveMilestonePoints(event = {}, ts, currentStatus = "open")
   return points;
 }
 
-function collectEventsForSubject(subjectId, subjectHistoryEvents) {
+function resolveSubjectHistoryKeys(subject = {}) {
+  const keys = new Set([
+    normalizeId(subject?.id),
+    normalizeId(subject?.subject_id),
+    normalizeId(subject?.subjectId),
+    normalizeId(subject?.subject_number),
+    normalizeId(subject?.subjectNumber),
+    normalizeId(subject?.raw?.id),
+    normalizeId(subject?.raw?.subject_id),
+    normalizeId(subject?.raw?.subjectId),
+    normalizeId(subject?.raw?.subject_number),
+    normalizeId(subject?.raw?.subjectNumber)
+  ]);
+  keys.delete("");
+  return [...keys];
+}
+
+function collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys = []) {
+  const keysSet = new Set(asArray(subjectHistoryKeys).map((value) => normalizeId(value)).filter(Boolean));
+  if (!keysSet.size) return [];
   if (Array.isArray(subjectHistoryEvents)) {
-    return subjectHistoryEvents.filter((event) => normalizeId(event?.subject_id) === subjectId);
+    return subjectHistoryEvents.filter((event) => keysSet.has(normalizeId(event?.subject_id)));
   }
   if (subjectHistoryEvents && typeof subjectHistoryEvents === "object") {
-    return asArray(subjectHistoryEvents[subjectId]);
+    const collected = [];
+    for (const key of keysSet) {
+      collected.push(...asArray(subjectHistoryEvents[key]));
+    }
+    return collected;
   }
   return [];
 }
@@ -194,6 +217,76 @@ function toStatusIcon(status = "open") {
   return "open";
 }
 
+function resolveLifecycleStatusFromEvent(event = {}, fallbackStatus = "closed") {
+  const eventType = normalizeId(event?.event_type).toLowerCase();
+  if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+    return "closed_invalid";
+  }
+  if (eventType === "subject_closed") {
+    return normalizeCloseStatus(event, fallbackStatus);
+  }
+  return "open";
+}
+
+function buildLifecycleSegments({
+  subjectId = "",
+  subjectCreatedTs,
+  lifecycleEvents = [],
+  endTs,
+  fallbackClosedStatus = "closed"
+} = {}) {
+  const safeEndTs = Math.max(endTs, subjectCreatedTs);
+  let state = "open";
+  let currentStart = subjectCreatedTs;
+  const segments = [];
+
+  for (const event of lifecycleEvents) {
+    const eventType = normalizeId(event?.event_type).toLowerCase();
+    const eventTs = toTimestamp(event?.created_at, currentStart);
+    const safeEventTs = Math.min(Math.max(eventTs, subjectCreatedTs), safeEndTs);
+
+    if (eventType === "subject_reopened") {
+      if (state !== "open" && safeEventTs > currentStart) {
+        segments.push({
+          subjectId,
+          status: state,
+          startAt: new Date(currentStart),
+          endAt: new Date(safeEventTs)
+        });
+        state = "open";
+        currentStart = safeEventTs;
+      }
+      continue;
+    }
+
+    if (!["subject_closed", "subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+      continue;
+    }
+
+    if (state === "open" && safeEventTs > currentStart) {
+      segments.push({
+        subjectId,
+        status: "open",
+        startAt: new Date(currentStart),
+        endAt: new Date(safeEventTs)
+      });
+      state = resolveLifecycleStatusFromEvent(event, fallbackClosedStatus);
+      currentStart = safeEventTs;
+    }
+  }
+
+  if (safeEndTs > currentStart) {
+    segments.push({
+      subjectId,
+      status: state,
+      startAt: new Date(currentStart),
+      endAt: new Date(safeEndTs)
+    });
+  }
+
+  return segments;
+}
+
 export function buildTrajectoryModel({
   subjects = [],
   subjectHistoryEvents = {},
@@ -212,7 +305,8 @@ export function buildTrajectoryModel({
     const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
     const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
 
-    const events = collectEventsForSubject(subjectId, subjectHistoryEvents)
+    const subjectHistoryKeys = resolveSubjectHistoryKeys(subject);
+    const events = collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys)
       .map((event = {}) => ({
         ...event,
         event_type: normalizeId(event.event_type).toLowerCase(),
@@ -283,24 +377,16 @@ export function buildTrajectoryModel({
 
     statusPoints.sort((a, b) => a.at.getTime() - b.at.getTime());
 
-    const rawSegments = [];
-    for (let index = 0; index < statusPoints.length; index += 1) {
-      const point = statusPoints[index];
-      if (point.contributesToLifecycle === false) continue;
-      const nextPoint = statusPoints[index + 1];
-      const segmentStartTs = point.at.getTime();
-      const nextLifecyclePoint = nextPoint && nextPoint.contributesToLifecycle !== false
-        ? nextPoint
-        : statusPoints.slice(index + 1).find((entry) => entry.contributesToLifecycle !== false);
-      const segmentEndTs = nextLifecyclePoint ? nextLifecyclePoint.at.getTime() : endTs;
-      if (segmentEndTs <= segmentStartTs) continue;
-      rawSegments.push({
-        subjectId,
-        status: point.status,
-        startAt: new Date(segmentStartTs),
-        endAt: new Date(segmentEndTs)
-      });
-    }
+    const lifecycleEvents = events.filter((event) => (
+      ["subject_closed", "subject_reopened", "subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)
+    ));
+    const rawSegments = buildLifecycleSegments({
+      subjectId,
+      subjectCreatedTs,
+      lifecycleEvents,
+      endTs,
+      fallbackClosedStatus: subject.status
+    });
 
     const lifecycleSegments = rawSegments
       .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
@@ -312,6 +398,8 @@ export function buildTrajectoryModel({
           objectiveDates
         })
       }));
+
+    console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments);
 
     const objectiveMarkers = objectiveDates.map((entry) => {
       const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
@@ -342,8 +430,12 @@ export function buildTrajectoryModel({
 
 export function __trajectoryModelTestUtils() {
   return {
+    buildLifecycleSegments,
+    collectEventsForSubject,
     normalizeStatus,
     normalizeCloseStatus,
+    resolveSubjectHistoryKeys,
+    resolveLifecycleStatusFromEvent,
     resolveObjectiveDates,
     resolveStatusAtTimestamp,
     splitSegmentByObjectiveBoundaries,

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -309,6 +309,68 @@ test("buildTrajectoryModel conserve un point à chaque évènement de cycle de v
   );
 });
 
+test("buildTrajectoryModel reconstruit 4 segments pour open → close → reopen → close", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "s-reopen-close", created_at: "2026-04-11T00:00:00.000Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "s-reopen-close": [
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-reopen-close", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T00:00:00.000Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T00:00:00.000Z" }
+    ]
+  );
+});
+
+test("buildTrajectoryModel récupère l'historique même si les événements sont indexés par subject_number", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "29d78a78-d219-45de-9d3f-8d3a7fd1b915", subject_number: 18, created_at: "2026-04-11T09:28:07.836Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "18": [
+        { subject_id: "18", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "18", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "18", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T06:58:22.818Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T09:28:07.836Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T06:58:22.818Z" }
+    ]
+  );
+});
+
 test("buildTrajectoryModel rend plusieurs blocages entrants à des dates différentes sans casser le cycle de vie", () => {
   const result = buildTrajectoryModel({
     subjects: [{ id: "s-blocked", created_at: "2026-01-01T00:00:00.000Z", status: "open" }],


### PR DESCRIPTION
### Motivation
- Make history loading resilient to schema variations in the `subject_history` table and avoid breaking UI when columns differ. 
- Surface loading/error state for trajectory history and avoid rendering incomplete timelines. 
- Improve trajectory lifecycle reconstruction to correctly handle reopen/close cycles and history keyed by alternate subject identifiers.

### Description
- In `project-situations-trajectory-service.js` add `HISTORY_SELECT_CANDIDATES` and implement sequential `select` attempts to tolerate different column names (`event_payload`, `payload`, or no payload`) and handle missing-column errors gracefully, normalizing payload into `payload` when present.
- In `project-situations.js` and `project-situations-events.js` introduce `historyStatus`, `isComplete`, and `errorMessage` in the trajectory history cache, add `resolveTrajectoryHistoryState`, show spinner/error messages while history is not ready, and prevent rendering of incomplete trajectories.
- In `project-situations-persistence.js` always call `ensureTrajectoryHistory` when loading a situation selection so the history cache is populated regardless of current layout.
- In `trajectory-model.js` add robust subject history key resolution (`resolveSubjectHistoryKeys`), update `collectEventsForSubject` to accept multiple subject keys (including `subject_number` and raw fields), and replace the previous lifecycle segment derivation with `buildLifecycleSegments` + `resolveLifecycleStatusFromEvent` to correctly produce segments for open→close→reopen→close cycles; expose new utilities for testing.
- Add tests in `trajectory-model.test.mjs` that verify reopen/close segment reconstruction and that events indexed by `subject_number` are correctly matched.

### Testing
- Ran unit tests for the trajectory model (including the two new tests) with the test suite under `trajectory-model.test.mjs`, and all tests passed.
- Exercised history fetch paths manually in development to validate retrying different `select` shapes and observed proper error/warning behavior when columns are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0569f7d788329a32725a9793c9b32)