### PR TITLE
Optimize map embed fetch logic and update CORS handling for Google Maps embed function

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -275,7 +275,18 @@ function renderProjectLocationMapBlock() {
 
   const uiState = ensureLocalisationUiState();
   const mapEmbedState = uiState.locationMapEmbed;
-  void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  const requestKey = getLocationMapRequestKey({
+    latitude,
+    longitude,
+    zoom: 16,
+    mapType: "satellite",
+    nonce: Number(uiState.locationMapRefreshNonce || 0)
+  });
+  const shouldFetchMapEmbedUrl = mapEmbedState.requestKey !== requestKey
+    || mapEmbedState.status === "idle";
+  if (shouldFetchMapEmbedUrl) {
+    void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  }
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
     return `
       <div class="settings-location-map-card is-blurred">

--- a/supabase/functions/google-maps-embed-url/index.ts
+++ b/supabase/functions/google-maps-embed-url/index.ts
@@ -2,7 +2,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.8";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+  "Access-Control-Allow-Headers": "authorization, Authorization, x-client-info, apikey, content-type, Content-Type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS"
 };
 
 function toFiniteNumber(value: unknown, fallback: number | null = null): number | null {
@@ -12,7 +13,7 @@ function toFiniteNumber(value: unknown, fallback: number | null = null): number 
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return new Response("ok", { status: 200, headers: corsHeaders });
   }
 
   try {


### PR DESCRIPTION
### Motivation
- Prevent redundant network requests when rendering the project location map by tracking the current embed request and supporting explicit refresh via a nonce.
- Ensure the Supabase edge function that returns Google Maps embed URLs responds correctly to CORS preflight requests and accepts common headers used by clients.

### Description
- In `project-parametres-localisation.js` compute a `requestKey` with `getLocationMapRequestKey` (including `nonce`) and only call `refreshProjectLocationMapEmbedUrl` when `mapEmbedState.requestKey` differs or the embed state is `idle` to avoid unnecessary fetches.
- Include the `nonce` from `uiState.locationMapRefreshNonce` in the request key so a forced refresh can be triggered without spamming requests.
- In `supabase/functions/google-maps-embed-url/index.ts` extend `corsHeaders` to include `Authorization` and `Content-Type` header names and add `Access-Control-Allow-Methods: POST, OPTIONS` and return an explicit `200` status for `OPTIONS` preflight responses.

### Testing
- Ran the project's automated unit tests and linters (`npm test` and `npm run lint`) and they completed successfully.
- No new automated tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21bb33464832991bec6671e20c41e)