### PR TITLE
Add Arkolia subject draft action and responsive layout refinements

### DIFF
--- a/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
+++ b/apps/web/js/views/studio/socotec/socotec-enr-pv-hangard-neuf.js
@@ -295,6 +295,65 @@ function renderNewSubjectButton() {
   });
 }
 
+
+function getSelectedSpanLabel() {
+  const identity = arkoliaUiState.identity || {};
+  const spanValue = identity.spanPreset === 'other'
+    ? normalizeDimension(identity.spanOther)
+    : normalizeDimension(identity.spanPreset);
+  return spanValue || '…';
+}
+
+function buildArkoliaDraftTitle() {
+  const selected = arkoliaUiState.selected || {};
+  const departmentCode = String(selected.departmentCode || '').trim() || '—';
+  const cityName = getSelectedCityName();
+  const length = normalizeDimension(arkoliaUiState.identity?.length) || '…';
+  const width = normalizeDimension(arkoliaUiState.identity?.width) || '…';
+  const span = getSelectedSpanLabel();
+  return `${departmentCode}_${cityName} : ENR - PV hangar neuf ${length} m x ${width} m, travée ${span} m`;
+}
+
+function buildArkoliaDraftDescription() {
+  const postalCode = getSelectedPostalCode();
+  const cityName = getSelectedCityName();
+  const relationName = String(arkoliaUiState.relation?.builderName || 'ARKOLIA').trim() || 'ARKOLIA';
+  const relationLabel = `**${relationName}**`;
+
+  const sections = [
+    ["Description de l'ouvrage", getIdentityDescription()],
+    ['Avis', getRelationSummary()],
+    ['Paramètres climatiques', getClimateText()],
+    ["Niveau d'assise", getAssiseText()],
+    ['Portance', getPortanceText()]
+  ];
+
+  const paragraphBlocks = sections
+    .map(([title, value]) => `\n### ${title}\n${value || '—'}`)
+    .join('\n\n');
+
+  const description = `## ${postalCode} ${cityName} ${relationLabel}\n\n${paragraphBlocks}`;
+  return description
+    .replace(/altitude\s+(\d+(?:[.,]\d+)?)\s+mètres/gi, (_match, value) => `altitude \`${String(value).replace(',', '.') } mètres\``)
+    .replace(/H\s*>\s*([0-9]+(?:[.,][0-9]+)?)\s*m/gi, (_match, value) => `\`H > ${String(value).replace(',', '.')} m\``);
+}
+
+function openArkoliaSubjectDraft() {
+  const opener = typeof window !== 'undefined' ? window.openStudioToolSubjectDraft : null;
+  if (typeof opener === 'function') {
+    opener({
+      origin: 'studio-arkolia-enr-pv-hangar-neuf',
+      title: buildArkoliaDraftTitle(),
+      description: buildArkoliaDraftDescription(),
+      meta: {
+        labels: ['enr', 'pv', 'hangar-neuf']
+      }
+    });
+  } else {
+    console.warn('[studio-tool-subject] open-draft unavailable', { toolKey: 'arkolia-enr-pv-hangar-neuf' });
+  }
+}
+
 function parseFrenchDecimalToNumber(value) {
   const normalized = String(value ?? '').trim().replace(/,/g, '.');
   const number = Number(normalized);
@@ -615,11 +674,11 @@ function renderIdentitySection() {
       </div>
     </div>
 
-    <div class="settings-seismic-sizing-layout__row settings-seismic-sizing-layout__row--top arkolia-result-layout arkolia-identity-row">
-      <div class="settings-stack settings-stack--lg">
+    <div class="settings-seismic-sizing-layout__row settings-seismic-sizing-layout__row--top arkolia-result-layout arkolia-identity-row arkolia-identity-row--analysis">
+      <div class="settings-stack settings-stack--lg arkolia-analysis-assise">
         ${renderAssiseCard()}
       </div>
-      <div class="settings-stack settings-stack--lg">
+      <div class="settings-stack settings-stack--lg arkolia-analysis-climate">
         <div class="arkolia-identity-preview arkolia-identity-preview--compact">
           <div class="arkolia-identity-preview__head">
             <div class="arkolia-identity-preview__title">Avis</div>
@@ -972,10 +1031,6 @@ function resetSuggestions() {
 function normalizeAltitude(value) {
   return Number.isFinite(value) ? `${value} m` : "—";
 }
-
-const ARKOLIA_SUMMARY_REQUIRED_FIELDS = [
-  "name", "hasCantonMismatch", "postalCode", "departmentCode", "departmentName", "codeInsee", "coordinates", "altitude", "frostDepthH", "frostDepthH0", "currentCantonName", "cantonName2014", "windZone", "snowZone"
-];
 
 function normalizeCoordinate(value) {
   const number = Number(value);
@@ -1499,7 +1554,7 @@ export async function renderSolidityArkolia(root) {
                 ${renderNewSubjectButton()}
               </div>
             </div>
-            <p><strong>Informations requises pour la synthèse :</strong> ${ARKOLIA_SUMMARY_REQUIRED_FIELDS.join(', ')}<br>Analyse autonome des fondations pour les hangars agricoles neufs avec panneaux photovoltaïques sur couverture bac acier. Recherche par ville avec auto-complétion, récupération du canton 2014 par code INSEE, affichage des coordonnées, détermination automatique des zones de vent et de neige. Définition automatique des dimensions minimales des fondations et profondeur hors gel à respecter.</p>
+            <p>Analyse autonome des fondations pour les hangars agricoles neufs avec panneaux photovoltaïques sur couverture bac acier. Recherche par ville avec auto-complétion, récupération du canton 2014 par code INSEE, affichage des coordonnées, détermination automatique des zones de vent et de neige. Définition automatique des dimensions minimales des fondations et profondeur hors gel à respecter.</p>
           </div>
           <div class="arkolia-head-reference">
             <label class="arkolia-head-reference__field" for="solidityArkoliaReference">
@@ -1555,5 +1610,15 @@ export async function renderSolidityArkolia(root) {
   renderAutocompleteDropdown();
 
   renderResultCard();
+
+  if (root.dataset.arkoliaSubjectActionBound !== 'true') {
+    root.dataset.arkoliaSubjectActionBound = 'true';
+    root.addEventListener('click', (event) => {
+      const newSubjectTrigger = event.target.closest('[data-action-id="arkoliaNewSubjectAction"]');
+      if (!newSubjectTrigger) return;
+      openArkoliaSubjectDraft();
+    });
+  }
+
   registerProjectPrimaryScrollSource(root.closest("#projectSolidityRouterScroll") || document.getElementById("projectSolidityRouterScroll"));
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -12764,10 +12764,28 @@ circle.situation-trajectory__hierarchy-link--blocked,
     grid-template-columns:minmax(0,1fr);
   }
 
-  .settings-seismic-chart-card.arkolia-map-card,
+  .settings-seismic-chart-card.arkolia-map-card{
+    height:490px;
+    min-height:490px;
+  }
+
   .settings-seismic-summary-card.arkolia-summary-card{
     height:auto;
     min-height:490px;
+  }
+
+  .settings-seismic-chart-card.arkolia-map-card .arkolia-map,
+  .settings-seismic-chart-card.arkolia-map-card .arkolia-map iframe{
+    height:100%;
+    min-height:100%;
+  }
+
+  .arkolia-identity-row--analysis .arkolia-analysis-climate{
+    order:1;
+  }
+
+  .arkolia-identity-row--analysis .arkolia-analysis-assise{
+    order:2;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a quick way to open a prefilled subject draft for the Arkolia "ENR - PV hangar neuf" workflow to speed up ticket/subject creation from the studio UI.
- Improve responsive presentation and ordering of the analysis preview blocks and ensure embedded Google Maps has a stable height on small screens.

### Description
- Implemented draft-building helpers and action: added `getSelectedSpanLabel`, `buildArkoliaDraftTitle`, `buildArkoliaDraftDescription`, and `openArkoliaSubjectDraft` to compose a title, rich Markdown description, and metadata for a subject draft.
- Wired the new subject button to open the draft by attaching a click listener in `renderSolidityArkolia` and guarding it with `root.dataset.arkoliaSubjectActionBound` to avoid duplicate bindings.
- Removed the displayed `ARKOLIA_SUMMARY_REQUIRED_FIELDS` list and its constant usage in the header paragraph to simplify the UI text.
- Added layout and CSS adjustments: introduced `arkolia-identity-row--analysis`, `arkolia-analysis-assise`, and `arkolia-analysis-climate` classes in markup and updated `style.css` to set map card min-heights and to alter ordering of analysis blocks on small screens.
- Minor description formatting: `buildArkoliaDraftDescription` normalizes French decimals and formats altitude and `H > ... m` occurrences as inline code.

### Testing
- Ran the frontend linting (`yarn lint`) and static checks which completed successfully.
- Executed the JavaScript unit test suite (`yarn test`) and observed all tests passing.
- Built the web assets (`yarn build`) to verify CSS and markup integration without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36d83c6a08329a83503e810dc7892)