### PR TITLE
Portalize trajectory zoom dropdown and include additional trajectory relation event types

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -756,7 +756,11 @@ export function createProjectSituationsEvents({
       "subject_parent_added",
       "subject_parent_removed",
       "subject_child_added",
-      "subject_child_removed"
+      "subject_child_removed",
+      "subject_blocked_by_added",
+      "subject_blocked_by_removed",
+      "subject_blocking_for_added",
+      "subject_blocking_for_removed"
     ]);
     return Object.values(eventsBySubjectId)
       .flatMap((events) => (Array.isArray(events) ? events : []))
@@ -1884,6 +1888,77 @@ export function createProjectSituationsEvents({
   }
 
   function bindEvents(root) {
+    function ensureTrajectoryZoomDropdownHost() {
+      let host = document.getElementById("trajectoryZoomDropdownHost");
+      if (!host) {
+        host = document.createElement("div");
+        host.id = "trajectoryZoomDropdownHost";
+        host.className = "trajectory-zoom-dropdown-host";
+        host.setAttribute("aria-hidden", "true");
+        document.body.appendChild(host);
+      }
+      return host;
+    }
+
+    function closeTrajectoryZoomDropdown(rootNode = null) {
+      const host = ensureTrajectoryZoomDropdownHost();
+      const openMenu = host.querySelector("[data-situation-trajectory-zoom-menu]");
+      const ownerDropdownId = String(host.dataset.ownerDropdownId || "").trim();
+      if (openMenu && ownerDropdownId) {
+        openMenu.classList.remove("situation-trajectory__zoom-menu--portal");
+        const ownerDropdown = document.querySelector(`[data-situation-trajectory-zoom-dropdown-id="${CSS.escape(ownerDropdownId)}"]`);
+        const ownerAnchor = ownerDropdown?.querySelector?.("[data-situation-trajectory-zoom-menu-anchor]");
+        if (ownerAnchor) ownerAnchor.appendChild(openMenu);
+      }
+      host.innerHTML = "";
+      host.dataset.ownerDropdownId = "";
+      host.style.left = "0px";
+      host.style.top = "0px";
+      host.setAttribute("aria-hidden", "true");
+
+      const searchRoot = rootNode || root || document;
+      searchRoot.querySelectorAll("[data-situation-trajectory-zoom-menu]").forEach((node) => {
+        node.classList.remove("gh-menu--open");
+        node.hidden = true;
+      });
+      searchRoot.querySelectorAll("[data-situation-trajectory-zoom-trigger]").forEach((node) => {
+        node.setAttribute("aria-expanded", "false");
+      });
+    }
+
+    function openTrajectoryZoomDropdown(triggerNode, menuNode) {
+      const host = ensureTrajectoryZoomDropdownHost();
+      const dropdownNode = triggerNode?.closest?.(".situation-trajectory__zoom-dropdown");
+      if (!dropdownNode || !menuNode) return;
+      if (!dropdownNode.dataset.situationTrajectoryZoomDropdownId) {
+        dropdownNode.dataset.situationTrajectoryZoomDropdownId = `trajectory-zoom-${Math.random().toString(36).slice(2)}`;
+      }
+      const dropdownId = dropdownNode.dataset.situationTrajectoryZoomDropdownId;
+      dropdownNode.setAttribute("data-situation-trajectory-zoom-dropdown-id", dropdownId);
+
+      const triggerRect = triggerNode.getBoundingClientRect();
+      host.innerHTML = "";
+      host.appendChild(menuNode);
+      host.dataset.ownerDropdownId = dropdownId;
+      host.setAttribute("aria-hidden", "false");
+      menuNode.classList.add("situation-trajectory__zoom-menu--portal");
+      menuNode.hidden = false;
+      menuNode.classList.add("gh-menu--open");
+      triggerNode.setAttribute("aria-expanded", "true");
+
+      const menuRect = menuNode.getBoundingClientRect();
+      const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+      const margin = 12;
+      let left = triggerRect.right - menuRect.width;
+      let top = triggerRect.bottom + 6;
+      if (left < margin) left = margin;
+      if (left + menuRect.width > viewportWidth - margin) left = Math.max(margin, viewportWidth - menuRect.width - margin);
+      if (top + menuRect.height > viewportHeight - margin) top = Math.max(margin, triggerRect.top - menuRect.height - 6);
+      host.style.left = `${Math.round(left)}px`;
+      host.style.top = `${Math.round(top)}px`;
+    }
+
     const openButton = root.querySelector("#openCreateSituationButton");
     if (openButton) {
       openButton.onclick = () => openCreateModal(root);
@@ -2053,17 +2128,9 @@ export function createProjectSituationsEvents({
         const menuNode = dropdownNode?.querySelector("[data-situation-trajectory-zoom-menu]");
         if (!menuNode) return;
         const isOpen = menuNode.classList.contains("gh-menu--open");
-        root.querySelectorAll("[data-situation-trajectory-zoom-menu]").forEach((node) => {
-          node.classList.remove("gh-menu--open");
-          node.hidden = true;
-        });
-        root.querySelectorAll("[data-situation-trajectory-zoom-trigger]").forEach((node) => {
-          node.setAttribute("aria-expanded", "false");
-        });
+        closeTrajectoryZoomDropdown(root);
         if (!isOpen) {
-          menuNode.hidden = false;
-          menuNode.classList.add("gh-menu--open");
-          triggerNode.setAttribute("aria-expanded", "true");
+          openTrajectoryZoomDropdown(triggerNode, menuNode);
         }
       });
     });
@@ -2083,14 +2150,10 @@ export function createProjectSituationsEvents({
     if (!root.dataset.trajectoryZoomDropdownDocBound) {
       root.dataset.trajectoryZoomDropdownDocBound = "true";
       document.addEventListener("click", () => {
-        root.querySelectorAll("[data-situation-trajectory-zoom-menu]").forEach((node) => {
-          node.classList.remove("gh-menu--open");
-          node.hidden = true;
-        });
-        root.querySelectorAll("[data-situation-trajectory-zoom-trigger]").forEach((node) => {
-          node.setAttribute("aria-expanded", "false");
-        });
+        closeTrajectoryZoomDropdown(root);
       });
+      window.addEventListener("resize", () => closeTrajectoryZoomDropdown(root));
+      window.addEventListener("scroll", () => closeTrajectoryZoomDropdown(root), true);
     }
     bindSituationGridEditableCells(root);
     bindSituationGridDnd(root);

--- a/apps/web/js/views/project-situations/project-situations-view-roadmap.js
+++ b/apps/web/js/views/project-situations/project-situations-view-roadmap.js
@@ -224,14 +224,16 @@ export function renderSituationRoadmapView(situation, subjects = [], options = {
                     <span data-situation-trajectory-zoom-current-label>${escapeHtml(selectedZoomLabel)}</span>
                     ${svgIcon("chevron-down", { className: "gh-chevron", width: 16, height: 16 })}
                   </button>
-                  <div
-                    class="gh-menu situation-trajectory__zoom-menu"
-                    role="menu"
-                    hidden
-                    data-situation-trajectory-zoom-menu
-                    data-situation-trajectory-zoom-situation-id="${escapeHtml(situationId)}"
-                  >
-                    ${renderZoomDropdownOptions(selectedZoom)}
+                  <div data-situation-trajectory-zoom-menu-anchor>
+                    <div
+                      class="gh-menu situation-trajectory__zoom-menu"
+                      role="menu"
+                      hidden
+                      data-situation-trajectory-zoom-menu
+                      data-situation-trajectory-zoom-situation-id="${escapeHtml(situationId)}"
+                    >
+                      ${renderZoomDropdownOptions(selectedZoom)}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -10219,6 +10219,19 @@ body.route--project .project-simple-scroll.project-simple-scroll--situation-view
   display:block;
 }
 
+.situation-trajectory__zoom-menu.situation-trajectory__zoom-menu--portal{
+  position:static;
+  top:auto;
+  right:auto;
+}
+
+.trajectory-zoom-dropdown-host{
+  position:fixed;
+  z-index:120;
+  left:0;
+  top:0;
+}
+
 .situation-trajectory__timeline{
   position:sticky;
   top:0;


### PR DESCRIPTION
### Motivation
- Prevent trajectory zoom menus from being clipped by overflow by rendering the dropdown into a fixed portal host. 
- Improve dropdown positioning and behavior across viewport resizes and scrolling. 
- Ensure trajectory relation events include blocking relations so timeline reconstruction considers those relation changes.

### Description
- Add a portal host and helpers: `ensureTrajectoryZoomDropdownHost`, `openTrajectoryZoomDropdown`, and `closeTrajectoryZoomDropdown` in `project-situations-events.js` to move the zoom menu into a fixed container and compute viewport-safe positioning. 
- Wire global close handlers for document `click`, `resize`, and `scroll` to call `closeTrajectoryZoomDropdown` and update dropdown open/closed state and `aria-expanded` attributes. 
- Update template in `project-situations-view-roadmap.js` to wrap the zoom menu with a `data-situation-trajectory-zoom-menu-anchor` container so the menu can be re-attached to its anchor when closed. 
- Add CSS rules in `style.css` for `.situation-trajectory__zoom-menu--portal` and `.trajectory-zoom-dropdown-host` to support portal rendering and ensure correct stacking/positioning. 
- Extend `resolveTrajectoryRelationEvents` to include four new relation event types: `subject_blocked_by_added`, `subject_blocked_by_removed`, `subject_blocking_for_added`, and `subject_blocking_for_removed`.

### Testing
- Ran the project's lint step via `npm run lint` and the frontend build via `npm run build`, both completed successfully. 
- Exercised dropdown behavior in the browser to verify opening, closing, repositioning on resize/scroll, and re-attaching to the original anchor. 
- Existing automated test suite (`npm test`) executed in CI and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c972b5508329893b9c040106a6f5)