### PR TITLE
fix(climate): allow nullable insee_code for canton lookup rows

### DIFF
--- a/supabase/migrations/202606150043_mdall_climate_allow_canton_lookup_rows.sql
+++ b/supabase/migrations/202606150043_mdall_climate_allow_canton_lookup_rows.sql
@@ -1,0 +1,6 @@
+-- Allow nullable insee_code for climate canton lookup reference rows used by seeds.
+-- - Rows with non-null insee_code represent commune -> canton mappings.
+-- - Rows with null insee_code represent canton name lookup reference rows inserted by seeds 002/003.
+-- - The partial index on (canton_code_2014) where insee_code is null depends on this behavior.
+alter table public.mdall_climate_commune_cantons
+  alter column insee_code drop not null;


### PR DESCRIPTION
### Motivation
- La seed Supabase échoue car `002_canton_2014_names.sql` et `003_current_canton_names.sql` insèrent des lignes avec `insee_code = NULL` alors que la colonne est `NOT NULL` dans le schéma initial. 
- Une migration précédente crée déjà un index partiel `where insee_code is null`, ce qui prouve que les lignes avec `insee_code NULL` sont intentionnelles et doivent être autorisées.

### Description
- Ajout d’une nouvelle migration `supabase/migrations/202606150043_mdall_climate_allow_canton_lookup_rows.sql` qui exécute `alter table public.mdall_climate_commune_cantons alter column insee_code drop not null;` et inclut un commentaire SQL expliquant la distinction entre lignes communes et lignes référentielles de cantons. 
- Aucun autre fichier n’a été modifié (pas de changement aux seeds, à leur ordre, aux index existants, ni de troncation de tables) et le diff est limité à cette migration unique.

### Testing
- La vérification `git status --short` a été exécutée avec succès et a montré le nouveau fichier non suivi. 
- Le commit `git add` + `git commit -m "fix(climate): allow nullable insee_code for canton lookup seed rows"` a été exécuté avec succès. 
- Le fichier a été inspecté via `nl -ba supabase/migrations/202606150043_mdall_climate_allow_canton_lookup_rows.sql` et contient les 6 lignes attendues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f9a79b808329bcee415ecce4e94c)