### PR TITLE
Ajuste l’affichage de la localisation dans Paramètres

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -1345,9 +1345,7 @@ export function renderLocalisationParametresContent() {
         title: "Localisation",
         description: "Localisation administrative et d’usage du projet.",
         badge: "LIVE",
-        body: `<div class="settings-form-grid">
-          ${renderLocationAutocompleteField({ id: "projectAddress", width: "col-span-2", fieldKey: "address", label: "Adresse", value: form.address || "", placeholder: getLocationFieldPlaceholder("address", "Ex. 12 avenue de la Gare, Annecy"), placeholderStrong: hasStrongPlaceholder("address") })}
-        </div>
+        body: `${renderLocationAutocompleteField({ id: "projectAddress", width: "col-span-2", fieldKey: "address", label: "Adresse", value: form.address || "", placeholder: getLocationFieldPlaceholder("address", "Ex. 12 avenue de la Gare, Annecy"), placeholderStrong: hasStrongPlaceholder("address") })}
         ${(ensureGeorisquesState().commune || Number.isFinite(form.latitude) || Number.isFinite(form.longitude)) ? `
           <div class="settings-auto-fields">
             ${renderAutoResolvedField("Commune résolue", ensureGeorisquesState().commune?.name || form.city || "—", "Données de localisation résolues automatiquement.", { muted: hasStaleLocationDerivedData() })}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9193,7 +9193,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 
 .settings-auto-fields{
   display:grid;
-  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns:repeat(auto-fit, minmax(170px, 1fr));
   gap:12px;
   margin:16px 0px;
 }


### PR DESCRIPTION
### Motivation
- Permettre que le champ d’adresse s’affiche sur toute la largeur disponible dans l’onglet Paramètres → Localisation et réduire la largeur minimale des cartes auto‑résolues pour améliorer la lisibilité sur écrans étroits.

### Description
- Suppression du wrapper grille autour du champ d’adresse dans `apps/web/js/views/project-parametres/project-parametres-localisation.js` et ajustement de la grille `.settings-auto-fields` de `minmax(220px, 1fr)` à `minmax(170px, 1fr)` dans `apps/web/style.css`; aucune autre logique métier modifiée; pas de skills supplémentaires utilisés.

### Testing
- Aucun test automatisé n’a été exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2235e26908329b9a159d5583ec296)