### PR TITLE
Fix climate seed policy verification query

### DIFF
--- a/supabase/seed-data/climate/verify_climate_seed.sql
+++ b/supabase/seed-data/climate/verify_climate_seed.sql
@@ -17,11 +17,17 @@ where schemaname = 'public'
 order by tablename, indexname;
 
 -- Ensure no public/authenticated SELECT policy exists on mdall_climate_* tables
-select polrelid::regclass as table_name, polname, polcmd, polroles
-from pg_policy
-where schemaname = 'public'
-  and polrelid::regclass::text like 'mdall_climate_%'
-  and polcmd = 'r';
+select
+  p.polrelid::regclass as table_name,
+  p.polname,
+  p.polcmd,
+  p.polroles
+from pg_policy p
+join pg_class c on c.oid = p.polrelid
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public'
+  and c.relname like 'mdall_climate_%'
+  and p.polcmd = 'r';
 
 -- Sample dynamic commune lookup (first available commune)
 with any_commune as (


### PR DESCRIPTION
### Motivation
- Fix Supabase deployment failure caused by `ERROR: column "schemaname" does not exist` when verifying policies for `mdall_climate_*` tables because `pg_policy` does not expose a `schemaname` column and the schema must be resolved via `pg_class` → `pg_namespace`.

### Description
- Replace the policy-check block in `supabase/seed-data/climate/verify_climate_seed.sql` with a query that joins `pg_policy` (`p`) to `pg_class` (`c`) and `pg_namespace` (`n`) and filters by `n.nspname = 'public'`, `c.relname like 'mdall_climate_%'` and `p.polcmd = 'r'`.
- Only `supabase/seed-data/climate/verify_climate_seed.sql` was modified and all seeds (`001`–`008`), migrations, workflow, and seed ordering remain unchanged.

### Testing
- Applied the patch and verified the repository diff shows the updated policy query using the `p`/`c`/`n` joins; this automated check succeeded.
- Printed the updated file with line numbers to confirm the replacement block is present and correct; this automated inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fb1f8e508329afdc6cb3005b7c9c)