### PR TITLE
Persist project location and context facts to Supabase (migration, service, UI save)

### DIFF
--- a/apps/web/js/services/project-location-supabase.js
+++ b/apps/web/js/services/project-location-supabase.js
@@ -1,0 +1,151 @@
+import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
+
+const SUPABASE_URL = getSupabaseUrl();
+
+function safeString(value = "") {
+  return String(value ?? "").trim();
+}
+
+function toNullableText(value = "") {
+  const normalized = safeString(value);
+  return normalized || null;
+}
+
+function toNullableNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+async function getAuthHeaders(extra = {}) {
+  return buildSupabaseAuthHeaders(extra);
+}
+
+async function resolveProjectId(projectId = "") {
+  const explicit = safeString(projectId);
+  if (explicit) return explicit;
+  return safeString(await resolveCurrentBackendProjectId().catch(() => ""));
+}
+
+async function fetchJsonOrThrow(url, init = {}, errorPrefix = "Supabase request failed") {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`${errorPrefix} (${res.status}): ${text}`);
+  }
+  return res;
+}
+
+export async function upsertProjectContextFact({ projectId, factKey, factValue, sourceType = "manual", sourceRef = "", confidence = null } = {}) {
+  const resolvedProjectId = await resolveProjectId(projectId);
+  const normalizedFactKey = safeString(factKey);
+  if (!resolvedProjectId) throw new Error("projectId is required");
+  if (!normalizedFactKey) throw new Error("factKey is required");
+
+  const payload = {
+    project_id: resolvedProjectId,
+    fact_key: normalizedFactKey,
+    fact_value: factValue && typeof factValue === "object" ? factValue : {},
+    source_type: safeString(sourceType) || "manual",
+    source_ref: toNullableText(sourceRef),
+    confidence: confidence == null ? null : Number(confidence)
+  };
+
+  const url = `${SUPABASE_URL}/rest/v1/project_context_facts`;
+  const res = await fetchJsonOrThrow(url, {
+    method: "POST",
+    headers: await getAuthHeaders({
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates,return=representation"
+    }),
+    body: JSON.stringify(payload)
+  }, "project_context_facts upsert failed");
+
+  const rows = await res.json().catch(() => []);
+  return Array.isArray(rows) ? (rows[0] || null) : rows;
+}
+
+export async function saveProjectLocationToSupabase({ projectId, address, city, postalCode, latitude, longitude, altitude, codeInsee } = {}) {
+  const resolvedProjectId = await resolveProjectId(projectId);
+  if (!resolvedProjectId) throw new Error("projectId is required");
+
+  const locationPayload = {
+    address: toNullableText(address),
+    city: toNullableText(city),
+    postal_code: toNullableText(postalCode),
+    latitude: toNullableNumber(latitude),
+    longitude: toNullableNumber(longitude),
+    altitude: toNullableNumber(altitude),
+    code_insee: toNullableText(codeInsee)
+  };
+
+  const projectsUrl = new URL(`${SUPABASE_URL}/rest/v1/projects`);
+  projectsUrl.searchParams.set("id", `eq.${resolvedProjectId}`);
+  projectsUrl.searchParams.set("select", "id,address,city,postal_code,latitude,longitude,altitude,code_insee");
+
+  const projectRes = await fetchJsonOrThrow(projectsUrl.toString(), {
+    method: "PATCH",
+    headers: await getAuthHeaders({
+      "Content-Type": "application/json",
+      Prefer: "return=representation"
+    }),
+    body: JSON.stringify(locationPayload)
+  }, "projects location update failed");
+
+  const updatedRows = await projectRes.json().catch(() => []);
+
+  await upsertProjectContextFact({
+    projectId: resolvedProjectId,
+    factKey: "address",
+    sourceType: "manual",
+    factValue: {
+      address: toNullableText(address),
+      city: toNullableText(city),
+      postalCode: toNullableText(postalCode),
+      latitude: toNullableNumber(latitude),
+      longitude: toNullableNumber(longitude),
+      altitude: toNullableNumber(altitude),
+      codeInsee: toNullableText(codeInsee)
+    }
+  });
+
+  return Array.isArray(updatedRows) ? (updatedRows[0] || null) : updatedRows;
+}
+
+export async function loadProjectLocationFromSupabase(projectId) {
+  const resolvedProjectId = await resolveProjectId(projectId);
+  if (!resolvedProjectId) return null;
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/projects`);
+  url.searchParams.set("id", `eq.${resolvedProjectId}`);
+  url.searchParams.set("select", "id,address,city,postal_code,latitude,longitude,altitude,code_insee");
+  url.searchParams.set("limit", "1");
+
+  const res = await fetchJsonOrThrow(url.toString(), {
+    method: "GET",
+    headers: await getAuthHeaders({ Accept: "application/json" }),
+    cache: "no-store"
+  }, "projects location fetch failed");
+
+  const rows = await res.json().catch(() => []);
+  return Array.isArray(rows) ? (rows[0] || null) : null;
+}
+
+export async function loadProjectContextFacts(projectId) {
+  const resolvedProjectId = await resolveProjectId(projectId);
+  if (!resolvedProjectId) return [];
+
+  const url = new URL(`${SUPABASE_URL}/rest/v1/project_context_facts`);
+  url.searchParams.set("project_id", `eq.${resolvedProjectId}`);
+  url.searchParams.set("select", "id,project_id,fact_key,fact_value,source_type,source_ref,confidence,created_at,updated_at");
+  url.searchParams.set("order", "updated_at.desc");
+
+  const res = await fetchJsonOrThrow(url.toString(), {
+    method: "GET",
+    headers: await getAuthHeaders({ Accept: "application/json" }),
+    cache: "no-store"
+  }, "project_context_facts fetch failed");
+
+  const rows = await res.json().catch(() => []);
+  return Array.isArray(rows) ? rows : [];
+}

--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -18,6 +18,7 @@ import {
   resolveFrenchPostalCode
 } from "../../services/georisques-service.js";
 import { persistCurrentProjectState } from "../../services/project-state-storage.js";
+import { saveProjectLocationToSupabase } from "../../services/project-location-supabase.js";
 import { svgIcon } from "../../ui/icons.js";
 import { buildGoogleMapsPlaceEmbedUrl, hasGoogleMapsEmbedApiKey } from "../../services/google-maps-embed-service.js";
 import {
@@ -758,6 +759,43 @@ async function refreshLocationDerivedData({ runEnrichment = false, triggerType =
 
   if (runEnrichment) {
     await runProjectBaseDataEnrichment({ triggerType, triggerLabel, force: true });
+  }
+
+  const codeInsee = String(store.projectForm?.georisques?.commune?.codeInsee || "").trim() || null;
+  const projectId = String(store.currentProjectId || "").trim();
+
+  console.info("[project-location] save.start", {
+    projectId,
+    address: String(store.projectForm.address || "").trim(),
+    city,
+    postalCode,
+    latitude: store.projectForm.latitude,
+    longitude: store.projectForm.longitude,
+    altitude: store.projectForm.altitude,
+    codeInsee
+  });
+
+  try {
+    const savedProject = await saveProjectLocationToSupabase({
+      projectId,
+      address: store.projectForm.address,
+      city,
+      postalCode,
+      latitude: store.projectForm.latitude,
+      longitude: store.projectForm.longitude,
+      altitude: store.projectForm.altitude,
+      codeInsee
+    });
+
+    console.info("[project-location] save.success", {
+      projectId,
+      savedProjectId: String(savedProject?.id || "").trim() || null
+    });
+  } catch (error) {
+    console.error("[project-location] save.failure", {
+      projectId,
+      message: error instanceof Error ? error.message : String(error)
+    });
   }
 
   persistCurrentProjectState();

--- a/supabase/migrations/202606150039_project_location_and_context_facts.sql
+++ b/supabase/migrations/202606150039_project_location_and_context_facts.sql
@@ -1,0 +1,127 @@
+-- Étape 1: Persistance robuste de la localisation projet et miroir de contexte enrichi.
+-- Cette migration ajoute:
+-- 1) des colonnes de localisation « classique » dans public.projects,
+-- 2) une table dédiée public.project_context_facts qui joue le rôle de miroir enrichi
+--    du contexte projet, alimenté progressivement par la Localisation, l'Atelier,
+--    l'extraction PDF, les messages et les sujets.
+
+alter table if exists public.projects
+  add column if not exists address text,
+  add column if not exists latitude double precision,
+  add column if not exists longitude double precision,
+  add column if not exists altitude double precision,
+  add column if not exists code_insee text;
+
+create table if not exists public.project_context_facts (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  fact_key text not null,
+  fact_value jsonb not null default '{}'::jsonb,
+  source_type text not null default 'manual',
+  source_ref text,
+  confidence numeric,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.project_context_facts is
+  'Miroir enrichi du contexte projet (adresse, zones sismiques/neige/vent/gel, risques, étages, etc.), alimenté progressivement par Localisation, Atelier, extraction PDF, messages et sujets.';
+
+comment on column public.project_context_facts.fact_key is
+  'Clé métier normalisée (ex: address, seismic_zone, snow_zone, wind_zone, frost_depth, floors_count, natural_risks).';
+
+comment on column public.project_context_facts.fact_value is
+  'Valeur enrichie en JSONB pouvant évoluer selon la source et la maturité des données.';
+
+comment on column public.project_context_facts.source_type is
+  'Origine de la donnée (manual, studio, pdf_extraction, message, subject_description, georisques, etc.).';
+
+create index if not exists idx_project_context_facts_project_id
+  on public.project_context_facts(project_id);
+
+create index if not exists idx_project_context_facts_fact_key
+  on public.project_context_facts(fact_key);
+
+create index if not exists idx_project_context_facts_source_type
+  on public.project_context_facts(source_type);
+
+create unique index if not exists ux_project_context_facts_project_key_source_ref
+  on public.project_context_facts(project_id, fact_key, source_type, coalesce(source_ref, ''));
+
+alter table if exists public.project_context_facts enable row level security;
+
+drop trigger if exists trg_project_context_facts_updated_at on public.project_context_facts;
+create trigger trg_project_context_facts_updated_at
+before update on public.project_context_facts
+for each row execute function public.set_updated_at();
+
+-- Lecture: propriétaires + collaborateurs actifs (par user direct ou via directory_people lié).
+drop policy if exists project_context_facts_select_project_members on public.project_context_facts;
+create policy project_context_facts_select_project_members
+on public.project_context_facts
+for select
+to authenticated
+using (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+  or project_id in (
+    select pc.project_id
+    from public.project_collaborators pc
+    left join public.directory_people dp on dp.id = pc.person_id
+    where pc.status = 'Actif'
+      and (
+        pc.collaborator_user_id = auth.uid()
+        or dp.linked_user_id = auth.uid()
+      )
+  )
+);
+
+-- Écriture: uniquement les acteurs pouvant modifier le projet (modèle actuel: propriétaire).
+drop policy if exists project_context_facts_insert_project_owner on public.project_context_facts;
+create policy project_context_facts_insert_project_owner
+on public.project_context_facts
+for insert
+to authenticated
+with check (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+);
+
+drop policy if exists project_context_facts_update_project_owner on public.project_context_facts;
+create policy project_context_facts_update_project_owner
+on public.project_context_facts
+for update
+to authenticated
+using (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+)
+with check (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+);
+
+drop policy if exists project_context_facts_delete_project_owner on public.project_context_facts;
+create policy project_context_facts_delete_project_owner
+on public.project_context_facts
+for delete
+to authenticated
+using (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+);


### PR DESCRIPTION
### Motivation
- Persist standard project location fields and create a structured, extensible mirror for enriched project context to improve sync and enrichment workflows.
- Expose a client-side service to read/write project location and context facts via the Supabase REST API using existing auth headers.
- Ensure the project parameters UI persists location changes to the backend automatically when derived data is refreshed.

### Description
- Add a Supabase migration that extends `public.projects` with `address`, `latitude`, `longitude`, `altitude`, and `code_insee`, and creates a new `public.project_context_facts` table with indexes, RLS policies, trigger for `updated_at`, and descriptive comments. 
- Add `apps/web/js/services/project-location-supabase.js` implementing helpers and API functions `upsertProjectContextFact`, `saveProjectLocationToSupabase`, `loadProjectLocationFromSupabase`, and `loadProjectContextFacts` that call the Supabase REST endpoints and handle auth, merging duplicates, and error reporting. 
- Integrate saving to Supabase from the UI by importing and calling `saveProjectLocationToSupabase` in `project-parametres-localisation.js` within `refreshLocationDerivedData`, including console logs and error handling. 

### Testing
- No automated tests were added or executed as part of this change.
- Manual flow exercised during development: UI location refresh triggers attempt to `PATCH` `projects` and `POST` `project_context_facts`, and errors are logged to the console when requests fail.
- Existing automated test suite was not run by this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f205d2ed708329b68675351439080d)