### PR TITLE
Add shared project location map card and integrate into localisation and studio solidity climate view

### DIFF
--- a/apps/web/js/views/project-parametres/project-parametres-localisation.js
+++ b/apps/web/js/views/project-parametres/project-parametres-localisation.js
@@ -29,7 +29,7 @@ import {
   rerenderProjectParametres,
   getParametresUiState
 } from "./project-parametres-core.js";
-import { renderSpinnerHtml } from "../ui/spinner.js";
+import { renderProjectLocationMapCard } from "../shared/project-location-map-card.js";
 
 function ensureLocalisationUiState() {
   const parametresUiState = getParametresUiState();
@@ -317,46 +317,15 @@ function renderProjectLocationMapBlock() {
   const latitude = Number(store.projectForm.latitude);
   const longitude = Number(store.projectForm.longitude);
   const isValidLocation = Number.isFinite(latitude) && Number.isFinite(longitude);
-
-  if (!isValidLocation) {
-    return `
-      <div class="settings-location-map-card${!isValidLocation ? " is-blurred" : ""}">
-        <div class="arkolia-map arkolia-map--placeholder${!isValidLocation ? " is-empty" : ""}" aria-hidden="true">
-          <div class="arkolia-map__placeholder-surface"></div>
-          <div class="arkolia-map__placeholder-blur"></div>
-        </div>
-      </div>
-    `;
-  }
+  if (!isValidLocation) return renderProjectLocationMapCard({ latitude, longitude });
 
   const uiState = ensureLocalisationUiState();
   const mapEmbedState = uiState.locationMapEmbed;
   if (mapEmbedState.status !== "success" || !mapEmbedState.url) {
     const shouldShowSpinner = mapEmbedState.status === "loading" && Boolean(uiState.locationMapValidationPending);
-    return `
-      <div class="settings-location-map-card is-blurred">
-        <div class="arkolia-map arkolia-map--placeholder" aria-hidden="true">
-          <div class="arkolia-map__placeholder-surface"></div>
-          <div class="arkolia-map__placeholder-blur"></div>
-          ${shouldShowSpinner ? `<div class="settings-location-map__spinner">${renderSpinnerHtml({ label: "Chargement de la carte", size: "md" })}</div>` : ""}
-        </div>
-      </div>
-    `;
+    return renderProjectLocationMapCard({ latitude, longitude, isLoading: true, showSpinner: shouldShowSpinner });
   }
-
-  return `
-    <div class="settings-location-map-card">
-      <div class="arkolia-map">
-        <iframe
-          title="Carte Google Maps de la localisation projet"
-          src="${escapeHtml(mapEmbedState.url)}"
-          loading="lazy"
-          allowfullscreen
-          referrerpolicy="no-referrer-when-downgrade"
-        ></iframe>
-      </div>
-    </div>
-  `;
+  return renderProjectLocationMapCard({ latitude, longitude, embedUrl: mapEmbedState.url });
 }
 
 function renderProjectLocationMapBlockIntoDom() {

--- a/apps/web/js/views/shared/project-location-map-card.js
+++ b/apps/web/js/views/shared/project-location-map-card.js
@@ -1,0 +1,57 @@
+import { escapeHtml } from "../../utils/escape-html.js";
+import { renderSpinnerHtml } from "../ui/spinner.js";
+
+export function renderProjectLocationMapCard({
+  latitude = null,
+  longitude = null,
+  embedUrl = "",
+  isLoading = false,
+  showSpinner = false,
+  iframeTitle = "Carte Google Maps de la localisation projet",
+  height = "",
+  containerClassName = "settings-location-map-card"
+} = {}) {
+  const lat = Number(latitude);
+  const lng = Number(longitude);
+  const isValidLocation = Number.isFinite(lat) && Number.isFinite(lng);
+
+  const wrapperStyle = String(height || "").trim() ? ` style="height:${escapeHtml(String(height))};"` : "";
+  const wrapperClass = escapeHtml(String(containerClassName || "settings-location-map-card"));
+
+  if (!isValidLocation) {
+    return `
+      <div class="${wrapperClass} is-blurred"${wrapperStyle}>
+        <div class="arkolia-map arkolia-map--placeholder is-empty" aria-hidden="true">
+          <div class="arkolia-map__placeholder-surface"></div>
+          <div class="arkolia-map__placeholder-blur"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (!embedUrl) {
+    return `
+      <div class="${wrapperClass} is-blurred"${wrapperStyle}>
+        <div class="arkolia-map arkolia-map--placeholder" aria-hidden="true">
+          <div class="arkolia-map__placeholder-surface"></div>
+          <div class="arkolia-map__placeholder-blur"></div>
+          ${isLoading && showSpinner ? `<div class="settings-location-map__spinner">${renderSpinnerHtml({ label: "Chargement de la carte", size: "md" })}</div>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="${wrapperClass}"${wrapperStyle}>
+      <div class="arkolia-map">
+        <iframe
+          title="${escapeHtml(iframeTitle)}"
+          src="${escapeHtml(embedUrl)}"
+          loading="lazy"
+          allowfullscreen
+          referrerpolicy="no-referrer-when-downgrade"
+        ></iframe>
+      </div>
+    </div>
+  `;
+}

--- a/apps/web/js/views/studio/solidity/solidity-climate.js
+++ b/apps/web/js/views/studio/solidity/solidity-climate.js
@@ -4,6 +4,8 @@ import { getLastStudioToolResult, resolveStudioClimateTool } from "../../../serv
 import { getEffectiveProjectLocation } from "./solidity-climate-tool-common.js";
 import { resolveCurrentBackendProjectId } from "../../../services/project-supabase-sync.js";
 import { renderGhActionButton } from "../../ui/gh-split-button.js";
+import { fetchGoogleMapsPlaceEmbedUrl } from "../../../services/google-maps-embed-service.js";
+import { renderProjectLocationMapCard } from "../../shared/project-location-map-card.js";
 
 const TOOL_KEYS = ["snow", "wind", "frost"];
 const TOOL_LABELS = {
@@ -12,7 +14,7 @@ const TOOL_LABELS = {
   frost: "Gel"
 };
 
-const state = { loading: false, error: "", projectId: "", location: null, results: {} };
+const state = { loading: false, error: "", projectId: "", location: null, results: {}, mapUrl: "", mapLoading: false };
 
 export async function renderSolidityClimate(root, { force = false } = {}) {
   if (!root) return;
@@ -88,43 +90,87 @@ function render(root) {
   const actionLabel = state.loading ? "Calcul en cours..." : hasResult ? "Recalculer" : "Calculer";
 
   root.innerHTML = `
-    <section class="arkolia-identity-preview arkolia-assise-card" data-solidity-tool-card="climate">
-      <header class="arkolia-identity-preview__header">
-        <div>
-          <h3 class="arkolia-identity-preview__title">Neige, Vent &amp; Gel</h3>
-          <p class="arkolia-identity-preview__meta">Résolution via service Supabase</p>
+    <section class="settings-section is-active" data-solidity-tool-card="climate">
+      <div class="settings-card settings-card--param studio-tool-card">
+        <div class="settings-card__head studio-tool-card__head">
+          <div>
+            <span class="settings-card__head-title">
+              <h4>Zones et charges climatiques</h4>
+              <div class="studio-tool-card__actions">
+                ${renderGhActionButton({ id: "solidityToolToSubject-climate", label: "Transformer en sujet", tone: "default", size: "md", disabled: !hasResult, mainAction: "" })}
+                ${renderGhActionButton({ id: "solidityToolCalculate-climate", label: actionLabel, tone: "primary", size: "md", disabled: !!state.loading, mainAction: "" })}
+              </div>
+            </span>
+          </div>
         </div>
-      </header>
-      <div class="arkolia-identity-preview__body">
-        <p class="arkolia-identity-preview__meta">${escapeHtml(state.loading ? "Chargement..." : "Utilise la localisation projet actuelle.")}</p>
-        ${state.error ? `<p class="gh-text-muted" style="color:var(--danger);">${escapeHtml(state.error)}</p>` : ""}
-        <div class="arkolia-identity-preview__coordinates">${renderCards()}</div>
+        <div class="settings-card__body studio-tool-card__body">
+          ${state.error ? `<p class="gh-text-muted" style="color:var(--danger);">${escapeHtml(state.error)}</p>` : ""}
+          <div data-solidity-climate-map class="studio-tool-map-layer">
+            ${renderMapCard()}
+          </div>
+          <div class="studio-tool-overlay-grid" style="display:grid;grid-template-columns:300px minmax(0px, 1fr);gap:16px;align-items:start;">
+            ${renderCards()}
+          </div>
+        </div>
       </div>
-      <footer class="arkolia-identity-preview__footer" style="display:flex;gap:8px;">
-        ${renderGhActionButton({ id: "solidityToolCalculate-climate", label: actionLabel, tone: "primary", size: "md", disabled: !!state.loading, mainAction: "" })}
-        ${renderGhActionButton({ id: "solidityToolToSubject-climate", label: "Transformer en sujet", tone: "default", size: "md", disabled: !hasResult, mainAction: "" })}
-      </footer>
     </section>
   `;
+  void refreshMapCard(root);
 }
 
 function renderCards() {
-  return `<div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;">${TOOL_KEYS.map((toolKey) => renderToolCard(toolKey)).join("")}</div>`;
+  return `<div class="studio-tool-cards-column">${renderAddressCard()}${TOOL_KEYS.map((toolKey) => renderToolCard(toolKey)).join("")}</div><div></div>`;
+}
+
+function renderAddressCard() {
+  const location = state.location || {};
+  const address = [location.address, location.postalCode, location.city].filter(Boolean).join(", ");
+  return `<article class="studio-tool-info-card"><strong>Adresse</strong><div>${escapeHtml(address || "—")}</div></article>`;
 }
 
 function renderToolCard(toolKey) {
   const result = state.results?.[toolKey]?.result_payload || null;
   const title = TOOL_LABELS[toolKey] || toolKey;
+  const altitudeValue = Number(result?.altitude ?? state.location?.altitude);
+  const altitudeLabel = Number.isFinite(altitudeValue) ? `${Math.round(altitudeValue)} m` : "—";
   const details = toolKey === "snow"
-    ? `<li>Zone neige: <strong>${escapeHtml(result?.snow_zone || "—")}</strong></li><li>Département: <strong>${escapeHtml(result?.department_code || "—")}</strong></li>`
+    ? `<li>Région: <strong>${escapeHtml(result?.snow_zone || "—")}</strong></li><li>Altitude: <strong>${escapeHtml(altitudeLabel)}</strong></li>`
     : toolKey === "wind"
-      ? `<li>Zone vent: <strong>${escapeHtml(result?.wind_zone || "—")}</strong></li><li>Département: <strong>${escapeHtml(result?.department_code || "—")}</strong></li>`
-      : `<li>H0: <strong>${escapeHtml(String(result?.h0_selected_m ?? "—"))}</strong></li><li>Altitude: <strong>${escapeHtml(String(result?.altitude ?? "—"))}</strong></li><li>H: <strong>${escapeHtml(String(result?.frost_depth_m ?? "—"))}</strong></li>`;
+      ? `<li>Région: <strong>${escapeHtml(result?.wind_zone || "—")}</strong></li>`
+      : `<li>Profondeur hors gel: <strong>${escapeHtml(String(result?.frost_depth_m ?? "—"))}</strong></li><li>H0: <strong>${escapeHtml(String(result?.h0_selected_m ?? "—"))}</strong></li>`;
 
   return `
-    <article class="arkolia-assise-card" style="padding:10px;">
-      <h4 class="arkolia-identity-preview__title" style="font-size:14px;">${escapeHtml(title)}</h4>
+    <article class="studio-tool-info-card">
+      <h4 class="studio-tool-info-card-title">${escapeHtml(title)}</h4>
       <ul>${details}</ul>
     </article>
   `;
+}
+
+function renderMapCard() {
+  return renderProjectLocationMapCard({
+    latitude: state.location?.latitude,
+    longitude: state.location?.longitude,
+    embedUrl: state.mapUrl,
+    isLoading: state.mapLoading,
+    showSpinner: true,
+    iframeTitle: "Carte Google Maps de la localisation du projet",
+    height: "calc(100vh - 186px)",
+    containerClassName: "studio-tool-map-card"
+  });
+}
+
+async function refreshMapCard(root) {
+  if (!root || !Number.isFinite(Number(state.location?.latitude)) || !Number.isFinite(Number(state.location?.longitude))) return;
+  state.mapLoading = true;
+  const host = root.querySelector("[data-solidity-climate-map]");
+  if (host) host.innerHTML = renderMapCard();
+  try {
+    state.mapUrl = await fetchGoogleMapsPlaceEmbedUrl({ latitude: Number(state.location.latitude), longitude: Number(state.location.longitude), zoom: 16, mapType: "satellite" });
+  } catch {
+    state.mapUrl = "";
+  } finally {
+    state.mapLoading = false;
+    if (host) host.innerHTML = renderMapCard();
+  }
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -14995,3 +14995,57 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   overscroll-behavior: none;
   cursor: crosshair;
 }
+
+.studio-tool-card__head{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:12px;
+}
+.studio-tool-card__actions{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin-top:8px;
+}
+.studio-tool-card__body{
+  position:relative;
+  min-height:calc(100vh - 170px);
+}
+.studio-tool-map-layer{
+  position:absolute;
+  inset:0;
+  z-index:1;
+}
+.studio-tool-map-card{
+  margin-top:0;
+  width:100%;
+}
+.studio-tool-overlay-grid{
+  position:relative;
+  z-index:2;
+  padding:16px;
+  pointer-events:none;
+}
+.studio-tool-cards-column{
+  display:grid;
+  grid-template-columns:minmax(0,1fr);
+  gap:8px;
+  pointer-events:auto;
+  padding-top:16px;
+}
+.studio-tool-info-card{
+  padding:10px;
+  border:1px solid var(--border-default);
+  border-radius:12px;
+  background:var(--bg);
+  backdrop-filter:blur(1px);
+}
+.studio-tool-info-card-title{
+  margin:0 0 8px;
+  font-size:14px;
+}
+.studio-tool-info-card ul{
+  margin:0;
+  padding-left:16px;
+}


### PR DESCRIPTION
### Motivation
- Provide a single reusable map card renderer to standardize map placeholder, loading spinner and iframe rendering across project UI. 
- Replace duplicated map/placeholder markup and spinner usage with a shared component to simplify rendering and reuse in multiple views. 
- Surface a project location preview in the Studio "Zones et charges climatiques" tool and fetch an embeddable Google Maps URL for richer context. 

### Description
- Add a new shared component `renderProjectLocationMapCard` in `views/shared/project-location-map-card.js` that handles placeholders, loading spinner and iframe embed rendering. 
- Replace inline map/placeholder markup in `project-parametres-localisation.js` to use the new `renderProjectLocationMapCard` and remove the old spinner import. 
- Update the solidity climate tool `solidity-climate.js` to a new card-style layout, add map support (state properties `mapUrl` and `mapLoading`), and integrate `renderProjectLocationMapCard` to render the map; add `refreshMapCard` to fetch embed URL via `fetchGoogleMapsPlaceEmbedUrl`. 
- Adjust UI/markup for the studio tool: reorganized action buttons, cards layout, tool detail formatting, and added `style.css` rules for `.studio-tool-*` classes to style the new layout. 

### Testing
- Built the web frontend locally with `yarn build` to validate bundling and import paths and the build completed successfully. 
- Ran lint and the JavaScript test suite with `yarn lint` and `yarn test`, and the test run completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31cfc44248329ab6c41f74acec53c)