### PR TITLE
Add shared pagination UI utilities

### DIFF
--- a/apps/web/js/views/ui/pagination.js
+++ b/apps/web/js/views/ui/pagination.js
@@ -1,0 +1,113 @@
+const DEFAULT_PAGE_SIZE = 25;
+const EDGE_WINDOW_SIZE = 2;
+const MIDDLE_WINDOW_SIZE = 3;
+
+function normalizePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function normalizePaginationState({ totalItems, pageSize, currentPage } = {}) {
+  const safeTotalItems = Math.max(0, Number.parseInt(totalItems, 10) || 0);
+  const safePageSize = normalizePositiveInteger(pageSize, DEFAULT_PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(safeTotalItems / safePageSize));
+  const normalizedPage = clamp(normalizePositiveInteger(currentPage, 1), 1, totalPages);
+  const startIndex = (normalizedPage - 1) * safePageSize;
+  const endIndex = Math.min(safeTotalItems, startIndex + safePageSize);
+
+  return {
+    totalItems: safeTotalItems,
+    pageSize: safePageSize,
+    totalPages,
+    currentPage: normalizedPage,
+    startIndex,
+    endIndex,
+    hasPreviousPage: normalizedPage > 1,
+    hasNextPage: normalizedPage < totalPages
+  };
+}
+
+export function paginateItems(items = [], paginationState) {
+  const safeItems = Array.isArray(items) ? items : [];
+  const normalized = normalizePaginationState({
+    totalItems: safeItems.length,
+    pageSize: paginationState?.pageSize,
+    currentPage: paginationState?.currentPage
+  });
+
+  return {
+    ...normalized,
+    items: safeItems.slice(normalized.startIndex, normalized.endIndex)
+  };
+}
+
+function getVisiblePages(currentPage, totalPages) {
+  const pages = new Set();
+
+  for (let page = 1; page <= Math.min(totalPages, EDGE_WINDOW_SIZE); page += 1) pages.add(page);
+  const middleStart = Math.max(1, currentPage - 1);
+  const middleEnd = Math.min(totalPages, middleStart + MIDDLE_WINDOW_SIZE - 1, currentPage + 1);
+  for (let page = middleStart; page <= middleEnd; page += 1) pages.add(page);
+  for (let page = Math.max(1, totalPages - EDGE_WINDOW_SIZE + 1); page <= totalPages; page += 1) pages.add(page);
+
+  const sorted = [...pages].sort((a, b) => a - b);
+  const tokens = [];
+
+  for (const page of sorted) {
+    const previous = tokens.length ? tokens[tokens.length - 1] : null;
+    if (typeof previous === 'number' && page - previous > 1) tokens.push('ellipsis');
+    tokens.push(page);
+  }
+
+  return tokens;
+}
+
+function renderPaginationButton({ entity, page, label, isActive = false, isDisabled = false }) {
+  const classes = ["project-pagination__button"];
+  if (isActive) classes.push("project-pagination__button--active");
+  if (isDisabled) classes.push("project-pagination__button--disabled");
+
+  const disabledAttr = isDisabled ? ' aria-disabled="true" tabindex="-1"' : "";
+
+  return `<button type="button" class="${classes.join(" ")}" data-pagination-entity="${entity}" data-pagination-page="${page}"${disabledAttr}>${label}</button>`;
+}
+
+export function renderPaginationControls(paginationState, options = {}) {
+  const entity = String(options.entity || "").trim();
+  if (!entity) return "";
+
+  const normalized = normalizePaginationState(paginationState);
+  if (normalized.totalPages <= 1) return "";
+
+  const pageTokens = getVisiblePages(normalized.currentPage, normalized.totalPages);
+  const pageButtons = pageTokens.map((token) => {
+    if (token === 'ellipsis') return '<span class="project-pagination__ellipsis" aria-hidden="true">...</span>';
+
+    return renderPaginationButton({
+      entity,
+      page: token,
+      label: String(token),
+      isActive: token === normalized.currentPage
+    });
+  }).join("");
+
+  return `<nav class="project-pagination" aria-label="Pagination">
+    ${renderPaginationButton({
+      entity,
+      page: normalized.currentPage - 1,
+      label: "Previous",
+      isDisabled: !normalized.hasPreviousPage
+    })}
+    ${pageButtons}
+    ${renderPaginationButton({
+      entity,
+      page: normalized.currentPage + 1,
+      label: "Next",
+      isDisabled: !normalized.hasNextPage
+    })}
+  </nav>`;
+}

--- a/apps/web/js/views/ui/pagination.test.mjs
+++ b/apps/web/js/views/ui/pagination.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizePaginationState,
+  paginateItems,
+  renderPaginationControls
+} from './pagination.js';
+
+test('normalizePaginationState enforces defaults and clamps currentPage', () => {
+  const state = normalizePaginationState({ totalItems: 60, pageSize: null, currentPage: 999 });
+  assert.equal(state.pageSize, 25);
+  assert.equal(state.totalPages, 3);
+  assert.equal(state.currentPage, 3);
+  assert.equal(state.startIndex, 50);
+  assert.equal(state.endIndex, 60);
+});
+
+test('paginateItems returns expected page slice', () => {
+  const items = Array.from({ length: 60 }, (_, i) => i + 1);
+  const page = paginateItems(items, { pageSize: 25, currentPage: 2 });
+  assert.equal(page.items.length, 25);
+  assert.deepEqual(page.items.slice(0, 3), [26, 27, 28]);
+  assert.deepEqual(page.items.slice(-2), [49, 50]);
+});
+
+test('renderPaginationControls hides controls when one page only', () => {
+  assert.equal(renderPaginationControls({ totalItems: 3, pageSize: 25, currentPage: 1 }, { entity: 'subjects' }), '');
+});
+
+test('renderPaginationControls renders buttons, active page and ellipsis', () => {
+  const html = renderPaginationControls({ totalItems: 675, pageSize: 25, currentPage: 4 }, { entity: 'subjects' });
+  assert.match(html, /data-pagination-entity="subjects"/);
+  assert.match(html, /project-pagination__button--active/);
+  assert.match(html, /project-pagination__ellipsis/);
+  assert.match(html, /Previous/);
+  assert.match(html, /Next/);
+});


### PR DESCRIPTION
### Motivation
- Provide a single reusable pagination component to enable client-side pagination for Subjects, Situations and Actions. 
- The codebase already contains slicing helpers but pagination was disabled (pageSize null) and no UI/handlers existed. 
- This prepares for subsequent steps to activate pagination across the views without changing business logic or server reload behaviour.

### Description
- Add `apps/web/js/views/ui/pagination.js` exporting `normalizePaginationState({ totalItems, pageSize, currentPage })`, `paginateItems(items, paginationState)` and `renderPaginationControls(paginationState, options)`.
- Enforce defaults and clamping: default `pageSize = 25`, `currentPage` >= 1, `totalPages = max(1, ceil(totalItems/pageSize))`, and clamp `currentPage` between 1 and `totalPages`.
- `renderPaginationControls` returns GitHub-like HTML (Previous / numbered pages / ellipsis / Next), hides when `totalPages <= 1`, marks active page with a dedicated class, disables Previous/Next at bounds, and emits `data-pagination-entity` and `data-pagination-page` attributes on buttons.
- Add unit tests at `apps/web/js/views/ui/pagination.test.mjs` covering normalization, slicing and control rendering, and do not modify other business logic files.

### Testing
- Run `node --test apps/web/js/views/ui/pagination.test.mjs` which executed 4 tests and all passed (4/4).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37e729800832983319b2505180362)