### PR TITLE
fix(db): add exact unique index for project_context_facts upsert

### DIFF
--- a/supabase/migrations/202606150042_project_context_facts_upsert_unique_index.sql
+++ b/supabase/migrations/202606150042_project_context_facts_upsert_unique_index.sql
@@ -1,0 +1,7 @@
+-- Add an exact unique index for Supabase/PostgREST upserts targeting
+-- onConflict: "project_id,fact_key,source_type,source_ref".
+create unique index if not exists ux_project_context_facts_project_key_source_type_source_ref
+  on public.project_context_facts(project_id, fact_key, source_type, source_ref);
+
+comment on index public.ux_project_context_facts_project_key_source_type_source_ref is
+  'Required exact unique index for Supabase/PostgREST upsert onConflict: "project_id,fact_key,source_type,source_ref".';


### PR DESCRIPTION
### Motivation
- Corriger l'erreur 500 lors de l'upsert dans `project_context_facts` causée par l'absence d'un index unique exact correspondant à l'`ON CONFLICT` utilisé par Supabase/PostgREST.

### Description
- Ajout d'une migration `supabase/migrations/202606150042_project_context_facts_upsert_unique_index.sql` créant l'index exact `ux_project_context_facts_project_key_source_type_source_ref` sur `(project_id, fact_key, source_type, source_ref)` et ajout d'un commentaire SQL expliquant la nécessité de cet index, sans modifier l'index existant basé sur `coalesce(source_ref, '')`.

### Testing
- Les vérifications locales automatisées ont été exécutées: `git add`/`git commit` ont réussi et le fichier de migration a été créé et inspecté (`nl`), et aucun test d'exécution de l'Edge Function ou test d'intégration Supabase n'a été lancé dans cette session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fd6f8fb083298fb116b6bde98676)