### PR TITLE
Trajectory: robust history reader (RPC + REST fallback), model fixes, UI and caching improvements

### DIFF
--- a/apps/web/js/services/project-situations-trajectory-service.js
+++ b/apps/web/js/services/project-situations-trajectory-service.js
@@ -42,6 +42,12 @@ const ACTIVITY_EVENT_TYPES = new Set([
   "subject_blocked_by_added",
   "subject_objectives_changed"
 ]);
+const HISTORY_SELECT_CANDIDATES = [
+  "id,project_id,subject_id,event_type,event_payload,created_at",
+  "id,project_id,subject_id,event_type,payload,created_at",
+  "id,project_id,subject_id,event_type,created_at"
+];
+const TRAJECTORY_HISTORY_RPC_NAME = "list_subject_history_for_trajectory";
 
 function normalizeId(value) {
   return String(value || "").trim();
@@ -71,12 +77,13 @@ function normalizeHistoryRow(row = {}) {
   const eventType = normalizeId(row.event_type || row.type).toLowerCase();
   const subjectId = normalizeId(row.subject_id || row.entity_id || row.subjectId);
   const createdAt = row.created_at || row.createdAt || "";
+  const payloadCandidate = row.event_payload ?? row.eventPayload ?? row.payload;
   return {
     ...row,
     event_type: eventType,
     subject_id: subjectId,
     created_at: createdAt,
-    payload: row.payload && typeof row.payload === "object" ? row.payload : {}
+    payload: payloadCandidate && typeof payloadCandidate === "object" ? payloadCandidate : {}
   };
 }
 
@@ -88,6 +95,75 @@ function groupEventsBySubjectId(events = []) {
     acc[subjectId].push(event);
     return acc;
   }, {});
+}
+
+function isMissingColumnError(status, rawBody = "") {
+  return status === 400 && /column subject_history\.[a-z_]+ does not exist/i.test(String(rawBody || ""));
+}
+
+function isMissingRpcFunctionError(status, rawBody = "") {
+  return (status === 404 || status === 400)
+    && /function\s+public\.list_subject_history_for_trajectory|could not find the function/i.test(String(rawBody || ""));
+}
+
+async function fetchTrajectoryHistoryViaRpc({ projectId, subjectIds, headers }) {
+  const rpcUrl = `${SUPABASE_URL}/rest/v1/rpc/${TRAJECTORY_HISTORY_RPC_NAME}`;
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      p_project_id: projectId,
+      p_subject_ids: subjectIds
+    }),
+    cache: "no-store"
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    const error = new Error(`trajectory history rpc failed (${response.status}): ${text}`);
+    error.status = response.status;
+    error.rawBody = text;
+    throw error;
+  }
+  return safeArray(await response.json().catch(() => []));
+}
+
+async function fetchTrajectoryHistoryViaRest({ projectId, subjectIds, headers }) {
+  let rows = null;
+  let lastErrorText = "";
+  let lastStatus = 0;
+  for (const select of HISTORY_SELECT_CANDIDATES) {
+    const url = new URL(`${SUPABASE_URL}/rest/v1/subject_history`);
+    url.searchParams.set("select", select);
+    url.searchParams.set("project_id", `eq.${projectId}`);
+    url.searchParams.set("subject_id", buildInFilterValue(subjectIds));
+    url.searchParams.set("event_type", `in.(${TRAJECTORY_EVENT_TYPES.join(",")})`);
+    url.searchParams.set("order", "created_at.asc");
+
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers,
+      cache: "no-store"
+    });
+
+    if (response.ok) {
+      rows = safeArray(await response.json());
+      break;
+    }
+
+    lastStatus = response.status;
+    lastErrorText = await response.text().catch(() => "");
+    if (!isMissingColumnError(response.status, lastErrorText)) {
+      throw new Error(`trajectory history fetch failed (${response.status}): ${lastErrorText}`);
+    }
+  }
+
+  if (!rows) {
+    throw new Error(`trajectory history fetch failed (${lastStatus}): ${lastErrorText}`);
+  }
+  return rows;
 }
 
 export async function loadProjectSituationsTrajectoryHistory({
@@ -106,25 +182,26 @@ export async function loadProjectSituationsTrajectoryHistory({
     };
   }
 
-  const url = new URL(`${SUPABASE_URL}/rest/v1/subject_history`);
-  url.searchParams.set("select", "id,project_id,subject_id,event_type,payload,created_at,created_by");
-  url.searchParams.set("project_id", `eq.${resolvedProjectId}`);
-  url.searchParams.set("subject_id", buildInFilterValue(scopedSubjectIds));
-  url.searchParams.set("event_type", `in.(${TRAJECTORY_EVENT_TYPES.join(",")})`);
-  url.searchParams.set("order", "created_at.asc");
-
-  const response = await fetch(url.toString(), {
-    method: "GET",
-    headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
-    cache: "no-store"
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`trajectory history fetch failed (${response.status}): ${text}`);
+  const headers = await getSupabaseAuthHeaders({ Accept: "application/json" });
+  let rows = [];
+  try {
+    rows = await fetchTrajectoryHistoryViaRpc({
+      projectId: resolvedProjectId,
+      subjectIds: scopedSubjectIds,
+      headers
+    });
+  } catch (error) {
+    if (!isMissingRpcFunctionError(error?.status, error?.rawBody)) {
+      throw error;
+    }
+    rows = await fetchTrajectoryHistoryViaRest({
+      projectId: resolvedProjectId,
+      subjectIds: scopedSubjectIds,
+      headers
+    });
   }
 
-  const normalizedEvents = safeArray(await response.json())
+  const normalizedEvents = safeArray(rows)
     .map(normalizeHistoryRow)
     .filter((event) => !!normalizeId(event.subject_id))
     .filter((event) => TRAJECTORY_EVENT_TYPES.includes(event.event_type));

--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -108,7 +108,9 @@ async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {})
     && typeof cached === "object"
     && cached.eventsBySubjectId
     && cached.statusEventsBySubjectId
-    && Array.isArray(cached.relationEvents);
+    && Array.isArray(cached.relationEvents)
+    && cached.historyStatus === "ready"
+    && cached.isComplete === true;
 
 
   if (hasUsableCachedPayload && cachedSignature === subjectIdsSignature) {
@@ -120,11 +122,24 @@ async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {})
       eventsBySubjectId: {},
       relationEvents: [],
       statusEventsBySubjectId: {},
-      subjectIdsSignature
+      subjectIdsSignature,
+      historyStatus: "ready",
+      isComplete: true,
+      errorMessage: ""
     };
     cacheBySituationId[normalizedSituationId] = emptyPayload;
     return emptyPayload;
   }
+
+  cacheBySituationId[normalizedSituationId] = {
+    eventsBySubjectId: {},
+    relationEvents: [],
+    statusEventsBySubjectId: {},
+    subjectIdsSignature,
+    historyStatus: "loading",
+    isComplete: false,
+    errorMessage: ""
+  };
 
   try {
     const history = await loadProjectSituationsTrajectoryHistory({
@@ -135,22 +150,26 @@ async function ensureTrajectoryHistory({ situationId = "", subjects = [] } = {})
       eventsBySubjectId: history?.eventsBySubjectId && typeof history.eventsBySubjectId === "object" ? history.eventsBySubjectId : {},
       relationEvents: Array.isArray(history?.relationEvents) ? history.relationEvents : [],
       statusEventsBySubjectId: history?.statusEventsBySubjectId && typeof history.statusEventsBySubjectId === "object" ? history.statusEventsBySubjectId : {},
-      subjectIdsSignature
+      subjectIdsSignature,
+      historyStatus: "ready",
+      isComplete: true,
+      errorMessage: ""
     };
     cacheBySituationId[normalizedSituationId] = payload;
     return payload;
   } catch (error) {
     console.error("[trajectory] history.ensure.error", error);
-    const fallbackPayload = hasUsableCachedPayload
-      ? cached
-      : {
-          eventsBySubjectId: {},
-          relationEvents: [],
-          statusEventsBySubjectId: {},
-          subjectIdsSignature
-        };
-    cacheBySituationId[normalizedSituationId] = fallbackPayload;
-    return fallbackPayload;
+    const errorPayload = {
+      eventsBySubjectId: {},
+      relationEvents: [],
+      statusEventsBySubjectId: {},
+      subjectIdsSignature,
+      historyStatus: "error",
+      isComplete: false,
+      errorMessage: error instanceof Error ? error.message : "Impossible de charger l'historique de trajectoire."
+    };
+    cacheBySituationId[normalizedSituationId] = errorPayload;
+    return errorPayload;
   }
 }
 

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -704,6 +704,31 @@ export function createProjectSituationsEvents({
     return scoped.statusEventsBySubjectId || scoped.eventsBySubjectId || {};
   }
 
+  function resolveTrajectoryHistoryState(situationId = "", subjects = []) {
+    const bySituationId = store?.projectSubjectsView?.trajectoryHistoryBySituationId;
+    if (!bySituationId || typeof bySituationId !== "object") {
+      return { status: "loading", isComplete: false, errorMessage: "" };
+    }
+    const scoped = bySituationId[situationId];
+    if (!scoped || typeof scoped !== "object") {
+      return { status: "loading", isComplete: false, errorMessage: "" };
+    }
+    const subjectIdsSignature = [...new Set((Array.isArray(subjects) ? subjects : [])
+      .map((subject) => String(subject?.id || "").trim())
+      .filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b))
+      .join(",");
+    const scopedSignature = String(scoped?.subjectIdsSignature || "").trim();
+    if (subjectIdsSignature && scopedSignature && scopedSignature !== subjectIdsSignature) {
+      return { status: "loading", isComplete: false, errorMessage: "" };
+    }
+    return {
+      status: String(scoped?.historyStatus || "").trim().toLowerCase() || "ready",
+      isComplete: scoped?.isComplete === true,
+      errorMessage: String(scoped?.errorMessage || "").trim()
+    };
+  }
+
 
   function resolveTrajectoryRelationEvents(situationId = "") {
     const bySituationId = store?.projectSubjectsView?.trajectoryHistoryBySituationId;
@@ -811,6 +836,11 @@ export function createProjectSituationsEvents({
     timelineContentNode.querySelectorAll(".situation-trajectory__timeline-objective").forEach((objectiveNode) => {
       const halfWidth = Math.round((objectiveNode.offsetWidth || 0) / 2);
       objectiveNode.style.marginLeft = `${-halfWidth}px`;
+      const lineHeight = Math.max(
+        0,
+        (timelineContentNode.clientHeight || 0) - ((objectiveNode.offsetTop || 0) + (objectiveNode.offsetHeight || 0))
+      );
+      objectiveNode.style.setProperty("--trajectory-objective-line-height", `${lineHeight}px`);
     });
   }
 
@@ -852,6 +882,7 @@ export function createProjectSituationsEvents({
           const objectiveIdsBySubjectId = rawSubjectsResult.objectiveIdsBySubjectId || {};
           const objectivesById = rawSubjectsResult.objectivesById || {};
           const historyBySubjectId = resolveTrajectoryHistoryBySubjectId(situationId);
+          const historyState = resolveTrajectoryHistoryState(situationId, subjects);
           const relationEvents = resolveTrajectoryRelationEvents(situationId);
           const situationStartDate = resolveTrajectorySituationStartDate(situationId);
 
@@ -873,6 +904,27 @@ export function createProjectSituationsEvents({
             endDate: resolveTrajectoryTimelineEndDate(),
             zoom: "day"
           });
+
+          if (historyState.status !== "ready" || historyState.isComplete !== true) {
+            if (itemsRootNode) itemsRootNode.innerHTML = "";
+            if (svgNode) svgNode.innerHTML = "";
+            if (spinnerNode) {
+              spinnerNode.hidden = false;
+              const spinnerLabel = spinnerNode.querySelector("span:last-child");
+              if (spinnerLabel) {
+                spinnerLabel.textContent = historyState.status === "error"
+                  ? "Trajectoire indisponible : historique incomplet."
+                  : "Chargement de la trajectoire…";
+              }
+            }
+            console.warn("[trajectory] history.incomplete", {
+              situationId,
+              status: historyState.status,
+              isComplete: historyState.isComplete,
+              message: historyState.errorMessage || ""
+            });
+            return;
+          }
 
           const { rows } = buildTrajectoryModel({
             subjects,
@@ -1840,6 +1892,17 @@ export function createProjectSituationsEvents({
         if (store.situationsView.selectedSituationLayout === nextLayout) return;
         store.situationsView.selectedSituationLayout = nextLayout;
         rerender(root);
+        if (nextLayout === "roadmap" && typeof loadSituationSelection === "function") {
+          const selectedSituationId = String(store?.situationsView?.selectedSituationId || "").trim();
+          if (selectedSituationId) {
+            loadSituationSelection(selectedSituationId)
+              .then(() => rerender(root))
+              .catch((error) => {
+                console.error("[trajectory] history.load.on.layout.error", error);
+                rerender(root);
+              });
+          }
+        }
       }
     });
 
@@ -1870,6 +1933,28 @@ export function createProjectSituationsEvents({
     bindSituationGridColumnResize(root);
     bindTrajectoryColumnResize(root);
     bindTrajectoryDom(root);
+    root.querySelectorAll("[data-situation-trajectory-opacity-input]").forEach((node) => {
+      const applyOpacity = () => {
+        const situationId = String(node.getAttribute("data-situation-trajectory-opacity-input") || "").trim();
+        if (!situationId) return;
+        const raw = Number(node.value);
+        const nextOpacity = Number.isFinite(raw) ? Math.max(0, Math.min(1, raw)) : 0.95;
+        if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+        if (!store.situationsView.trajectoryCardOpacityBySituationId || typeof store.situationsView.trajectoryCardOpacityBySituationId !== "object") {
+          store.situationsView.trajectoryCardOpacityBySituationId = {};
+        }
+        store.situationsView.trajectoryCardOpacityBySituationId[situationId] = nextOpacity;
+        const trajectoryNode = node.closest("[data-situation-trajectory]");
+        if (trajectoryNode) {
+          trajectoryNode.style.setProperty("--situation-trajectory-card-opacity", String(nextOpacity.toFixed(2)));
+          trajectoryNode.style.setProperty("--situation-trajectory-title-opacity", String(nextOpacity.toFixed(2)));
+        }
+        const valueNode = root.querySelector(`[data-situation-trajectory-opacity-value="${situationId}"]`);
+        if (valueNode) valueNode.textContent = nextOpacity.toFixed(2);
+      };
+      node.addEventListener("input", applyOpacity);
+      node.addEventListener("change", applyOpacity);
+    });
     bindSituationGridEditableCells(root);
     bindSituationGridDnd(root);
 

--- a/apps/web/js/views/project-situations/project-situations-persistence.js
+++ b/apps/web/js/views/project-situations/project-situations-persistence.js
@@ -32,8 +32,7 @@ export function createProjectSituationsPersistence({
     try {
       const subjects = await loadSubjectsForSituation(selectedSituation, store.projectSubjectsView);
       uiState.selectedSituationSubjects = safeArray(subjects);
-      const selectedLayout = String(store?.situationsView?.selectedSituationLayout || "").trim().toLowerCase();
-      if (selectedLayout === "roadmap" && typeof ensureTrajectoryHistory === "function") {
+      if (typeof ensureTrajectoryHistory === "function") {
         await ensureTrajectoryHistory({
           situationId: normalizedId,
           subjects: uiState.selectedSituationSubjects

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -64,6 +64,12 @@ function normalizeLeftColumnWidth(value) {
   return Math.max(TRAJECTORY_LEFT_WIDTH.min, Math.min(TRAJECTORY_LEFT_WIDTH.max, Math.round(width)));
 }
 
+function normalizeTrajectoryOpacity(value, fallback = 0.95) {
+  const opacity = Number(value);
+  if (!Number.isFinite(opacity)) return fallback;
+  return Math.max(0, Math.min(1, opacity));
+}
+
 export function renderSituationRoadmapView(situation, subjects = [], options = {}) {
   const subjectCount = Array.isArray(subjects) ? subjects.length : 0;
   const title = String(situation?.title || "Situation");
@@ -73,6 +79,8 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
     ? options.store.projectSubjectsView.rawSubjectsResult
     : {};
   const leftColumnWidth = normalizeLeftColumnWidth(options?.store?.situationsView?.trajectoryLeftColumnWidthBySituationId?.[situationId]);
+  const cardOpacity = normalizeTrajectoryOpacity(options?.store?.situationsView?.trajectoryCardOpacityBySituationId?.[situationId], 0.95);
+  const cardOpacityLabel = cardOpacity.toFixed(2);
 
 
   const projectDataAttribute = projectId ? ` data-project-id="${escapeHtml(projectId)}"` : "";
@@ -157,16 +165,31 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
         class="situation-trajectory"
         data-situation-trajectory
         data-situation-id="${escapeHtml(situationId)}"${projectDataAttribute}
-        style="--situation-trajectory-left-width:${leftColumnWidth}px;"
+        style="--situation-trajectory-left-width:${leftColumnWidth}px;--situation-trajectory-card-opacity:${cardOpacityLabel};--situation-trajectory-title-opacity:${cardOpacityLabel};"
       >
         <div class="situation-trajectory__timeline" role="presentation">
           <div class="situation-trajectory__timeline-track" data-situation-trajectory-timeline-track>
-            <label class="situation-trajectory__zoom" for="trajectoryZoomSelect">
-              <span>Zoom</span>
-              <select id="trajectoryZoomSelect" name="trajectoryZoom">
-                ${renderZoomOptions()}
-              </select>
-            </label>
+            <div class="situation-trajectory__toolbar">
+              <label class="situation-trajectory__opacity" for="trajectoryOpacityRange-${escapeHtml(situationId)}">
+                <span>Opacity</span>
+                <input
+                  id="trajectoryOpacityRange-${escapeHtml(situationId)}"
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value="${escapeHtml(cardOpacityLabel)}"
+                  data-situation-trajectory-opacity-input="${escapeHtml(situationId)}"
+                />
+                <output class="mono" data-situation-trajectory-opacity-value="${escapeHtml(situationId)}">${escapeHtml(cardOpacityLabel)}</output>
+              </label>
+              <label class="situation-trajectory__zoom" for="trajectoryZoomSelect">
+                <span>Zoom</span>
+                <select id="trajectoryZoomSelect" name="trajectoryZoom">
+                  ${renderZoomOptions()}
+                </select>
+              </label>
+            </div>
             <div class="situation-trajectory__timeline-content" data-situation-trajectory-timeline-content></div>
             <button
               type="button"

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -106,12 +106,35 @@ function resolveObjectiveMilestonePoints(event = {}, ts, currentStatus = "open")
   return points;
 }
 
-function collectEventsForSubject(subjectId, subjectHistoryEvents) {
+function resolveSubjectHistoryKeys(subject = {}) {
+  const keys = new Set([
+    normalizeId(subject?.id),
+    normalizeId(subject?.subject_id),
+    normalizeId(subject?.subjectId),
+    normalizeId(subject?.subject_number),
+    normalizeId(subject?.subjectNumber),
+    normalizeId(subject?.raw?.id),
+    normalizeId(subject?.raw?.subject_id),
+    normalizeId(subject?.raw?.subjectId),
+    normalizeId(subject?.raw?.subject_number),
+    normalizeId(subject?.raw?.subjectNumber)
+  ]);
+  keys.delete("");
+  return [...keys];
+}
+
+function collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys = []) {
+  const keysSet = new Set(asArray(subjectHistoryKeys).map((value) => normalizeId(value)).filter(Boolean));
+  if (!keysSet.size) return [];
   if (Array.isArray(subjectHistoryEvents)) {
-    return subjectHistoryEvents.filter((event) => normalizeId(event?.subject_id) === subjectId);
+    return subjectHistoryEvents.filter((event) => keysSet.has(normalizeId(event?.subject_id)));
   }
   if (subjectHistoryEvents && typeof subjectHistoryEvents === "object") {
-    return asArray(subjectHistoryEvents[subjectId]);
+    const collected = [];
+    for (const key of keysSet) {
+      collected.push(...asArray(subjectHistoryEvents[key]));
+    }
+    return collected;
   }
   return [];
 }
@@ -194,6 +217,76 @@ function toStatusIcon(status = "open") {
   return "open";
 }
 
+function resolveLifecycleStatusFromEvent(event = {}, fallbackStatus = "closed") {
+  const eventType = normalizeId(event?.event_type).toLowerCase();
+  if (["subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+    return "closed_invalid";
+  }
+  if (eventType === "subject_closed") {
+    return normalizeCloseStatus(event, fallbackStatus);
+  }
+  return "open";
+}
+
+function buildLifecycleSegments({
+  subjectId = "",
+  subjectCreatedTs,
+  lifecycleEvents = [],
+  endTs,
+  fallbackClosedStatus = "closed"
+} = {}) {
+  const safeEndTs = Math.max(endTs, subjectCreatedTs);
+  let state = "open";
+  let currentStart = subjectCreatedTs;
+  const segments = [];
+
+  for (const event of lifecycleEvents) {
+    const eventType = normalizeId(event?.event_type).toLowerCase();
+    const eventTs = toTimestamp(event?.created_at, currentStart);
+    const safeEventTs = Math.min(Math.max(eventTs, subjectCreatedTs), safeEndTs);
+
+    if (eventType === "subject_reopened") {
+      if (state !== "open" && safeEventTs > currentStart) {
+        segments.push({
+          subjectId,
+          status: state,
+          startAt: new Date(currentStart),
+          endAt: new Date(safeEventTs)
+        });
+        state = "open";
+        currentStart = safeEventTs;
+      }
+      continue;
+    }
+
+    if (!["subject_closed", "subject_rejected", "review_rejected", "subject_invalidated"].includes(eventType)) {
+      continue;
+    }
+
+    if (state === "open" && safeEventTs > currentStart) {
+      segments.push({
+        subjectId,
+        status: "open",
+        startAt: new Date(currentStart),
+        endAt: new Date(safeEventTs)
+      });
+      state = resolveLifecycleStatusFromEvent(event, fallbackClosedStatus);
+      currentStart = safeEventTs;
+    }
+  }
+
+  if (safeEndTs > currentStart) {
+    segments.push({
+      subjectId,
+      status: state,
+      startAt: new Date(currentStart),
+      endAt: new Date(safeEndTs)
+    });
+  }
+
+  return segments;
+}
+
 export function buildTrajectoryModel({
   subjects = [],
   subjectHistoryEvents = {},
@@ -212,7 +305,8 @@ export function buildTrajectoryModel({
     const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
     const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
 
-    const events = collectEventsForSubject(subjectId, subjectHistoryEvents)
+    const subjectHistoryKeys = resolveSubjectHistoryKeys(subject);
+    const events = collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys)
       .map((event = {}) => ({
         ...event,
         event_type: normalizeId(event.event_type).toLowerCase(),
@@ -283,24 +377,16 @@ export function buildTrajectoryModel({
 
     statusPoints.sort((a, b) => a.at.getTime() - b.at.getTime());
 
-    const rawSegments = [];
-    for (let index = 0; index < statusPoints.length; index += 1) {
-      const point = statusPoints[index];
-      if (point.contributesToLifecycle === false) continue;
-      const nextPoint = statusPoints[index + 1];
-      const segmentStartTs = point.at.getTime();
-      const nextLifecyclePoint = nextPoint && nextPoint.contributesToLifecycle !== false
-        ? nextPoint
-        : statusPoints.slice(index + 1).find((entry) => entry.contributesToLifecycle !== false);
-      const segmentEndTs = nextLifecyclePoint ? nextLifecyclePoint.at.getTime() : endTs;
-      if (segmentEndTs <= segmentStartTs) continue;
-      rawSegments.push({
-        subjectId,
-        status: point.status,
-        startAt: new Date(segmentStartTs),
-        endAt: new Date(segmentEndTs)
-      });
-    }
+    const lifecycleEvents = events.filter((event) => (
+      ["subject_closed", "subject_reopened", "subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)
+    ));
+    const rawSegments = buildLifecycleSegments({
+      subjectId,
+      subjectCreatedTs,
+      lifecycleEvents,
+      endTs,
+      fallbackClosedStatus: subject.status
+    });
 
     const lifecycleSegments = rawSegments
       .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
@@ -312,6 +398,8 @@ export function buildTrajectoryModel({
           objectiveDates
         })
       }));
+
+    console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments);
 
     const objectiveMarkers = objectiveDates.map((entry) => {
       const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
@@ -342,8 +430,12 @@ export function buildTrajectoryModel({
 
 export function __trajectoryModelTestUtils() {
   return {
+    buildLifecycleSegments,
+    collectEventsForSubject,
     normalizeStatus,
     normalizeCloseStatus,
+    resolveSubjectHistoryKeys,
+    resolveLifecycleStatusFromEvent,
     resolveObjectiveDates,
     resolveStatusAtTimestamp,
     splitSegmentByObjectiveBoundaries,

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -309,6 +309,68 @@ test("buildTrajectoryModel conserve un point à chaque évènement de cycle de v
   );
 });
 
+test("buildTrajectoryModel reconstruit 4 segments pour open → close → reopen → close", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "s-reopen-close", created_at: "2026-04-11T00:00:00.000Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "s-reopen-close": [
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "s-reopen-close", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "s-reopen-close", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T00:00:00.000Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T00:00:00.000Z" }
+    ]
+  );
+});
+
+test("buildTrajectoryModel récupère l'historique même si les événements sont indexés par subject_number", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      { id: "29d78a78-d219-45de-9d3f-8d3a7fd1b915", subject_number: 18, created_at: "2026-04-11T09:28:07.836Z", status: "closed" }
+    ],
+    subjectHistoryEvents: {
+      "18": [
+        { subject_id: "18", event_type: "subject_closed", created_at: "2026-04-19T18:03:00.000Z", payload: { closed_status: "closed" } },
+        { subject_id: "18", event_type: "subject_reopened", created_at: "2026-04-20T14:00:00.000Z" },
+        { subject_id: "18", event_type: "subject_closed", created_at: "2026-04-20T14:07:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    today: "2026-04-28T06:58:22.818Z"
+  });
+
+  const [row] = result.rows;
+  assert.deepEqual(
+    row.lifecycleSegments.map((segment) => ({
+      status: segment.status,
+      start: segment.startAt.toISOString(),
+      end: segment.endAt.toISOString()
+    })),
+    [
+      { status: "open", start: "2026-04-11T09:28:07.836Z", end: "2026-04-19T18:03:00.000Z" },
+      { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
+      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T06:58:22.818Z" }
+    ]
+  );
+});
+
 test("buildTrajectoryModel rend plusieurs blocages entrants à des dates différentes sans casser le cycle de vie", () => {
   const result = buildTrajectoryModel({
     subjects: [{ id: "s-blocked", created_at: "2026-01-01T00:00:00.000Z", status: "open" }],

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10131,6 +10131,9 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory{
   --situation-trajectory-left-width:320px;
+  --situation-trajectory-card-opacity:.95;
+  --situation-trajectory-title-opacity:.95;
+  --situation-trajectory-objective-color:rgb(248, 81, 73);
   display:flex;
   flex-direction:column;
   min-height:100%;
@@ -10138,11 +10141,19 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   background:var(--bgColor-default, #0d1117);
 }
 
-.situation-trajectory__zoom{
+.situation-trajectory__toolbar{
   position:absolute;
   top:6px;
   right:12px;
   z-index:6;
+  display:flex;
+  align-items:center;
+  gap:10px;
+  pointer-events:auto;
+}
+
+.situation-trajectory__opacity,
+.situation-trajectory__zoom{
   display:flex;
   align-items:center;
   gap:8px;
@@ -10153,7 +10164,10 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   backdrop-filter:blur(2px);
   font-size:12px;
   color:var(--fgColor-muted, #8b949e);
-  pointer-events:auto;
+}
+
+.situation-trajectory__opacity input[type="range"]{
+  width:96px;
 }
 
 .situation-trajectory__zoom select{
@@ -10242,12 +10256,23 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   max-width:160px;
   padding:1px 6px;
   border-radius:999px;
-  border: solid 1px var(--muted);
-  color: var(--muted);
+  border:solid 1px var(--situation-trajectory-objective-color);
+  color:var(--situation-trajectory-objective-color);
   font-size:11px;
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
+  --trajectory-objective-line-height:0px;
+}
+
+.situation-trajectory__timeline-objective::after{
+  content:"";
+  position:absolute;
+  left:50%;
+  top:100%;
+  height:var(--trajectory-objective-line-height, 0px);
+  border-left:1px dashed var(--situation-trajectory-objective-color);
+  opacity:.7;
 }
 
 .situation-trajectory__splitter{
@@ -10334,11 +10359,10 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
-  background:rgb(13, 17, 23);
+  background:rgba(13, 17, 23, var(--situation-trajectory-card-opacity, .95));
   border:solid 1px rgb(61, 68, 77);
   outline-color:rgb(240, 246, 252);
   box-shadow:rgba(1, 4, 9, 0.4) 0px 1px 1px 0px, rgba(1, 4, 9, 0.8) 0px 3px 6px 0px;
-  opacity:.95;
   pointer-events:auto;
   cursor:pointer;
   z-index:1;
@@ -10391,6 +10415,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 
 .situation-trajectory__segment-title{
   color:rgb(145, 152, 161);
+  opacity:var(--situation-trajectory-title-opacity, .95);
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
@@ -10530,7 +10555,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__svg-line--objective{
-  stroke:rgb(248, 81, 73);
+  stroke:var(--situation-trajectory-objective-color);
   stroke-dasharray:4 4;
   opacity:.7;
 }

--- a/supabase/migrations/202606150037_subject_history_trajectory_reader_rpc.sql
+++ b/supabase/migrations/202606150037_subject_history_trajectory_reader_rpc.sql
@@ -1,0 +1,52 @@
+-- Reader RPC for trajectory view.
+-- Goal: provide a stable, front-friendly read model for lifecycle/relation events across many subjects.
+
+create or replace function public.list_subject_history_for_trajectory(
+  p_project_id uuid,
+  p_subject_ids uuid[]
+)
+returns table (
+  id uuid,
+  project_id uuid,
+  subject_id uuid,
+  event_type text,
+  created_at timestamptz,
+  event_payload jsonb
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select
+    h.id,
+    h.project_id,
+    h.subject_id,
+    h.event_type,
+    h.created_at,
+    h.event_payload
+  from public.subject_history h
+  where h.project_id = p_project_id
+    and h.subject_id = any(coalesce(p_subject_ids, array[]::uuid[]))
+    and h.event_type in (
+      'subject_created',
+      'subject_closed',
+      'subject_reopened',
+      'subject_rejected',
+      'review_rejected',
+      'subject_invalidated',
+      'subject_parent_added',
+      'subject_parent_removed',
+      'subject_child_added',
+      'subject_child_removed',
+      'subject_blocked_by_added',
+      'subject_blocked_by_removed',
+      'subject_blocking_for_added',
+      'subject_blocking_for_removed',
+      'subject_objectives_changed'
+    )
+  order by h.created_at asc;
+$$;
+
+comment on function public.list_subject_history_for_trajectory(uuid, uuid[]) is
+  'Trajectory reader for many subjects. Returns canonical event_payload from subject_history for lifecycle and relation rendering.';


### PR DESCRIPTION
### Motivation
- Provide a reliable, front-friendly reader for subject history to render trajectory views across many subjects and handle schema differences. 
- Make the trajectory UI resilient to partial/failed history loads and allow per-situation opacity tuning. 
- Ensure lifecycle segments are correctly reconstructed from history events indexed in different ways (id, subject_number, etc.).

### Description
- Add a dedicated RPC `public.list_subject_history_for_trajectory` with migration `supabase/migrations/202606150037_subject_history_trajectory_reader_rpc.sql` to return canonical `event_payload` and a stable reader for trajectory queries. 
- Implement client-side fetching with `fetchTrajectoryHistoryViaRpc` and a `fetchTrajectoryHistoryViaRest` fallback that probes alternate `select` shapes (`HISTORY_SELECT_CANDIDATES`) and handles missing-column and missing-RPC errors. 
- Normalize history rows (`normalizeHistoryRow`) to accept `event_payload` / `eventPayload` / `payload` and unify `event_type`, `subject_id`, and `created_at`, and group events by subject id for the trajectory renderer. 
- Improve caching/state for trajectory history in `ensureTrajectoryHistory` to include `historyStatus`, `isComplete`, and `errorMessage`, and expose `resolveTrajectoryHistoryState` so the UI shows loading/error states and avoids rendering incomplete timelines. 
- Add UI controls and styling: an opacity range for trajectory cards, toolbar layout, objective timeline connector lines, CSS variables for opacity and objective color, and spinner messages when history is not ready. 
- Enhance model logic in `trajectory-model.js` to collect history by multiple subject keys (`resolveSubjectHistoryKeys`), build lifecycle segments deterministically (`buildLifecycleSegments`), infer closed/rejected statuses (`resolveLifecycleStatusFromEvent`), and expose related test utilities. 
- Add tests in `trajectory-model.test.mjs` to cover reopen/close segment reconstruction and subject_number-indexed history handling. 

### Testing
- Ran trajectory unit tests (`apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs`) via the repository test runner (e.g. `node --test`), and the new tests passed. 
- Existing trajectory-related tests were executed and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0569f7d788329a32725a9793c9b32)