### PR TITLE
Fix map refresh flow on location validation

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -29,6 +29,7 @@ import {
   rerenderProjectParametres,
   getParametresUiState
 } from "./project-parametres-core.js";
+import { renderSpinnerHtml } from "../ui/spinner.js";
 
 function ensureLocalisationUiState() {
   const parametresUiState = getParametresUiState();
@@ -76,6 +77,9 @@ function ensureLocalisationUiState() {
   if (!parametresUiState.locationPendingSelectionPromise || typeof parametresUiState.locationPendingSelectionPromise.then !== "function") {
     parametresUiState.locationPendingSelectionPromise = null;
   }
+  if (typeof parametresUiState.locationMapValidationPending !== "boolean") {
+    parametresUiState.locationMapValidationPending = false;
+  }
   if (!parametresUiState.locationMapEmbed || typeof parametresUiState.locationMapEmbed !== "object") {
     parametresUiState.locationMapEmbed = {
       status: "idle",
@@ -120,6 +124,9 @@ async function refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom = 1
     uiState.locationMapEmbed.lastErrorAt = Date.now();
   } finally {
     if (uiState.locationMapEmbed.requestKey === requestKey) {
+      if (uiState.locationMapEmbed.status !== "loading") {
+        uiState.locationMapValidationPending = false;
+      }
       rerenderProjectParametres();
     }
   }
@@ -337,11 +344,13 @@ function renderProjectLocationMapBlock() {
     void refreshProjectLocationMapEmbedUrl({ latitude, longitude, zoom: 16, mapType: "satellite" });
   }
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
+    const shouldShowSpinner = mapEmbedState.status === "loading" && Boolean(uiState.locationMapValidationPending);
     return `
       <div class="settings-location-map-card is-blurred">
         <div class="arkolia-map arkolia-map--placeholder" aria-hidden="true">
           <div class="arkolia-map__placeholder-surface"></div>
           <div class="arkolia-map__placeholder-blur"></div>
+          ${shouldShowSpinner ? `<div class="settings-location-map__spinner">${renderSpinnerHtml({ label: "Chargement de la carte", size: "md" })}</div>` : ""}
         </div>
       </div>
     `;
@@ -1490,8 +1499,18 @@ export function bindLocalisationParametresSection(root) {
           } catch {
             syncProjectLocationFields({ address: value, altitude: null });
           }
+
+          const locationHasChanged = hasProjectLocationChanged(previousLocationSignature);
+          if (!locationHasChanged) {
+            parametresUiState.locationEditBaseSignature = "";
+            parametresUiState.locationEditInProgress = false;
+            parametresUiState.locationSaveInProgress = false;
+            return;
+          }
+
+          parametresUiState.locationMapValidationPending = true;
           try {
-            await refreshLocationDerivedData({ runEnrichment: hasProjectLocationChanged(previousLocationSignature) && shouldAutoRunProjectBaseDataEnrichment(), triggerType: "automatic", triggerLabel: "Validation d’une modification de la localisation projet" });
+            await refreshLocationDerivedData({ runEnrichment: locationHasChanged && shouldAutoRunProjectBaseDataEnrichment(), triggerType: "automatic", triggerLabel: "Validation d’une modification de la localisation projet" });
           } finally {
             parametresUiState.locationEditBaseSignature = "";
             parametresUiState.locationEditInProgress = false;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -12301,6 +12301,18 @@ circle.situation-trajectory__hierarchy-link--blocked,
   display:block;
 }
 
+
+.settings-location-map-card .arkolia-map--placeholder{
+  position:relative;
+}
+
+.settings-location-map__spinner{
+  position:absolute;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
 .settings-location-map-card.is-blurred .arkolia-map__placeholder-blur{
   backdrop-filter:blur(5px) saturate(.8);
   background:linear-gradient(180deg, rgba(13,17,23,.18), rgba(13,17,23,.34));


### PR DESCRIPTION
### Motivation
- Prevent redundant map re-renders and unnecessary save/refresh when the project address is validated but did not change.
- Provide clear feedback by showing a spinner in the map placeholder while a refreshed map embed is being fetched after a real address change.

### Description
- Add a UI state flag `locationMapValidationPending` and initialize it in `ensureLocalisationUiState()` to track map refresh triggered by an address validation.
- Early-return from the address `onValidate` flow when `hasProjectLocationChanged(previousLocationSignature)` is false so no save/refresh occurs if the address is unchanged.
- Set `locationMapValidationPending` before calling `refreshLocationDerivedData()` when the location actually changed, and clear it when the map embed request completes in `refreshProjectLocationMapEmbedUrl()`.
- Render a centered spinner inside the map placeholder while the embed is loading by importing `renderSpinnerHtml` and adding CSS rules `.settings-location-map-card .arkolia-map--placeholder` and `.settings-location-map__spinner`.

### Testing
- Ran the test suite with `npm test --silent` and all automated tests passed (233 tests run, 228 passed, 5 skipped, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3126aaea0832990a48d1608faa34a)