### PR TITLE
Refactor Atelier Neige/Vent/Gel: new "Zones et charges climatiques" UI and shared location map

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -29,7 +29,7 @@ import {
   rerenderProjectParametres,
   getParametresUiState
 } from "./project-parametres-core.js";
-import { renderSpinnerHtml } from "../ui/spinner.js";
+import { renderProjectLocationMapCard } from "../shared/project-location-map-card.js";
 
 function ensureLocalisationUiState() {
   const parametresUiState = getParametresUiState();
@@ -317,46 +317,15 @@ function renderProjectLocationMapBlock() {
   const latitude = Number(store.projectForm.latitude);
   const longitude = Number(store.projectForm.longitude);
   const isValidLocation = Number.isFinite(latitude) && Number.isFinite(longitude);
-
-  if (!isValidLocation) {
-    return `
-      <div class="settings-location-map-card${!isValidLocation ? " is-blurred" : ""}">
-        <div class="arkolia-map arkolia-map--placeholder${!isValidLocation ? " is-empty" : ""}" aria-hidden="true">
-          <div class="arkolia-map__placeholder-surface"></div>
-          <div class="arkolia-map__placeholder-blur"></div>
-        </div>
-      </div>
-    `;
-  }
+  if (!isValidLocation) return renderProjectLocationMapCard({ latitude, longitude });
 
   const uiState = ensureLocalisationUiState();
   const mapEmbedState = uiState.locationMapEmbed;
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
     const shouldShowSpinner = mapEmbedState.status === "loading" && Boolean(uiState.locationMapValidationPending);
-    return `
-      <div class="settings-location-map-card is-blurred">
-        <div class="arkolia-map arkolia-map--placeholder" aria-hidden="true">
-          <div class="arkolia-map__placeholder-surface"></div>
-          <div class="arkolia-map__placeholder-blur"></div>
-          ${shouldShowSpinner ? `<div class="settings-location-map__spinner">${renderSpinnerHtml({ label: "Chargement de la carte", size: "md" })}</div>` : ""}
-        </div>
-      </div>
-    `;
+    return renderProjectLocationMapCard({ latitude, longitude, isLoading: true, showSpinner: shouldShowSpinner });
   }
-
-  return `
-    <div class="settings-location-map-card">
-      <div class="arkolia-map">
-        <iframe
-          title="Carte Google Maps de la localisation projet"
-          src="${escapeHtml(mapEmbedState.url)}"
-          loading="lazy"
-          allowfullscreen
-          referrerpolicy="no-referrer-when-downgrade"
-        ></iframe>
-      </div>
-    </div>
-  `;
+  return renderProjectLocationMapCard({ latitude, longitude, embedUrl: mapEmbedState.url });
 }
 
 function renderProjectLocationMapBlockIntoDom() {

--- a/apps/web/js/views/shared/project-location-map-card.js
+++ b/apps/web/js/views/shared/project-location-map-card.js
@@ -1,0 +1,52 @@
+import { escapeHtml } from "../../utils/escape-html.js";
+import { renderSpinnerHtml } from "../ui/spinner.js";
+
+export function renderProjectLocationMapCard({
+  latitude = null,
+  longitude = null,
+  embedUrl = "",
+  isLoading = false,
+  showSpinner = false,
+  iframeTitle = "Carte Google Maps de la localisation projet"
+} = {}) {
+  const lat = Number(latitude);
+  const lng = Number(longitude);
+  const isValidLocation = Number.isFinite(lat) && Number.isFinite(lng);
+
+  if (!isValidLocation) {
+    return `
+      <div class="settings-location-map-card is-blurred">
+        <div class="arkolia-map arkolia-map--placeholder is-empty" aria-hidden="true">
+          <div class="arkolia-map__placeholder-surface"></div>
+          <div class="arkolia-map__placeholder-blur"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (!embedUrl) {
+    return `
+      <div class="settings-location-map-card is-blurred">
+        <div class="arkolia-map arkolia-map--placeholder" aria-hidden="true">
+          <div class="arkolia-map__placeholder-surface"></div>
+          <div class="arkolia-map__placeholder-blur"></div>
+          ${isLoading && showSpinner ? `<div class="settings-location-map__spinner">${renderSpinnerHtml({ label: "Chargement de la carte", size: "md" })}</div>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="settings-location-map-card">
+      <div class="arkolia-map">
+        <iframe
+          title="${escapeHtml(iframeTitle)}"
+          src="${escapeHtml(embedUrl)}"
+          loading="lazy"
+          allowfullscreen
+          referrerpolicy="no-referrer-when-downgrade"
+        ></iframe>
+      </div>
+    </div>
+  `;
+}

--- a/apps/web/js/views/studio/solidity/solidity-climate.js
+++ b/apps/web/js/views/studio/solidity/solidity-climate.js
@@ -4,6 +4,8 @@ import { getLastStudioToolResult, resolveStudioClimateTool } from "../../../serv
 import { getEffectiveProjectLocation } from "./solidity-climate-tool-common.js";
 import { resolveCurrentBackendProjectId } from "../../../services/project-supabase-sync.js";
 import { renderGhActionButton } from "../../ui/gh-split-button.js";
+import { fetchGoogleMapsPlaceEmbedUrl } from "../../../services/google-maps-embed-service.js";
+import { renderProjectLocationMapCard } from "../../shared/project-location-map-card.js";
 
 const TOOL_KEYS = ["snow", "wind", "frost"];
 const TOOL_LABELS = {
@@ -12,7 +14,7 @@ const TOOL_LABELS = {
   frost: "Gel"
 };
 
-const state = { loading: false, error: "", projectId: "", location: null, results: {} };
+const state = { loading: false, error: "", projectId: "", location: null, results: {}, mapUrl: "", mapLoading: false };
 
 export async function renderSolidityClimate(root, { force = false } = {}) {
   if (!root) return;
@@ -88,38 +90,49 @@ function render(root) {
   const actionLabel = state.loading ? "Calcul en cours..." : hasResult ? "Recalculer" : "Calculer";
 
   root.innerHTML = `
-    <section class="arkolia-identity-preview arkolia-assise-card" data-solidity-tool-card="climate">
-      <header class="arkolia-identity-preview__header">
+    <section class="arkolia-identity-preview arkolia-assise-card" data-solidity-tool-card="climate" style="display:grid;gap:16px;">
+      <header class="arkolia-summary-card__title-row">
         <div>
-          <h3 class="arkolia-identity-preview__title">Neige, Vent &amp; Gel</h3>
-          <p class="arkolia-identity-preview__meta">Résolution via service Supabase</p>
+          <h3 class="arkolia-identity-preview__title">Zones et charges climatiques</h3>
+        </div>
+        <div style="display:flex;gap:8px;align-items:center;margin-left:auto;">
+          ${renderGhActionButton({ id: "solidityToolToSubject-climate", label: "Transformer en sujet", tone: "default", size: "md", disabled: !hasResult, mainAction: "" })}
+          ${renderGhActionButton({ id: "solidityToolCalculate-climate", label: actionLabel, tone: "primary", size: "md", disabled: !!state.loading, mainAction: "" })}
         </div>
       </header>
-      <div class="arkolia-identity-preview__body">
-        <p class="arkolia-identity-preview__meta">${escapeHtml(state.loading ? "Chargement..." : "Utilise la localisation projet actuelle.")}</p>
+      <div class="arkolia-identity-preview__body" style="padding:0;">
         ${state.error ? `<p class="gh-text-muted" style="color:var(--danger);">${escapeHtml(state.error)}</p>` : ""}
-        <div class="arkolia-identity-preview__coordinates">${renderCards()}</div>
+        <div style="display:grid;grid-template-columns:300px minmax(0px, 1fr);gap:16px;align-items:start;">
+          ${renderCards()}
+        </div>
       </div>
-      <footer class="arkolia-identity-preview__footer" style="display:flex;gap:8px;">
-        ${renderGhActionButton({ id: "solidityToolCalculate-climate", label: actionLabel, tone: "primary", size: "md", disabled: !!state.loading, mainAction: "" })}
-        ${renderGhActionButton({ id: "solidityToolToSubject-climate", label: "Transformer en sujet", tone: "default", size: "md", disabled: !hasResult, mainAction: "" })}
-      </footer>
+      <div data-solidity-climate-map>
+        ${renderMapCard()}
+      </div>
     </section>
   `;
+  void refreshMapCard(root);
 }
 
 function renderCards() {
-  return `<div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;">${TOOL_KEYS.map((toolKey) => renderToolCard(toolKey)).join("")}</div>`;
+  return `<div style="display:grid;grid-template-columns:minmax(0,1fr);gap:8px;">${renderAddressCard()}${TOOL_KEYS.map((toolKey) => renderToolCard(toolKey)).join("")}</div><div></div>`;
+}
+function renderAddressCard() {
+  const location = state.location || {};
+  const address = [location.address, location.postalCode, location.city].filter(Boolean).join(", ");
+  return `<article class="arkolia-assise-card" style="padding:10px;"><strong>Adresse</strong><div>${escapeHtml(address || "—")}</div></article>`;
 }
 
 function renderToolCard(toolKey) {
   const result = state.results?.[toolKey]?.result_payload || null;
   const title = TOOL_LABELS[toolKey] || toolKey;
+  const altitudeValue = Number(result?.altitude ?? state.location?.altitude);
+  const altitudeLabel = Number.isFinite(altitudeValue) ? `${Math.round(altitudeValue)} m` : "—";
   const details = toolKey === "snow"
-    ? `<li>Zone neige: <strong>${escapeHtml(result?.snow_zone || "—")}</strong></li><li>Département: <strong>${escapeHtml(result?.department_code || "—")}</strong></li>`
+    ? `<li>Région: <strong>${escapeHtml(result?.snow_zone || "—")}</strong></li><li>Altitude: <strong>${escapeHtml(altitudeLabel)}</strong></li>`
     : toolKey === "wind"
-      ? `<li>Zone vent: <strong>${escapeHtml(result?.wind_zone || "—")}</strong></li><li>Département: <strong>${escapeHtml(result?.department_code || "—")}</strong></li>`
-      : `<li>H0: <strong>${escapeHtml(String(result?.h0_selected_m ?? "—"))}</strong></li><li>Altitude: <strong>${escapeHtml(String(result?.altitude ?? "—"))}</strong></li><li>H: <strong>${escapeHtml(String(result?.frost_depth_m ?? "—"))}</strong></li>`;
+      ? `<li>Région: <strong>${escapeHtml(result?.wind_zone || "—")}</strong></li>`
+      : `<li>Profondeur hors gel: <strong>${escapeHtml(String(result?.frost_depth_m ?? "—"))}</strong></li><li>H0: <strong>${escapeHtml(String(result?.h0_selected_m ?? "—"))}</strong></li>`;
 
   return `
     <article class="arkolia-assise-card" style="padding:10px;">
@@ -127,4 +140,30 @@ function renderToolCard(toolKey) {
       <ul>${details}</ul>
     </article>
   `;
+}
+
+function renderMapCard() {
+  return renderProjectLocationMapCard({
+    latitude: state.location?.latitude,
+    longitude: state.location?.longitude,
+    embedUrl: state.mapUrl,
+    isLoading: state.mapLoading,
+    showSpinner: true,
+    iframeTitle: "Carte Google Maps de la localisation du projet"
+  });
+}
+
+async function refreshMapCard(root) {
+  if (!root || !Number.isFinite(Number(state.location?.latitude)) || !Number.isFinite(Number(state.location?.longitude))) return;
+  state.mapLoading = true;
+  const host = root.querySelector("[data-solidity-climate-map]");
+  if (host) host.innerHTML = renderMapCard();
+  try {
+    state.mapUrl = await fetchGoogleMapsPlaceEmbedUrl({ latitude: Number(state.location.latitude), longitude: Number(state.location.longitude), zoom: 16, mapType: "satellite" });
+  } catch {
+    state.mapUrl = "";
+  } finally {
+    state.mapLoading = false;
+    if (host) host.innerHTML = renderMapCard();
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the old combined "Neige, Vent & Gel" view with a clearer page titled "Zones et charges climatiques" and match the title row styling used elsewhere. 
- Surface the key climate info (address, snow region & altitude, wind region, frost depths) as separate cards in a simple vertical grid and align actions on the title line as requested. 
- Reuse a single shared renderer for the project location map so the same placeholder/spinner/iframe logic is available both in the Atelier screen and in Paramètres → Localisation.

### Description
- Added a new shared component `apps/web/js/views/shared/project-location-map-card.js` that renders the placeholder, spinner and Google Maps iframe for a given `latitude`/`longitude`/`embedUrl`.
- Updated `apps/web/js/views/project-parametres/project-parametres-localisation.js` to delegate map rendering to `renderProjectLocationMapCard` instead of inlining the iframe HTML.
- Reworked `apps/web/js/views/studio/solidity/solidity-climate.js` to: replace the header with `Zones et charges climatiques` using the summary title row class, move action buttons (`Transformer en sujet` then `Calculer/Recalculer`) to the right of the title, implement a two-column container with `grid-template-columns: 300px minmax(0px, 1fr); gap: 16px;`, render four cards (Adresse, Neige with rounded altitude in meters, Vent region, Gel with frost depth and H0), and add a map block under the grid that fetches the embed URL via `fetchGoogleMapsPlaceEmbedUrl` and uses the shared map component.
- Minor state additions in `solidity-climate.js` to hold `mapUrl` and `mapLoading`, and small formatting/label changes for the climate detail lines.

### Testing
- Attempted to run linting with `npm run -s lint` but the lint script was not available in this environment so automated lint checks could not be completed (failed/unavailable). 
- No other automated test suites were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31cfc44248329ab6c41f74acec53c)