### PR TITLE
Support SUPABASE_DB_DSN and improve DB host resolution in deploy workflow

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -15,6 +15,7 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_DSN: ${{ secrets.SUPABASE_DB_DSN }}
 
     steps:
       - name: Checkout repository
@@ -37,14 +38,26 @@ jobs:
       - name: Apply climate seed data
         run: |
           echo "Applying climate seed data..."
-          DB_HOST="db.${SUPABASE_PROJECT_REF}.supabase.co"
-          DB_HOSTADDR="$(getent ahostsv4 "${DB_HOST}" | awk 'NR==1 { print $1 }')"
-          if [ -z "${DB_HOSTADDR}" ]; then
-            echo "Could not resolve IPv4 address for ${DB_HOST}"
-            exit 1
+          if [ -n "${SUPABASE_DB_DSN}" ]; then
+            echo "Using SUPABASE_DB_DSN secret for database connectivity."
+            DB_DSN="${SUPABASE_DB_DSN}"
+          else
+            DB_HOST="db.${SUPABASE_PROJECT_REF}.supabase.co"
+            DB_HOSTADDR="$(getent ahostsv4 "${DB_HOST}" | awk 'NR==1 { print $1 }' || true)"
+            if [ -z "${DB_HOSTADDR}" ]; then
+              DB_HOSTADDR="$(dig +short A "${DB_HOST}" | head -n1 || true)"
+            fi
+            if [ -z "${DB_HOSTADDR}" ]; then
+              DB_HOSTADDR="$(nslookup -query=A "${DB_HOST}" 2>/dev/null | awk '/^Address: / { print $2; exit }' || true)"
+            fi
+            if [ -z "${DB_HOSTADDR}" ]; then
+              echo "Could not resolve an IPv4 address for ${DB_HOST}."
+              echo "Set SUPABASE_DB_DSN secret to a Supabase Session Pooler DSN to run seeds from GitHub Actions."
+              exit 1
+            fi
+            echo "Using IPv4 ${DB_HOSTADDR} for ${DB_HOST}"
+            DB_DSN="host=${DB_HOST} hostaddr=${DB_HOSTADDR} port=5432 dbname=postgres user=postgres sslmode=require"
           fi
-          echo "Using IPv4 ${DB_HOSTADDR} for ${DB_HOST}"
-          DB_DSN="host=${DB_HOST} hostaddr=${DB_HOSTADDR} port=5432 dbname=postgres user=postgres sslmode=require"
           for sql_file in \
             supabase/seed-data/climate/001_commune_canton_2014.sql \
             supabase/seed-data/climate/002_canton_2014_names.sql \


### PR DESCRIPTION
### Motivation
- Allow seeding from GitHub Actions using a Supabase Session Pooler DSN and make database host resolution more robust when IPv4 lookup via `getent` fails.

### Description
- Add `SUPABASE_DB_DSN` to the workflow `env` and use it when present as the `DB_DSN` for `psql` commands.
- When `SUPABASE_DB_DSN` is not set, attempt IPv4 resolution for `db.${SUPABASE_PROJECT_REF}.supabase.co` using `getent`, then `dig`, then `nslookup`, and fail with an actionable message if no address is found.
- Preserve existing seeding steps and `PGPASSWORD` usage while emitting clearer logs about which DSN or IP is being used.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f262a625008329a6769fe3c309e541)