### PR TITLE
Use GH editable field for project name, tweak localisation layout and auto-fields sizing

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-general.js
+++ b/apps/web/js/views/project-parametres/project-parametres-general.js
@@ -1,7 +1,7 @@
 import { store } from "../../store.js";
 import { PROJECT_TAB_IDS } from "../../constants.js";
 import { escapeHtml } from "../../utils/escape-html.js";
-import { bindGhEditableFields } from "../ui/gh-input.js";
+import { bindGhEditableFields, renderGhEditableField } from "../ui/gh-input.js";
 import {
   persistCurrentProjectNameToSupabase,
   syncCurrentProjectIdentityFromSupabase
@@ -9,7 +9,6 @@ import {
 import {
   renderSettingsBlock,
   renderSectionCard,
-  renderInputField,
   bindBaseParametresUi,
   bindProjectTabToggles,
   refreshProjectTabsVisibility
@@ -27,7 +26,7 @@ function renderProjectTabsFeatureCard(projectTabs) {
       id: "tabVisibilitySituations",
       key: PROJECT_TAB_IDS.SITUATIONS,
       label: "Situations",
-      description: "Affiche l’onglet Situations actuellement branché sur les jalons projet."
+      description: "Affiche l’onglet Situations pour suivre les jalons et points clés du projet."
     }
   ];
 
@@ -89,13 +88,12 @@ export function renderGeneralParametresContent() {
     cards: [
       renderSectionCard({
         title: "Nom du projet",
-        description: "Description",
-        body: `<div class="settings-form-grid settings-form-grid--thirds">
-          ${renderInputField({ id: "projectName", label: "Nom de projet", value: form.projectName || "", placeholder: "Projet demo" })}
-          <div class="project-general-created-at">
-            <div class="gh-editable-field__label">Date de création du projet</div>
-            <div class="project-general-created-at__value">${escapeHtml(projectCreatedAt)}</div>
-          </div>
+        description: "Ajouter ou modifier le nom de votre projet.",
+        body: `<div class="form-row form-row--settings"><label for="projectName">Nom de projet</label></div>
+        ${renderGhEditableField({ id: "projectName", label: "", value: form.projectName || "", placeholder: "Projet demo" })}
+        <div class="form-row form-row--settings"><label>Date de création du projet</label></div>
+        <div class="project-general-created-at">
+          <div class="project-general-created-at__value">${escapeHtml(projectCreatedAt)}</div>
         </div>`
       }),
       renderSectionCard({

--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -1345,9 +1345,7 @@ export function renderLocalisationParametresContent() {
         title: "Localisation",
         description: "Localisation administrative et d’usage du projet.",
         badge: "LIVE",
-        body: `<div class="settings-form-grid">
-          ${renderLocationAutocompleteField({ id: "projectAddress", width: "col-span-2", fieldKey: "address", label: "Adresse", value: form.address || "", placeholder: getLocationFieldPlaceholder("address", "Ex. 12 avenue de la Gare, Annecy"), placeholderStrong: hasStrongPlaceholder("address") })}
-        </div>
+        body: `${renderLocationAutocompleteField({ id: "projectAddress", width: "col-span-2", fieldKey: "address", label: "Adresse", value: form.address || "", placeholder: getLocationFieldPlaceholder("address", "Ex. 12 avenue de la Gare, Annecy"), placeholderStrong: hasStrongPlaceholder("address") })}
         ${(ensureGeorisquesState().commune || Number.isFinite(form.latitude) || Number.isFinite(form.longitude)) ? `
           <div class="settings-auto-fields">
             ${renderAutoResolvedField("Commune résolue", ensureGeorisquesState().commune?.name || form.city || "—", "Données de localisation résolues automatiquement.", { muted: hasStaleLocationDerivedData() })}

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9193,7 +9193,7 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
 
 .settings-auto-fields{
   display:grid;
-  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns:repeat(auto-fit, minmax(170px, 1fr));
   gap:12px;
   margin:16px 0px;
 }


### PR DESCRIPTION
### Motivation
- Replace the plain input for the project name with the shared GH-editable component to provide in-place editing and validation behavior and clarify the field description and created-at label. 
- Surface auto-resolved localisation fields more directly in the localisation card and ensure they display correctly on narrower layouts. 
- Minor copy tweak for the Situations feature description to better reflect its purpose.

### Description
- Replace `renderInputField` with `renderGhEditableField` in `project-parametres-general.js` and add the `renderGhEditableField` import. 
- Rework the project name section markup to use `renderGhEditableField`, update the section `description`, and adjust the created-at label/display. 
- Simplify the localisation card body in `project-parametres-localisation.js` to render the address autocomplete and conditional auto-resolved fields without the old grid wrapper. 
- Adjust CSS in `apps/web/style.css` to change `.settings-auto-fields` `grid-template-columns` min width from `220px` to `170px` to improve responsiveness. 
- Update the Situations feature `description` string in `project-parametres-general.js`.

### Testing
- Ran the frontend build and linter via `npm run build` and `npm run lint`, both succeeded. 
- Executed the test suite via `npm test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2235e26908329b9a159d5583ec296)