### PR TITLE
Add client-side pagination UI and default pageSize (25) for actions, situations and subjects

### DIFF
--- a/apps/web/js/store.js
+++ b/apps/web/js/store.js
@@ -44,7 +44,7 @@ function createProjectSubjectsViewState() {
   search: "",
   displayDepth: "situations",
   page: 1,
-  pageSize: 80,
+  pageSize: 25,
   detailsModalOpen: false
   };
 }
@@ -75,7 +75,7 @@ function createSituationsViewState() {
     search: "",
     displayDepth: "situations",
     page: 1,
-    pageSize: 80,
+    pageSize: 25,
     detailsModalOpen: false,
     handwritingComposerDraftBySubjectId: {},
     handwritingComposerDraftByKey: {}
@@ -84,6 +84,13 @@ function createSituationsViewState() {
 
 const projectSubjectsView = createProjectSubjectsViewState();
 const situationsView = createSituationsViewState();
+const projectActionsView = {
+  pagination: {
+    mode: "client",
+    pageSize: 25,
+    currentPage: 1
+  }
+};
 
 export const store = {
   user: null,
@@ -171,5 +178,6 @@ export const store = {
   },
 
   projectSubjectsView,
-  situationsView
+  situationsView,
+  projectActionsView
 };

--- a/apps/web/js/views/project-actions.js
+++ b/apps/web/js/views/project-actions.js
@@ -3,11 +3,13 @@ import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrol
 import { getRunLogEntries, getRunMetrics } from "../services/project-automation.js";
 import { syncProjectActionsFromSupabase } from "../services/project-supabase-sync.js";
 import { svgIcon } from "../ui/icons.js";
+import { store } from "../store.js";
 import {
   renderDataTableEmptyState,
   renderDataTableHead,
   renderDataTableShell
 } from "./ui/data-table-shell.js";
+import { normalizePaginationState, paginateItems, renderPaginationControls } from "./ui/pagination.js";
 
 function getRunSuccessIconSvg() {
   return svgIcon("check-circle-fill", {
@@ -332,8 +334,27 @@ function renderRunRows(entries) {
 
 function renderRunsTable() {
   const entries = getRunLogEntries();
+  if (!store.projectActionsView || typeof store.projectActionsView !== "object") {
+    store.projectActionsView = { pagination: { mode: "client", pageSize: 25, currentPage: 1 } };
+  }
+  const pagination = normalizePaginationState({
+    totalItems: entries.length,
+    pageSize: store.projectActionsView?.pagination?.pageSize,
+    currentPage: store.projectActionsView?.pagination?.currentPage
+  });
+  store.projectActionsView.pagination = {
+    ...(store.projectActionsView.pagination && typeof store.projectActionsView.pagination === "object"
+      ? store.projectActionsView.pagination
+      : {}),
+    mode: "client",
+    pageSize: pagination.pageSize,
+    currentPage: pagination.currentPage,
+    totalPages: pagination.totalPages,
+    totalItems: pagination.totalItems
+  };
+  const paged = paginateItems(entries, pagination);
 
-  return renderDataTableShell({
+  const tableHtml = renderDataTableShell({
     className: "workflow-runs-table data-table-shell--document-scroll",
     gridTemplate: "minmax(280px,1.6fr) 220px 170px 120px 120px",
     headHtml: renderDataTableHead({
@@ -348,13 +369,14 @@ function renderRunsTable() {
         "Statut"
       ]
     }),
-    bodyHtml: renderRunRows(entries),
-    state: entries.length ? "ready" : "empty",
+    bodyHtml: renderRunRows(paged.items),
+    state: paged.items.length ? "ready" : "empty",
     emptyHtml: renderDataTableEmptyState({
       title: "Aucune action exécutée",
       description: "Lance une analyse ou un enrichissement manuel pour alimenter le journal d’exécution."
     })
   });
+  return `${tableHtml}${renderPaginationControls(pagination, { entity: "actions" })}`;
 }
 
 function renderProjectActionsContent(root) {
@@ -377,11 +399,36 @@ export function renderProjectActions(root) {
   });
 
   renderProjectActionsContent(root);
+  root.onclick = (event) => {
+    const trigger = event.target?.closest?.('[data-pagination-entity="actions"][data-pagination-page]');
+    if (!trigger) return;
+    event.preventDefault();
+    const nextPage = Math.max(1, Number.parseInt(trigger.getAttribute("data-pagination-page") || "1", 10) || 1);
+    if (!store.projectActionsView || typeof store.projectActionsView !== "object") store.projectActionsView = {};
+    if (!store.projectActionsView.pagination || typeof store.projectActionsView.pagination !== "object") {
+      store.projectActionsView.pagination = { mode: "client", pageSize: 25, currentPage: 1 };
+    }
+    store.projectActionsView.pagination.currentPage = nextPage;
+    renderProjectActionsContent(root);
+  };
   debugProjectScrollPolicy("render-project-actions");
 
   syncProjectActionsFromSupabase({ force: true })
     .then(() => {
       if (!root?.isConnected) return;
+      const entries = getRunLogEntries();
+      const pagination = normalizePaginationState({
+        totalItems: entries.length,
+        pageSize: store.projectActionsView?.pagination?.pageSize,
+        currentPage: store.projectActionsView?.pagination?.currentPage
+      });
+      if (!store.projectActionsView || typeof store.projectActionsView !== "object") {
+        store.projectActionsView = { pagination: { mode: "client", pageSize: 25, currentPage: 1 } };
+      }
+      if (!store.projectActionsView.pagination || typeof store.projectActionsView.pagination !== "object") {
+        store.projectActionsView.pagination = { mode: "client", pageSize: 25, currentPage: 1 };
+      }
+      store.projectActionsView.pagination.currentPage = pagination.currentPage;
       renderProjectActionsContent(root);
     })
     .catch((error) => {

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -2041,6 +2041,20 @@ export function createProjectSituationsEvents({
         }
         store.situationsView.situationsStatusFilter = value;
         store.situationsView.filters.status = value;
+        ensureSituationsPaginationState().currentPage = 1;
+        rerender(root);
+      });
+    });
+
+    root.querySelectorAll('[data-pagination-entity="situations"][data-pagination-page]').forEach((node) => {
+      node.addEventListener("click", (event) => {
+        event.preventDefault();
+        const nextPage = Math.max(1, Number.parseInt(node.getAttribute("data-pagination-page") || "1", 10) || 1);
+        const pagination = ensureSituationsPaginationState();
+        const totalPages = Math.max(1, Number.parseInt(pagination.totalPages, 10) || 1);
+        const previousPage = Math.max(1, Number.parseInt(pagination.currentPage, 10) || 1);
+        pagination.currentPage = Math.min(nextPage, totalPages);
+        logPagination({ entity: "situations", previousPage, nextPage: pagination.currentPage, totalPages });
         rerender(root);
       });
     });
@@ -2169,3 +2183,21 @@ export function createProjectSituationsEvents({
     bindEvents
   };
 }
+  function ensureSituationsPaginationState() {
+    if (!store.situationsView || typeof store.situationsView !== "object") store.situationsView = {};
+    if (!store.situationsView.pagination || typeof store.situationsView.pagination !== "object") {
+      store.situationsView.pagination = { currentPage: 1, pageSize: 25 };
+    }
+    return store.situationsView.pagination;
+  }
+  function isPaginationDebugEnabled() {
+    try {
+      return String(window?.localStorage?.getItem?.("debug:pagination") || "").trim() === "1";
+    } catch (_) {
+      return false;
+    }
+  }
+  function logPagination({ entity, previousPage, nextPage, totalPages }) {
+    if (!isPaginationDebugEnabled()) return;
+    console.info("[pagination]", { entity, previousPage, nextPage, totalPages });
+  }

--- a/apps/web/js/views/project-situations/project-situations-state.js
+++ b/apps/web/js/views/project-situations/project-situations-state.js
@@ -123,7 +123,7 @@ export function createProjectSituationsState({ store }) {
     if (!Number.isFinite(Number(view.pagination.currentPage)) || Number(view.pagination.currentPage) < 1) view.pagination.currentPage = 1;
     if (!Number.isFinite(Number(view.pagination.totalItems)) || Number(view.pagination.totalItems) < 0) view.pagination.totalItems = 0;
     if (!Number.isFinite(Number(view.pagination.loadedItems)) || Number(view.pagination.loadedItems) < 0) view.pagination.loadedItems = 0;
-    if (!Number.isFinite(Number(view.pagination.pageSize)) || Number(view.pagination.pageSize) <= 0) view.pagination.pageSize = null;
+    if (!Number.isFinite(Number(view.pagination.pageSize)) || Number(view.pagination.pageSize) <= 0) view.pagination.pageSize = 25;
     if (typeof view.pagination.hasNextPage !== "boolean") view.pagination.hasNextPage = false;
     if (typeof view.pagination.sourceComplete !== "boolean") view.pagination.sourceComplete = true;
     if (typeof view.pagination.nextCursor !== "string" && view.pagination.nextCursor !== null) view.pagination.nextCursor = null;

--- a/apps/web/js/views/project-situations/project-situations-table.js
+++ b/apps/web/js/views/project-situations/project-situations-table.js
@@ -4,6 +4,7 @@ import { renderStatusBadge } from "../ui/status-badges.js";
 import { renderTableHeadFilterToggle } from "../ui/table-head-filter-toggle.js";
 import { renderDataTableHead } from "../ui/data-table-shell.js";
 import { renderIssuesTable } from "../ui/issues-table.js";
+import { renderPaginationControls } from "../ui/pagination.js";
 
 export function createProjectSituationsTable({
   store,
@@ -87,13 +88,15 @@ export function createProjectSituationsTable({
       });
     }
 
-    return renderIssuesTable({
+    const tableHtml = renderIssuesTable({
       gridTemplate: "minmax(420px, 1.6fr) 90px",
       headHtml: getSituationsTableHeadHtml(),
       rowsHtml: situations.map((situation) => renderSituationTitleCell(situation)).join(""),
       emptyTitle: "Aucune situation",
       emptyDescription: "Aucune situation n’est disponible pour ce projet."
     });
+    const paginationHtml = renderPaginationControls(pagination, { entity: "situations" });
+    return `${tableHtml}${paginationHtml}`;
   }
 
   return {

--- a/apps/web/js/views/project-subjects/project-subjects-events.js
+++ b/apps/web/js/views/project-subjects/project-subjects-events.js
@@ -5714,6 +5714,7 @@ export function createProjectSubjectsEvents(config) {
       const searchInput = event.target.closest?.("#situationsSearch");
       if (!searchInput) return;
       store.situationsView.search = String(searchInput.value || "");
+      resetSubjectsPaginationPage();
       rerenderPanels();
     });
 
@@ -5981,6 +5982,7 @@ export function createProjectSubjectsEvents(config) {
       if (subjectsStatusFilterButton) {
         event.preventDefault();
         store.situationsView.subjectsStatusFilter = String(subjectsStatusFilterButton.dataset.subjectsStatusFilter || "open").toLowerCase() === "closed" ? "closed" : "open";
+        resetSubjectsPaginationPage();
         rerenderPanels();
         return;
       }
@@ -6006,12 +6008,28 @@ export function createProjectSubjectsEvents(config) {
         event.stopPropagation();
 
         store.situationsView.subjectsPriorityFilter = normalizeBackendPriority(subjectsPriorityItem.dataset.subjectsPriorityFilter || "");
+        resetSubjectsPaginationPage();
 
         const currentBtn = root.querySelector("#subjectsPriorityHeadBtn");
         const currentDropdown = root.querySelector("#subjectsPriorityHeadDropdown");
         if (currentDropdown) currentDropdown.classList.remove("gh-menu--open");
         if (currentBtn) currentBtn.setAttribute("aria-expanded", "false");
 
+        rerenderPanels();
+        return;
+      }
+
+      const paginationButton = event.target.closest('[data-pagination-entity="subjects"][data-pagination-page]');
+      if (paginationButton) {
+        event.preventDefault();
+        const nextPage = Math.max(1, Number.parseInt(paginationButton.dataset.paginationPage || "1", 10) || 1);
+        const pagination = store.projectSubjectsView?.pagination && typeof store.projectSubjectsView.pagination === "object"
+          ? store.projectSubjectsView.pagination
+          : (store.projectSubjectsView.pagination = { currentPage: 1, pageSize: 25 });
+        const totalPages = Math.max(1, Number.parseInt(pagination.totalPages, 10) || 1);
+        const previousPage = Math.max(1, Number.parseInt(pagination.currentPage, 10) || 1);
+        pagination.currentPage = Math.min(nextPage, totalPages);
+        logPagination({ entity: "subjects", previousPage, nextPage: pagination.currentPage, totalPages });
         rerenderPanels();
         return;
       }
@@ -6166,3 +6184,21 @@ export function createProjectSubjectsEvents(config) {
     bindSituationsEvents
   };
 }
+    const resetSubjectsPaginationPage = () => {
+      if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") store.projectSubjectsView = {};
+      if (!store.projectSubjectsView.pagination || typeof store.projectSubjectsView.pagination !== "object") {
+        store.projectSubjectsView.pagination = { currentPage: 1, pageSize: 25 };
+      }
+      store.projectSubjectsView.pagination.currentPage = 1;
+    };
+    const isPaginationDebugEnabled = () => {
+      try {
+        return String(window?.localStorage?.getItem?.("debug:pagination") || "").trim() === "1";
+      } catch {
+        return false;
+      }
+    };
+    const logPagination = ({ entity, previousPage, nextPage, totalPages }) => {
+      if (!isPaginationDebugEnabled()) return;
+      console.info("[pagination]", { entity, previousPage, nextPage, totalPages });
+    };

--- a/apps/web/js/views/project-subjects/project-subjects-state.js
+++ b/apps/web/js/views/project-subjects/project-subjects-state.js
@@ -91,7 +91,7 @@ export function createProjectSubjectsState({ store }) {
     if (!Number.isFinite(Number(v.pagination.currentPage)) || Number(v.pagination.currentPage) < 1) v.pagination.currentPage = 1;
     if (!Number.isFinite(Number(v.pagination.totalItems)) || Number(v.pagination.totalItems) < 0) v.pagination.totalItems = 0;
     if (!Number.isFinite(Number(v.pagination.loadedItems)) || Number(v.pagination.loadedItems) < 0) v.pagination.loadedItems = 0;
-    if (!Number.isFinite(Number(v.pagination.pageSize)) || Number(v.pagination.pageSize) <= 0) v.pagination.pageSize = null;
+    if (!Number.isFinite(Number(v.pagination.pageSize)) || Number(v.pagination.pageSize) <= 0) v.pagination.pageSize = 25;
     if (typeof v.pagination.hasNextPage !== "boolean") v.pagination.hasNextPage = false;
     if (typeof v.pagination.sourceComplete !== "boolean") v.pagination.sourceComplete = true;
     if (typeof v.pagination.nextCursor !== "string" && v.pagination.nextCursor !== null) v.pagination.nextCursor = null;

--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -1,6 +1,7 @@
 import { renderProblemsCountsIconHtml } from "../ui/subissues-counts.js";
 import { getDisplayAuthorName } from "../ui/author-identity.js";
 import { findCollaboratorByAssigneeId, normalizeAssigneeIds } from "../../services/subject-assignees-service.js";
+import { renderPaginationControls } from "../ui/pagination.js";
 export function getSituationsTableGridTemplate() {
   return "minmax(0, 1fr) 84px max-content";
 }
@@ -54,7 +55,7 @@ function renderSubjectChildrenCounterHtml(sujet, deps) {
 
 function renderWelcomeHtml(deps) {
   const { renderIssuesTable } = deps;
-  return renderIssuesTable({
+  const tableHtml = renderIssuesTable({
     gridTemplate: getSituationsTableGridTemplate(),
     headHtml: renderSituationsTableHeadHtml({
       deps,
@@ -323,4 +324,6 @@ export function renderProjectSubjectsTable({ filteredSituations, deps }) {
       ? "Aucun résultat pour cette page avec les filtres actuels."
       : "Aucun résultat pour les filtres actuels."
   });
+  const paginationHtml = renderPaginationControls(pagination, { entity: "subjects" });
+  return `${tableHtml}${paginationHtml}`;
 }

--- a/apps/web/js/views/ui/pagination.js
+++ b/apps/web/js/views/ui/pagination.js
@@ -1,0 +1,113 @@
+const DEFAULT_PAGE_SIZE = 25;
+const EDGE_WINDOW_SIZE = 2;
+const MIDDLE_WINDOW_SIZE = 3;
+
+function normalizePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function normalizePaginationState({ totalItems, pageSize, currentPage } = {}) {
+  const safeTotalItems = Math.max(0, Number.parseInt(totalItems, 10) || 0);
+  const safePageSize = normalizePositiveInteger(pageSize, DEFAULT_PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(safeTotalItems / safePageSize));
+  const normalizedPage = clamp(normalizePositiveInteger(currentPage, 1), 1, totalPages);
+  const startIndex = (normalizedPage - 1) * safePageSize;
+  const endIndex = Math.min(safeTotalItems, startIndex + safePageSize);
+
+  return {
+    totalItems: safeTotalItems,
+    pageSize: safePageSize,
+    totalPages,
+    currentPage: normalizedPage,
+    startIndex,
+    endIndex,
+    hasPreviousPage: normalizedPage > 1,
+    hasNextPage: normalizedPage < totalPages
+  };
+}
+
+export function paginateItems(items = [], paginationState) {
+  const safeItems = Array.isArray(items) ? items : [];
+  const normalized = normalizePaginationState({
+    totalItems: safeItems.length,
+    pageSize: paginationState?.pageSize,
+    currentPage: paginationState?.currentPage
+  });
+
+  return {
+    ...normalized,
+    items: safeItems.slice(normalized.startIndex, normalized.endIndex)
+  };
+}
+
+function getVisiblePages(currentPage, totalPages) {
+  const pages = new Set();
+
+  for (let page = 1; page <= Math.min(totalPages, EDGE_WINDOW_SIZE); page += 1) pages.add(page);
+  const middleStart = Math.max(1, currentPage - 1);
+  const middleEnd = Math.min(totalPages, middleStart + MIDDLE_WINDOW_SIZE - 1, currentPage + 1);
+  for (let page = middleStart; page <= middleEnd; page += 1) pages.add(page);
+  for (let page = Math.max(1, totalPages - EDGE_WINDOW_SIZE + 1); page <= totalPages; page += 1) pages.add(page);
+
+  const sorted = [...pages].sort((a, b) => a - b);
+  const tokens = [];
+
+  for (const page of sorted) {
+    const previous = tokens.length ? tokens[tokens.length - 1] : null;
+    if (typeof previous === 'number' && page - previous > 1) tokens.push('ellipsis');
+    tokens.push(page);
+  }
+
+  return tokens;
+}
+
+function renderPaginationButton({ entity, page, label, isActive = false, isDisabled = false }) {
+  const classes = ["project-pagination__button"];
+  if (isActive) classes.push("project-pagination__button--active");
+  if (isDisabled) classes.push("project-pagination__button--disabled");
+
+  const disabledAttr = isDisabled ? ' aria-disabled="true" tabindex="-1"' : "";
+
+  return `<button type="button" class="${classes.join(" ")}" data-pagination-entity="${entity}" data-pagination-page="${page}"${disabledAttr}>${label}</button>`;
+}
+
+export function renderPaginationControls(paginationState, options = {}) {
+  const entity = String(options.entity || "").trim();
+  if (!entity) return "";
+
+  const normalized = normalizePaginationState(paginationState);
+  if (normalized.totalPages <= 1) return "";
+
+  const pageTokens = getVisiblePages(normalized.currentPage, normalized.totalPages);
+  const pageButtons = pageTokens.map((token) => {
+    if (token === 'ellipsis') return '<span class="project-pagination__ellipsis" aria-hidden="true">...</span>';
+
+    return renderPaginationButton({
+      entity,
+      page: token,
+      label: String(token),
+      isActive: token === normalized.currentPage
+    });
+  }).join("");
+
+  return `<nav class="project-pagination" aria-label="Pagination">
+    ${renderPaginationButton({
+      entity,
+      page: normalized.currentPage - 1,
+      label: "Previous",
+      isDisabled: !normalized.hasPreviousPage
+    })}
+    ${pageButtons}
+    ${renderPaginationButton({
+      entity,
+      page: normalized.currentPage + 1,
+      label: "Next",
+      isDisabled: !normalized.hasNextPage
+    })}
+  </nav>`;
+}

--- a/apps/web/js/views/ui/pagination.test.mjs
+++ b/apps/web/js/views/ui/pagination.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizePaginationState,
+  paginateItems,
+  renderPaginationControls
+} from './pagination.js';
+
+test('normalizePaginationState enforces defaults and clamps currentPage', () => {
+  const state = normalizePaginationState({ totalItems: 60, pageSize: null, currentPage: 999 });
+  assert.equal(state.pageSize, 25);
+  assert.equal(state.totalPages, 3);
+  assert.equal(state.currentPage, 3);
+  assert.equal(state.startIndex, 50);
+  assert.equal(state.endIndex, 60);
+});
+
+test('paginateItems returns expected page slice', () => {
+  const items = Array.from({ length: 60 }, (_, i) => i + 1);
+  const page = paginateItems(items, { pageSize: 25, currentPage: 2 });
+  assert.equal(page.items.length, 25);
+  assert.deepEqual(page.items.slice(0, 3), [26, 27, 28]);
+  assert.deepEqual(page.items.slice(-2), [49, 50]);
+});
+
+test('renderPaginationControls hides controls when one page only', () => {
+  assert.equal(renderPaginationControls({ totalItems: 3, pageSize: 25, currentPage: 1 }, { entity: 'subjects' }), '');
+});
+
+test('renderPaginationControls renders buttons, active page and ellipsis', () => {
+  const html = renderPaginationControls({ totalItems: 675, pageSize: 25, currentPage: 4 }, { entity: 'subjects' });
+  assert.match(html, /data-pagination-entity="subjects"/);
+  assert.match(html, /project-pagination__button--active/);
+  assert.match(html, /project-pagination__ellipsis/);
+  assert.match(html, /Previous/);
+  assert.match(html, /Next/);
+});


### PR DESCRIPTION
### Motivation
- Provide consistent client-side pagination for project actions, situations and subjects and standardize default page sizes across views.
- Avoid extremely large default page sizes and enable users to navigate long lists with lightweight controls.

### Description
- Change default page size from `80` to `25` in the initial store states for project subjects and situations and set `pagination.pageSize` fallback to `25` in their state initializers (`store.js`, `project-subjects-state.js`, `project-situations-state.js`).
- Add a `projectActionsView` store entry and integrate pagination into the Project Actions view, including normalization, paging of entries, rendering of pagination controls and a click handler to update `store.projectActionsView.pagination` (`views/project-actions.js`).
- Add a centralized pagination utility module with `normalizePaginationState`, `paginateItems`, and `renderPaginationControls`, plus page token logic and helpers (`views/ui/pagination.js`).
- Wire pagination controls and event handlers into situations and subjects views and tables to reset page on filter changes, handle page button clicks, and log pagination when debug is enabled; and append pagination controls to table HTML (`project-situations-*` and `project-subjects-*` view files). 
- Add unit tests for pagination helpers (`views/ui/pagination.test.mjs`).

### Testing
- Ran the new pagination unit tests (`views/ui/pagination.test.mjs`) with Node's test runner and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37e729800832983319b2505180362)