### PR TITLE
fix(ci): build Supabase seed DSN from IPv4 pooler secrets

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -14,7 +14,6 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-      SUPABASE_DB_DSN: ${{ secrets.SUPABASE_DB_DSN }}
 
     steps:
       - name: Checkout repository
@@ -36,25 +35,21 @@ jobs:
 
       - name: Apply climate seed data
         env:
-          SUPABASE_DB_DSN: ${{ secrets.SUPABASE_DB_DSN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_DB_HOST: ${{ secrets.SUPABASE_DB_HOST }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           echo "Applying climate seed data..."
-          if [ -z "$SUPABASE_DB_DSN" ]; then
-            echo "ERROR: SUPABASE_DB_DSN is not set. You must configure a Supabase pooler connection string (IPv4 compatible)."
+          if [ -z "$SUPABASE_DB_HOST" ] || [ -z "$SUPABASE_DB_PASSWORD" ] || [ -z "$SUPABASE_PROJECT_REF" ]; then
+            echo "ERROR: Missing Supabase DB configuration (SUPABASE_DB_HOST / PASSWORD / PROJECT_REF)"
             exit 1
           fi
           # IMPORTANT:
-          # Do not use direct Supabase DB connection (IPv6)
-          # GitHub Actions requires IPv4 → use Supavisor pooler
-          DB_DSN="${SUPABASE_DB_DSN}"
-          echo "Using Supabase pooler connection (IPv4 compatible)"
-
-          if printf '%s' "$DB_DSN" | grep -Eq ':[^:@/]+@'; then
-            PSQL_BASE_CMD=(psql "$DB_DSN" -v ON_ERROR_STOP=1)
-          else
-            PSQL_BASE_CMD=(env PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1)
-          fi
+          # Use Supabase pooler (IPv4)
+          # Direct DB connection (db.<project-ref>) uses IPv6 and fails in GitHub Actions
+          DB_DSN="postgresql://postgres.${SUPABASE_PROJECT_REF}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres?sslmode=require"
+          echo "Using Supabase pooler connection (IPv4)"
+          PSQL_BASE_CMD=(psql "$DB_DSN" -v ON_ERROR_STOP=1)
 
           for sql_file in \
             supabase/seed-data/climate/001_commune_canton_2014.sql \


### PR DESCRIPTION
### Motivation
- Avoid direct IPv6 DB host usage that fails in GitHub Actions by using the Supabase pooler (IPv4) via existing secrets. 
- Keep the seed step minimal and secure while preserving seed ordering, verification, and logging behavior.

### Description
- Removed reliance on `SUPABASE_DB_DSN` and added `SUPABASE_DB_HOST` + `SUPABASE_PROJECT_REF` as the inputs used to build the DSN for the seed step. 
- Added a strict precheck that exits if `SUPABASE_DB_HOST`, `SUPABASE_DB_PASSWORD`, or `SUPABASE_PROJECT_REF` are missing. 
- Constructed `DB_DSN` as `postgresql://postgres.${SUPABASE_PROJECT_REF}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:5432/postgres?sslmode=require` and set `PSQL_BASE_CMD=(psql "$DB_DSN" -v ON_ERROR_STOP=1)`. 
- Added the requested non-sensitive log and a clear YAML comment: `# IMPORTANT: Use Supabase pooler (IPv4)` and preserved the SQL loop, `verify_climate_seed.sql`, `SELECT COUNT(*)` checks, and `-v ON_ERROR_STOP=1`.

### Testing
- Verified workflow files are present with `rg --files .github/workflows`, which succeeded. 
- Printed and inspected the modified workflow with `sed -n '1,260p' .github/workflows/deploy-supabase.yml` and `nl -ba ... | sed -n '1,130p'`, both succeeded. 
- Searched the modified file for remaining DSN/PGPASSWORD/direct-host patterns with `rg -n "SUPABASE_DB_DSN|db\.\$\{SUPABASE_PROJECT_REF\}\.supabase\.co|PGPASSWORD=|Applying climate seed data|pooler"`, which returned the updated step lines and no remaining direct-host references. 
- Checked repository status with `git -C /workspace/Mdall status --short`, which showed only the intended workflow change; all automated checks run during the rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f65b1a68832997e3cb885daa8aac)