### PR TITLE
Refactor Supabase seed step: move DB password to step env and simplify DB_DSN

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -13,7 +13,6 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
 
     steps:
@@ -35,16 +34,12 @@ jobs:
         run: supabase db push --debug
 
       - name: Apply climate seed data
+        env:
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           echo "Applying climate seed data..."
-          DB_HOST="db.${SUPABASE_PROJECT_REF}.supabase.co"
-          DB_HOSTADDR="$(getent ahostsv4 "${DB_HOST}" | awk 'NR==1 { print $1 }')"
-          if [ -z "${DB_HOSTADDR}" ]; then
-            echo "Could not resolve IPv4 address for ${DB_HOST}"
-            exit 1
-          fi
-          echo "Using IPv4 ${DB_HOSTADDR} for ${DB_HOST}"
-          DB_DSN="host=${DB_HOST} hostaddr=${DB_HOSTADDR} port=5432 dbname=postgres user=postgres sslmode=require"
+          DB_DSN="host=db.${SUPABASE_PROJECT_REF}.supabase.co port=5432 dbname=postgres user=postgres sslmode=require"
           for sql_file in \
             supabase/seed-data/climate/001_commune_canton_2014.sql \
             supabase/seed-data/climate/002_canton_2014_names.sql \
@@ -58,7 +53,7 @@ jobs:
             PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -f "$sql_file"
           done
 
-          echo "Running climate seed verification..."
+          echo "Verifying climate seed data..."
           PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -f supabase/seed-data/climate/verify_climate_seed.sql
 
           snow_count="$(PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1 -tA -c "SELECT COUNT(*) FROM public.mdall_climate_snow_departments;")"


### PR DESCRIPTION
### Motivation
- Reduce credential exposure in job-level env and simplify database connection by avoiding IPv4 resolution in the seed step.

### Description
- Remove `SUPABASE_DB_PASSWORD` from the job-level `env` and add it to the `Apply climate seed data` step's `env` block. 
- Replace the previous IPv4 resolution logic with a simplified `DB_DSN` that uses the Supabase host name (`db.${SUPABASE_PROJECT_REF}.supabase.co`) and standard connection parameters. 
- Update the seed step log text from "Running climate seed verification..." to "Verifying climate seed data..." and keep the existing `psql` invocations and verification queries unchanged.

### Testing
- No automated tests were added or run for these workflow changes; please run the GitHub Actions workflow to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f262a625008329a6769fe3c309e541)