### PR TITLE
Fix studio module import paths after JS tree move

### DIFF
--- a/apps/web/js/views/studio/seismic/seismic-general.js
+++ b/apps/web/js/views/studio/seismic/seismic-general.js
@@ -1,14 +1,14 @@
-import { store } from "../../store.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { renderGhEditableField, bindGhEditableFields } from "../ui/gh-input.js";
-import { renderGhSelectMenu, bindGhSelectMenus, bindGhActionButtons } from "../ui/gh-split-button.js";
+import { store } from "../../../store.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { renderGhEditableField, bindGhEditableFields } from "../../ui/gh-input.js";
+import { renderGhSelectMenu, bindGhSelectMenus, bindGhActionButtons } from "../../ui/gh-split-button.js";
 import {
   getSeismicSizingValues,
   buildElasticResponseSpectrumTable,
   computeElasticResponseValue
-} from "../../services/seismic-spectrum.js";
-import { renderSvgLineChart, getNiceChartTicks } from "../../utils/svg-line-chart.js";
+} from "../../../services/seismic-spectrum.js";
+import { renderSvgLineChart, getNiceChartTicks } from "../../../utils/svg-line-chart.js";
 
 let currentSeismicRoot = null;
 

--- a/apps/web/js/views/studio/solidity/solidity-general.js
+++ b/apps/web/js/views/studio/solidity/solidity-general.js
@@ -1,17 +1,17 @@
-import { resolveFrenchCommune, fetchFrenchAltitude } from "../../services/georisques-service.js";
-import { getCantonByCommuneCode } from "../../services/zoning/canton-service.js";
-import { getWindRegionsByDepartmentCode } from "../../services/zoning/wind-regions-service.js";
-import { getSnowRegionsByDepartmentCode } from "../../services/zoning/snow-regions-service.js";
-import { getWindZoneByDepartmentAndCanton } from "../../services/zoning/wind-canton-regions-service.js";
-import { getSnowZoneByDepartmentAndCanton } from "../../services/zoning/snow-canton-regions-service.js";
-import { getFrostDepthByDepartmentCode } from "../../services/zoning/frost-depth-service.js";
-import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../services/google-maps-embed-service.js";
-import { readPersistedCurrentProjectState } from "../../services/project-state-storage.js";
-import { store } from "../../store.js";
-import { svgIcon } from "../../ui/icons.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { renderGhActionButton } from "../ui/gh-split-button.js";
+import { resolveFrenchCommune, fetchFrenchAltitude } from "../../../services/georisques-service.js";
+import { getCantonByCommuneCode } from "../../../services/zoning/canton-service.js";
+import { getWindRegionsByDepartmentCode } from "../../../services/zoning/wind-regions-service.js";
+import { getSnowRegionsByDepartmentCode } from "../../../services/zoning/snow-regions-service.js";
+import { getWindZoneByDepartmentAndCanton } from "../../../services/zoning/wind-canton-regions-service.js";
+import { getSnowZoneByDepartmentAndCanton } from "../../../services/zoning/snow-canton-regions-service.js";
+import { getFrostDepthByDepartmentCode } from "../../../services/zoning/frost-depth-service.js";
+import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../../services/google-maps-embed-service.js";
+import { readPersistedCurrentProjectState } from "../../../services/project-state-storage.js";
+import { store } from "../../../store.js";
+import { svgIcon } from "../../../ui/icons.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { renderGhActionButton } from "../../ui/gh-split-button.js";
 
 const solidityGeneralUiState = {
   loading: false,

--- a/apps/web/js/views/studio/solidity/solidity-georisks.js
+++ b/apps/web/js/views/studio/solidity/solidity-georisks.js
@@ -1,9 +1,9 @@
-import { store } from "../../store.js";
-import { fetchGeorisquesForCommune } from "../../services/georisques-service.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { persistCurrentProjectState, readPersistedCurrentProjectState } from "../../services/project-state-storage.js";
-import { shouldAutoRunProjectBaseDataEnrichment } from "../../services/project-automation.js";
+import { store } from "../../../store.js";
+import { fetchGeorisquesForCommune } from "../../../services/georisques-service.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { persistCurrentProjectState, readPersistedCurrentProjectState } from "../../../services/project-state-storage.js";
+import { shouldAutoRunProjectBaseDataEnrichment } from "../../../services/project-automation.js";
 
 const georisksUiState = {
   isLoading: false,


### PR DESCRIPTION
### Motivation

- Relative imports in several studio view modules were broken after the JS files were relocated, causing 404s when loading resources. 
- The goal is to rewire imports to the new `apps/web/js` layout so modules resolve correctly at runtime. 
- This prevents missing resource errors for services, utils, UI helpers and the project shell used by studio views.

### Description

- Updated import specifiers in `apps/web/js/views/studio/solidity/solidity-general.js` to reference the moved modules under `../../../services`, `../../../store.js`, `../../../utils`, and `../../` for local view helpers. 
- Updated import specifiers in `apps/web/js/views/studio/solidity/solidity-georisks.js` to reference `../../../services`, `../../../store.js`, `../../../utils`, and `../../project-shell-chrome.js`. 
- Updated import specifiers in `apps/web/js/views/studio/seismic/seismic-general.js` to reference `../../../services`, `../../../store.js`, `../../../utils`, and `../../ui`/`../../project-shell-chrome.js` as appropriate.

### Testing

- Verified the code changes with a local diff review using `git diff` and inspected the modified files to confirm updated import paths. 
- Ran quick file searches (`rg`/`sed`) to confirm the new specifiers are present in the three updated files. 
- Attempted to run `npm -C apps/web run -s test -- --runInBand` and `npm -C apps/web run -s lint`, but these commands could not be executed in the current environment and produced no usable output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a4eb5fa08329b289bc64e5761005)