### PR TITLE
Brancher le bouton Nouveau sujet pour ENR - PV hangar neuf

### DIFF
--- a/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
+++ b/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
@@ -295,6 +295,61 @@ function renderNewSubjectButton() {
   });
 }
 
+
+function getSelectedSpanLabel() {
+  const identity = arkoliaUiState.identity || {};
+  const spanValue = identity.spanPreset === 'other'
+    ? normalizeDimension(identity.spanOther)
+    : normalizeDimension(identity.spanPreset);
+  return spanValue || '…';
+}
+
+function buildArkoliaDraftTitle() {
+  const selected = arkoliaUiState.selected || {};
+  const departmentCode = String(selected.departmentCode || '').trim() || '—';
+  const cityName = getSelectedCityName();
+  const length = normalizeDimension(arkoliaUiState.identity?.length) || '…';
+  const width = normalizeDimension(arkoliaUiState.identity?.width) || '…';
+  const span = getSelectedSpanLabel();
+  return `${departmentCode} ${cityName} ENR - PV hangar neuf ${length} m x ${width} m, travée ${span} m`;
+}
+
+function buildArkoliaDraftDescription() {
+  const postalCode = getSelectedPostalCode();
+  const cityName = getSelectedCityName();
+  const relationName = String(arkoliaUiState.relation?.builderName || 'ARKOLIA').trim() || 'ARKOLIA';
+
+  const sections = [
+    ["Description de l'ouvrage", getIdentityDescription()],
+    ['Avis', getRelationSummary()],
+    ['Paramètres climatiques', getClimateText()],
+    ["Niveau d'assise", getAssiseText()],
+    ['Portance', getPortanceText()]
+  ];
+
+  const paragraphBlocks = sections
+    .map(([title, value]) => `### ${title}\n${value || '—'}`)
+    .join('\n\n');
+
+  return `${postalCode} ${cityName} ${relationName}\n\n${paragraphBlocks}`;
+}
+
+function openArkoliaSubjectDraft() {
+  const opener = typeof window !== 'undefined' ? window.openStudioToolSubjectDraft : null;
+  if (typeof opener === 'function') {
+    opener({
+      origin: 'studio-arkolia-enr-pv-hangar-neuf',
+      title: buildArkoliaDraftTitle(),
+      description: buildArkoliaDraftDescription(),
+      meta: {
+        labels: ['enr', 'pv', 'hangar-neuf']
+      }
+    });
+  } else {
+    console.warn('[studio-tool-subject] open-draft unavailable', { toolKey: 'arkolia-enr-pv-hangar-neuf' });
+  }
+}
+
 function parseFrenchDecimalToNumber(value) {
   const normalized = String(value ?? '').trim().replace(/,/g, '.');
   const number = Number(normalized);
@@ -1555,5 +1610,15 @@ export async function renderSolidityArkolia(root) {
   renderAutocompleteDropdown();
 
   renderResultCard();
+
+  if (root.dataset.arkoliaSubjectActionBound !== 'true') {
+    root.dataset.arkoliaSubjectActionBound = 'true';
+    root.addEventListener('click', (event) => {
+      const newSubjectTrigger = event.target.closest('[data-action-id="arkoliaNewSubjectAction"]');
+      if (!newSubjectTrigger) return;
+      openArkoliaSubjectDraft();
+    });
+  }
+
   registerProjectPrimaryScrollSource(root.closest("#projectSolidityRouterScroll") || document.getElementById("projectSolidityRouterScroll"));
 }


### PR DESCRIPTION
### Motivation
- Permettre au bouton `Nouveau sujet` de l'outil « ENR - PV hangar neuf » d'ouvrir directement le formulaire de création de sujet pré-rempli, en réutilisant la mécanique existante utilisée par « Transformer en sujet » dans l'outil Climatique.

### Description
- Ajout de fonctions utilitaires `getSelectedSpanLabel`, `buildArkoliaDraftTitle`, `buildArkoliaDraftDescription` et `openArkoliaSubjectDraft` dans `apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js` pour générer titre et description pré-remplis.
- Le titre pré-rempli suit le format demandé : `Numéro de département + Nom de la ville + ENR - PV hangar neuf + longueur m x largeur m, travée X m` via `buildArkoliaDraftTitle()`.
- La description pré-remplie commence par `code postal + nom ville + relation` puis ajoute des paragraphes titrés contenant les champs associés (`Description de l'ouvrage`, `Avis`, `Paramètres climatiques`, `Niveau d'assise`, `Portance`) via `buildArkoliaDraftDescription()`.
- Raccordement du bouton rendu par `renderNewSubjectButton()` à l'ouverture du brouillon : ajout d'un écouteur sur le `root` qui déclenche `openArkoliaSubjectDraft()` lorsque l'élément `data-action-id="arkoliaNewSubjectAction"` est cliqué et utilisation de `window.openStudioToolSubjectDraft` pour ouvrir le draft.

### Testing
- Vérification syntaxique JavaScript avec `node --check apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js` et correction des littéraux multilignes erronés, commande exécutée avec succès.
- Inspection rapide de l'état du working tree avec `git status --short` et commit du fichier modifié effectué avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36d83c6a08329a83503e810dc7892)