### PR TITLE
Persist kanban ordering for situation_subjects and add server/client reorder APIs

### DIFF
--- a/apps/web/js/services/project-situations-supabase.js
+++ b/apps/web/js/services/project-situations-supabase.js
@@ -5,6 +5,10 @@ import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
 const SUPABASE_URL = getSupabaseUrl();
 const FRONT_PROJECT_MAP_STORAGE_KEY = "mdall.supabaseProjectMap.v1";
 
+function logSituationKanbanOrder(event, payload = {}) {
+  console.info(`[situation-kanban-order] ${event}`, payload);
+}
+
 
 function safeArray(value) {
   return Array.isArray(value) ? value : [];
@@ -631,9 +635,9 @@ export async function loadManualSituationSubjectIds(situationId) {
   if (!normalizedSituationId) return [];
 
   const url = new URL(`${SUPABASE_URL}/rest/v1/situation_subjects`);
-  url.searchParams.set("select", "subject_id,created_at,kanban_status");
+  url.searchParams.set("select", "subject_id,created_at,kanban_status,kanban_order");
   url.searchParams.set("situation_id", `eq.${normalizedSituationId}`);
-  url.searchParams.set("order", "created_at.asc");
+  url.searchParams.set("order", "kanban_order.asc,created_at.asc");
 
   const res = await fetch(url.toString(), {
     method: "GET",
@@ -646,7 +650,14 @@ export async function loadManualSituationSubjectIds(situationId) {
     throw new Error(`situation_subjects fetch failed (${res.status}): ${text}`);
   }
 
-  return normalizeArrayOfStrings(safeArray(await res.json()).map((row) => row?.subject_id));
+  const rows = safeArray(await res.json());
+  const subjectIds = normalizeArrayOfStrings(rows.map((row) => row?.subject_id));
+  logSituationKanbanOrder("load", {
+    source: "loadManualSituationSubjectIds",
+    situationId: normalizedSituationId,
+    count: subjectIds.length
+  });
+  return subjectIds;
 }
 
 export async function loadSituationSubjectIdsMap(situationIds = []) {
@@ -654,9 +665,9 @@ export async function loadSituationSubjectIdsMap(situationIds = []) {
   if (!normalizedIds.length) return {};
 
   const url = new URL(`${SUPABASE_URL}/rest/v1/situation_subjects`);
-  url.searchParams.set("select", "situation_id,subject_id,created_at,kanban_status");
+  url.searchParams.set("select", "situation_id,subject_id,created_at,kanban_status,kanban_order");
   url.searchParams.set("situation_id", `in.(${normalizedIds.join(",")})`);
-  url.searchParams.set("order", "created_at.asc");
+  url.searchParams.set("order", "situation_id.asc,kanban_order.asc,created_at.asc");
 
   const res = await fetch(url.toString(), {
     method: "GET",
@@ -678,6 +689,11 @@ export async function loadSituationSubjectIdsMap(situationIds = []) {
     if (!Array.isArray(map[situationId])) map[situationId] = [];
     if (!map[situationId].includes(subjectId)) map[situationId].push(subjectId);
   });
+  logSituationKanbanOrder("load", {
+    source: "loadSituationSubjectIdsMap",
+    situations: normalizedIds.length,
+    rows: rows.length
+  });
   return map;
 }
 
@@ -687,9 +703,9 @@ export async function loadSituationKanbanStatusMap(situationIds = []) {
   if (!normalizedIds.length) return {};
 
   const url = new URL(`${SUPABASE_URL}/rest/v1/situation_subjects`);
-  url.searchParams.set("select", "situation_id,subject_id,kanban_status,created_at");
+  url.searchParams.set("select", "situation_id,subject_id,kanban_status,created_at,kanban_order");
   url.searchParams.set("situation_id", `in.(${normalizedIds.join(",")})`);
-  url.searchParams.set("order", "created_at.asc");
+  url.searchParams.set("order", "situation_id.asc,kanban_order.asc,created_at.asc");
 
   const res = await fetch(url.toString(), {
     method: "GET",
@@ -712,7 +728,64 @@ export async function loadSituationKanbanStatusMap(situationIds = []) {
     if (!map[situationId] || typeof map[situationId] !== "object" || Array.isArray(map[situationId])) map[situationId] = {};
     map[situationId][subjectId] = kanbanStatus;
   });
+  logSituationKanbanOrder("load", {
+    source: "loadSituationKanbanStatusMap",
+    situations: normalizedIds.length,
+    rows: rows.length
+  });
   return map;
+}
+
+export async function reorderSituationKanbanSubjects(situationId, kanbanStatus, orderedSubjectIds = []) {
+  const normalizedSituationId = normalizeUuid(situationId);
+  const normalizedStatus = normalizeSituationKanbanStatus(kanbanStatus);
+  const normalizedSubjectIds = normalizeArrayOfStrings(orderedSubjectIds).map(normalizeUuid).filter(Boolean);
+  if (!normalizedSituationId) throw new Error("situationId is required");
+  if (!normalizedStatus) throw new Error("kanbanStatus is required");
+  if (!normalizedSubjectIds.length) throw new Error("orderedSubjectIds is required");
+
+  const payload = {
+    p_situation_id: normalizedSituationId,
+    p_kanban_status: normalizedStatus,
+    p_subject_ids: normalizedSubjectIds
+  };
+
+  logSituationKanbanOrder("reorder:start", {
+    situationId: normalizedSituationId,
+    kanbanStatus: normalizedStatus,
+    count: normalizedSubjectIds.length
+  });
+
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/reorder_situation_kanban_subjects`, {
+      method: "POST",
+      headers: await getSupabaseAuthHeaders({
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      }),
+      body: JSON.stringify(payload)
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`reorder_situation_kanban_subjects failed (${res.status}): ${text}`);
+    }
+
+    const rows = safeArray(await res.json());
+    logSituationKanbanOrder("reorder:success", {
+      situationId: normalizedSituationId,
+      kanbanStatus: normalizedStatus,
+      updated: rows.length
+    });
+    return rows;
+  } catch (error) {
+    logSituationKanbanOrder("reorder:error", {
+      situationId: normalizedSituationId,
+      kanbanStatus: normalizedStatus,
+      message: error instanceof Error ? error.message : String(error || "unknown")
+    });
+    throw error;
+  }
 }
 
 export async function setSituationSubjectKanbanStatus(situationId, subjectId, kanbanStatus) {
@@ -753,21 +826,80 @@ export async function addSubjectToSituation(situationId, subjectId, options = {}
   if (!normalizedSituationId) throw new Error("situationId is required");
   if (!normalizedSubjectId) throw new Error("subjectId is required");
 
+  const explicitStatus = normalizeSituationKanbanStatus(options.kanbanStatus);
+  const targetStatus = explicitStatus || "non_active";
+
+  const existingUrl = new URL(`${SUPABASE_URL}/rest/v1/situation_subjects`);
+  existingUrl.searchParams.set("select", "situation_id,subject_id,kanban_status,kanban_order");
+  existingUrl.searchParams.set("situation_id", `eq.${normalizedSituationId}`);
+  existingUrl.searchParams.set("subject_id", `eq.${normalizedSubjectId}`);
+  existingUrl.searchParams.set("limit", "1");
+
+  const existingRes = await fetch(existingUrl.toString(), {
+    method: "GET",
+    headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
+    cache: "no-store"
+  });
+
+  if (!existingRes.ok) {
+    const text = await existingRes.text().catch(() => "");
+    throw new Error(`situation_subjects existing fetch failed (${existingRes.status}): ${text}`);
+  }
+
+  const existingRow = (safeArray(await existingRes.json())[0]) || null;
+  if (existingRow) {
+    return existingRow;
+  }
+
+  const orderUrl = new URL(`${SUPABASE_URL}/rest/v1/situation_subjects`);
+  orderUrl.searchParams.set("select", "kanban_order");
+  orderUrl.searchParams.set("situation_id", `eq.${normalizedSituationId}`);
+  orderUrl.searchParams.set("kanban_status", `eq.${targetStatus}`);
+  orderUrl.searchParams.set("order", "kanban_order.desc");
+  orderUrl.searchParams.set("limit", "1");
+
+  const orderRes = await fetch(orderUrl.toString(), {
+    method: "GET",
+    headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
+    cache: "no-store"
+  });
+
+  if (!orderRes.ok) {
+    const text = await orderRes.text().catch(() => "");
+    throw new Error(`situation_subjects order fetch failed (${orderRes.status}): ${text}`);
+  }
+
+  const highestOrderRow = (safeArray(await orderRes.json())[0]) || null;
+  const nextOrder = Number.isFinite(Number(highestOrderRow?.kanban_order))
+    ? (Number(highestOrderRow.kanban_order) + 1)
+    : 0;
+
   const res = await fetch(`${SUPABASE_URL}/rest/v1/situation_subjects`, {
     method: "POST",
     headers: await getSupabaseAuthHeaders({
       Accept: "application/json",
       "Content-Type": "application/json",
-      Prefer: "resolution=merge-duplicates,return=representation"
+      Prefer: "return=representation"
     }),
     body: JSON.stringify({
       situation_id: normalizedSituationId,
       subject_id: normalizedSubjectId,
-      ...(normalizeSituationKanbanStatus(options.kanbanStatus) ? { kanban_status: normalizeSituationKanbanStatus(options.kanbanStatus) } : {})
+      kanban_status: targetStatus,
+      kanban_order: nextOrder
     })
   });
 
   if (!res.ok) {
+    if (res.status === 409) {
+      const conflictRes = await fetch(existingUrl.toString(), {
+        method: "GET",
+        headers: await getSupabaseAuthHeaders({ Accept: "application/json" }),
+        cache: "no-store"
+      });
+      if (conflictRes.ok) {
+        return (safeArray(await conflictRes.json())[0]) || null;
+      }
+    }
     const text = await res.text().catch(() => "");
     throw new Error(`situation_subjects insert failed (${res.status}): ${text}`);
   }
@@ -806,7 +938,7 @@ export async function loadSubjectsForSituation(situation, projectSubjectsState =
 
   if (normalizedSituation.mode === "manual") {
     const subjectIds = await loadManualSituationSubjectIds(normalizedSituation.id);
-    return sortSubjects(subjectIds.map((subjectId) => subjectsById[subjectId]).filter(Boolean));
+    return subjectIds.map((subjectId) => subjectsById[subjectId]).filter(Boolean);
   }
 
   const flatSubjects = Object.values(subjectsById);

--- a/supabase/migrations/202606150038_situation_subjects_kanban_order_rpc.sql
+++ b/supabase/migrations/202606150038_situation_subjects_kanban_order_rpc.sql
@@ -1,0 +1,239 @@
+begin;
+
+-- Ajoute un ordre manuel persistant pour les cartes kanban par situation et par colonne.
+alter table if exists public.situation_subjects
+  add column if not exists kanban_order integer not null default 0;
+
+comment on column public.situation_subjects.kanban_order is
+  'Ordre manuel (0-based) du sujet dans une colonne kanban, scoped par situation_id + kanban_status.';
+
+-- Backfill idempotent avec un ordre stable pour les données existantes.
+with ranked as (
+  select
+    ss.id,
+    (row_number() over (
+      partition by ss.situation_id, ss.kanban_status
+      order by ss.created_at asc, ss.subject_id asc
+    ) - 1)::integer as next_kanban_order
+  from public.situation_subjects ss
+)
+update public.situation_subjects ss
+set kanban_order = ranked.next_kanban_order
+from ranked
+where ranked.id = ss.id;
+
+-- Index de lecture/tri pour charger rapidement une colonne kanban ordonnée.
+create index if not exists idx_situation_subjects_kanban_scope_order
+  on public.situation_subjects (situation_id, kanban_status, kanban_order);
+
+create or replace function public.reorder_situation_kanban_subjects(
+  p_situation_id uuid,
+  p_kanban_status text,
+  p_subject_ids uuid[]
+)
+returns table(subject_id uuid, kanban_order integer)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status text := trim(coalesce(p_kanban_status, ''));
+  v_expected_count integer;
+  v_distinct_count integer;
+  v_actual_count integer;
+begin
+  if p_situation_id is null then
+    raise exception 'p_situation_id is required';
+  end if;
+
+  if v_status = '' then
+    raise exception 'p_kanban_status is required';
+  end if;
+
+  if p_subject_ids is null then
+    raise exception 'p_subject_ids is required';
+  end if;
+
+  if v_status not in ('non_active', 'to_activate', 'in_progress', 'in_arbitration', 'resolved') then
+    raise exception 'Invalid kanban status: %', v_status;
+  end if;
+
+  select array_length(p_subject_ids, 1),
+         cardinality(array(select distinct x from unnest(p_subject_ids) as x))
+  into v_expected_count, v_distinct_count;
+
+  if coalesce(v_expected_count, 0) = 0 then
+    raise exception 'p_subject_ids must not be empty';
+  end if;
+
+  if v_expected_count <> v_distinct_count then
+    raise exception 'p_subject_ids contains duplicates';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(format('%s|%s', p_situation_id::text, v_status), 0));
+
+  select count(*)
+  into v_actual_count
+  from public.situation_subjects ss
+  where ss.situation_id = p_situation_id
+    and ss.kanban_status = v_status;
+
+  if v_actual_count <> v_expected_count then
+    raise exception 'p_subject_ids size (%) must match existing column size (%)', v_expected_count, v_actual_count;
+  end if;
+
+  if exists (
+    select 1
+    from unnest(p_subject_ids) as requested(subject_id)
+    left join public.situation_subjects ss
+      on ss.situation_id = p_situation_id
+     and ss.kanban_status = v_status
+     and ss.subject_id = requested.subject_id
+    where ss.id is null
+  ) then
+    raise exception 'p_subject_ids contains subjects outside the target situation/status';
+  end if;
+
+  return query
+  with ordered as (
+    select t.subject_id, (t.ord - 1)::integer as next_kanban_order
+    from unnest(p_subject_ids) with ordinality as t(subject_id, ord)
+  ),
+  updated as (
+    update public.situation_subjects ss
+    set kanban_order = ordered.next_kanban_order
+    from ordered
+    where ss.situation_id = p_situation_id
+      and ss.kanban_status = v_status
+      and ss.subject_id = ordered.subject_id
+    returning ss.subject_id, ss.kanban_order
+  )
+  select u.subject_id, u.kanban_order
+  from updated u
+  order by u.kanban_order asc;
+end;
+$$;
+
+comment on function public.reorder_situation_kanban_subjects(uuid, text, uuid[]) is
+  'Réordonne atomiquement les sujets d''une colonne kanban pour une situation donnée.';
+
+grant execute on function public.reorder_situation_kanban_subjects(uuid, text, uuid[]) to authenticated;
+revoke all on function public.reorder_situation_kanban_subjects(uuid, text, uuid[]) from public;
+
+create or replace function public.move_situation_kanban_subject(
+  p_situation_id uuid,
+  p_subject_id uuid,
+  p_target_kanban_status text,
+  p_target_kanban_order integer default null
+)
+returns table(subject_id uuid, kanban_status text, kanban_order integer)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_source_status text;
+  v_target_status text := trim(coalesce(p_target_kanban_status, ''));
+  v_source_ids uuid[];
+  v_target_ids uuid[];
+  v_insert_pos integer;
+  v_target_len integer;
+begin
+  if p_situation_id is null then
+    raise exception 'p_situation_id is required';
+  end if;
+
+  if p_subject_id is null then
+    raise exception 'p_subject_id is required';
+  end if;
+
+  if v_target_status = '' then
+    raise exception 'p_target_kanban_status is required';
+  end if;
+
+  if v_target_status not in ('non_active', 'to_activate', 'in_progress', 'in_arbitration', 'resolved') then
+    raise exception 'Invalid target kanban status: %', v_target_status;
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_situation_id::text, 0));
+
+  select ss.kanban_status
+  into v_source_status
+  from public.situation_subjects ss
+  where ss.situation_id = p_situation_id
+    and ss.subject_id = p_subject_id;
+
+  if v_source_status is null then
+    raise exception 'Subject % is not linked to situation %', p_subject_id, p_situation_id;
+  end if;
+
+  select coalesce(array_agg(ss.subject_id order by ss.kanban_order asc, ss.created_at asc, ss.subject_id asc), '{}'::uuid[])
+  into v_source_ids
+  from public.situation_subjects ss
+  where ss.situation_id = p_situation_id
+    and ss.kanban_status = v_source_status
+    and ss.subject_id <> p_subject_id;
+
+  if v_source_status = v_target_status then
+    v_target_ids := v_source_ids;
+  else
+    select coalesce(array_agg(ss.subject_id order by ss.kanban_order asc, ss.created_at asc, ss.subject_id asc), '{}'::uuid[])
+    into v_target_ids
+    from public.situation_subjects ss
+    where ss.situation_id = p_situation_id
+      and ss.kanban_status = v_target_status;
+  end if;
+
+  v_target_len := coalesce(array_length(v_target_ids, 1), 0);
+
+  if p_target_kanban_order is null then
+    v_insert_pos := v_target_len;
+  else
+    v_insert_pos := greatest(0, least(p_target_kanban_order, v_target_len));
+  end if;
+
+  v_target_ids :=
+    coalesce(v_target_ids[1:v_insert_pos], '{}'::uuid[])
+    || array[p_subject_id]
+    || coalesce(v_target_ids[v_insert_pos + 1:v_target_len], '{}'::uuid[]);
+
+  -- Réordonne la colonne source après retrait.
+  with ordered_source as (
+    select t.subject_id, (t.ord - 1)::integer as next_kanban_order
+    from unnest(v_source_ids) with ordinality as t(subject_id, ord)
+  )
+  update public.situation_subjects ss
+  set kanban_order = ordered_source.next_kanban_order
+  from ordered_source
+  where ss.situation_id = p_situation_id
+    and ss.kanban_status = v_source_status
+    and ss.subject_id = ordered_source.subject_id;
+
+  -- Réordonne la colonne cible (et met à jour le statut de la carte déplacée).
+  return query
+  with ordered_target as (
+    select t.subject_id, (t.ord - 1)::integer as next_kanban_order
+    from unnest(v_target_ids) with ordinality as t(subject_id, ord)
+  ),
+  updated_target as (
+    update public.situation_subjects ss
+    set kanban_status = v_target_status,
+        kanban_order = ordered_target.next_kanban_order
+    from ordered_target
+    where ss.situation_id = p_situation_id
+      and ss.subject_id = ordered_target.subject_id
+    returning ss.subject_id, ss.kanban_status, ss.kanban_order
+  )
+  select ut.subject_id, ut.kanban_status, ut.kanban_order
+  from updated_target ut
+  order by ut.kanban_order asc;
+end;
+$$;
+
+comment on function public.move_situation_kanban_subject(uuid, uuid, text, integer) is
+  'Déplace une carte vers une colonne kanban cible et réordonne atomiquement les colonnes source et cible.';
+
+grant execute on function public.move_situation_kanban_subject(uuid, uuid, text, integer) to authenticated;
+revoke all on function public.move_situation_kanban_subject(uuid, uuid, text, integer) from public;
+
+commit;


### PR DESCRIPTION
### Motivation
- Introduce a persistent, stable manual order for kanban cards per situation and column so UI ordering is reliable across clients and sessions.
- Provide atomic server-side operations to reorder or move cards between columns to avoid race conditions and keep kanban state consistent.

### Description
- Add `kanban_order` integer column to `public.situation_subjects`, backfill a stable 0-based order, and create index `idx_situation_subjects_kanban_scope_order` for ordered reads via the migration `202606150038_situation_subjects_kanban_order_rpc.sql`.
- Implement RPCs `reorder_situation_kanban_subjects` and `move_situation_kanban_subject` to atomically reorder a column or move a card between columns, with validation, advisory locking and appropriate grants.
- Update client code in `apps/web/js/services/project-situations-supabase.js` to request `kanban_order` in queries and order results by `kanban_order`, add `reorderSituationKanbanSubjects` that calls the new RPC, and change `addSubjectToSituation` to compute and set `kanban_order` (including duplicate/conflict handling) while adding lightweight logging via `logSituationKanbanOrder`.
- Adjust `loadSubjectsForSituation` to rely on server-provided order for manual situations and remove the extra client-side sorting step.

### Testing
- Applied the migration to a development/test database and exercised the RPCs manually, confirming backfill, index creation, and both `reorder`/`move` functions executed successfully.
- Ran the web app unit/integration tests after the client changes, and the test suite completed successfully with no regressions related to situations or subjects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ddccba70832991430eb40d30e3df)