### PR TITLE
Refactor situation-trajectory CSS: dashed segment styling, marker sizing, and accent color variable

### DIFF
--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10358,6 +10358,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment{
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
   transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
@@ -10371,19 +10372,28 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment--dashed{
-  border-style:dashed;
+  height:2px;
+  border:none;
+  border-top:2px dashed var(--situation-trajectory-segment-accent-color);
+  border-radius:0;
+  background:transparent;
+  box-shadow:none;
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--green{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--red{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
+}
+
+.situation-trajectory__segment--dashed .situation-trajectory__segment-label{
+  display:none;
 }
 
 .situation-trajectory__segment-label{
@@ -10403,16 +10413,20 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   width:16px;
   height:16px;
   border-radius:999px;
-  background:rgb(99, 110, 123);
+  background:var(--situation-trajectory-segment-accent-color);
   flex:0 0 16px;
 }
 
 .situation-trajectory__segment--green .situation-trajectory__segment-label::before{
-  background:rgb(35, 134, 54);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--green:not(.situation-trajectory__segment--dashed) .situation-trajectory__segment-label::before{
+  display:none;
 }
 
 .situation-trajectory__segment--red .situation-trajectory__segment-label::before{
-  background:rgb(207, 34, 46);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment-title{
@@ -10431,8 +10445,6 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__point,
 .situation-trajectory__marker{
   transform:translate(-50%, -50%);
-  width:20px;
-  height:20px;
   appearance:none;
   border:none;
   padding:0;
@@ -10454,7 +10466,14 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   display:inline-flex;
   align-items:center;
   justify-content:center;
+  width:20px;
+  height:20px;
   z-index:3;
+}
+
+.situation-trajectory__marker{
+  width:16px;
+  height:16px;
 }
 
 .situation-trajectory__point-icon{
@@ -10477,7 +10496,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__marker::before,
 .situation-trajectory__marker::after{
   border-top:2px solid rgb(248, 81, 73);
-  top:6px;
+  top:4px;
 }
 
 .situation-trajectory__marker::before{ transform:rotate(45deg); }
@@ -10526,13 +10545,13 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__marker--cross::before{
   border-top:2px solid rgb(248, 81, 73);
   transform:rotate(45deg);
-  top:6px;
+  top:4px;
 }
 
 .situation-trajectory__marker--cross::after{
   border-top:2px solid rgb(248, 81, 73);
   transform:rotate(-45deg);
-  top:6px;
+  top:4px;
 }
 
 .situation-trajectory__marker--check::before{
@@ -10541,8 +10560,8 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   border-right:2px solid rgb(63, 185, 80);
   border-bottom:2px solid rgb(63, 185, 80);
   transform:rotate(45deg);
-  left:4px;
-  top:1px;
+  left:3px;
+  top:0;
 }
 
 .situation-trajectory__svg-line{


### PR DESCRIPTION
### Motivation
- Standardize the visual treatment of trajectory segments by introducing a themeable accent color and making dashed segments visually distinct and compact. 
- Improve alignment and sizing of point/marker elements so markers render consistently across states. 
- Hide redundant labels for dashed segments to reduce visual clutter.

### Description
- Add `--situation-trajectory-segment-accent-color` with a default and use it for segment dot and dashed border coloring. 
- Replace the old dashed border approach with a 2px top dashed rule, remove box-shadow and background for dashed segments, and set per-state accent colors for green/red/gray variants. 
- Hide `.situation-trajectory__segment-label` for dashed segments and hide the colored dot for green non-dashed segments. 
- Adjust size and positioning for markers and points by setting explicit `width`/`height` for `.situation-trajectory__marker` and `.situation-trajectory__point`, and tweak pseudo-element offsets (reduce `top` values and adjust check-mark `left`/`top`) for better visual alignment.

### Testing
- Ran the style linter with `yarn lint` and it completed successfully. 
- Ran the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08852f4b48329966f19512f0bd73b)