### PR TITLE
Fix infinite map embed refresh loop on CORS/preflight failures

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -275,7 +275,18 @@ function renderProjectLocationMapBlock() {
 
   const uiState = ensureLocalisationUiState();
   const mapEmbedState = uiState.locationMapEmbed;
-  void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  const requestKey = getLocationMapRequestKey({
+    latitude,
+    longitude,
+    zoom: 16,
+    mapType: "satellite",
+    nonce: Number(uiState.locationMapRefreshNonce || 0)
+  });
+  const shouldFetchMapEmbedUrl = mapEmbedState.requestKey !== requestKey
+    || mapEmbedState.status === "idle";
+  if (shouldFetchMapEmbedUrl) {
+    void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  }
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
     return `
       <div class="settings-location-map-card is-blurred">


### PR DESCRIPTION
### Motivation
- Rendering repeatedly retriggered the same Supabase Edge Function call when the function returned a non-OK response (e.g., CORS/preflight failures), causing an infinite request/rerender loop.
- The goal is to stop refetching the same map embed request unless the request key or nonce changes, avoiding spammed network calls and console errors.

### Description
- Compute the current map `requestKey` inside `renderProjectLocationMapBlock` with `getLocationMapRequestKey` and the `uiState.locationMapRefreshNonce`.
- Only invoke `refreshProjectLocationMapEmbedUrl` when `mapEmbedState.requestKey !== requestKey` or when `mapEmbedState.status === "idle"`, preventing repeated fetches for the same failing request.
- Change is localized to `apps/web/js/views/project-parametres/project-parametres-localisation.js` and does not alter the fetch logic itself.

### Testing
- No automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21bb33464832991bec6671e20c41e)