### PR TITLE
Fix relative import paths in seismic and solidity studio views

### DIFF
--- a/apps/web/js/views/studio/seismic/seismic-general.js
+++ b/apps/web/js/views/studio/seismic/seismic-general.js
@@ -1,14 +1,14 @@
-import { store } from "../../store.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { renderGhEditableField, bindGhEditableFields } from "../ui/gh-input.js";
-import { renderGhSelectMenu, bindGhSelectMenus, bindGhActionButtons } from "../ui/gh-split-button.js";
+import { store } from "../../../store.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { renderGhEditableField, bindGhEditableFields } from "../../ui/gh-input.js";
+import { renderGhSelectMenu, bindGhSelectMenus, bindGhActionButtons } from "../../ui/gh-split-button.js";
 import {
   getSeismicSizingValues,
   buildElasticResponseSpectrumTable,
   computeElasticResponseValue
-} from "../../services/seismic-spectrum.js";
-import { renderSvgLineChart, getNiceChartTicks } from "../../utils/svg-line-chart.js";
+} from "../../../services/seismic-spectrum.js";
+import { renderSvgLineChart, getNiceChartTicks } from "../../../utils/svg-line-chart.js";
 
 let currentSeismicRoot = null;
 

--- a/apps/web/js/views/studio/solidity/solidity-arkolia.js
+++ b/apps/web/js/views/studio/solidity/solidity-arkolia.js
@@ -1,16 +1,16 @@
-import { searchFrenchCommunes, fetchFrenchAltitude } from "../../services/georisques-service.js";
-import { getCantonByCommuneCode } from "../../services/zoning/canton-service.js";
-import { getWindRegionsByDepartmentCode } from "../../services/zoning/wind-regions-service.js";
-import { getSnowRegionsByDepartmentCode } from "../../services/zoning/snow-regions-service.js";
-import { getWindZoneByDepartmentAndCanton } from "../../services/zoning/wind-canton-regions-service.js";
-import { getSnowZoneByDepartmentAndCanton } from "../../services/zoning/snow-canton-regions-service.js";
-import { getFrostDepthByDepartmentCode } from "../../services/zoning/frost-depth-service.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../services/google-maps-embed-service.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { svgIcon } from "../../ui/icons.js";
-import { store } from "../../store.js";
-import { renderGhActionButton } from "../ui/gh-split-button.js";
+import { searchFrenchCommunes, fetchFrenchAltitude } from "../../../services/georisques-service.js";
+import { getCantonByCommuneCode } from "../../../services/zoning/canton-service.js";
+import { getWindRegionsByDepartmentCode } from "../../../services/zoning/wind-regions-service.js";
+import { getSnowRegionsByDepartmentCode } from "../../../services/zoning/snow-regions-service.js";
+import { getWindZoneByDepartmentAndCanton } from "../../../services/zoning/wind-canton-regions-service.js";
+import { getSnowZoneByDepartmentAndCanton } from "../../../services/zoning/snow-canton-regions-service.js";
+import { getFrostDepthByDepartmentCode } from "../../../services/zoning/frost-depth-service.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../../services/google-maps-embed-service.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { svgIcon } from "../../../ui/icons.js";
+import { store } from "../../../store.js";
+import { renderGhActionButton } from "../../ui/gh-split-button.js";
 
 const DEFAULT_IDENTITY = {
   length: "",

--- a/apps/web/js/views/studio/solidity/solidity-general.js
+++ b/apps/web/js/views/studio/solidity/solidity-general.js
@@ -1,17 +1,17 @@
-import { resolveFrenchCommune, fetchFrenchAltitude } from "../../services/georisques-service.js";
-import { getCantonByCommuneCode } from "../../services/zoning/canton-service.js";
-import { getWindRegionsByDepartmentCode } from "../../services/zoning/wind-regions-service.js";
-import { getSnowRegionsByDepartmentCode } from "../../services/zoning/snow-regions-service.js";
-import { getWindZoneByDepartmentAndCanton } from "../../services/zoning/wind-canton-regions-service.js";
-import { getSnowZoneByDepartmentAndCanton } from "../../services/zoning/snow-canton-regions-service.js";
-import { getFrostDepthByDepartmentCode } from "../../services/zoning/frost-depth-service.js";
-import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../services/google-maps-embed-service.js";
-import { readPersistedCurrentProjectState } from "../../services/project-state-storage.js";
-import { store } from "../../store.js";
-import { svgIcon } from "../../ui/icons.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { renderGhActionButton } from "../ui/gh-split-button.js";
+import { resolveFrenchCommune, fetchFrenchAltitude } from "../../../services/georisques-service.js";
+import { getCantonByCommuneCode } from "../../../services/zoning/canton-service.js";
+import { getWindRegionsByDepartmentCode } from "../../../services/zoning/wind-regions-service.js";
+import { getSnowRegionsByDepartmentCode } from "../../../services/zoning/snow-regions-service.js";
+import { getWindZoneByDepartmentAndCanton } from "../../../services/zoning/wind-canton-regions-service.js";
+import { getSnowZoneByDepartmentAndCanton } from "../../../services/zoning/snow-canton-regions-service.js";
+import { getFrostDepthByDepartmentCode } from "../../../services/zoning/frost-depth-service.js";
+import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../../services/google-maps-embed-service.js";
+import { readPersistedCurrentProjectState } from "../../../services/project-state-storage.js";
+import { store } from "../../../store.js";
+import { svgIcon } from "../../../ui/icons.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { renderGhActionButton } from "../../ui/gh-split-button.js";
 
 const solidityGeneralUiState = {
   loading: false,

--- a/apps/web/js/views/studio/solidity/solidity-georisks.js
+++ b/apps/web/js/views/studio/solidity/solidity-georisks.js
@@ -1,9 +1,9 @@
-import { store } from "../../store.js";
-import { fetchGeorisquesForCommune } from "../../services/georisques-service.js";
-import { escapeHtml } from "../../utils/escape-html.js";
-import { registerProjectPrimaryScrollSource } from "../project-shell-chrome.js";
-import { persistCurrentProjectState, readPersistedCurrentProjectState } from "../../services/project-state-storage.js";
-import { shouldAutoRunProjectBaseDataEnrichment } from "../../services/project-automation.js";
+import { store } from "../../../store.js";
+import { fetchGeorisquesForCommune } from "../../../services/georisques-service.js";
+import { escapeHtml } from "../../../utils/escape-html.js";
+import { registerProjectPrimaryScrollSource } from "../../project-shell-chrome.js";
+import { persistCurrentProjectState, readPersistedCurrentProjectState } from "../../../services/project-state-storage.js";
+import { shouldAutoRunProjectBaseDataEnrichment } from "../../../services/project-automation.js";
 
 const georisksUiState = {
   isLoading: false,


### PR DESCRIPTION
### Motivation
- Adjust import paths after reorganizing or moving frontend modules so imports resolve correctly and avoid runtime module-not-found errors.
- Apply consistent relative paths for shared `services`, `utils`, and `ui` modules used by seismic and solidity view files.

### Description
- Updated relative import prefixes (e.g. from `"../../..."` to `"../../../..."`) in `apps/web/js/views/studio/seismic/seismic-general.js`, `apps/web/js/views/studio/solidity/solidity-arkolia.js`, `apps/web/js/views/studio/solidity/solidity-general.js`, and `apps/web/js/views/studio/solidity/solidity-georisks.js` so they reference the correct module locations.
- Adjusted a few imports that needed one less `..` (e.g. `project-shell-chrome.js` and `gh-split-button.js`) to match the files' new relative locations.

### Testing
- Ran frontend lint, unit tests, and a local build with `npm run lint`, `npm test`, and `npm run build`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a4eb5fa08329b289bc64e5761005)