### PR TITLE
Add studio “Transformer en sujet” draft prefill flow for climate tools

### DIFF
--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -1061,6 +1061,33 @@ function ensureSubjectsCollaboratorsLoaded() {
 
 
 
+
+export function openStudioToolSubjectDraft({
+  title = "",
+  description = "",
+  meta = null,
+  origin = "studio-tool"
+} = {}) {
+  console.info("[studio-tool-subject] open-draft", { origin });
+  const options = {
+    origin: "table",
+    initialTitle: String(title || ""),
+    initialDescription: String(description || "")
+  };
+  if (meta && typeof meta === "object") options.meta = meta;
+  openCreateSubjectForm(options);
+  console.info("[studio-tool-subject] draft-prefilled", {
+    titleLength: options.initialTitle.length,
+    descriptionLength: options.initialDescription.length
+  });
+  rerenderPanels();
+  return true;
+}
+
+if (typeof window !== "undefined") {
+  window.openStudioToolSubjectDraft = openStudioToolSubjectDraft;
+}
+
 /* =========================================================
    Public render
 ========================================================= */

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -548,15 +548,20 @@ function openCreateSubjectForm(options = {}) {
     ? (String(options.parentSubjectId || sourceSubjectId || "").trim() || null)
     : null;
   const scopeHost = String(options.scopeHost || "").trim().toLowerCase() === "drilldown" ? "drilldown" : "main";
+  const initialTitle = String(options.initialTitle || "");
+  const initialDescription = String(options.initialDescription || "");
+  const initialMeta = options.meta && typeof options.meta === "object" ? options.meta : null;
   store.situationsView.subjectsSubview = "subjects";
   if (mode !== "subissue") store.situationsView.showTableOnly = true;
   store.situationsView.createSubjectForm = {
     isOpen: true,
-    title: "",
-    description: "",
+    title: initialTitle,
+    description: initialDescription,
     previewMode: false,
     createMore: mode === "subissue" ? false : previousCreateMore,
-    meta: mode === "subissue" ? buildSubissueDraftMeta(parentSubjectId) : buildDefaultDraftSubjectMeta(),
+    meta: mode === "subissue"
+      ? buildSubissueDraftMeta(parentSubjectId)
+      : (initialMeta ? { ...buildDefaultDraftSubjectMeta(), ...initialMeta } : buildDefaultDraftSubjectMeta()),
     validationError: "",
     isSubmitting: false,
     uploadSessionId: "",

--- a/apps/web/js/views/studio/solidity/solidity-climate.js
+++ b/apps/web/js/views/studio/solidity/solidity-climate.js
@@ -16,6 +16,18 @@ const TOOL_LABELS = {
 
 const state = { loading: false, error: "", projectId: "", location: null, results: {}, mapUrl: "", mapLoading: false };
 
+function buildClimateDraftDescription() {
+  return TOOL_KEYS
+    .map((toolKey) => String(state.results?.[toolKey]?.markdown_summary || "").trim())
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function buildClimateDraftTitle() {
+  const city = String(state.location?.city || "").trim();
+  return city ? `Charges climatiques — ${city}` : "";
+}
+
 export async function renderSolidityClimate(root, { force = false } = {}) {
   if (!root) return;
   if (!force && root.dataset.solidityClimateMounted === "true") return;
@@ -34,8 +46,21 @@ export async function renderSolidityClimate(root, { force = false } = {}) {
 
     const toSubjectTrigger = event.target.closest('[data-action-id="solidityToolToSubject-climate"]');
     if (toSubjectTrigger) {
-      console.info("[studio-tools] transform-to-subject.click", { toolKey: "climate" });
-      console.info("[studio-tools] transform-to-subject.todo", { toolKeys: TOOL_KEYS });
+      const description = buildClimateDraftDescription();
+      const title = buildClimateDraftTitle();
+      const opener = typeof window !== "undefined" ? window.openStudioToolSubjectDraft : null;
+      if (typeof opener === "function") {
+        opener({
+          origin: "studio-climate",
+          title,
+          description,
+          meta: {
+            labels: ["climatique"]
+          }
+        });
+      } else {
+        console.warn("[studio-tool-subject] open-draft unavailable", { toolKey: "climate" });
+      }
     }
   };
 


### PR DESCRIPTION
### Motivation
- Éviter la création automatique d’un sujet depuis les outils Atelier en ouvrant d’abord un brouillon contrôlé par l’utilisateur.
- Préremplir le formulaire de création avec une description issue des `markdown_summary` (neige/vent/gel) et proposer un titre suggéré quand possible.
- Réutiliser le flux normal de création (`createSubjectFromDraft`) pour conserver les comportements existants (annulation, uploading, mise à jour de description).

### Description
- `openCreateSubjectForm` (fichier `apps/web/js/views/project-subjects/project-subjects-view.js`) accepte maintenant `options.initialTitle`, `options.initialDescription` et `options.meta` et initialise le formulaire sans casser les appels existants.
- Ajout de `openStudioToolSubjectDraft(...)` dans `apps/web/js/views/project-subjects.js` qui logge les événements `[studio-tool-subject] open-draft` et `[studio-tool-subject] draft-prefilled`, appelle `openCreateSubjectForm` et relance le rendu des panneaux.
- Le bouton « Transformer en sujet » de l’outil climatique (fichier `apps/web/js/views/studio/solidity/solidity-climate.js`) appelle le nouvel ouvreur au lieu de créer directement un sujet, en construisant la description par concaténation des `markdown_summary` et en suggérant un titre basé sur la ville, et en passant un `meta` minimal (étiquette `climatique`).
- La preview Markdown reste inchangée puisqu’elle est calculée depuis `form.description` (utilise déjà `mdToHtml` dans le rendu du formulaire).

### Testing
- Exécution ciblée des tests Node liés au flux de création de sujet: `node --test apps/web/js/views/project-subjects/project-subjects-create-subject-context.test.mjs apps/web/js/views/project-subjects/project-subjects-create-subissue-submit-flow.test.mjs` et tous les tests sont passés.
- Les comportements managés par le formulaire (préremplissage, annulation, création via `createSubjectFromDraft`) sont préservés par l’implémentation et la preview Markdown utilise la valeur préremplie `description`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33956de9c8329a081968657e232e3)