### PR TITLE
Resolve Supabase DB host IPv4 in CI with dig/nslookup fallbacks

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -38,9 +38,15 @@ jobs:
         run: |
           echo "Applying climate seed data..."
           DB_HOST="db.${SUPABASE_PROJECT_REF}.supabase.co"
-          DB_HOSTADDR="$(getent ahostsv4 "${DB_HOST}" | awk 'NR==1 { print $1 }')"
+          DB_HOSTADDR="$(getent ahostsv4 "${DB_HOST}" | awk 'NR==1 { print $1 }' || true)"
           if [ -z "${DB_HOSTADDR}" ]; then
-            echo "Could not resolve IPv4 address for ${DB_HOST}"
+            DB_HOSTADDR="$(dig +short A "${DB_HOST}" | head -n1 || true)"
+          fi
+          if [ -z "${DB_HOSTADDR}" ]; then
+            DB_HOSTADDR="$(nslookup -query=A "${DB_HOST}" 2>/dev/null | awk '/^Address: / { print $2; exit }' || true)"
+          fi
+          if [ -z "${DB_HOSTADDR}" ]; then
+            echo "Could not resolve an IPv4 address for ${DB_HOST}; GitHub runner cannot reach IPv6-only endpoints."
             exit 1
           fi
           echo "Using IPv4 ${DB_HOSTADDR} for ${DB_HOST}"


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Actions deploy workflow can reach Supabase Postgres when the host resolves to IPv6-only by obtaining an IPv4 address via fallback resolvers to avoid `psql` connectivity failures.

### Description
- Update ` .github/workflows/deploy-supabase.yml` so `getent` is non-fatal and add fallbacks using `dig` and `nslookup` to populate `DB_HOSTADDR`, and improve the error message when no IPv4 address can be found while keeping the existing seed/apply logic and `psql` usage.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f262a625008329a6769fe3c309e541)