### PR TITLE
Hydrate project location and context facts from Supabase on project startup

### DIFF
--- a/apps/web/js/demo-context.js
+++ b/apps/web/js/demo-context.js
@@ -1,5 +1,6 @@
 import { store, DEFAULT_PROJECT_PHASES } from "./store.js";
 import { syncCurrentProjectIdentityFromSupabase, syncProjectsCatalogFromSupabase } from "./services/project-supabase-sync.js";
+import { hydrateProjectLocationAndContextFromSupabase } from "./services/project-location-supabase.js";
 
 const STORAGE_KEYS = {
   userId: "rapsobot.demoUserId",
@@ -191,6 +192,7 @@ export function initializeDemoContext() {
       const hasActiveProject = catalog.some((project) => project.id === activeProjectId);
       setCurrentDemoProject(hasActiveProject ? activeProjectId : catalog[0].id);
       syncCurrentProjectIdentityFromSupabase().catch(() => undefined);
+      hydrateProjectLocationAndContextFromSupabase(store.currentProjectId).catch(() => undefined);
     })
     .catch(() => undefined);
 }
@@ -199,5 +201,6 @@ export function syncCurrentProjectFromRoute(projectId) {
   if (!projectId) return null;
   const project = setCurrentDemoProject(projectId);
   syncCurrentProjectIdentityFromSupabase().catch(() => undefined);
+  hydrateProjectLocationAndContextFromSupabase(projectId).catch(() => undefined);
   return project;
 }

--- a/apps/web/js/services/project-location-supabase.js
+++ b/apps/web/js/services/project-location-supabase.js
@@ -1,6 +1,8 @@
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+import { store } from "../store.js";
 import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
 import { listProjectContextFacts, upsertProjectContextFact } from "./project-context-facts-service.js";
+import { readPersistedProjectState } from "./project-state-storage.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 
@@ -113,4 +115,72 @@ export async function loadProjectLocationFromSupabase(projectId) {
 
 export async function loadProjectContextFacts(projectId) {
   return listProjectContextFacts(projectId);
+}
+
+function applyLocationToStore(row = {}) {
+  const toText = (value) => safeString(value);
+  const toNumberOrNull = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+  store.projectForm = {
+    ...store.projectForm,
+    address: toText(row?.address),
+    city: toText(row?.city),
+    postalCode: toText(row?.postal_code),
+    latitude: toNumberOrNull(row?.latitude),
+    longitude: toNumberOrNull(row?.longitude),
+    altitude: toNumberOrNull(row?.altitude),
+    codeInsee: toText(row?.code_insee)
+  };
+}
+
+function applyContextFactsToStore(facts = []) {
+  const normalizedFacts = Array.isArray(facts) ? facts : [];
+  store.projectContextFacts = normalizedFacts;
+  store.projectForm = {
+    ...store.projectForm,
+    contextFacts: normalizedFacts
+  };
+}
+
+export async function hydrateProjectLocationAndContextFromSupabase(projectId) {
+  const resolvedProjectId = await resolveProjectId(projectId);
+  if (!resolvedProjectId) return { source: "none", location: null, contextFacts: [] };
+
+  console.info("[project-location] hydrate.start", { projectId: resolvedProjectId });
+  try {
+    const [locationRow, contextFacts] = await Promise.all([
+      loadProjectLocationFromSupabase(resolvedProjectId),
+      loadProjectContextFacts(resolvedProjectId)
+    ]);
+    if (locationRow && typeof locationRow === "object") {
+      applyLocationToStore(locationRow);
+    }
+    applyContextFactsToStore(contextFacts);
+    console.info("[project-location] hydrate.success", {
+      projectId: resolvedProjectId,
+      locationLoaded: Boolean(locationRow),
+      contextFactsCount: Array.isArray(contextFacts) ? contextFacts.length : 0,
+      source: "supabase"
+    });
+    return { source: "supabase", location: locationRow, contextFacts: contextFacts || [] };
+  } catch (error) {
+    console.error("[project-location] hydrate.failure", {
+      projectId: resolvedProjectId,
+      message: error instanceof Error ? error.message : String(error)
+    });
+    const persistedState = readPersistedProjectState(resolvedProjectId);
+    const persistedForm = persistedState?.projectForm && typeof persistedState.projectForm === "object"
+      ? persistedState.projectForm
+      : null;
+    if (persistedForm) {
+      store.projectForm = {
+        ...store.projectForm,
+        ...persistedForm
+      };
+      applyContextFactsToStore(Array.isArray(persistedForm.contextFacts) ? persistedForm.contextFacts : []);
+    }
+    return { source: "localStorage", location: null, contextFacts: store.projectContextFacts || [] };
+  }
 }

--- a/apps/web/js/store.js
+++ b/apps/web/js/store.js
@@ -134,8 +134,12 @@ export const store = {
     climateBaseTemperatures: "",
     projectTabs: { ...DEFAULT_PROJECT_TABS_VISIBILITY },
     webhookUrl: "",
-    pdfFile: null
+    pdfFile: null,
+    codeInsee: "",
+    contextFacts: []
   },
+
+  projectContextFacts: [],
 
   projectAutomation: {
     catalog: {


### PR DESCRIPTION
### Motivation
- Faire de Supabase la source prioritaire de la localisation projet et du contexte enrichi au moment où un projet devient actif.
- Hydrater le `store` pour que les vues Paramètres / Atelier lisent des valeurs persistantes au lieu de defaults (ex: Annecy/74000).
- Conserver `localStorage` comme fallback si la lecture Supabase échoue.

### Description
- Ajout de `hydrateProjectLocationAndContextFromSupabase(projectId)` dans `apps/web/js/services/project-location-supabase.js` avec instrumentation `console.info`/`console.error` (`[project-location] hydrate.start/success/failure`).
- Ajout des helpers internes `applyLocationToStore` et `applyContextFactsToStore` qui injectent la localisation dans `store.projectForm` et les faits dans `store.projectContextFacts` ainsi que `store.projectForm.contextFacts`.
- Raccordement de l’hydratation au point d’entrée projet via `apps/web/js/demo-context.js` (appel lors de l’initialisation du catalogue et dans `syncCurrentProjectFromRoute`).
- Extension du store : ajout de `projectForm.codeInsee`, `projectForm.contextFacts` et du top-level `projectContextFacts`; et fallback à l’état persisté via `readPersistedProjectState` en cas d’échec Supabase.

### Testing
- Lancer la suite automatisée avec `npm test` a été effectué.
- Résultat: 233 tests exécutés, 228 passés, 5 ignorés, 0 échec (aucune erreur détectée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f226f830488329a28fcf83fe71fcbd)