### PR TITLE
Add retry delay and request-key checks for Google Maps embed; fix Supabase CORS handling

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -67,7 +67,8 @@ function ensureLocalisationUiState() {
     parametresUiState.locationMapEmbed = {
       status: "idle",
       requestKey: "",
-      url: ""
+      url: "",
+      lastErrorAt: 0
     };
   }
 
@@ -77,6 +78,8 @@ function ensureLocalisationUiState() {
 function getLocationMapRequestKey({ latitude = null, longitude = null, zoom = 16, mapType = "satellite", nonce = 0 } = {}) {
   return `${latitude}|${longitude}|${zoom}|${mapType}|${nonce}`;
 }
+
+const MAP_EMBED_ERROR_RETRY_DELAY_MS = 30_000;
 
 async function refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom = 16, mapType = "satellite" } = {}) {
   const uiState = ensureLocalisationUiState();
@@ -96,10 +99,12 @@ async function refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom = 1
     if (uiState.locationMapEmbed.requestKey !== requestKey) return;
     uiState.locationMapEmbed.status = "success";
     uiState.locationMapEmbed.url = embedUrl;
+    uiState.locationMapEmbed.lastErrorAt = 0;
   } catch {
     if (uiState.locationMapEmbed.requestKey !== requestKey) return;
     uiState.locationMapEmbed.status = "error";
     uiState.locationMapEmbed.url = "";
+    uiState.locationMapEmbed.lastErrorAt = Date.now();
   } finally {
     if (uiState.locationMapEmbed.requestKey === requestKey) {
       rerenderProjectParametres();
@@ -275,7 +280,20 @@ function renderProjectLocationMapBlock() {
 
   const uiState = ensureLocalisationUiState();
   const mapEmbedState = uiState.locationMapEmbed;
-  void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  const requestKey = getLocationMapRequestKey({
+    latitude,
+    longitude,
+    zoom: 16,
+    mapType: "satellite",
+    nonce: Number(uiState.locationMapRefreshNonce || 0)
+  });
+  const shouldFetchMapEmbedUrl = mapEmbedState.requestKey !== requestKey
+    || mapEmbedState.status === "idle";
+  const errorRetryDelayElapsed = mapEmbedState.status !== "error"
+    || (Date.now() - Number(mapEmbedState.lastErrorAt || 0)) >= MAP_EMBED_ERROR_RETRY_DELAY_MS;
+  if (shouldFetchMapEmbedUrl && errorRetryDelayElapsed) {
+    void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  }
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
     return `
       <div class="settings-location-map-card is-blurred">

--- a/supabase/functions/google-maps-embed-url/index.ts
+++ b/supabase/functions/google-maps-embed-url/index.ts
@@ -2,7 +2,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.8";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+  "Access-Control-Allow-Headers": "authorization, Authorization, x-client-info, apikey, content-type, Content-Type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS"
 };
 
 function toFiniteNumber(value: unknown, fallback: number | null = null): number | null {
@@ -12,7 +13,7 @@ function toFiniteNumber(value: unknown, fallback: number | null = null): number 
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return new Response("ok", { status: 200, headers: corsHeaders });
   }
 
   try {


### PR DESCRIPTION
### Motivation
- Prevent repeated rapid retries and unnecessary requests when fetching Google Maps embed URLs after errors or during rapid renders.
- Persist minimal error metadata in UI state to throttle retry attempts and avoid spamming the embed API.
- Ensure the Supabase edge function responds correctly to preflight `OPTIONS` requests and accepts common header capitalizations and methods.

### Description
- Add a `locationMapEmbed.lastErrorAt` timestamp to UI state and initialize it in `ensureLocalisationUiState` to track the last embed error time.
- Introduce `MAP_EMBED_ERROR_RETRY_DELAY_MS` and use it in `renderProjectLocationMapBlock` to delay retries for `status === "error"` until the cooldown elapses, and avoid re-fetching when the current `requestKey` matches.
- Update `refreshProjectLocationMapEmbedUrl` to set `lastErrorAt` on failure and reset it on success, and to continue to rerender only when the request key still matches.
- Replace unconditional background fetch call in `renderProjectLocationMapBlock` with guarded logic that computes `requestKey` and only triggers `refreshProjectLocationMapEmbedUrl` when needed and when retry delay has elapsed.
- Update the Supabase function CORS headers to include additional common header capitalizations and `Content-Type`, add `Access-Control-Allow-Methods: POST, OPTIONS`, and make the `OPTIONS` response explicit with status `200`.

### Testing
- No automated tests were added or modified for this change and no automated test run was included with this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21bb33464832991bec6671e20c41e)