### PR TITLE
Add climate seed step to deploy, harden resolve-climate-tool, and simplify tool click handlers

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -14,6 +14,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
 
     steps:
       - name: Checkout repository
@@ -32,6 +33,40 @@ jobs:
 
       - name: Push database migrations
         run: supabase db push --debug
+
+      - name: Apply climate seed data
+        run: |
+          echo "Applying climate seed data..."
+          DB_DSN="host=db.${SUPABASE_PROJECT_REF}.supabase.co port=5432 dbname=postgres user=postgres sslmode=require"
+          for sql_file in \
+            supabase/seed-data/climate/001_commune_canton_2014.sql \
+            supabase/seed-data/climate/002_canton_2014_names.sql \
+            supabase/seed-data/climate/003_current_canton_names.sql \
+            supabase/seed-data/climate/004_snow_departments.sql \
+            supabase/seed-data/climate/005_snow_canton_overrides.sql \
+            supabase/seed-data/climate/006_wind_departments.sql \
+            supabase/seed-data/climate/007_wind_canton_overrides.sql \
+            supabase/seed-data/climate/008_frost_departments.sql; do
+            echo "Applying $(basename "$sql_file")"
+            PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -f "$sql_file"
+          done
+
+          echo "Running climate seed verification..."
+          PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -f supabase/seed-data/climate/verify_climate_seed.sql
+
+          snow_count="$(PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -tA -c "SELECT COUNT(*) FROM public.mdall_climate_snow_departments;")"
+          wind_count="$(PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -tA -c "SELECT COUNT(*) FROM public.mdall_climate_wind_departments;")"
+          frost_count="$(PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -tA -c "SELECT COUNT(*) FROM public.mdall_climate_frost_departments;")"
+
+          echo "snow_count=${snow_count}"
+          echo "wind_count=${wind_count}"
+          echo "frost_count=${frost_count}"
+
+          if [ "$snow_count" = "0" ] || [ "$wind_count" = "0" ] || [ "$frost_count" = "0" ]; then
+            echo "Climate seed verification failed: one or more core tables are empty."
+            exit 1
+          fi
+          echo "Climate seed verification done"
 
       - name: Set Edge Function secrets
         env:

--- a/apps/web/js/views/studio/solidity/solidity-frost.js
+++ b/apps/web/js/views/studio/solidity/solidity-frost.js
@@ -14,15 +14,17 @@ export async function renderSolidityFrost(root, { force = false } = {}) {
   render(root);
 
   root.onclick = async (event) => {
-    const actionRoot = event.target.closest(".gh-action");
-    const actionId = String(actionRoot?.dataset?.actionId || "").trim();
-    if (actionId === "solidityToolCalculate-frost") {
-      console.info("[studio-tools] frost.calculate.click");
+    const calculateTrigger = event.target.closest('[data-action-id="solidityToolCalculate-frost"]');
+    if (calculateTrigger) {
+      console.info("[studio-tools] calculate.click", { toolKey: "frost" });
       await calculateClimateTool(state, "frost");
       render(root);
       return;
     }
-    if (actionId === "solidityToolToSubject-frost") {
+
+    const toSubjectTrigger = event.target.closest('[data-action-id="solidityToolToSubject-frost"]');
+    if (toSubjectTrigger) {
+      console.info("[studio-tools] transform-to-subject.click", { toolKey: "frost" });
       console.info("[studio-tools] transform-to-subject.todo", { toolKey: "frost" });
     }
   };

--- a/apps/web/js/views/studio/solidity/solidity-snow.js
+++ b/apps/web/js/views/studio/solidity/solidity-snow.js
@@ -14,15 +14,17 @@ export async function renderSoliditySnow(root, { force = false } = {}) {
   render(root);
 
   root.onclick = async (event) => {
-    const actionRoot = event.target.closest(".gh-action");
-    const actionId = String(actionRoot?.dataset?.actionId || "").trim();
-    if (actionId === "solidityToolCalculate-snow") {
-      console.info("[studio-tools] snow.calculate.click");
+    const calculateTrigger = event.target.closest('[data-action-id="solidityToolCalculate-snow"]');
+    if (calculateTrigger) {
+      console.info("[studio-tools] calculate.click", { toolKey: "snow" });
       await calculateClimateTool(state, "snow");
       render(root);
       return;
     }
-    if (actionId === "solidityToolToSubject-snow") {
+
+    const toSubjectTrigger = event.target.closest('[data-action-id="solidityToolToSubject-snow"]');
+    if (toSubjectTrigger) {
+      console.info("[studio-tools] transform-to-subject.click", { toolKey: "snow" });
       console.info("[studio-tools] transform-to-subject.todo", { toolKey: "snow" });
     }
   };

--- a/apps/web/js/views/studio/solidity/solidity-wind.js
+++ b/apps/web/js/views/studio/solidity/solidity-wind.js
@@ -14,15 +14,17 @@ export async function renderSolidityWind(root, { force = false } = {}) {
   render(root);
 
   root.onclick = async (event) => {
-    const actionRoot = event.target.closest(".gh-action");
-    const actionId = String(actionRoot?.dataset?.actionId || "").trim();
-    if (actionId === "solidityToolCalculate-wind") {
-      console.info("[studio-tools] wind.calculate.click");
+    const calculateTrigger = event.target.closest('[data-action-id="solidityToolCalculate-wind"]');
+    if (calculateTrigger) {
+      console.info("[studio-tools] calculate.click", { toolKey: "wind" });
       await calculateClimateTool(state, "wind");
       render(root);
       return;
     }
-    if (actionId === "solidityToolToSubject-wind") {
+
+    const toSubjectTrigger = event.target.closest('[data-action-id="solidityToolToSubject-wind"]');
+    if (toSubjectTrigger) {
+      console.info("[studio-tools] transform-to-subject.click", { toolKey: "wind" });
       console.info("[studio-tools] transform-to-subject.todo", { toolKey: "wind" });
     }
   };

--- a/supabase/functions/resolve-climate-tool/index.ts
+++ b/supabase/functions/resolve-climate-tool/index.ts
@@ -103,7 +103,8 @@ Deno.serve(async (req: Request) => {
   } catch (error) {
     console.error("[resolve-climate-tool] resolve.failure", error);
     if (error instanceof HttpError) {
-      return json({ error: error.message }, error.status);
+      const parsed = tryParseJson(error.message);
+      return json(parsed ?? { error: error.message }, error.status);
     }
     return json({ error: "Internal server error", details: error instanceof Error ? error.message : String(error) }, 500);
   }
@@ -112,6 +113,7 @@ Deno.serve(async (req: Request) => {
 async function resolveClimateTool(supabase: any, toolKey: ToolKey, location: any) {
   const codeInsee = String(location?.code_insee ?? "").trim();
   const altitude = Number(location?.altitude ?? 0);
+  console.log("[resolve-climate-tool] location input", { toolKey, location, codeInsee, altitude });
   if (!codeInsee) {
     throw new HttpError(400, "code_insee is required in location payload");
   }
@@ -123,46 +125,112 @@ async function resolveClimateTool(supabase: any, toolKey: ToolKey, location: any
     .maybeSingle();
 
   if (communeError) throw new Error(`commune lookup failed: ${communeError.message}`);
-  if (!commune) throw new HttpError(400, `No commune mapping found for code_insee=${codeInsee}`);
+
+  const fallbackDepartmentCode = inferDepartmentCodeFromInsee(codeInsee);
+  const resolvedCommune = commune ?? {
+    insee_code: codeInsee,
+    canton_code_2014: null,
+    canton_name_2014: null,
+    canton_name_current: null,
+    department_code: fallbackDepartmentCode
+  };
+
+  if (!resolvedCommune.department_code) {
+    throw new HttpError(400, `No commune mapping found for code_insee=${codeInsee}`);
+  }
+  const resolvedDepartmentCode = normalizeDepartmentCode(resolvedCommune.department_code);
+  console.log("[resolve-climate-tool] resolved department_code", {
+    raw: resolvedCommune.department_code,
+    normalized: resolvedDepartmentCode,
+    toolKey
+  });
 
   if (toolKey === "snow") {
-    const warning = commune.canton_name_current && commune.canton_name_2014 && commune.canton_name_current !== commune.canton_name_2014
-      ? `Le canton courant (${commune.canton_name_current}) diffère du canton réglementaire 2014 (${commune.canton_name_2014}).`
+    const attemptedQueries: Array<{ type: string; department_code: string; row_count: number; raw: unknown }> = [];
+    const warning = resolvedCommune.canton_name_current && resolvedCommune.canton_name_2014 && resolvedCommune.canton_name_current !== resolvedCommune.canton_name_2014
+      ? `Le canton courant (${resolvedCommune.canton_name_current}) diffère du canton réglementaire 2014 (${resolvedCommune.canton_name_2014}).`
       : null;
 
     const { data: override } = await supabase
       .from("mdall_climate_snow_canton_overrides")
       .select("resolved_zone")
-      .eq("department_code", commune.department_code)
-      .eq("canton_name_normalized", normalizeName(commune.canton_name_2014 || commune.canton_name_current || ""))
+      .eq("department_code", resolvedDepartmentCode)
+      .eq("canton_name_normalized", normalizeName(resolvedCommune.canton_name_2014 || resolvedCommune.canton_name_current || ""))
       .maybeSingle();
 
     let zone = override?.resolved_zone ?? null;
     if (!zone) {
-      const { data: dept } = await supabase
+      const { count: snowTableCount, error: snowTableCountError } = await supabase
         .from("mdall_climate_snow_departments")
-        .select("resolved_zone")
-        .eq("department_code", commune.department_code)
-        .limit(1)
-        .maybeSingle();
-      zone = dept?.resolved_zone ?? null;
-    }
-    if (!zone) throw new HttpError(400, `No snow zone found for department=${commune.department_code}`);
+        .select("department_code", { count: "exact", head: true });
+      console.log("[resolve-climate-tool] snow table count", { count: snowTableCount, error: snowTableCountError?.message ?? null });
+      if (snowTableCountError) throw new Error(`snow table count failed: ${snowTableCountError.message}`);
+      if ((snowTableCount ?? 0) === 0) {
+        throw new HttpError(400, "Snow data not seeded in database");
+      }
 
-    const result = { department_code: commune.department_code, canton_code_2014: commune.canton_code_2014, canton_name_2014: commune.canton_name_2014, canton_name_current: commune.canton_name_current, snow_zone: zone, warning };
-    return { result, markdownSummary: `## Neige\n- Zone neige: **${zone}**\n- Département: **${commune.department_code}**\n${warning ? `- ⚠️ ${warning}\n` : ""}` };
+      console.log("[resolve-climate-tool] snow query start", { department_code: resolvedDepartmentCode, column: "department_code" });
+      const { data: deptRows, error: deptError } = await supabase
+        .from("mdall_climate_snow_departments")
+        .select("department_code,resolved_zone")
+        .eq("department_code", resolvedDepartmentCode);
+      if (deptError) throw new Error(`snow dept lookup failed: ${deptError.message}`);
+      attemptedQueries.push({ type: "eq", department_code: resolvedDepartmentCode, row_count: deptRows?.length ?? 0, raw: deptRows ?? null });
+      console.log("[resolve-climate-tool] snow query result", {
+        department_code: resolvedDepartmentCode,
+        row_count: deptRows?.length ?? 0,
+        raw: deptRows ?? null
+      });
+      zone = deptRows?.[0]?.resolved_zone ?? null;
+
+      if (!zone) {
+        console.log("[resolve-climate-tool] snow fallback attempt", { department_code: resolvedDepartmentCode, strategy: "ilike-trim-leading-zeroes" });
+        const fallbackPattern = `%${resolvedDepartmentCode}%`;
+        const { data: fallbackRows, error: fallbackError } = await supabase
+          .from("mdall_climate_snow_departments")
+          .select("department_code,resolved_zone")
+          .ilike("department_code", fallbackPattern);
+        if (fallbackError) throw new Error(`snow fallback lookup failed: ${fallbackError.message}`);
+
+        const normalizedMatches = (fallbackRows ?? []).filter((row: any) =>
+          normalizeDepartmentCode(row?.department_code) === resolvedDepartmentCode
+        );
+        attemptedQueries.push({
+          type: "ilike-normalized-match",
+          department_code: resolvedDepartmentCode,
+          row_count: normalizedMatches.length,
+          raw: fallbackRows ?? null
+        });
+        console.log("[resolve-climate-tool] snow fallback", {
+          department_code: resolvedDepartmentCode,
+          row_count: normalizedMatches.length,
+          raw: fallbackRows ?? null
+        });
+        zone = normalizedMatches[0]?.resolved_zone ?? null;
+      }
+    }
+    if (!zone) {
+      throw new HttpError(400, JSON.stringify({
+        code: "SNOW_ZONE_NOT_FOUND",
+        message: "No snow zone found",
+        debug: { department_code: resolvedDepartmentCode, attempted_queries: attemptedQueries }
+      }));
+    }
+
+    const result = { department_code: resolvedDepartmentCode, canton_code_2014: resolvedCommune.canton_code_2014, canton_name_2014: resolvedCommune.canton_name_2014, canton_name_current: resolvedCommune.canton_name_current, snow_zone: zone, warning };
+    return { result, markdownSummary: `## Neige\n- Zone neige: **${zone}**\n- Département: **${resolvedDepartmentCode}**\n${warning ? `- ⚠️ ${warning}\n` : ""}` };
   }
 
   if (toolKey === "wind") {
-    const warning = commune.canton_name_current && commune.canton_name_2014 && commune.canton_name_current !== commune.canton_name_2014
-      ? `Le canton courant (${commune.canton_name_current}) diffère du canton réglementaire 2014 (${commune.canton_name_2014}).`
+    const warning = resolvedCommune.canton_name_current && resolvedCommune.canton_name_2014 && resolvedCommune.canton_name_current !== resolvedCommune.canton_name_2014
+      ? `Le canton courant (${resolvedCommune.canton_name_current}) diffère du canton réglementaire 2014 (${resolvedCommune.canton_name_2014}).`
       : null;
 
     const { data: override } = await supabase
       .from("mdall_climate_wind_canton_overrides")
       .select("resolved_zone")
-      .eq("department_code", commune.department_code)
-      .eq("canton_name_normalized", normalizeName(commune.canton_name_2014 || commune.canton_name_current || ""))
+      .eq("department_code", resolvedCommune.department_code)
+      .eq("canton_name_normalized", normalizeName(resolvedCommune.canton_name_2014 || resolvedCommune.canton_name_current || ""))
       .maybeSingle();
 
     let zone = override?.resolved_zone ?? null;
@@ -170,24 +238,24 @@ async function resolveClimateTool(supabase: any, toolKey: ToolKey, location: any
       const { data: dept } = await supabase
         .from("mdall_climate_wind_departments")
         .select("resolved_zone")
-        .eq("department_code", commune.department_code)
+        .eq("department_code", resolvedCommune.department_code)
         .limit(1)
         .maybeSingle();
       zone = dept?.resolved_zone ?? null;
     }
-    if (!zone) throw new HttpError(400, `No wind zone found for department=${commune.department_code}`);
+    if (!zone) throw new HttpError(400, `No wind zone found for department=${resolvedCommune.department_code}`);
 
-    const result = { department_code: commune.department_code, canton_code_2014: commune.canton_code_2014, canton_name_2014: commune.canton_name_2014, canton_name_current: commune.canton_name_current, wind_zone: zone, warning };
-    return { result, markdownSummary: `## Vent\n- Zone vent: **${zone}**\n- Département: **${commune.department_code}**\n${warning ? `- ⚠️ ${warning}\n` : ""}` };
+    const result = { department_code: resolvedCommune.department_code, canton_code_2014: resolvedCommune.canton_code_2014, canton_name_2014: resolvedCommune.canton_name_2014, canton_name_current: resolvedCommune.canton_name_current, wind_zone: zone, warning };
+    return { result, markdownSummary: `## Vent\n- Zone vent: **${zone}**\n- Département: **${resolvedCommune.department_code}**\n${warning ? `- ⚠️ ${warning}\n` : ""}` };
   }
 
   const { data: frost } = await supabase
     .from("mdall_climate_frost_departments")
     .select("h0_min_m,h0_max_m,h0_default_m")
-    .eq("department_code", commune.department_code)
+    .eq("department_code", resolvedCommune.department_code)
     .maybeSingle();
 
-  if (!frost) throw new HttpError(400, `No frost data found for department=${commune.department_code}`);
+  if (!frost) throw new HttpError(400, `No frost data found for department=${resolvedCommune.department_code}`);
 
   const h0 = Number(frost.h0_default_m ?? frost.h0_max_m ?? frost.h0_min_m ?? 0);
   const h = h0 + ((altitude - 150) / 4000);
@@ -196,7 +264,7 @@ async function resolveClimateTool(supabase: any, toolKey: ToolKey, location: any
     : null;
 
   const result = {
-    department_code: commune.department_code,
+    department_code: resolvedCommune.department_code,
     altitude,
     h0_min_m: frost.h0_min_m,
     h0_max_m: frost.h0_max_m,
@@ -207,6 +275,24 @@ async function resolveClimateTool(supabase: any, toolKey: ToolKey, location: any
   };
 
   return { result, markdownSummary: `## Gel\n- H0 retenu: **${h0} m**\n- Altitude: **${altitude} m**\n- Profondeur hors gel (H): **${h.toFixed(3)} m**\n- Formule: \`H = H0 + ((altitude - 150) / 4000)\`\n${warning ? `- ⚠️ ${warning}\n` : ""}` };
+}
+
+function normalizeDepartmentCode(value: unknown) {
+  const raw = String(value ?? "").trim().toUpperCase();
+  if (!raw) return "";
+  if (raw === "2A" || raw === "2B") return raw;
+  if (/^\d+$/.test(raw)) return String(Number(raw));
+  return raw.replace(/^0+/, "") || "0";
+}
+
+
+function inferDepartmentCodeFromInsee(codeInsee: string) {
+  const normalized = String(codeInsee ?? "").trim().toUpperCase();
+  if (!normalized) return null;
+  if (normalized.startsWith("2A") || normalized.startsWith("2B")) return normalized.slice(0, 2);
+  if (/^97[1-6]/.test(normalized) || /^98[4678]/.test(normalized)) return normalized.slice(0, 3);
+  if (/^\d{5}$/.test(normalized)) return normalized.slice(0, 2);
+  return null;
 }
 
 function normalizeName(value: string) {
@@ -227,4 +313,12 @@ function mapToolResultToContextFact(toolKey: ToolKey, result: any) {
 
 function json(payload: unknown, status = 200) {
   return new Response(JSON.stringify(payload), { status, headers: jsonHeaders });
+}
+
+function tryParseJson(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
### Motivation
- Ensure climate reference tables are seeded during deployment and fail early if missing so runtime tool resolution is reliable. 
- Make the climate resolver function more robust to missing commune mappings and inconsistent department formats to avoid runtime 400/500 errors. 
- Simplify and standardize front-end click detection and logging for the snow/wind/frost solidity tools.

### Description
- Add `SUPABASE_PROJECT_REF` environment var and an `Apply climate seed data` step to `.github/workflows/deploy-supabase.yml` that runs a sequence of SQL seed files, verifies core table row counts, and fails the job if seed verification fails. 
- Replace brittle `.gh-action` dataset parsing in `solidity-snow.js`, `solidity-wind.js`, and `solidity-frost.js` with `data-action-id` selectors and unified console logs including the `toolKey`. 
- Harden `supabase/functions/resolve-climate-tool/index.ts` by adding `inferDepartmentCodeFromInsee`, `normalizeDepartmentCode`, and `tryParseJson` helpers, logging of input/resolution info, and fallback behavior when a commune row is missing by inferring department codes. 
- Improve snow lookup logic to inspect table counts, perform direct `eq` queries, attempt `ilike` fallbacks with normalized matching, and return a structured `SNOW_ZONE_NOT_FOUND` debug payload when resolution fails.

### Testing
- No automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24746fab083299b7da4b17edede4b)