### PR TITLE
Use existing pulse icon for Spectre sidenav item

### DIFF
--- a/apps/web/js/views/project-studio.js
+++ b/apps/web/js/views/project-studio.js
@@ -52,7 +52,7 @@ function renderStudioNav() {
         renderSideNavItem({
           label: "Spectre",
           targetId: "seismic-general",
-          iconHtml: svgIcon("gear", { className: "octicon octicon-gear" })
+          iconHtml: svgIcon("pulse", { className: "octicon octicon-pulse" })
         })
       ]
     }),


### PR DESCRIPTION
### Motivation
- Reuse the already-present `pulse` SVG symbol from `apps/web/assets/icons.svg` for the Atelier -> Parasismique item to avoid adding a duplicate icon and match the provided SVG.

### Description
- Replace `svgIcon("gear", { className: "octicon octicon-gear" })` with `svgIcon("pulse", { className: "octicon octicon-pulse" })` for the "Spectre" side-nav item in `apps/web/js/views/project-studio.js`.

### Testing
- Verified the `pulse` symbol exists in `apps/web/assets/icons.svg` and validated the change by running `rg` against the assets, inspecting the updated file with `nl`/`sed`, and committing the change with `git` (all commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38b9eb6888329bd613f8d78c27d7e)