### PR TITLE
Add Google Maps embed: function, frontend retry logic, and deploy workflow updates

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -43,6 +43,7 @@ jobs:
           MATHPIX_APP_ID: ${{ secrets.MATHPIX_APP_ID }}
           MATHPIX_APP_KEY: ${{ secrets.MATHPIX_APP_KEY }}
           MYSCRIPT_APP_KEY: ${{ secrets.MYSCRIPT_APP_KEY }}
+          GOOGLE_MAPS_EMBED_API_KEY: ${{ secrets.GOOGLE_MAPS_EMBED_API_KEY }}
         run: |
           ARGS=()
           [ -n "$SUPABASE_URL" ] && ARGS+=("SUPABASE_URL=$SUPABASE_URL")
@@ -53,6 +54,7 @@ jobs:
           [ -n "$MATHPIX_APP_ID" ] && ARGS+=("MATHPIX_APP_ID=$MATHPIX_APP_ID")
           [ -n "$MATHPIX_APP_KEY" ] && ARGS+=("MATHPIX_APP_KEY=$MATHPIX_APP_KEY")
           [ -n "$MYSCRIPT_APP_KEY" ] && ARGS+=("MYSCRIPT_APP_KEY=$MYSCRIPT_APP_KEY")
+          [ -n "$GOOGLE_MAPS_EMBED_API_KEY" ] && ARGS+=("GOOGLE_MAPS_EMBED_API_KEY=$GOOGLE_MAPS_EMBED_API_KEY")
           if [ "${#ARGS[@]}" -gt 0 ]; then
             supabase secrets set "${ARGS[@]}"
           else
@@ -69,3 +71,4 @@ jobs:
           supabase functions deploy upload-subject-message-attachment --no-verify-jwt --debug
           supabase functions deploy subject-mdall-exchange --no-verify-jwt --debug
           supabase functions deploy recognize-handwritten-document --no-verify-jwt --debug
+          supabase functions deploy google-maps-embed-url --no-verify-jwt --debug

--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -67,7 +67,8 @@ function ensureLocalisationUiState() {
     parametresUiState.locationMapEmbed = {
       status: "idle",
       requestKey: "",
-      url: ""
+      url: "",
+      lastErrorAt: 0
     };
   }
 
@@ -77,6 +78,8 @@ function ensureLocalisationUiState() {
 function getLocationMapRequestKey({ latitude = null, longitude = null, zoom = 16, mapType = "satellite", nonce = 0 } = {}) {
   return `${latitude}|${longitude}|${zoom}|${mapType}|${nonce}`;
 }
+
+const MAP_EMBED_ERROR_RETRY_DELAY_MS = 30_000;
 
 async function refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom = 16, mapType = "satellite" } = {}) {
   const uiState = ensureLocalisationUiState();
@@ -96,10 +99,12 @@ async function refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom = 1
     if (uiState.locationMapEmbed.requestKey !== requestKey) return;
     uiState.locationMapEmbed.status = "success";
     uiState.locationMapEmbed.url = embedUrl;
+    uiState.locationMapEmbed.lastErrorAt = 0;
   } catch {
     if (uiState.locationMapEmbed.requestKey !== requestKey) return;
     uiState.locationMapEmbed.status = "error";
     uiState.locationMapEmbed.url = "";
+    uiState.locationMapEmbed.lastErrorAt = Date.now();
   } finally {
     if (uiState.locationMapEmbed.requestKey === requestKey) {
       rerenderProjectParametres();
@@ -275,7 +280,20 @@ function renderProjectLocationMapBlock() {
 
   const uiState = ensureLocalisationUiState();
   const mapEmbedState = uiState.locationMapEmbed;
-  void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  const requestKey = getLocationMapRequestKey({
+    latitude,
+    longitude,
+    zoom: 16,
+    mapType: "satellite",
+    nonce: Number(uiState.locationMapRefreshNonce || 0)
+  });
+  const shouldFetchMapEmbedUrl = mapEmbedState.requestKey !== requestKey
+    || mapEmbedState.status === "idle";
+  const errorRetryDelayElapsed = mapEmbedState.status !== "error"
+    || (Date.now() - Number(mapEmbedState.lastErrorAt || 0)) >= MAP_EMBED_ERROR_RETRY_DELAY_MS;
+  if (shouldFetchMapEmbedUrl && errorRetryDelayElapsed) {
+    void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
+  }
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
     return `
       <div class="settings-location-map-card is-blurred">

--- a/supabase/functions/google-maps-embed-url/index.ts
+++ b/supabase/functions/google-maps-embed-url/index.ts
@@ -2,7 +2,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.8";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+  "Access-Control-Allow-Headers": "authorization, Authorization, x-client-info, apikey, content-type, Content-Type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS"
 };
 
 function toFiniteNumber(value: unknown, fallback: number | null = null): number | null {
@@ -12,7 +13,7 @@ function toFiniteNumber(value: unknown, fallback: number | null = null): number 
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return new Response("ok", { status: 200, headers: corsHeaders });
   }
 
   try {


### PR DESCRIPTION
### Motivation
- Provide a secure server-side endpoint to generate Google Maps embed URLs and surface them in the project settings map UI. 
- Prevent repeated failing requests by adding retry/backoff and tracking of embed error time to improve UX and reduce API calls.

### Description
- Add a new Edge Function `supabase/functions/google-maps-embed-url` that validates env vars, checks Authorization, returns JSON errors, and includes CORS headers and `OPTIONS` handling. 
- Update the deploy workflow `/.github/workflows/deploy-supabase.yml` to set the `GOOGLE_MAPS_EMBED_API_KEY` secret and deploy the new `google-maps-embed-url` function. 
- Enhance frontend `project-parametres-localisation.js` by extending `locationMapEmbed` state with `lastErrorAt`, adding `MAP_EMBED_ERROR_RETRY_DELAY_MS`, and using a requestKey/nonce-based fetch gating to avoid duplicate in-flight requests and to delay retries after errors. 
- Tighten CORS and preflight handling in the function by adding `Access-Control-Allow-Methods` and normalizing header names, and ensure `OPTIONS` returns status `200`.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21bb33464832991bec6671e20c41e)