### PR TITLE
Improve trajectory objective handling and overdue segment styling

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -66,6 +66,10 @@ function toObjectiveDeltaArray(value) {
   return [];
 }
 
+function normalizeObjectiveIds(value) {
+  return asArray(value).map((entry) => normalizeId(entry)).filter(Boolean);
+}
+
 function resolveObjectiveMilestonePoints(event = {}, ts, currentStatus = "open") {
   const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
   const action = normalizeId(payload.action).toLowerCase();
@@ -139,64 +143,46 @@ function collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys = []) 
   return [];
 }
 
-function resolveObjectiveDates({ subjectId, objectivesById = {}, objectiveIdsBySubjectId = {} } = {}) {
-  return asArray(objectiveIdsBySubjectId[subjectId])
-    .map((objectiveId) => objectivesById?.[objectiveId])
+function resolveObjectiveDatesFromIds(objectiveIds = [], objectivesById = {}) {
+  return normalizeObjectiveIds(objectiveIds)
+    .map((objectiveId) => objectivesById?.[objectiveId] || { id: objectiveId })
     .map((objective = {}) => ({
-      objectiveId: normalizeId(objective.id),
+      objectiveId: normalizeId(objective.id) || normalizeId(objective.objective_id),
       dueDate: toDate(objective.due_date || objective.dueDate)
     }))
     .filter((entry) => !!entry.objectiveId && !!entry.dueDate)
     .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
 }
 
-function splitSegmentByObjectiveBoundaries(segment, objectiveDates = []) {
-  const boundaries = objectiveDates
-    .map((entry) => entry.dueDate.getTime())
-    .filter((ts) => ts > segment.startAt.getTime() && ts < segment.endAt.getTime());
+function splitSegmentByBoundaries(segment, boundaries = []) {
+  const splitPoints = boundaries
+    .filter((ts) => ts > segment.startAt.getTime() && ts < segment.endAt.getTime())
+    .sort((a, b) => a - b);
 
-  if (!boundaries.length) return [segment];
+  if (!splitPoints.length) return [segment];
 
   const splits = [];
   let startTs = segment.startAt.getTime();
-  for (const boundaryTs of boundaries) {
-    splits.push({
-      ...segment,
-      startAt: new Date(startTs),
-      endAt: new Date(boundaryTs)
-    });
+  for (const boundaryTs of splitPoints) {
+    if (boundaryTs <= startTs) continue;
+    splits.push({ ...segment, startAt: new Date(startTs), endAt: new Date(boundaryTs) });
     startTs = boundaryTs;
   }
-  splits.push({
-    ...segment,
-    startAt: new Date(startTs),
-    endAt: new Date(segment.endAt.getTime())
-  });
+  if (segment.endAt.getTime() > startTs) {
+    splits.push({ ...segment, startAt: new Date(startTs), endAt: new Date(segment.endAt.getTime()) });
+  }
   return splits;
 }
 
-function resolveSegmentStyle({ status, endAt, objectiveDates }) {
+function resolveSegmentStyle({ status, startAt, endAt, overdueWindows = [] }) {
   const statusKey = normalizeStatus(status);
+  const startTs = startAt.getTime();
   const endTs = endAt.getTime();
-  const hasObjectivePassed = objectiveDates.some((entry) => endTs > entry.dueDate.getTime());
-
-  if (hasObjectivePassed) {
-    return {
-      lineStyle: statusKey === "open" ? "solid" : "dashed",
-      lineColor: "red"
-    };
-  }
-
-  if (statusKey === "open") {
-    return {
-      lineStyle: "solid",
-      lineColor: "green"
-    };
-  }
+  const isOverdue = overdueWindows.some((window) => startTs >= window.startTs && endTs <= window.endTs);
 
   return {
-    lineStyle: "dashed",
-    lineColor: "gray"
+    lineStyle: statusKey === "open" ? "solid" : "dashed",
+    lineColor: isOverdue ? "red" : (statusKey === "open" ? "green" : "gray")
   };
 }
 
@@ -302,7 +288,9 @@ export function buildTrajectoryModel({
     const subjectId = normalizeId(subject.id);
     const subjectTitle = String(subject?.title || subjectId || "Sujet");
     const subjectNumber = resolveSubjectDisplayIdentifier(subject, subjectId);
-    const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
+    const currentObjectiveIds = normalizeObjectiveIds(objectiveIdsBySubjectId[subjectId]);
+    const currentObjectiveDates = resolveObjectiveDatesFromIds(currentObjectiveIds, objectivesById);
+    const objectiveDates = currentObjectiveDates;
     const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
 
     const subjectHistoryKeys = resolveSubjectHistoryKeys(subject);
@@ -380,6 +368,18 @@ export function buildTrajectoryModel({
     const lifecycleEvents = events.filter((event) => (
       ["subject_closed", "subject_reopened", "subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)
     ));
+    const objectiveTimelineEvents = events
+      .filter((event) => event.event_type === "subject_objectives_changed")
+      .map((event) => {
+        const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
+        const delta = payload?.delta && typeof payload.delta === "object" ? payload.delta : {};
+        return {
+          atTs: event.created_at.getTime(),
+          added: normalizeObjectiveIds(toObjectiveDeltaArray(delta.added)),
+          removed: normalizeObjectiveIds(toObjectiveDeltaArray(delta.removed))
+        };
+      })
+      .sort((a, b) => a.atTs - b.atTs);
     const rawSegments = buildLifecycleSegments({
       subjectId,
       subjectCreatedTs,
@@ -388,18 +388,58 @@ export function buildTrajectoryModel({
       fallbackClosedStatus: subject.status
     });
 
+    const finalSegment = rawSegments[rawSegments.length - 1] || null;
+    const finalStatus = normalizeStatus(finalSegment?.status || fallbackStartStatus);
+    const finalClosedTs = finalStatus === "open" ? null : (finalSegment?.startAt?.getTime?.() ?? null);
+    const objectiveIdsFromHistory = objectiveTimelineEvents.flatMap((entry) => [...entry.added, ...entry.removed]);
+    const candidateObjectiveIds = [...new Set([...currentObjectiveIds, ...objectiveIdsFromHistory])];
+    const candidateObjectiveDates = resolveObjectiveDatesFromIds(candidateObjectiveIds, objectivesById);
+
+    const isObjectiveAssignedAt = (objectiveId, targetTs) => {
+      let assigned = currentObjectiveIds.includes(objectiveId);
+      for (let index = objectiveTimelineEvents.length - 1; index >= 0; index -= 1) {
+        const event = objectiveTimelineEvents[index];
+        if (event.atTs <= targetTs) continue;
+        const hasAdded = event.added.includes(objectiveId);
+        const hasRemoved = event.removed.includes(objectiveId);
+        if (hasAdded && !hasRemoved) assigned = false;
+        else if (hasRemoved && !hasAdded) assigned = true;
+      }
+      return assigned;
+    };
+
+    const overdueWindows = candidateObjectiveDates
+      .map((entry) => {
+        const dueTs = entry.dueDate.getTime();
+        let endTsForObjective = null;
+        if (finalStatus === "open") {
+          if (isObjectiveAssignedAt(entry.objectiveId, todayTs)) {
+            endTsForObjective = todayTs;
+          }
+        } else if (Number.isFinite(finalClosedTs) && isObjectiveAssignedAt(entry.objectiveId, finalClosedTs)) {
+          endTsForObjective = finalClosedTs;
+        }
+        if (!Number.isFinite(endTsForObjective) || endTsForObjective <= dueTs) return null;
+        return { objectiveId: entry.objectiveId, startTs: dueTs, endTs: endTsForObjective };
+      })
+      .filter(Boolean);
+
+    const splitBoundaries = [...new Set([
+      ...objectiveDates.map((entry) => entry.dueDate.getTime()),
+      ...overdueWindows.flatMap((window) => [window.startTs, window.endTs])
+    ])];
+
     const lifecycleSegments = rawSegments
-      .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
+      .flatMap((segment) => splitSegmentByBoundaries(segment, splitBoundaries))
       .map((segment) => ({
         ...segment,
         ...resolveSegmentStyle({
           status: segment.status,
+          startAt: segment.startAt,
           endAt: segment.endAt,
-          objectiveDates
+          overdueWindows
         })
       }));
-
-    console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments);
 
     const objectiveMarkers = objectiveDates.map((entry) => {
       const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
@@ -436,9 +476,9 @@ export function __trajectoryModelTestUtils() {
     normalizeCloseStatus,
     resolveSubjectHistoryKeys,
     resolveLifecycleStatusFromEvent,
-    resolveObjectiveDates,
+    resolveObjectiveDates: resolveObjectiveDatesFromIds,
     resolveStatusAtTimestamp,
-    splitSegmentByObjectiveBoundaries,
+    splitSegmentByObjectiveBoundaries: splitSegmentByBoundaries,
     resolveSegmentStyle
   };
 }

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -143,7 +143,7 @@ test("buildTrajectoryModel crée toujours un premier point open depuis subject.c
   assert.equal(row.statusPoints[0].at.toISOString(), "2026-01-01T00:00:00.000Z");
 });
 
-test("buildTrajectoryModel rend un segment red dashed après objectif quand le sujet est fermé après objectif", () => {
+test("buildTrajectoryModel arrête la ligne rouge à la fermeture finale puis repasse en gray dashed", () => {
   const result = buildTrajectoryModel({
     subjects: [
       {
@@ -169,10 +169,52 @@ test("buildTrajectoryModel rend un segment red dashed après objectif quand le s
   });
 
   const [row] = result.rows;
-  const redDashedSegment = row.lifecycleSegments.find((segment) => segment.startAt.toISOString() === "2026-01-08T00:00:00.000Z");
-  assert.ok(redDashedSegment);
-  assert.equal(redDashedSegment.lineColor, "red");
-  assert.equal(redDashedSegment.lineStyle, "dashed");
+  const redOpenSegment = row.lifecycleSegments.find((segment) => (
+    segment.startAt.toISOString() === "2026-01-05T00:00:00.000Z"
+    && segment.endAt.toISOString() === "2026-01-08T00:00:00.000Z"
+  ));
+  assert.ok(redOpenSegment);
+  assert.equal(redOpenSegment.lineColor, "red");
+  assert.equal(redOpenSegment.lineStyle, "solid");
+
+  const afterCloseSegment = row.lifecycleSegments.find((segment) => segment.startAt.toISOString() === "2026-01-08T00:00:00.000Z");
+  assert.ok(afterCloseSegment);
+  assert.equal(afterCloseSegment.lineColor, "gray");
+  assert.equal(afterCloseSegment.lineStyle, "dashed");
+});
+
+test("buildTrajectoryModel ne trace pas de ligne rouge si l'objectif n'est plus affecté au moment de la fermeture", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-objective-removed-before-close",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "closed"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-objective-removed-before-close": [
+        { subject_id: "s-objective-removed-before-close", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        {
+          subject_id: "s-objective-removed-before-close",
+          event_type: "subject_objectives_changed",
+          created_at: "2026-01-06T00:00:00.000Z",
+          payload: { action: "removed", delta: { added: [], removed: ["o-removed"] } }
+        },
+        { subject_id: "s-objective-removed-before-close", event_type: "subject_closed", created_at: "2026-01-08T00:00:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    objectivesById: {
+      "o-removed": { id: "o-removed", due_date: "2026-01-05T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-objective-removed-before-close": []
+    },
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.ok(row.lifecycleSegments.every((segment) => segment.lineColor !== "red"));
 });
 
 test("buildTrajectoryModel mappe les événements de rejet vers closed_invalid/reject", () => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10358,6 +10358,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment{
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
   transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
@@ -10371,19 +10372,28 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment--dashed{
-  border-style:dashed;
+  height:2px;
+  border:none;
+  border-top:2px dashed var(--situation-trajectory-segment-accent-color);
+  border-radius:0;
+  background:transparent;
+  box-shadow:none;
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--green{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--red{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
+}
+
+.situation-trajectory__segment--dashed .situation-trajectory__segment-label{
+  display:none;
 }
 
 .situation-trajectory__segment-label{
@@ -10403,16 +10413,20 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   width:16px;
   height:16px;
   border-radius:999px;
-  background:rgb(99, 110, 123);
+  background:var(--situation-trajectory-segment-accent-color);
   flex:0 0 16px;
 }
 
 .situation-trajectory__segment--green .situation-trajectory__segment-label::before{
-  background:rgb(35, 134, 54);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--green:not(.situation-trajectory__segment--dashed) .situation-trajectory__segment-label::before{
+  display:none;
 }
 
 .situation-trajectory__segment--red .situation-trajectory__segment-label::before{
-  background:rgb(207, 34, 46);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment-title{
@@ -10431,8 +10445,6 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__point,
 .situation-trajectory__marker{
   transform:translate(-50%, -50%);
-  width:20px;
-  height:20px;
   appearance:none;
   border:none;
   padding:0;
@@ -10454,7 +10466,14 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   display:inline-flex;
   align-items:center;
   justify-content:center;
+  width:20px;
+  height:20px;
   z-index:3;
+}
+
+.situation-trajectory__marker{
+  width:16px;
+  height:16px;
 }
 
 .situation-trajectory__point-icon{
@@ -10477,7 +10496,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__marker::before,
 .situation-trajectory__marker::after{
   border-top:2px solid rgb(248, 81, 73);
-  top:6px;
+  top:4px;
 }
 
 .situation-trajectory__marker::before{ transform:rotate(45deg); }
@@ -10526,13 +10545,13 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__marker--cross::before{
   border-top:2px solid rgb(248, 81, 73);
   transform:rotate(45deg);
-  top:6px;
+  top:4px;
 }
 
 .situation-trajectory__marker--cross::after{
   border-top:2px solid rgb(248, 81, 73);
   transform:rotate(-45deg);
-  top:6px;
+  top:4px;
 }
 
 .situation-trajectory__marker--check::before{
@@ -10541,8 +10560,8 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   border-right:2px solid rgb(63, 185, 80);
   border-bottom:2px solid rgb(63, 185, 80);
   transform:rotate(45deg);
-  left:4px;
-  top:1px;
+  left:3px;
+  top:0;
 }
 
 .situation-trajectory__svg-line{


### PR DESCRIPTION
### Motivation

- Fix incorrect objective date resolution and ensure overdue red segments stop at final closure and only appear while objectives are assigned. 
- Simplify segment splitting and make dashed/colored segment rendering more consistent and themeable. 

### Description

- Added `normalizeObjectiveIds`, `resolveObjectiveDatesFromIds`, and replaced the old `resolveObjectiveDates` usage to handle objective ids or object maps uniformly. 
- Replaced `splitSegmentByObjectiveBoundaries` with `splitSegmentByBoundaries` that sorts split points and avoids empty/overlapping splits. 
- Compute objective timeline events and candidate objective ids, implement `isObjectiveAssignedAt` to determine objective assignment by timestamp and build `overdueWindows` so `resolveSegmentStyle` can color segments red only when fully inside overdue windows. 
- Wire up new split boundaries into lifecycle segment splitting, update test export mapping, and adjust CSS to use an accent variable for dashed segments, change dashed segments to be thin top borders, tweak marker/point sizing and positions, and hide labels for dashed segments. 

### Testing

- Ran the `trajectory-model.test.mjs` suite which was updated with new scenarios for final-closure red-line cutoff and objective removal before close, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08852f4b48329966f19512f0bd73b)