### PR TITLE
Hydrate project location and context from Supabase and expose to store/UI

### DIFF
--- a/apps/web/js/demo-context.js
+++ b/apps/web/js/demo-context.js
@@ -1,5 +1,6 @@
 import { store, DEFAULT_PROJECT_PHASES } from "./store.js";
 import { syncCurrentProjectIdentityFromSupabase, syncProjectsCatalogFromSupabase } from "./services/project-supabase-sync.js";
+import { hydrateProjectLocationAndContextFromSupabase } from "./services/project-location-supabase.js";
 
 const STORAGE_KEYS = {
   userId: "rapsobot.demoUserId",
@@ -191,6 +192,7 @@ export function initializeDemoContext() {
       const hasActiveProject = catalog.some((project) => project.id === activeProjectId);
       setCurrentDemoProject(hasActiveProject ? activeProjectId : catalog[0].id);
       syncCurrentProjectIdentityFromSupabase().catch(() => undefined);
+      hydrateProjectLocationAndContextFromSupabase(store.currentProjectId).catch(() => undefined);
     })
     .catch(() => undefined);
 }
@@ -199,5 +201,6 @@ export function syncCurrentProjectFromRoute(projectId) {
   if (!projectId) return null;
   const project = setCurrentDemoProject(projectId);
   syncCurrentProjectIdentityFromSupabase().catch(() => undefined);
+  hydrateProjectLocationAndContextFromSupabase(projectId).catch(() => undefined);
   return project;
 }

--- a/apps/web/js/services/project-location-supabase.js
+++ b/apps/web/js/services/project-location-supabase.js
@@ -1,6 +1,8 @@
 import { buildSupabaseAuthHeaders, getSupabaseUrl } from "../../assets/js/auth.js";
+import { store } from "../store.js";
 import { resolveCurrentBackendProjectId } from "./project-supabase-sync.js";
 import { listProjectContextFacts, upsertProjectContextFact } from "./project-context-facts-service.js";
+import { readPersistedProjectState } from "./project-state-storage.js";
 
 const SUPABASE_URL = getSupabaseUrl();
 
@@ -113,4 +115,72 @@ export async function loadProjectLocationFromSupabase(projectId) {
 
 export async function loadProjectContextFacts(projectId) {
   return listProjectContextFacts(projectId);
+}
+
+function applyLocationToStore(row = {}) {
+  const toText = (value) => safeString(value);
+  const toNumberOrNull = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+  store.projectForm = {
+    ...store.projectForm,
+    address: toText(row?.address),
+    city: toText(row?.city),
+    postalCode: toText(row?.postal_code),
+    latitude: toNumberOrNull(row?.latitude),
+    longitude: toNumberOrNull(row?.longitude),
+    altitude: toNumberOrNull(row?.altitude),
+    codeInsee: toText(row?.code_insee)
+  };
+}
+
+function applyContextFactsToStore(facts = []) {
+  const normalizedFacts = Array.isArray(facts) ? facts : [];
+  store.projectContextFacts = normalizedFacts;
+  store.projectForm = {
+    ...store.projectForm,
+    contextFacts: normalizedFacts
+  };
+}
+
+export async function hydrateProjectLocationAndContextFromSupabase(projectId) {
+  const resolvedProjectId = await resolveProjectId(projectId);
+  if (!resolvedProjectId) return { source: "none", location: null, contextFacts: [] };
+
+  console.info("[project-location] hydrate.start", { projectId: resolvedProjectId });
+  try {
+    const [locationRow, contextFacts] = await Promise.all([
+      loadProjectLocationFromSupabase(resolvedProjectId),
+      loadProjectContextFacts(resolvedProjectId)
+    ]);
+    if (locationRow && typeof locationRow === "object") {
+      applyLocationToStore(locationRow);
+    }
+    applyContextFactsToStore(contextFacts);
+    console.info("[project-location] hydrate.success", {
+      projectId: resolvedProjectId,
+      locationLoaded: Boolean(locationRow),
+      contextFactsCount: Array.isArray(contextFacts) ? contextFacts.length : 0,
+      source: "supabase"
+    });
+    return { source: "supabase", location: locationRow, contextFacts: contextFacts || [] };
+  } catch (error) {
+    console.error("[project-location] hydrate.failure", {
+      projectId: resolvedProjectId,
+      message: error instanceof Error ? error.message : String(error)
+    });
+    const persistedState = readPersistedProjectState(resolvedProjectId);
+    const persistedForm = persistedState?.projectForm && typeof persistedState.projectForm === "object"
+      ? persistedState.projectForm
+      : null;
+    if (persistedForm) {
+      store.projectForm = {
+        ...store.projectForm,
+        ...persistedForm
+      };
+      applyContextFactsToStore(Array.isArray(persistedForm.contextFacts) ? persistedForm.contextFacts : []);
+    }
+    return { source: "localStorage", location: null, contextFacts: store.projectContextFacts || [] };
+  }
 }

--- a/apps/web/js/store.js
+++ b/apps/web/js/store.js
@@ -134,8 +134,12 @@ export const store = {
     climateBaseTemperatures: "",
     projectTabs: { ...DEFAULT_PROJECT_TABS_VISIBILITY },
     webhookUrl: "",
-    pdfFile: null
+    pdfFile: null,
+    codeInsee: "",
+    contextFacts: []
   },
+
+  projectContextFacts: [],
 
   projectAutomation: {
     catalog: {

--- a/apps/web/js/views/studio/solidity/solidity-general.js
+++ b/apps/web/js/views/studio/solidity/solidity-general.js
@@ -16,7 +16,7 @@ import { renderGhActionButton } from "../../ui/gh-split-button.js";
 const solidityGeneralUiState = {
   loading: false,
   error: "",
-  detailsExpanded: false,
+  detailsExpanded: true,
   selected: null,
   locationSignature: "",
   requestSequence: 0
@@ -286,15 +286,15 @@ function renderSummaryCard(selected) {
     : "—";
 
   const extraRows = hasSelection ? [
-    renderKeyValue("Code INSEE", selected.codeInsee || "—", { compact: true }),
-    renderKeyValue("Coordonnées", `${normalizeCoordinate(selected.lat)} / ${normalizeCoordinate(selected.lon)}`, { compact: true }),
+    renderKeyValue("Zone de vent", selected.windZone || "—", { compact: true }),
+    renderKeyValue("Zone de neige", selected.snowZone || "—", { compact: true }),
     renderKeyValue("Altitude", normalizeAltitude(selected.altitude), { compact: true }),
     renderKeyValue("H0 retenu", selected.frostDepthH0Label || "—", { compact: true, muted: selected.hasMultipleFrostDepthH0Values }),
     renderKeyValue("H calculé", selected.frostDepthHLabel || "—", { compact: true }),
     renderKeyValue("Canton actuel", selected.currentCantonName || "—", { compact: true }),
     renderKeyValue("Canton 2014", selected.cantonName2014 || selected.cantonName || "—", { compact: true, muted: selected.hasCantonMismatch }),
-    renderKeyValue("Zone de vent", selected.windZone || "—", { compact: true }),
-    renderKeyValue("Zone de neige", selected.snowZone || "—", { compact: true })
+    renderKeyValue("Coordonnées", `${normalizeCoordinate(selected.lat)} / ${normalizeCoordinate(selected.lon)}`, { compact: true }),
+    renderKeyValue("Code INSEE", selected.codeInsee || "—", { compact: true })
   ].join("") : "";
 
   return `
@@ -570,7 +570,7 @@ export async function renderSolidityGeneral(root, { force = true } = {}) {
   if (!root) return;
   currentRoot = root;
   solidityGeneralUiState.error = "";
-  solidityGeneralUiState.detailsExpanded = false;
+  solidityGeneralUiState.detailsExpanded = true;
 
   if (root.dataset.solidityGeneralRendered !== "true") {
     root.innerHTML = `


### PR DESCRIPTION
### Motivation
- Load and apply project geographic location and contextual facts from Supabase into the client-side project form so UI and automation can use up-to-date location data. 
- Provide a resilient hydration flow that falls back to persisted local project state when Supabase requests fail. 
- Surface additional fields (`codeInsee`, `contextFacts`) in the store and make the solidity summary UI show details by default for better UX during development. 

### Description
- Added `apps/web/js/services/project-location-supabase.js` which implements `hydrateProjectLocationAndContextFromSupabase`, location/context loaders, store application helpers, and a fallback to `readPersistedProjectState`. 
- Wired hydration into project lifecycle by importing and calling `hydrateProjectLocationAndContextFromSupabase` from `apps/web/js/demo-context.js` during initialization and `syncCurrentProjectFromRoute`. 
- Extended `apps/web/js/store.js` to include `codeInsee` and `contextFacts` in `projectForm` and added top-level `projectContextFacts`. 
- Adjusted the solidity/general UI in `apps/web/js/views/studio/solidity/solidity-general.js` to default `detailsExpanded` to `true` and reordered the summary card fields to prioritize wind/snow zones and show coordinates and `codeInsee` consistently. 

### Testing
- Ran linting with `npm run lint` and the linter completed successfully. 
- Built the frontend with `npm run build` and the build succeeded without errors. 
- Executed unit tests with `npm test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f226f830488329a28fcf83fe71fcbd)