### PR TITLE
Render overdue objective lines in trajectory and compute overdue windows in model

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -365,6 +365,26 @@ export function renderTrajectoryDom({
       segmentCount += 1;
     }
 
+    for (const overdueLine of asArray(row.overdueLines)) {
+      const startTs = toTimestamp(overdueLine.startAt);
+      const endTs = toTimestamp(overdueLine.endAt);
+      if (!intersectsRange(startTs, endTs, visibleStartTs, visibleEndTs)) continue;
+      const displayStartTs = toRenderTimestamp(startTs, timeScale, startTs);
+      const displayEndTs = toRenderTimestamp(endTs, timeScale, endTs);
+      const displayLeftTs = Math.min(displayStartTs, displayEndTs);
+      const displayRightTs = Math.max(displayStartTs, displayEndTs);
+      const overdueNode = document.createElement("div");
+      const lineStyle = String(overdueLine?.lineStyle || "").trim().toLowerCase();
+      overdueNode.className = [
+        "situation-trajectory__overdue-line",
+        lineStyle === "dashed" ? "situation-trajectory__overdue-line--dashed" : ""
+      ].filter(Boolean).join(" ");
+      overdueNode.style.left = `${timeScale.timeToX(displayLeftTs)}px`;
+      overdueNode.style.top = `${y}px`;
+      overdueNode.style.width = `${Math.max(0, timeScale.timeToX(displayRightTs) - timeScale.timeToX(displayLeftTs))}px`;
+      fragmentItems.appendChild(overdueNode);
+    }
+
     const statusPoints = asArray(row.statusPoints);
     const statusPointTotalsByTs = new Map();
     for (const point of statusPoints) {
@@ -427,6 +447,10 @@ export function renderTrajectoryDom({
       }
       const objectiveId = normalizeId(marker?.objectiveId);
       if (objectiveId) markerNode.dataset.trajectoryObjectiveId = objectiveId;
+      const markerSymbol = markerType === "check" ? "check" : "x";
+      markerNode.innerHTML = `<span class="situation-trajectory__marker-icon" aria-hidden="true">${
+        svgIcon(markerSymbol, { className: "ui-icon", width: 16, height: 16 })
+      }</span>`;
       markerNode.setAttribute("tabindex", "0");
       markerNode.setAttribute("role", "button");
       markerNode.title = `Objectif ${objectiveId || "inconnu"} · ${formatDateLabel(marker.at)} · ${markerType === "check" ? "check" : "cross"}`;

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.js
@@ -66,6 +66,10 @@ function toObjectiveDeltaArray(value) {
   return [];
 }
 
+function normalizeObjectiveIds(value) {
+  return asArray(value).map((entry) => normalizeId(entry)).filter(Boolean);
+}
+
 function resolveObjectiveMilestonePoints(event = {}, ts, currentStatus = "open") {
   const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
   const action = normalizeId(payload.action).toLowerCase();
@@ -139,64 +143,46 @@ function collectEventsForSubject(subjectHistoryEvents, subjectHistoryKeys = []) 
   return [];
 }
 
-function resolveObjectiveDates({ subjectId, objectivesById = {}, objectiveIdsBySubjectId = {} } = {}) {
-  return asArray(objectiveIdsBySubjectId[subjectId])
-    .map((objectiveId) => objectivesById?.[objectiveId])
+function resolveObjectiveDatesFromIds(objectiveIds = [], objectivesById = {}) {
+  return normalizeObjectiveIds(objectiveIds)
+    .map((objectiveId) => objectivesById?.[objectiveId] || { id: objectiveId })
     .map((objective = {}) => ({
-      objectiveId: normalizeId(objective.id),
+      objectiveId: normalizeId(objective.id) || normalizeId(objective.objective_id),
       dueDate: toDate(objective.due_date || objective.dueDate)
     }))
     .filter((entry) => !!entry.objectiveId && !!entry.dueDate)
     .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime());
 }
 
-function splitSegmentByObjectiveBoundaries(segment, objectiveDates = []) {
-  const boundaries = objectiveDates
-    .map((entry) => entry.dueDate.getTime())
-    .filter((ts) => ts > segment.startAt.getTime() && ts < segment.endAt.getTime());
+function splitSegmentByBoundaries(segment, boundaries = []) {
+  const splitPoints = boundaries
+    .filter((ts) => ts > segment.startAt.getTime() && ts < segment.endAt.getTime())
+    .sort((a, b) => a - b);
 
-  if (!boundaries.length) return [segment];
+  if (!splitPoints.length) return [segment];
 
   const splits = [];
   let startTs = segment.startAt.getTime();
-  for (const boundaryTs of boundaries) {
-    splits.push({
-      ...segment,
-      startAt: new Date(startTs),
-      endAt: new Date(boundaryTs)
-    });
+  for (const boundaryTs of splitPoints) {
+    if (boundaryTs <= startTs) continue;
+    splits.push({ ...segment, startAt: new Date(startTs), endAt: new Date(boundaryTs) });
     startTs = boundaryTs;
   }
-  splits.push({
-    ...segment,
-    startAt: new Date(startTs),
-    endAt: new Date(segment.endAt.getTime())
-  });
+  if (segment.endAt.getTime() > startTs) {
+    splits.push({ ...segment, startAt: new Date(startTs), endAt: new Date(segment.endAt.getTime()) });
+  }
   return splits;
 }
 
-function resolveSegmentStyle({ status, endAt, objectiveDates }) {
+function resolveSegmentStyle({ status, startAt, endAt, overdueWindows = [] }) {
   const statusKey = normalizeStatus(status);
+  const startTs = startAt.getTime();
   const endTs = endAt.getTime();
-  const hasObjectivePassed = objectiveDates.some((entry) => endTs > entry.dueDate.getTime());
-
-  if (hasObjectivePassed) {
-    return {
-      lineStyle: statusKey === "open" ? "solid" : "dashed",
-      lineColor: "red"
-    };
-  }
-
-  if (statusKey === "open") {
-    return {
-      lineStyle: "solid",
-      lineColor: "green"
-    };
-  }
+  const isOverdue = overdueWindows.some((window) => startTs >= window.startTs && endTs <= window.endTs);
 
   return {
-    lineStyle: "dashed",
-    lineColor: "gray"
+    lineStyle: statusKey === "open" ? "solid" : "dashed",
+    lineColor: isOverdue ? "red" : (statusKey === "open" ? "green" : "gray")
   };
 }
 
@@ -302,7 +288,9 @@ export function buildTrajectoryModel({
     const subjectId = normalizeId(subject.id);
     const subjectTitle = String(subject?.title || subjectId || "Sujet");
     const subjectNumber = resolveSubjectDisplayIdentifier(subject, subjectId);
-    const objectiveDates = resolveObjectiveDates({ subjectId, objectivesById, objectiveIdsBySubjectId });
+    const currentObjectiveIds = normalizeObjectiveIds(objectiveIdsBySubjectId[subjectId]);
+    const currentObjectiveDates = resolveObjectiveDatesFromIds(currentObjectiveIds, objectivesById);
+    const objectiveDates = currentObjectiveDates;
     const latestObjectiveTs = objectiveDates.length ? objectiveDates[objectiveDates.length - 1].dueDate.getTime() : null;
 
     const subjectHistoryKeys = resolveSubjectHistoryKeys(subject);
@@ -321,7 +309,11 @@ export function buildTrajectoryModel({
       fallbackProjectStartTs
     );
 
-    const endTs = Math.max(todayTs, latestObjectiveTs || 0, subjectCreatedTs);
+    const latestActivityTs = events.length ? events[events.length - 1].created_at.getTime() : subjectCreatedTs;
+    const normalizedSubjectStatus = normalizeStatus(subject.status);
+    const endTs = normalizedSubjectStatus === "open"
+      ? Math.max(todayTs, latestObjectiveTs || 0, subjectCreatedTs, latestActivityTs)
+      : Math.max(subjectCreatedTs, latestActivityTs);
     const fallbackStartStatus = normalizeStatus(subject.status);
 
     const statusPoints = [];
@@ -380,6 +372,18 @@ export function buildTrajectoryModel({
     const lifecycleEvents = events.filter((event) => (
       ["subject_closed", "subject_reopened", "subject_rejected", "review_rejected", "subject_invalidated"].includes(event.event_type)
     ));
+    const objectiveTimelineEvents = events
+      .filter((event) => event.event_type === "subject_objectives_changed")
+      .map((event) => {
+        const payload = event?.payload && typeof event.payload === "object" ? event.payload : {};
+        const delta = payload?.delta && typeof payload.delta === "object" ? payload.delta : {};
+        return {
+          atTs: event.created_at.getTime(),
+          added: normalizeObjectiveIds(toObjectiveDeltaArray(delta.added)),
+          removed: normalizeObjectiveIds(toObjectiveDeltaArray(delta.removed))
+        };
+      })
+      .sort((a, b) => a.atTs - b.atTs);
     const rawSegments = buildLifecycleSegments({
       subjectId,
       subjectCreatedTs,
@@ -388,18 +392,67 @@ export function buildTrajectoryModel({
       fallbackClosedStatus: subject.status
     });
 
+    const finalSegment = rawSegments[rawSegments.length - 1] || null;
+    const finalStatus = normalizeStatus(finalSegment?.status || fallbackStartStatus);
+    const finalClosedTs = finalStatus === "open" ? null : (finalSegment?.startAt?.getTime?.() ?? null);
+    const objectiveIdsFromHistory = objectiveTimelineEvents.flatMap((entry) => [...entry.added, ...entry.removed]);
+    const candidateObjectiveIds = [...new Set([...currentObjectiveIds, ...objectiveIdsFromHistory])];
+    const candidateObjectiveDates = resolveObjectiveDatesFromIds(candidateObjectiveIds, objectivesById);
+
+    const isObjectiveAssignedAt = (objectiveId, targetTs) => {
+      let assigned = currentObjectiveIds.includes(objectiveId);
+      for (let index = objectiveTimelineEvents.length - 1; index >= 0; index -= 1) {
+        const event = objectiveTimelineEvents[index];
+        if (event.atTs <= targetTs) continue;
+        const hasAdded = event.added.includes(objectiveId);
+        const hasRemoved = event.removed.includes(objectiveId);
+        if (hasAdded && !hasRemoved) assigned = false;
+        else if (hasRemoved && !hasAdded) assigned = true;
+      }
+      return assigned;
+    };
+
+    const overdueWindows = candidateObjectiveDates
+      .map((entry) => {
+        const dueTs = entry.dueDate.getTime();
+        let endTsForObjective = null;
+        if (finalStatus === "open") {
+          if (isObjectiveAssignedAt(entry.objectiveId, todayTs)) {
+            endTsForObjective = todayTs;
+          }
+        } else if (Number.isFinite(finalClosedTs) && isObjectiveAssignedAt(entry.objectiveId, finalClosedTs)) {
+          endTsForObjective = finalClosedTs;
+        }
+        if (!Number.isFinite(endTsForObjective) || endTsForObjective <= dueTs) return null;
+        return { objectiveId: entry.objectiveId, startTs: dueTs, endTs: endTsForObjective };
+      })
+      .filter(Boolean);
+
+    const splitBoundaries = [...new Set([
+      ...objectiveDates.map((entry) => entry.dueDate.getTime()),
+      ...overdueWindows.flatMap((window) => [window.startTs, window.endTs])
+    ])];
+
     const lifecycleSegments = rawSegments
-      .flatMap((segment) => splitSegmentByObjectiveBoundaries(segment, objectiveDates))
+      .flatMap((segment) => splitSegmentByBoundaries(segment, splitBoundaries))
       .map((segment) => ({
         ...segment,
         ...resolveSegmentStyle({
           status: segment.status,
+          startAt: segment.startAt,
           endAt: segment.endAt,
-          objectiveDates
+          overdueWindows
         })
       }));
 
-    console.log("[trajectory] lifecycleSegments", subjectId, lifecycleSegments);
+    const overdueLineStyle = finalStatus === "open" ? "solid" : "dashed";
+    const overdueLines = overdueWindows.map((window) => ({
+      subjectId,
+      objectiveId: window.objectiveId,
+      startAt: new Date(window.startTs),
+      endAt: new Date(window.endTs),
+      lineStyle: overdueLineStyle
+    }));
 
     const objectiveMarkers = objectiveDates.map((entry) => {
       const statusAtDueDate = resolveStatusAtTimestamp(statusPoints, entry.dueDate.getTime(), fallbackStartStatus);
@@ -421,6 +474,7 @@ export function buildTrajectoryModel({
       subjectNumber,
       statusPoints,
       lifecycleSegments,
+      overdueLines,
       objectiveMarkers
     };
   });
@@ -436,9 +490,9 @@ export function __trajectoryModelTestUtils() {
     normalizeCloseStatus,
     resolveSubjectHistoryKeys,
     resolveLifecycleStatusFromEvent,
-    resolveObjectiveDates,
+    resolveObjectiveDates: resolveObjectiveDatesFromIds,
     resolveStatusAtTimestamp,
-    splitSegmentByObjectiveBoundaries,
+    splitSegmentByObjectiveBoundaries: splitSegmentByBoundaries,
     resolveSegmentStyle
   };
 }

--- a/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs
@@ -114,6 +114,42 @@ test("buildTrajectoryModel utilise subject.created_at si subject_created absent 
   assert.equal(row.objectiveMarkers[0].markerColor, "red");
 });
 
+test("buildTrajectoryModel démarre overdueLines à la due date (même si antérieure à la création du sujet)", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-overdue-before-creation",
+        created_at: "2026-04-22T12:31:00.000Z",
+        status: "open"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-overdue-before-creation": [
+        { subject_id: "s-overdue-before-creation", event_type: "subject_created", created_at: "2026-04-22T12:31:00.000Z" },
+        {
+          subject_id: "s-overdue-before-creation",
+          event_type: "subject_objectives_changed",
+          created_at: "2026-04-22T12:31:00.000Z",
+          payload: { action: "added", delta: { added: ["o-permis"], removed: [] } }
+        }
+      ]
+    },
+    objectivesById: {
+      "o-permis": { id: "o-permis", due_date: "2026-04-20T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-overdue-before-creation": ["o-permis"]
+    },
+    today: "2026-04-28T06:58:22.818Z"
+  });
+
+  const [row] = result.rows;
+  assert.equal(row.overdueLines.length, 1);
+  assert.equal(row.overdueLines[0].startAt.toISOString(), "2026-04-20T00:00:00.000Z");
+  assert.equal(row.overdueLines[0].endAt.toISOString(), "2026-04-28T06:58:22.818Z");
+  assert.equal(row.overdueLines[0].lineStyle, "solid");
+});
+
 test("normalizeCloseStatus remonte closed_invalid et closed_duplicate depuis le payload", () => {
   const { normalizeCloseStatus } = __trajectoryModelTestUtils();
   assert.equal(normalizeCloseStatus({ payload: { closed_status: "invalid" } }), "closed_invalid");
@@ -143,7 +179,7 @@ test("buildTrajectoryModel crée toujours un premier point open depuis subject.c
   assert.equal(row.statusPoints[0].at.toISOString(), "2026-01-01T00:00:00.000Z");
 });
 
-test("buildTrajectoryModel rend un segment red dashed après objectif quand le sujet est fermé après objectif", () => {
+test("buildTrajectoryModel arrête les segments à la dernière activité quand le sujet est fermé", () => {
   const result = buildTrajectoryModel({
     subjects: [
       {
@@ -169,10 +205,50 @@ test("buildTrajectoryModel rend un segment red dashed après objectif quand le s
   });
 
   const [row] = result.rows;
-  const redDashedSegment = row.lifecycleSegments.find((segment) => segment.startAt.toISOString() === "2026-01-08T00:00:00.000Z");
-  assert.ok(redDashedSegment);
-  assert.equal(redDashedSegment.lineColor, "red");
-  assert.equal(redDashedSegment.lineStyle, "dashed");
+  const redOpenSegment = row.lifecycleSegments.find((segment) => (
+    segment.startAt.toISOString() === "2026-01-05T00:00:00.000Z"
+    && segment.endAt.toISOString() === "2026-01-08T00:00:00.000Z"
+  ));
+  assert.ok(redOpenSegment);
+  assert.equal(redOpenSegment.lineColor, "red");
+  assert.equal(redOpenSegment.lineStyle, "solid");
+
+  const afterCloseSegment = row.lifecycleSegments.find((segment) => segment.startAt.toISOString() === "2026-01-08T00:00:00.000Z");
+  assert.equal(afterCloseSegment, undefined);
+});
+
+test("buildTrajectoryModel ne trace pas de ligne rouge si l'objectif n'est plus affecté au moment de la fermeture", () => {
+  const result = buildTrajectoryModel({
+    subjects: [
+      {
+        id: "s-objective-removed-before-close",
+        created_at: "2026-01-01T00:00:00.000Z",
+        status: "closed"
+      }
+    ],
+    subjectHistoryEvents: {
+      "s-objective-removed-before-close": [
+        { subject_id: "s-objective-removed-before-close", event_type: "subject_created", created_at: "2026-01-01T00:00:00.000Z" },
+        {
+          subject_id: "s-objective-removed-before-close",
+          event_type: "subject_objectives_changed",
+          created_at: "2026-01-06T00:00:00.000Z",
+          payload: { action: "removed", delta: { added: [], removed: ["o-removed"] } }
+        },
+        { subject_id: "s-objective-removed-before-close", event_type: "subject_closed", created_at: "2026-01-08T00:00:00.000Z", payload: { closed_status: "closed" } }
+      ]
+    },
+    objectivesById: {
+      "o-removed": { id: "o-removed", due_date: "2026-01-05T00:00:00.000Z" }
+    },
+    objectiveIdsBySubjectId: {
+      "s-objective-removed-before-close": []
+    },
+    today: "2026-01-10T00:00:00.000Z"
+  });
+
+  const [row] = result.rows;
+  assert.ok(row.lifecycleSegments.every((segment) => segment.lineColor !== "red"));
 });
 
 test("buildTrajectoryModel mappe les événements de rejet vers closed_invalid/reject", () => {
@@ -334,8 +410,7 @@ test("buildTrajectoryModel reconstruit 4 segments pour open → close → reopen
     [
       { status: "open", start: "2026-04-11T00:00:00.000Z", end: "2026-04-19T18:03:00.000Z" },
       { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
-      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
-      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T00:00:00.000Z" }
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" }
     ]
   );
 });
@@ -365,8 +440,7 @@ test("buildTrajectoryModel récupère l'historique même si les événements son
     [
       { status: "open", start: "2026-04-11T09:28:07.836Z", end: "2026-04-19T18:03:00.000Z" },
       { status: "closed", start: "2026-04-19T18:03:00.000Z", end: "2026-04-20T14:00:00.000Z" },
-      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" },
-      { status: "closed", start: "2026-04-20T14:07:00.000Z", end: "2026-04-28T06:58:22.818Z" }
+      { status: "open", start: "2026-04-20T14:00:00.000Z", end: "2026-04-20T14:07:00.000Z" }
     ]
   );
 });

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10358,6 +10358,7 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment{
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
   transform:translateY(-50%);
   height:28px;
   border-radius:var(--radius);
@@ -10375,15 +10376,15 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--green{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--red{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment--dashed.situation-trajectory__segment--gray{
-  border-color:rgb(61, 68, 77);
+  --situation-trajectory-segment-accent-color:rgb(99, 110, 123);
 }
 
 .situation-trajectory__segment-label{
@@ -10403,16 +10404,39 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   width:16px;
   height:16px;
   border-radius:999px;
-  background:rgb(99, 110, 123);
+  background:var(--situation-trajectory-segment-accent-color);
   flex:0 0 16px;
 }
 
 .situation-trajectory__segment--green .situation-trajectory__segment-label::before{
-  background:rgb(35, 134, 54);
+  --situation-trajectory-segment-accent-color:rgb(35, 134, 54);
+}
+
+.situation-trajectory__segment--green:not(.situation-trajectory__segment--dashed) .situation-trajectory__segment-label::before{
+  display:none;
 }
 
 .situation-trajectory__segment--red .situation-trajectory__segment-label::before{
+  display:none;
+}
+
+.situation-trajectory__segment--dashed.situation-trajectory__segment--gray .situation-trajectory__segment-label{
+  display:none;
+}
+
+.situation-trajectory__overdue-line{
+  position:absolute;
+  transform:translateY(-50%);
+  height:1px;
   background:rgb(207, 34, 46);
+  pointer-events:none;
+  z-index:4;
+}
+
+.situation-trajectory__overdue-line--dashed{
+  height:0;
+  background:transparent;
+  border-top:1px dashed rgb(207, 34, 46);
 }
 
 .situation-trajectory__segment-title{
@@ -10431,8 +10455,6 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
 .situation-trajectory__point,
 .situation-trajectory__marker{
   transform:translate(-50%, -50%);
-  width:20px;
-  height:20px;
   appearance:none;
   border:none;
   padding:0;
@@ -10443,14 +10465,18 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   pointer-events:auto;
 }
 
-.situation-trajectory__marker::before,
-.situation-trajectory__marker::after{
-  content:"";
-  position:absolute;
-  inset:0;
+.situation-trajectory__point{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:20px;
+  height:20px;
+  z-index:3;
 }
 
-.situation-trajectory__point{
+.situation-trajectory__marker{
+  width:16px;
+  height:16px;
   display:inline-flex;
   align-items:center;
   justify-content:center;
@@ -10474,14 +10500,16 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   justify-content:center;
 }
 
-.situation-trajectory__marker::before,
-.situation-trajectory__marker::after{
-  border-top:2px solid rgb(248, 81, 73);
-  top:6px;
+.situation-trajectory__marker-icon{
+  display:inline-flex;
+  width:16px;
+  height:16px;
+  color:rgb(248, 81, 73);
 }
 
-.situation-trajectory__marker::before{ transform:rotate(45deg); }
-.situation-trajectory__marker::after{ transform:rotate(-45deg); }
+.situation-trajectory__marker--check .situation-trajectory__marker-icon{
+  color:rgb(63, 185, 80);
+}
 
 .situation-trajectory__point:hover,
 .situation-trajectory__point:focus-visible,
@@ -10517,32 +10545,12 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   color:var(--muted);
 }
 
-.situation-trajectory__marker--cross::before,
-.situation-trajectory__marker--cross::after{
-  inset:2px;
+.situation-trajectory__point--milestone{
+  transform:translate(-50%, calc(-50% - 14px));
+}
+
+.situation-trajectory__point--milestone .situation-trajectory__point-icon{
   background:transparent;
-}
-
-.situation-trajectory__marker--cross::before{
-  border-top:2px solid rgb(248, 81, 73);
-  transform:rotate(45deg);
-  top:6px;
-}
-
-.situation-trajectory__marker--cross::after{
-  border-top:2px solid rgb(248, 81, 73);
-  transform:rotate(-45deg);
-  top:6px;
-}
-
-.situation-trajectory__marker--check::before{
-  width:4px;
-  height:8px;
-  border-right:2px solid rgb(63, 185, 80);
-  border-bottom:2px solid rgb(63, 185, 80);
-  transform:rotate(45deg);
-  left:4px;
-  top:1px;
 }
 
 .situation-trajectory__svg-line{


### PR DESCRIPTION
### Motivation

- Surface objective overdue periods on the trajectory view and compute them reliably from objective assignments and history so overdue intervals can be highlighted. 
- Ensure lifecycle segments are split at objective and overdue boundaries and close segments stop at the last activity for closed subjects. 
- Improve marker rendering to use the shared `svgIcon` and tidy point/marker visual rules.

### Description

- Added `normalizeObjectiveIds` and `resolveObjectiveDatesFromIds` helpers and replaced previous objective resolution with deterministic ID normalization. 
- Compute objective timeline events from `subject_objectives_changed`, derive candidate objectives, and build `overdueWindows` (start at due date, end at today or closure time when still assigned) in `buildTrajectoryModel`. 
- Use `splitSegmentByBoundaries` and include objective due dates and overdue window bounds when splitting segments, and update `resolveSegmentStyle` to mark segments red/solid when inside overdue windows. 
- Produce `overdueLines` in the model (with `lineStyle` depending on final status) and expose renamed test utilities mapping (`resolveObjectiveDates`, `splitSegmentByObjectiveBoundaries`). 
- Render overdue lines in the DOM via `trajectory-dom-renderer.js` as `.situation-trajectory__overdue-line` elements and wire dashed/solid styles; switch objective markers to render inline SVG via `svgIcon`. 
- CSS updates to support segment accent variable, overdue line visuals, marker icon sizing/color, and refinements to segment/point/marker layout.
- Updated and added unit tests in `trajectory-model.test.mjs` to cover overdue line start behavior, closing semantics, and objective removal scenarios.

### Testing

- Ran the trajectory model unit tests in `apps/web/js/views/project-situations/trajectory/trajectory-model.test.mjs` after changes and all tests passed. 
- The new tests for overdue windows and the adjusted lifecycle/segment expectations were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08852f4b48329966f19512f0bd73b)