### PR TITLE
PV hangar neuf — expand summary details by default, persist state, and reorder Relation cards

### DIFF
--- a/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
+++ b/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
@@ -44,7 +44,7 @@ const arkoliaUiState = {
   debounceTimer: null,
   mapUrl: "",
   mapLoading: false,
-  detailsExpanded: false,
+  detailsExpanded: true,
   summaryLoading: false,
   identity: { ...DEFAULT_IDENTITY },
   relation: { ...DEFAULT_RELATION },
@@ -85,6 +85,32 @@ function showCopyButtonSuccess(button, copiedTitle, defaultTitle) {
     resetCopyButtonState(button, defaultTitle);
   }, 2000);
   button.dataset.arkoliaCopyResetTimer = String(timerId);
+}
+
+function getArkoliaDetailsExpandedStorageKey() {
+  const projectId = String(store.currentProjectId || "default").trim() || "default";
+  return `rapsobot.arkolia.detailsExpanded.${projectId}`;
+}
+
+function readPersistedArkoliaDetailsExpanded() {
+  try {
+    const raw = localStorage.getItem(getArkoliaDetailsExpandedStorageKey());
+    if (raw === null) return true;
+    return raw === 'true';
+  } catch {
+    return true;
+  }
+}
+
+function persistArkoliaDetailsExpanded(value) {
+  const nextValue = Boolean(value);
+  arkoliaUiState.detailsExpanded = nextValue;
+  try {
+    localStorage.setItem(getArkoliaDetailsExpandedStorageKey(), String(nextValue));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getArkoliaReferenceStorageKey() {
@@ -555,35 +581,35 @@ function renderIdentitySection() {
       <span class="settings-card__head-title"><h4>Relation et avis</h4></span>
     </div>
 
-    <div class="arkolia-relation-generalities-card">
-      <div class="arkolia-identity-section__title">Généralités</div>
-      <div class="arkolia-relation-generalities">
-        <div class="arkolia-relation-generalities__line arkolia-relation-generalities__line--inline">
-          ${renderIdentityRadioGroup('buildingOpen', [
-            { value: 'open', label: 'Bâtiment ouvert' }
-          ], relation.buildingOpen ? 'open' : '', { dataAttribute: 'data-arkolia-relation-radio' })}
-          <div class="arkolia-relation-generalities__label">Bâtiment fermé :</div>
-          ${renderIdentityRadioGroup('closedFacades', [
-            { value: 'Nord', label: 'Nord' },
-            { value: 'Sud', label: 'Sud' },
-            { value: 'Est', label: 'Est' },
-            { value: 'Ouest', label: 'Ouest' }
-          ], relation.closedFacades, { type: 'checkbox', dataAttribute: 'data-arkolia-relation-checkbox' })}
-        </div>
+    <div class="settings-stack settings-stack--lg">
+      <div class="arkolia-relation-generalities-card">
+        <div class="arkolia-identity-section__title">Généralités</div>
+        <div class="arkolia-relation-generalities">
+          <div class="arkolia-relation-generalities__line arkolia-relation-generalities__line--inline">
+            ${renderIdentityRadioGroup('buildingOpen', [
+              { value: 'open', label: 'Bâtiment ouvert' }
+            ], relation.buildingOpen ? 'open' : '', { dataAttribute: 'data-arkolia-relation-radio' })}
+            <div class="arkolia-relation-generalities__label">Bâtiment fermé :</div>
+            ${renderIdentityRadioGroup('closedFacades', [
+              { value: 'Nord', label: 'Nord' },
+              { value: 'Sud', label: 'Sud' },
+              { value: 'Est', label: 'Est' },
+              { value: 'Ouest', label: 'Ouest' }
+            ], relation.closedFacades, { type: 'checkbox', dataAttribute: 'data-arkolia-relation-checkbox' })}
+          </div>
 
-        <div class="arkolia-relation-generalities__line arkolia-relation-generalities__line--inline">
-          <div class="arkolia-relation-generalities__label">Rugosité du terrain :</div>
-          ${renderIdentityRadioGroup('terrainRoughness', [
-            { value: 'II', label: 'II' },
-            { value: 'IIIa', label: 'IIIa' },
-            { value: 'IIIb', label: 'IIIb' },
-            { value: 'IV', label: 'IV' }
-          ], relation.terrainRoughness || 'IIIa', { dataAttribute: 'data-arkolia-relation-radio' })}
+          <div class="arkolia-relation-generalities__line arkolia-relation-generalities__line--inline">
+            <div class="arkolia-relation-generalities__label">Rugosité du terrain :</div>
+            ${renderIdentityRadioGroup('terrainRoughness', [
+              { value: 'II', label: 'II' },
+              { value: 'IIIa', label: 'IIIa' },
+              { value: 'IIIb', label: 'IIIb' },
+              { value: 'IV', label: 'IV' }
+            ], relation.terrainRoughness || 'IIIa', { dataAttribute: 'data-arkolia-relation-radio' })}
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="arkolia-relation-cards-grid">
       <div class="arkolia-identity-preview arkolia-identity-preview--compact">
         <div class="arkolia-identity-preview__head">
           <div class="arkolia-identity-preview__title">Relation</div>
@@ -1068,7 +1094,7 @@ function bindSummaryCardActions() {
   if (!toggle || toggle.dataset.bound === 'true') return;
   toggle.dataset.bound = 'true';
   toggle.addEventListener('click', () => {
-    arkoliaUiState.detailsExpanded = !arkoliaUiState.detailsExpanded;
+    persistArkoliaDetailsExpanded(!arkoliaUiState.detailsExpanded);
     renderResultCard();
   });
 }
@@ -1454,7 +1480,7 @@ export async function renderSolidityArkolia(root) {
   resetSuggestions();
   arkoliaUiState.selected = null;
   arkoliaUiState.query = "";
-  arkoliaUiState.detailsExpanded = false;
+  arkoliaUiState.detailsExpanded = readPersistedArkoliaDetailsExpanded();
   arkoliaUiState.identity = { ...DEFAULT_IDENTITY };
   arkoliaUiState.relation = { ...DEFAULT_RELATION };
   arkoliaUiState.referenceName = readPersistedArkoliaReference();


### PR DESCRIPTION
### Motivation
- Make the summary details panel more discoverable by opening `arkolia-summary-card__details` by default and remember the user's preference per project.
- Improve the layout of the "Relation et avis" block to match the requested presentation and grouping.

### Description
- Set the default `arkoliaUiState.detailsExpanded` to `true` in `apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js`.
- Add per-project persistence functions `getArkoliaDetailsExpandedStorageKey()`, `readPersistedArkoliaDetailsExpanded()` and `persistArkoliaDetailsExpanded()` that store the expanded state in `localStorage` and update `arkoliaUiState.detailsExpanded`.
- Use `readPersistedArkoliaDetailsExpanded()` when initializing the view (`renderSolidityArkolia`) and call `persistArkoliaDetailsExpanded()` from the summary toggle handler instead of flipping the in-memory flag directly.
- Reorganize the markup inside `renderIdentitySection()` to wrap `arkolia-relation-generalities-card` and the three compact identity previews in a `div` with class `settings-stack settings-stack--lg`, and ensure the compact cards appear in the requested order: `Relation`, then `Avis`, then `Paramètres climatiques`.

### Testing
- Confirmed changes by searching for affected identifiers with `rg` and inspecting the modified file content with file view commands; those inspections matched the intended edits (succeeded).
- Verified the new persistence and initialization logic is present in `apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js` by inspecting the diff and file snippets (succeeded).
- No automated unit/UI tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35426a7088329881361ed58966ef6)