### PR TITLE
Make hierarchy arrow curves symmetric in trajectory view

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -181,17 +181,19 @@ function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse 
   const laneStartX = x + 2;
   const laneMidX = x + 18;
   const laneEndX = x + 34;
-  const curvePad = direction * 9;
+  const cornerRadius = 9;
+  const curvePad = direction * cornerRadius;
 
   const path = document.createElementNS(SVG_NS, "path");
   path.setAttribute(
     "d",
     [
       `M ${laneStartX} ${startY}`,
-      `L ${laneMidX - 3} ${startY}`,
+      `L ${laneMidX - cornerRadius} ${startY}`,
       `Q ${laneMidX} ${startY} ${laneMidX} ${startY + curvePad}`,
       `L ${laneMidX} ${endY - curvePad}`,
-      `Q ${laneMidX} ${endY} ${laneEndX} ${endY}`
+      `Q ${laneMidX} ${endY} ${laneMidX + cornerRadius} ${endY}`,
+      `L ${laneEndX} ${endY}`
     ].join(" ")
   );
   path.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);


### PR DESCRIPTION
### Motivation
- Corriger un défaut visuel dans la vue trajectoire où la courbe d'arrivée des flèches parent→enfant avait un rayon apparent plus grand que la courbe de départ, rendant les liens hiérarchiques asymétriques.
- Maintenir le comportement existant des marqueurs (cercle de départ et flèche d'arrivée) et des styles pour les liens supprimés tout en corrigeant la géométrie du tracé SVG.

### Description
- Introduit `cornerRadius = 9` et réutilise cette valeur pour les deux coins afin d'assurer une courbure identique au départ et à l'arrivée du lien hiérarchique dans `apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js`.
- Ajusté la génération du `d` du `path` SVG pour utiliser `laneMidX - cornerRadius` et `laneMidX + cornerRadius` et pour ajouter un segment final `L ${laneEndX} ${endY}` afin d'avoir des coins symétriques.
- Aucun changement aux éléments de marqueur existants (`circle` et `polygon` pour la flèche) ni aux classes CSS appliquées aux liens supprimés.

### Testing
- Exécuté `node --test apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs`.
- Tous les tests du fichier ont réussi (`7` tests exécutés, `0` échecs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ac8e82988329999c66a043b14cdf)