### PR TITLE
Use Supavisor pooler (port 6543) for Supabase seed step and require DB host/password env vars

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -14,7 +14,6 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-      SUPABASE_DB_DSN: ${{ secrets.SUPABASE_DB_DSN }}
 
     steps:
       - name: Checkout repository
@@ -36,25 +35,21 @@ jobs:
 
       - name: Apply climate seed data
         env:
-          SUPABASE_DB_DSN: ${{ secrets.SUPABASE_DB_DSN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_DB_HOST: ${{ secrets.SUPABASE_DB_HOST }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           echo "Applying climate seed data..."
-          if [ -z "$SUPABASE_DB_DSN" ]; then
-            echo "ERROR: SUPABASE_DB_DSN is not set. You must configure a Supabase pooler connection string (IPv4 compatible)."
+          if [ -z "$SUPABASE_DB_HOST" ] || [ -z "$SUPABASE_DB_PASSWORD" ] || [ -z "$SUPABASE_PROJECT_REF" ]; then
+            echo "ERROR: Missing Supabase DB configuration"
             exit 1
           fi
           # IMPORTANT:
-          # Do not use direct Supabase DB connection (IPv6)
-          # GitHub Actions requires IPv4 → use Supavisor pooler
-          DB_DSN="${SUPABASE_DB_DSN}"
-          echo "Using Supabase pooler connection (IPv4 compatible)"
-
-          if printf '%s' "$DB_DSN" | grep -Eq ':[^:@/]+@'; then
-            PSQL_BASE_CMD=(psql "$DB_DSN" -v ON_ERROR_STOP=1)
-          else
-            PSQL_BASE_CMD=(env PGPASSWORD="${SUPABASE_DB_PASSWORD}" psql "$DB_DSN" -v ON_ERROR_STOP=1)
-          fi
+          # Use Supabase pooler (IPv4) on port 6543
+          # Port 5432 = session/direct connection → may use IPv6 → fails in GitHub Actions
+          DB_DSN="postgresql://postgres.${SUPABASE_PROJECT_REF}:${SUPABASE_DB_PASSWORD}@${SUPABASE_DB_HOST}:6543/postgres?sslmode=require"
+          echo "Using Supabase pooler (transaction mode, port 6543)"
+          PSQL_BASE_CMD=(psql "$DB_DSN" -v ON_ERROR_STOP=1)
 
           for sql_file in \
             supabase/seed-data/climate/001_commune_canton_2014.sql \


### PR DESCRIPTION
### Motivation

- Prevent IPv6-related failures in GitHub Actions by avoiding direct DB session connections and using the Supavisor pooler on an IPv4-compatible port.  

### Description

- Remove reliance on a single `SUPABASE_DB_DSN` secret and instead require `SUPABASE_DB_HOST`, `SUPABASE_DB_PASSWORD`, and `SUPABASE_PROJECT_REF` for the seed step.  
- Construct a pooler connection string `postgresql://postgres.<project_ref>:<password>@<host>:6543/postgres?sslmode=require` and set `PSQL_BASE_CMD` to use that DSN.  
- Add validation to error out when required Supabase DB configuration variables are missing and update log messages to reflect pooler/transaction-mode usage.  

### Testing

- No automated tests were executed for this workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f65b1a68832997e3cb885daa8aac)