### PR TITLE
Render dashed trajectory segments as centered 2px dashed lines

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10358,6 +10358,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment{
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
   transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
@@ -10371,19 +10372,28 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment--dashed{
-  border-style:dashed;
+  height:2px;
+  border:none;
+  border-top:2px dashed var(--situation-trajectory-segment-accent-color);
+  border-radius:0;
+  background:transparent;
+  box-shadow:none;
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--green{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--red{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
+}
+
+.situation-trajectory__segment--dashed .situation-trajectory__segment-label{
+  display:none;
 }
 
 .situation-trajectory__segment-label{
@@ -10403,16 +10413,16 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   width:16px;
   height:16px;
   border-radius:999px;
-  background:rgb(99, 110, 123);
+  background:var(--situation-trajectory-segment-accent-color);
   flex:0 0 16px;
 }
 
 .situation-trajectory__segment--green .situation-trajectory__segment-label::before{
-  background:rgb(35, 134, 54);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--red .situation-trajectory__segment-label::before{
-  background:rgb(207, 34, 46);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment-title{


### PR DESCRIPTION
### Motivation
- Replace the current dashed-segment “card” UI in the trajectory view with a minimal 2px centered dashed line and remove the title/number and circular `::before` indicator while keeping the accent color previously used by the indicator.

### Description
- Introduced `--situation-trajectory-segment-accent-color` on `.situation-trajectory__segment` and use it for dashed variants to unify color handling.
- Rewrote `.situation-trajectory__segment--dashed` to `height:2px`, `border-top:2px dashed var(--situation-trajectory-segment-accent-color)`, removed card background, border/box-shadow, and border-radius so it renders as a simple centered line.
- Added variant rules (`--green`, `--red`, `--gray`) to set the accent color and hid `.situation-trajectory__segment-label` for dashed segments so title, number and label bullet are not shown.
- Updated the label `::before` to use the accent variable for color consistency.

### Testing
- Ran `node --test apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs` and all tests passed (7/7).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08852f4b48329966f19512f0bd73b)