### PR TITLE
Render blocked relations in trajectory with red link and blocked icon

### DIFF
--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.js
@@ -9,6 +9,13 @@ const HIERARCHY_EVENT_TYPES = new Set([
   "subject_child_removed"
 ]);
 
+const BLOCKED_RELATION_EVENT_TYPES = new Set([
+  "subject_blocked_by_added",
+  "subject_blocked_by_removed",
+  "subject_blocking_for_added",
+  "subject_blocking_for_removed"
+]);
+
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
@@ -127,11 +134,14 @@ function renderPointIconHtml(pointType = "open", point = {}) {
   }${blockedIconHtml}</span>`;
 }
 
-function buildHierarchyLinks(relationEvents = []) {
+function buildRelationLinks(relationEvents = [], { relationType = "hierarchy" } = {}) {
   const dedupe = new Map();
+  const safeRelationType = String(relationType || "hierarchy").trim().toLowerCase();
+  const isBlockedRelation = safeRelationType === "blocked";
+
   for (const event of asArray(relationEvents)) {
     const type = String(event?.event_type || "").trim().toLowerCase();
-    if (!HIERARCHY_EVENT_TYPES.has(type)) continue;
+    if (isBlockedRelation ? !BLOCKED_RELATION_EVENT_TYPES.has(type) : !HIERARCHY_EVENT_TYPES.has(type)) continue;
 
     const subjectId = normalizeId(event?.subject_id);
     const counterpartId = normalizeId(event?.payload?.counterpart_subject_id || event?.counterpart_subject_id);
@@ -140,21 +150,32 @@ function buildHierarchyLinks(relationEvents = []) {
     const at = new Date(event?.created_at || event?.at || Date.now());
     if (Number.isNaN(at.getTime())) continue;
 
-    const isParentEvent = type.startsWith("subject_parent_");
-    const parentId = isParentEvent ? counterpartId : subjectId;
-    const childId = isParentEvent ? subjectId : counterpartId;
-    const action = type.endsWith("_removed") ? "removed" : "added";
-    const key = `${parentId}|${childId}|${at.toISOString()}|${action}`;
+    let sourceId = "";
+    let targetId = "";
 
-    if (!dedupe.has(key) || isParentEvent) {
+    if (isBlockedRelation) {
+      const isBlockedByEvent = type.startsWith("subject_blocked_by_");
+      sourceId = isBlockedByEvent ? subjectId : counterpartId;
+      targetId = isBlockedByEvent ? counterpartId : subjectId;
+    } else {
+      const isParentEvent = type.startsWith("subject_parent_");
+      sourceId = isParentEvent ? counterpartId : subjectId;
+      targetId = isParentEvent ? subjectId : counterpartId;
+    }
+
+    const action = type.endsWith("_removed") ? "removed" : "added";
+    const key = `${sourceId}|${targetId}|${at.toISOString()}|${action}`;
+
+    if (!dedupe.has(key) || (!isBlockedRelation && type.startsWith("subject_parent_"))) {
       dedupe.set(key, {
-        parentId,
-        childId,
+        sourceId,
+        targetId,
         action,
         at
       });
     }
   }
+
   return [...dedupe.values()].sort((a, b) => a.at.getTime() - b.at.getTime());
 }
 
@@ -173,35 +194,37 @@ function createSvgLine({ x, y1, y2, classNames = [] } = {}) {
   return line;
 }
 
-function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse = false } = {}) {
-  const startY = isReverse ? childY : parentY;
-  const endY = isReverse ? parentY : childY;
+function createHierarchyPath({ x, sourceY, targetY, isRemoved = false, isReverse = false, isBlockedRelation = false } = {}) {
+  const startY = isReverse ? targetY : sourceY;
+  const endY = isReverse ? sourceY : targetY;
   const direction = endY >= startY ? 1 : -1;
 
   const laneStartX = x + 2;
   const laneMidX = x + 18;
   const laneEndX = x + 34;
-  const curvePad = direction * 9;
+  const cornerRadius = 9;
+  const curvePad = direction * cornerRadius;
 
   const path = document.createElementNS(SVG_NS, "path");
   path.setAttribute(
     "d",
     [
       `M ${laneStartX} ${startY}`,
-      `L ${laneMidX - 3} ${startY}`,
+      `L ${laneMidX - cornerRadius} ${startY}`,
       `Q ${laneMidX} ${startY} ${laneMidX} ${startY + curvePad}`,
       `L ${laneMidX} ${endY - curvePad}`,
-      `Q ${laneMidX} ${endY} ${laneEndX} ${endY}`
+      `Q ${laneMidX} ${endY} ${laneMidX + cornerRadius} ${endY}`,
+      `L ${laneEndX} ${endY}`
     ].join(" ")
   );
-  path.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+  path.setAttribute("class", `situation-trajectory__hierarchy-link${isBlockedRelation ? " situation-trajectory__hierarchy-link--blocked" : ""}${isRemoved ? " is-removed" : ""}`);
 
   const markerCircle = (() => {
     const circle = document.createElementNS(SVG_NS, "circle");
     circle.setAttribute("cx", String(laneStartX));
     circle.setAttribute("cy", String(startY));
     circle.setAttribute("r", "2.5");
-    circle.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+    circle.setAttribute("class", `situation-trajectory__hierarchy-link${isBlockedRelation ? " situation-trajectory__hierarchy-link--blocked" : ""}${isRemoved ? " is-removed" : ""}`);
     return circle;
   })();
 
@@ -215,9 +238,36 @@ function createHierarchyPath({ x, parentY, childY, isRemoved = false, isReverse 
       `${laneEndX - arrowSize},${endY + (direction * arrowSize)}`
     ].join(" ")
   );
-  arrow.setAttribute("class", `situation-trajectory__hierarchy-link${isRemoved ? " is-removed" : ""}`);
+  arrow.setAttribute("class", `situation-trajectory__hierarchy-link${isBlockedRelation ? " situation-trajectory__hierarchy-link--blocked" : ""}${isRemoved ? " is-removed" : ""}`);
 
-  return { path, markerCircle, arrow };
+  const blockedIcon = isBlockedRelation ? (() => {
+    const iconSize = 12;
+    const icon = document.createElementNS(SVG_NS, "svg");
+    icon.setAttribute("viewBox", "0 0 16 16");
+    icon.setAttribute("width", String(iconSize));
+    icon.setAttribute("height", String(iconSize));
+    icon.setAttribute("x", String(laneMidX - (iconSize / 2)));
+    icon.setAttribute("y", String(((startY + endY) / 2) - (iconSize / 2)));
+    icon.setAttribute("class", `situation-trajectory__hierarchy-link situation-trajectory__hierarchy-link--blocked situation-trajectory__hierarchy-link--blocked-icon${isRemoved ? " is-removed" : ""}`);
+
+    const backdrop = document.createElementNS(SVG_NS, "circle");
+    backdrop.setAttribute("cx", "8");
+    backdrop.setAttribute("cy", "8");
+    backdrop.setAttribute("r", "7");
+    backdrop.setAttribute("fill", "rgb(21, 27, 35)");
+    backdrop.setAttribute("class", "situation-trajectory__hierarchy-link--blocked-icon-backdrop");
+
+    const use = document.createElementNS(SVG_NS, "use");
+    use.setAttribute("href", "assets/icons.svg#blocked");
+    use.setAttribute("xlink:href", "assets/icons.svg#blocked");
+    use.setAttribute("class", "situation-trajectory__hierarchy-link--blocked-icon-glyph");
+
+    icon.appendChild(backdrop);
+    icon.appendChild(use);
+    return icon;
+  })() : null;
+
+  return { path, markerCircle, arrow, blockedIcon };
 }
 
 export function renderTrajectoryDom({
@@ -465,42 +515,50 @@ export function renderTrajectoryDom({
     if (subjectId) rowIndexBySubjectId.set(subjectId, index);
   });
 
-  const hierarchyLinks = buildHierarchyLinks(relationEvents);
+  const hierarchyLinks = buildRelationLinks(relationEvents, { relationType: "hierarchy" });
+  const blockedLinks = buildRelationLinks(relationEvents, { relationType: "blocked" });
   const linkRowMin = Math.max(0, rowStart - 2);
   const linkRowMax = Math.min(Math.max(0, rowCount - 1), rowEnd + 2);
   let linkCount = 0;
 
-  for (const link of hierarchyLinks) {
-    const parentIndex = rowIndexBySubjectId.get(link.parentId);
-    const childIndex = rowIndexBySubjectId.get(link.childId);
-    if (!Number.isInteger(parentIndex) || !Number.isInteger(childIndex)) continue;
+  const renderLinks = (links = [], { isBlockedRelation = false } = {}) => {
+    for (const link of links) {
+      const sourceIndex = rowIndexBySubjectId.get(link.sourceId);
+      const targetIndex = rowIndexBySubjectId.get(link.targetId);
+      if (!Number.isInteger(sourceIndex) || !Number.isInteger(targetIndex)) continue;
 
-    if ((parentIndex < linkRowMin || parentIndex > linkRowMax)
-      && (childIndex < linkRowMin || childIndex > linkRowMax)) {
-      continue;
+      if ((sourceIndex < linkRowMin || sourceIndex > linkRowMax)
+        && (targetIndex < linkRowMin || targetIndex > linkRowMax)) {
+        continue;
+      }
+
+      const ts = toTimestamp(link.at);
+      if (ts < visibleStartTs || ts > visibleEndTs) continue;
+      const displayTs = toRenderTimestamp(ts, timeScale, ts);
+
+      const x = timeScale.timeToX(displayTs);
+      const sourceY = (sourceIndex * safeRowHeight) + (safeRowHeight / 2);
+      const targetY = (targetIndex * safeRowHeight) + (safeRowHeight / 2);
+
+      const { path, markerCircle, arrow, blockedIcon } = createHierarchyPath({
+        x,
+        sourceY,
+        targetY,
+        isRemoved: link.action === "removed",
+        isReverse: link.action === "removed",
+        isBlockedRelation
+      });
+
+      fragmentSvg.appendChild(path);
+      if (markerCircle) fragmentSvg.appendChild(markerCircle);
+      if (blockedIcon) fragmentSvg.appendChild(blockedIcon);
+      fragmentSvg.appendChild(arrow);
+      linkCount += 1;
     }
+  };
 
-    const ts = toTimestamp(link.at);
-    if (ts < visibleStartTs || ts > visibleEndTs) continue;
-    const displayTs = toRenderTimestamp(ts, timeScale, ts);
-
-    const x = timeScale.timeToX(displayTs);
-    const parentY = (parentIndex * safeRowHeight) + (safeRowHeight / 2);
-    const childY = (childIndex * safeRowHeight) + (safeRowHeight / 2);
-
-    const { path, markerCircle, arrow } = createHierarchyPath({
-      x,
-      parentY,
-      childY,
-      isRemoved: link.action === "removed",
-      isReverse: link.action === "removed"
-    });
-
-    fragmentSvg.appendChild(path);
-    if (markerCircle) fragmentSvg.appendChild(markerCircle);
-    fragmentSvg.appendChild(arrow);
-    linkCount += 1;
-  }
+  renderLinks(hierarchyLinks, { isBlockedRelation: false });
+  renderLinks(blockedLinks, { isBlockedRelation: true });
 
   svg.appendChild(fragmentSvg);
   itemsRoot.appendChild(fragmentItems);
@@ -525,7 +583,7 @@ export function __trajectoryDomRendererTestUtils() {
     collectObjectiveVerticalTimestamps,
     resolvePointIcon,
     intersectsRange,
-    buildHierarchyLinks,
+    buildRelationLinks,
     toDayCenterTimestamp,
     toRenderTimestamp
   };

--- a/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
+++ b/apps/web/js/views/project-situations/trajectory/trajectory-dom-renderer.test.mjs
@@ -212,19 +212,20 @@ test("renderTrajectoryDom rend uniquement les lignes visibles et les éléments 
   const hierarchyLinks = queryByClass(svg, "situation-trajectory__hierarchy-link");
   assert.ok(hierarchyLinks.length >= 1);
 
+
   globalThis.document = originalDocument;
   Date.now = originalNow;
 });
 
 test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
   const {
-    buildHierarchyLinks,
+    buildRelationLinks,
     resolvePointIcon,
     collectObjectiveVerticalTimestamps,
     toRenderTimestamp
   } = __trajectoryDomRendererTestUtils();
 
-  assert.equal(typeof buildHierarchyLinks, "function");
+  assert.equal(typeof buildRelationLinks, "function");
   assert.equal(typeof resolvePointIcon, "function");
   assert.equal(typeof collectObjectiveVerticalTimestamps, "function");
   assert.equal(typeof toRenderTimestamp, "function");
@@ -241,7 +242,7 @@ test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
   const dayRenderDate = new Date(dayRenderTs);
   assert.equal(dayRenderDate.getHours(), 12);
 
-  const links = buildHierarchyLinks([
+  const links = buildRelationLinks([
     {
       event_type: "subject_parent_added",
       subject_id: "child-1",
@@ -254,7 +255,7 @@ test("__trajectoryDomRendererTestUtils expose les helpers clés", () => {
       created_at: "2026-01-03T00:00:00.000Z",
       payload: { counterpart_subject_id: "child-1" }
     }
-  ]);
+  ], { relationType: "hierarchy" });
   assert.equal(links.length, 1);
 });
 
@@ -484,6 +485,68 @@ test("renderTrajectoryDom applique les classes red+dashed et dessine un lien rem
 
   globalThis.document = originalDocument;
   Date.now = originalNow;
+});
+
+test("renderTrajectoryDom dessine les liens bloqué par en rouge avec icône blocked au milieu", () => {
+  const originalDocument = globalThis.document;
+  globalThis.document = createMockDocument();
+
+  const scene = new MockNode("div");
+  scene.clientHeight = 300;
+  const svg = new MockNode("svg");
+  const itemsRoot = new MockNode("div");
+
+  const rows = [
+    { subjectId: "blocker", lifecycleSegments: [], statusPoints: [], objectiveMarkers: [] },
+    { subjectId: "blocked", lifecycleSegments: [], statusPoints: [], objectiveMarkers: [] }
+  ];
+
+  const timeScale = createTrajectoryTimeScale({
+    startDate: "2026-01-01T00:00:00.000Z",
+    endDate: "2026-01-10T00:00:00.000Z",
+    zoom: "day",
+    pxPerUnit: 12
+  });
+
+  renderTrajectoryDom({
+    scene,
+    svg,
+    itemsRoot,
+    rows,
+    relationEvents: [
+      {
+        event_type: "subject_blocked_by_added",
+        subject_id: "blocked",
+        created_at: "2026-01-06T00:00:00.000Z",
+        payload: { counterpart_subject_id: "blocker" }
+      }
+    ],
+    timeScale,
+    scrollLeft: 0,
+    scrollTop: 0,
+    viewportWidth: 600,
+    viewportHeight: 200,
+    rowHeight: 20,
+    overscan: 0
+  });
+
+  const blockedPaths = queryByClass(svg, "situation-trajectory__hierarchy-link--blocked")
+    .filter((node) => node.tagName === "PATH");
+  const blockedArrows = queryByClass(svg, "situation-trajectory__hierarchy-link--blocked")
+    .filter((node) => node.tagName === "POLYGON");
+  const blockedIcons = queryByClass(svg, "situation-trajectory__hierarchy-link--blocked")
+    .filter((node) => node.tagName === "SVG");
+
+  assert.equal(blockedPaths.length, 1);
+  assert.equal(blockedArrows.length, 1);
+  assert.ok(String(blockedArrows[0].getAttribute("points") || "").includes(",10"));
+  assert.equal(blockedIcons.length, 1);
+  assert.equal(blockedIcons[0].getAttribute("width"), "12");
+  assert.equal(blockedIcons[0].childNodes[0]?.tagName, "CIRCLE");
+  assert.equal(blockedIcons[0].childNodes[0]?.getAttribute("fill"), "rgb(21, 27, 35)");
+  assert.ok(String(blockedIcons[0].childNodes[1]?.getAttribute("href") || "").includes("#blocked"));
+
+  globalThis.document = originalDocument;
 });
 
 test("renderTrajectoryDom affiche une icône par point de statut et ajoute l'indicateur bloqué", () => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10606,11 +10606,29 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   stroke-dasharray:4 4;
 }
 
+.situation-trajectory__hierarchy-link--blocked{
+  stroke:var(--danger-fg, #f85149);
+}
+
+path.situation-trajectory__hierarchy-link--blocked{
+  fill:none;
+}
+
 .situation-trajectory__hierarchy-link[points],
 polygon.situation-trajectory__hierarchy-link,
 circle.situation-trajectory__hierarchy-link{
   fill:rgb(139, 148, 158);
   stroke:none;
+}
+
+polygon.situation-trajectory__hierarchy-link--blocked,
+circle.situation-trajectory__hierarchy-link--blocked,
+.situation-trajectory__hierarchy-link--blocked-icon .situation-trajectory__hierarchy-link--blocked-icon-glyph{
+  fill:var(--danger-fg, #f85149);
+}
+
+.situation-trajectory__hierarchy-link--blocked-icon .situation-trajectory__hierarchy-link--blocked-icon-backdrop{
+  fill:rgb(21, 27, 35);
 }
 
 .situation-trajectory[data-trajectory-opacity-zero="true"] .situation-trajectory__hierarchy-link:hover{


### PR DESCRIPTION
### Motivation

- Add visual support for "blocked" relation events in the trajectory view so blocking relationships are drawn and identifiable.
- Reuse the existing relation rendering pipeline by generalizing link building to support multiple relation types.

### Description

- Introduce `BLOCKED_RELATION_EVENT_TYPES` and replace `buildHierarchyLinks` with a generalized `buildRelationLinks` that accepts a `relationType` option and deduplicates relation events into `sourceId`/`targetId` entries. 
- Update path creation (`createHierarchyPath`) to accept `sourceY`/`targetY`, support a `isBlockedRelation` flag, add a blocked-specific class, and optionally create an inline blocked SVG icon centered on the link. 
- Render both hierarchy links and blocked links in `renderTrajectoryDom` by calling `buildRelationLinks` for `hierarchy` and `blocked` relations and appending blocked icons when present. 
- Add CSS rules to style blocked links and the blocked icon, including red stroke and backdrop/icon glyph styles. 
- Update test exports to expose `buildRelationLinks` via `__trajectoryDomRendererTestUtils` and modify existing tests to use the new API, plus add a new test that asserts blocked links are drawn with the red style and blocked icon.

### Testing

- Ran the `trajectory-dom-renderer` unit tests in `trajectory-dom-renderer.test.mjs`, including the new test for blocked relations, and all tests passed. 
- Verified existing rendering tests were updated to use `buildRelationLinks` and continued to succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ac8e82988329999c66a043b14cdf)