### PR TITLE
Add Arkolia subject draft creation and fix responsive map height

### DIFF
--- a/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
+++ b/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
@@ -295,6 +295,65 @@ function renderNewSubjectButton() {
   });
 }
 
+
+function getSelectedSpanLabel() {
+  const identity = arkoliaUiState.identity || {};
+  const spanValue = identity.spanPreset === 'other'
+    ? normalizeDimension(identity.spanOther)
+    : normalizeDimension(identity.spanPreset);
+  return spanValue || '…';
+}
+
+function buildArkoliaDraftTitle() {
+  const selected = arkoliaUiState.selected || {};
+  const departmentCode = String(selected.departmentCode || '').trim() || '—';
+  const cityName = getSelectedCityName();
+  const length = normalizeDimension(arkoliaUiState.identity?.length) || '…';
+  const width = normalizeDimension(arkoliaUiState.identity?.width) || '…';
+  const span = getSelectedSpanLabel();
+  return `${departmentCode}_${cityName} : ENR - PV hangar neuf ${length} m x ${width} m, travée ${span} m`;
+}
+
+function buildArkoliaDraftDescription() {
+  const postalCode = getSelectedPostalCode();
+  const cityName = getSelectedCityName();
+  const relationName = String(arkoliaUiState.relation?.builderName || 'ARKOLIA').trim() || 'ARKOLIA';
+  const relationLabel = `**${relationName}**`;
+
+  const sections = [
+    ["Description de l'ouvrage", getIdentityDescription()],
+    ['Avis', getRelationSummary()],
+    ['Paramètres climatiques', getClimateText()],
+    ["Niveau d'assise", getAssiseText()],
+    ['Portance', getPortanceText()]
+  ];
+
+  const paragraphBlocks = sections
+    .map(([title, value]) => `\n### ${title}\n${value || '—'}`)
+    .join('\n\n');
+
+  const description = `## ${postalCode} ${cityName} ${relationLabel}\n\n${paragraphBlocks}`;
+  return description
+    .replace(/altitude\s+(\d+(?:[.,]\d+)?)\s+mètres/gi, (_match, value) => `altitude \`${String(value).replace(',', '.') } mètres\``)
+    .replace(/H\s*>\s*([0-9]+(?:[.,][0-9]+)?)\s*m/gi, (_match, value) => `\`H > ${String(value).replace(',', '.')} m\``);
+}
+
+function openArkoliaSubjectDraft() {
+  const opener = typeof window !== 'undefined' ? window.openStudioToolSubjectDraft : null;
+  if (typeof opener === 'function') {
+    opener({
+      origin: 'studio-arkolia-enr-pv-hangar-neuf',
+      title: buildArkoliaDraftTitle(),
+      description: buildArkoliaDraftDescription(),
+      meta: {
+        labels: ['enr', 'pv', 'hangar-neuf']
+      }
+    });
+  } else {
+    console.warn('[studio-tool-subject] open-draft unavailable', { toolKey: 'arkolia-enr-pv-hangar-neuf' });
+  }
+}
+
 function parseFrenchDecimalToNumber(value) {
   const normalized = String(value ?? '').trim().replace(/,/g, '.');
   const number = Number(normalized);
@@ -973,10 +1032,6 @@ function normalizeAltitude(value) {
   return Number.isFinite(value) ? `${value} m` : "—";
 }
 
-const ARKOLIA_SUMMARY_REQUIRED_FIELDS = [
-  "name", "hasCantonMismatch", "postalCode", "departmentCode", "departmentName", "codeInsee", "coordinates", "altitude", "frostDepthH", "frostDepthH0", "currentCantonName", "cantonName2014", "windZone", "snowZone"
-];
-
 function normalizeCoordinate(value) {
   const number = Number(value);
   return Number.isFinite(number) ? number.toFixed(6) : "—";
@@ -1499,7 +1554,7 @@ export async function renderSolidityArkolia(root) {
                 ${renderNewSubjectButton()}
               </div>
             </div>
-            <p><strong>Informations requises pour la synthèse :</strong> ${ARKOLIA_SUMMARY_REQUIRED_FIELDS.join(', ')}<br>Analyse autonome des fondations pour les hangars agricoles neufs avec panneaux photovoltaïques sur couverture bac acier. Recherche par ville avec auto-complétion, récupération du canton 2014 par code INSEE, affichage des coordonnées, détermination automatique des zones de vent et de neige. Définition automatique des dimensions minimales des fondations et profondeur hors gel à respecter.</p>
+            <p>Analyse autonome des fondations pour les hangars agricoles neufs avec panneaux photovoltaïques sur couverture bac acier. Recherche par ville avec auto-complétion, récupération du canton 2014 par code INSEE, affichage des coordonnées, détermination automatique des zones de vent et de neige. Définition automatique des dimensions minimales des fondations et profondeur hors gel à respecter.</p>
           </div>
           <div class="arkolia-head-reference">
             <label class="arkolia-head-reference__field" for="solidityArkoliaReference">
@@ -1555,5 +1610,15 @@ export async function renderSolidityArkolia(root) {
   renderAutocompleteDropdown();
 
   renderResultCard();
+
+  if (root.dataset.arkoliaSubjectActionBound !== 'true') {
+    root.dataset.arkoliaSubjectActionBound = 'true';
+    root.addEventListener('click', (event) => {
+      const newSubjectTrigger = event.target.closest('[data-action-id="arkoliaNewSubjectAction"]');
+      if (!newSubjectTrigger) return;
+      openArkoliaSubjectDraft();
+    });
+  }
+
   registerProjectPrimaryScrollSource(root.closest("#projectSolidityRouterScroll") || document.getElementById("projectSolidityRouterScroll"));
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -12764,10 +12764,20 @@ circle.situation-trajectory__hierarchy-link--blocked,
     grid-template-columns:minmax(0,1fr);
   }
 
-  .settings-seismic-chart-card.arkolia-map-card,
+  .settings-seismic-chart-card.arkolia-map-card{
+    height:490px;
+    min-height:490px;
+  }
+
   .settings-seismic-summary-card.arkolia-summary-card{
     height:auto;
     min-height:490px;
+  }
+
+  .settings-seismic-chart-card.arkolia-map-card .arkolia-map,
+  .settings-seismic-chart-card.arkolia-map-card .arkolia-map iframe{
+    height:100%;
+    min-height:100%;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a way to open a pre-filled Arkolia subject draft for the "ENR - PV hangar neuf" workflow using the new "Nouveau sujet" action. 
- Improve responsive rendering of the embedded Google Maps card so it has a consistent minimum height on small screens.

### Description
- Implemented draft builders: `getSelectedSpanLabel`, `buildArkoliaDraftTitle`, and `buildArkoliaDraftDescription` to assemble a title and detailed markdown description from the current UI state. 
- Added `openArkoliaSubjectDraft` which calls `window.openStudioToolSubjectDraft` with `origin`, `title`, `description`, and `meta.labels` when available. 
- Rendered the new action button via `renderNewSubjectButton` and bound a single click handler on the root (guarded by `root.dataset.arkoliaSubjectActionBound`) to trigger the draft opener. 
- Removed the previous summary-required-fields line from the header text and kept the informational paragraph. 
- Adjusted CSS to ensure `.settings-seismic-chart-card.arkolia-map-card` has a fixed `height` and `min-height` of `490px` on small screens and made the map container and iframe fill that height.

### Testing
- Ran unit tests with `yarn test` and they passed. 
- Ran the linter with `yarn lint` and no issues were reported. 
- Built the frontend with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36d83c6a08329a83503e810dc7892)