### PR TITLE
Adjust studio climate tool map and card styling

### DIFF
--- a/apps/web/js/views/shared/project-location-map-card.js
+++ b/apps/web/js/views/shared/project-location-map-card.js
@@ -21,9 +21,9 @@ export function renderProjectLocationMapCard({
   if (!isValidLocation) {
     return `
       <div class="${wrapperClass} is-blurred"${wrapperStyle}>
-        <div class="arkolia-map arkolia-map--placeholder is-empty" aria-hidden="true">
-          <div class="arkolia-map__placeholder-surface"></div>
-          <div class="arkolia-map__placeholder-blur"></div>
+        <div class="studio-map studio-map--placeholder is-empty" aria-hidden="true">
+          <div class="studio-map__placeholder-surface"></div>
+          <div class="studio-map__placeholder-blur"></div>
         </div>
       </div>
     `;
@@ -32,9 +32,9 @@ export function renderProjectLocationMapCard({
   if (!embedUrl) {
     return `
       <div class="${wrapperClass} is-blurred"${wrapperStyle}>
-        <div class="arkolia-map arkolia-map--placeholder" aria-hidden="true">
-          <div class="arkolia-map__placeholder-surface"></div>
-          <div class="arkolia-map__placeholder-blur"></div>
+        <div class="studio-map studio-map--placeholder" aria-hidden="true">
+          <div class="studio-map__placeholder-surface"></div>
+          <div class="studio-map__placeholder-blur"></div>
           ${isLoading && showSpinner ? `<div class="settings-location-map__spinner">${renderSpinnerHtml({ label: "Chargement de la carte", size: "md" })}</div>` : ""}
         </div>
       </div>
@@ -43,7 +43,7 @@ export function renderProjectLocationMapCard({
 
   return `
     <div class="${wrapperClass}"${wrapperStyle}>
-      <div class="arkolia-map">
+      <div class="studio-map">
         <iframe
           title="${escapeHtml(iframeTitle)}"
           src="${escapeHtml(embedUrl)}"

--- a/apps/web/js/views/studio/solidity/solidity-climate.js
+++ b/apps/web/js/views/studio/solidity/solidity-climate.js
@@ -125,7 +125,7 @@ function renderCards() {
 function renderAddressCard() {
   const location = state.location || {};
   const address = [location.address, location.postalCode, location.city].filter(Boolean).join(", ");
-  return `<article class="studio-tool-info-card"><strong>Adresse</strong><div>${escapeHtml(address || "—")}</div></article>`;
+  return `<article class="studio-tool-info-card"><h4>Adresse</h4><ul><li>${escapeHtml(address || "—")}</li></ul></article>`;
 }
 
 function renderToolCard(toolKey) {
@@ -155,7 +155,7 @@ function renderMapCard() {
     isLoading: state.mapLoading,
     showSpinner: true,
     iframeTitle: "Carte Google Maps de la localisation du projet",
-    height: "calc(100vh - 186px)",
+    height: "calc(100vh - 210px)",
     containerClassName: "studio-tool-map-card"
   });
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -12380,6 +12380,40 @@ circle.situation-trajectory__hierarchy-link--blocked,
   background:linear-gradient(180deg, rgba(13,17,23,.08), rgba(13,17,23,.2));
 }
 
+
+.studio-map--placeholder{
+  position:relative;
+  overflow:hidden;
+  background:
+    linear-gradient(135deg, rgba(110,118,129,.1), rgba(110,118,129,.04)),
+    radial-gradient(circle at 20% 30%, rgba(255,255,255,.08), transparent 34%),
+    linear-gradient(90deg, rgba(255,255,255,.03) 0, rgba(255,255,255,.03) 8%, transparent 8%, transparent 18%, rgba(255,255,255,.025) 18%, rgba(255,255,255,.025) 26%, transparent 26%, transparent 100%),
+    linear-gradient(0deg, rgba(34,139,34,.18), rgba(34,139,34,.08));
+}
+
+.studio-map__placeholder-surface,
+.studio-map__placeholder-blur{
+  position:absolute;
+  inset:0;
+}
+
+.studio-map__placeholder-surface{
+  background:
+    linear-gradient(115deg, rgba(166,124,82,.25) 0 12%, transparent 12% 100%),
+    linear-gradient(90deg, transparent 0 14%, rgba(255,255,255,.09) 14% 15%, transparent 15% 48%, rgba(255,255,255,.06) 48% 49%, transparent 49% 100%),
+    linear-gradient(180deg, rgba(255,255,255,.04), transparent 40%),
+    radial-gradient(circle at 72% 28%, rgba(30,64,34,.5), transparent 18%),
+    radial-gradient(circle at 78% 34%, rgba(30,64,34,.42), transparent 20%),
+    radial-gradient(circle at 61% 72%, rgba(255,255,255,.08), transparent 12%),
+    linear-gradient(0deg, rgba(59,92,44,.55), rgba(84,111,54,.38));
+  transform:scale(1.04);
+}
+
+.studio-map__placeholder-blur{
+  backdrop-filter:blur(2.5px) saturate(.9);
+  background:linear-gradient(180deg, rgba(13,17,23,.08), rgba(13,17,23,.2));
+}
+
 .settings-seismic-summary-card.arkolia-summary-card{
   padding:14px;
   display:flex;
@@ -15009,6 +15043,17 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
 .studio-tool-map-card{
   margin-top:0;
   width:100%;
+  height:calc(100vh - 210px);
+}
+.studio-tool-map-card .studio-map{
+  height:100%;
+  width:100%;
+}
+.studio-tool-map-card .studio-map > iframe{
+  height:100%;
+  width:100%;
+  border:none;
+  border-radius:var(--radius);
 }
 .studio-tool-overlay-grid{
   position:relative;
@@ -15029,13 +15074,15 @@ body.route--project .project-collaborator-create__body .project-collaborators-mo
   border-radius:var(--radius);
   background:var(--bg);
 }
-.studio-tool-info-card-title{
+ .studio-tool-info-card-title,
+.studio-tool-info-card > h4{
   margin:0 0 8px;
   font-size:14px;
   color:var(--muted);
 }
 .studio-tool-info-card ul{
   margin:0;
-  padding-left:16px;
-  font-size:13px;
+  padding-left:0;
+  list-style:none;
+  font-size:14px;
 }


### PR DESCRIPTION
### Motivation
- Ensure the Atelier "Neige, Vent & Gel" tool map fits the viewport and its surrounding card follows the requested sizing.
- Replace the legacy `arkolia-map` wrapper with a `studio-map` wrapper so card-scoped styles can target the studio tool consistently.
- Improve the Adresse card markup and list styling for visual consistency and readability.

### Description
- Updated the climate tool map height from `calc(100vh - 186px)` to `calc(100vh - 210px)` in `apps/web/js/views/studio/solidity/solidity-climate.js` and added matching sizing in CSS for `.studio-tool-map-card`.
- Renamed the shared map wrapper class usages from `arkolia-map` to `studio-map` in `apps/web/js/views/shared/project-location-map-card.js` and added `studio-map` placeholder styles to preserve existing placeholder visuals.
- Added scoped rules so `.studio-tool-map-card .studio-map` and its `iframe` use `height:100%`, `width:100%`, `border:none` and `border-radius:var(--radius)` in `apps/web/style.css`.
- Changed the Adresse card markup to `<h4>Adresse</h4>` with the address inside `<ul><li>…</li></ul>` and updated `.studio-tool-info-card` title selector to match plain `h4` headings.
- Adjusted `.studio-tool-info-card ul` to remove list markers (`list-style:none`, `padding-left:0`) and increased `font-size` to `14px`.

### Testing
- Verified the updated selectors and occurrences with `rg` searches which returned the expected modified files and lines.
- Inspected file snippets with `sed -n` to confirm the new `h4` address markup, the changed height, and the `studio-map` wrapper and `iframe` output.
- Reviewed the produced code diff to confirm the set of edits and generated PR metadata; all automated checks used during the rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f334a334f4832986eff513c99248a5)