### PR TITLE
chore: scaffold climate data import helpers

### DIFF
--- a/scripts/import-climate-data/README.md
+++ b/scripts/import-climate-data/README.md
@@ -1,0 +1,16 @@
+# Climate data import helpers
+
+Ce dossier contient le socle technique pour importer progressivement les données climatiques vers Supabase.
+
+## Pourquoi des imports découpés
+
+Les données sources sont volumineuses. Les imports sont donc générés fichier JSON par fichier JSON pour éviter des diffs trop gros et faciliter la revue.
+
+## Ce qui est inclus à l'étape 2.0
+
+- helpers Node réutilisables pour lire un JSON source ;
+- normaliser les noms de cantons (sans accents, apostrophes et tirets, en minuscules) ;
+- générer des instructions `INSERT` SQL ;
+- écrire des fichiers SQL de sortie.
+
+Les scripts d'import spécifiques (`2.1+`) seront ajoutés séparément, un fichier source à la fois.

--- a/scripts/import-climate-data/helpers.mjs
+++ b/scripts/import-climate-data/helpers.mjs
@@ -1,0 +1,76 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+export async function readJsonFile(relativePath) {
+  const absolutePath = path.resolve(projectRoot, relativePath);
+  const rawContent = await readFile(absolutePath, 'utf8');
+  return JSON.parse(rawContent);
+}
+
+export function escapeSqlString(value) {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+export function normalizeCantonName(value) {
+  if (!value) {
+    return '';
+  }
+
+  return String(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/['’\-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function buildSqlValue(value) {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'TRUE' : 'FALSE';
+  }
+
+  return escapeSqlString(value);
+}
+
+export function buildInsertStatement({ tableName, columns, rows, onConflictClause = '' }) {
+  if (!rows.length) {
+    return `-- No rows generated for ${tableName}.`;
+  }
+
+  const formattedColumns = columns.join(', ');
+  const formattedRows = rows
+    .map((row) => {
+      const values = columns.map((column) => buildSqlValue(row[column]));
+      return `  (${values.join(', ')})`;
+    })
+    .join(',\n');
+
+  const suffix = onConflictClause ? `\n${onConflictClause}` : '';
+
+  return `INSERT INTO ${tableName} (${formattedColumns})\nVALUES\n${formattedRows}${suffix};`;
+}
+
+export async function writeSqlFile(relativeOutputPath, sqlContent) {
+  const absolutePath = path.resolve(projectRoot, relativeOutputPath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, `${sqlContent.trim()}\n`, 'utf8');
+  return absolutePath;
+}


### PR DESCRIPTION
### Motivation
- Préparer le socle technique pour importer progressivement les JSON climatiques vers Supabase (étape 2.0) sans modifier le front ni importer de données massives.

### Description
- Ajout de `scripts/import-climate-data/helpers.mjs` fournissant `readJsonFile`, `escapeSqlString`, `normalizeCantonName`, `buildInsertStatement` et `writeSqlFile`, ainsi qu'un `scripts/import-climate-data/README.md` expliquant le découpage import fichier-par-fichier; aucun JSON n'a été déplacé et aucun runtime front n'a été modifié.

### Testing
- Exécution de `npm test` dans le dépôt réussie, la suite signale 233 tests (228 passés, 5 sautés) et aucune erreur liée aux changements introduits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f231a47ed48329bf578315ebd07dde)