### PR TITLE
Refactor situation-trajectory segment styles and add accent color variable

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10358,6 +10358,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment{
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
   transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
@@ -10371,19 +10372,28 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment--dashed{
-  border-style:dashed;
+  height:2px;
+  border:none;
+  border-top:2px dashed var(--situation-trajectory-segment-accent-color);
+  border-radius:0;
+  background:transparent;
+  box-shadow:none;
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--green{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--red{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
+}
+
+.situation-trajectory__segment--dashed .situation-trajectory__segment-label{
+  display:none;
 }
 
 .situation-trajectory__segment-label{
@@ -10403,16 +10413,20 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   width:16px;
   height:16px;
   border-radius:999px;
-  background:rgb(99, 110, 123);
+  background:var(--situation-trajectory-segment-accent-color);
   flex:0 0 16px;
 }
 
 .situation-trajectory__segment--green .situation-trajectory__segment-label::before{
-  background:rgb(35, 134, 54);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--green:not(.situation-trajectory__segment--dashed) .situation-trajectory__segment-label::before{
+  display:none;
 }
 
 .situation-trajectory__segment--red .situation-trajectory__segment-label::before{
-  background:rgb(207, 34, 46);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment-title{


### PR DESCRIPTION
### Motivation
- Make segment coloring and dashed-segment visuals more flexible by introducing a shared accent color variable and improving dashed styling and label behavior.

### Description
- Introduce `--situation-trajectory-segment-accent-color` on `.situation-trajectory__segment` and use it for the segment indicator and dashed borders.
- Convert dashed segments to a 2px top dashed border, remove their background and shadow, and set per-state accent colors for green, red, and gray via the new variable.
- Hide `.situation-trajectory__segment-label` inside dashed segments and hide the indicator `::before` for non-dashed green segments by adjusting display rules.

### Testing
- Built the web styles with `yarn build` and the CSS bundle compiled successfully.
- Ran the automated test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08852f4b48329966f19512f0bd73b)