### PR TITLE
Afficher l'avatar auteur dans la liste Sujets (corrige sujets pré‑remplis Atelier)

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -1,5 +1,6 @@
 import { renderProblemsCountsIconHtml } from "../ui/subissues-counts.js";
 import { getDisplayAuthorName } from "../ui/author-identity.js";
+import { getAuthorIdentity } from "../ui/author-identity.js";
 import { findCollaboratorByAssigneeId, normalizeAssigneeIds } from "../../services/subject-assignees-service.js";
 import { normalizePaginationState, paginateItems, renderPaginationControls } from "../ui/pagination.js";
 export function getSituationsTableGridTemplate() {
@@ -186,6 +187,17 @@ export function renderFlatSujetRow(sujet, situationId, options = {}) {
     agent: firstNonEmpty(getEntityDescriptionState("sujet", sujet.id)?.agent, sujet?.agent, sujet?.raw?.agent, "system"),
     fallback: "System"
   });
+  const descriptionState = getEntityDescriptionState("sujet", sujet.id) || {};
+  const authorIdentity = getAuthorIdentity({
+    author,
+    agent: firstNonEmpty(descriptionState?.agent, sujet?.agent, sujet?.raw?.agent, "system"),
+    avatarUrl: firstNonEmpty(descriptionState?.avatarUrl, descriptionState?.avatar_url, ""),
+    currentUserAvatar: String(deps?.store?.user?.avatar || ""),
+    fallbackName: "System"
+  });
+  const authorAvatarHtml = authorIdentity.avatarHtml
+    ? `<span class="issue-row-author-avatar issue-row-author-avatar--${escapeHtml(authorIdentity.avatarType || "agent")}" aria-hidden="true">${authorIdentity.avatarHtml}</span>`
+    : `<span class="issue-row-author-avatar issue-row-author-avatar--fallback" aria-hidden="true">${escapeHtml(authorIdentity.avatarInitial || "S")}</span>`;
   const openedLabel = formatRelativeTimeLabel(getEntityListTimestamp("sujet", sujet), "opened");
   const subjectMeta = getSubjectSidebarMeta(sujet.id);
   const subjectLabelsHtml = subjectMeta.labels
@@ -216,7 +228,7 @@ export function renderFlatSujetRow(sujet, situationId, options = {}) {
             <button type="button" class="row-title-trigger js-row-title-trigger theme-text theme-text--pb ${titleSeenClass}" data-row-entity-type="sujet" data-row-entity-id="${escapeHtml(sujet.id)}">${escapeHtml(firstNonEmpty(sujet.title, sujet.id, "Non classé"))}</button>
             ${renderSubjectChildrenCounterHtml(sujet, deps)}${subjectLabelsHtml ? `<span class="issue-row-subject-labels">${subjectLabelsHtml}</span>` : ""}
           </span>
-          <span class="issue-row-title-grid__meta issue-row-meta-text mono-small">${blockedBadge}${escapeHtml(displayRef)} - ${escapeHtml(author)} • ${escapeHtml(openedLabel)}${objectiveLabel}</span>
+          <span class="issue-row-title-grid__meta issue-row-meta-text mono-small">${blockedBadge}${escapeHtml(displayRef)} - ${authorAvatarHtml}<span class="issue-row-author-name">${escapeHtml(author)}</span> • ${escapeHtml(openedLabel)}${objectiveLabel}</span>
         </span>
       </div>
       <div class="cell cell-messages-value">${renderSubjectMessagesCountCellHtml(sujet, deps)}</div>

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -2270,6 +2270,34 @@ body.subject-create-subissue-modal-open #situationsDetailsHost{
 .issue-row-blocked-pill .octicon-blocked{color:var(--danger-fg,#f85149);fill:currentColor;}
 .issue-row-subject-children-counter{margin-left:2px;flex:0 0 auto;}
 .issue-row-subject-children-counter span:last-child{white-space:nowrap;}
+.issue-row-author-avatar{
+  display:inline-flex;
+  width:16px;
+  height:16px;
+  border-radius:50%;
+  overflow:hidden;
+  align-items:center;
+  justify-content:center;
+  margin:0 4px 0 0;
+  vertical-align:middle;
+  flex:0 0 auto;
+}
+.issue-row-author-avatar img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+.issue-row-author-avatar--fallback{
+  border:1px solid var(--border);
+  background:var(--panel);
+  color:var(--muted);
+  font-size:10px;
+  font-weight:600;
+  line-height:1;
+}
+.issue-row-author-name{
+  vertical-align:middle;
+}
 
 
 /* Verdict badges (F/D/S/HM/PM/SO) */


### PR DESCRIPTION
### Motivation
- La ligne de la liste « Sujet » n’affichait que le nom de l’auteur tandis que le panneau détail utilisait un pipeline d’identité auteur qui rendait un avatar, d’où une divergence d’affichage pour les sujets pré‑remplis générés par les outils Atelier.
- L’objectif est d’uniformiser le rendu auteur entre la liste et le détail et de fournir des fallbacks robustes (avatar URL, icône système, initiales) pour fiabiliser l’affichage.

### Description
- Utilisation de `getAuthorIdentity` dans `renderFlatSujetRow` pour construire une identité auteur complète avec `avatarUrl`, `currentUserAvatar` et fallback d’initiales.
- Injection d’un fragment HTML compact `authorAvatarHtml` dans la meta‑ligne de la rangée sujet pour afficher l’avatar à côté du nom et de la date.
- Ajout de règles CSS compactes (`.issue-row-author-avatar`, img crop, fallback styling, `.issue-row-author-name`) pour assurer un rendu visuel cohérent et adapté à la ligne.
- Fichiers modifiés : `apps/web/js/views/project-subjects/project-subjects-table.js` et `apps/web/style.css`.

### Testing
- Exécution de la suite de tests automatisés avec `npm test --silent` : suite exécutée (237 tests), résultat `232 passed`, `0 failed`, `5 skipped` et la commande s’est terminée sans erreur.
- Les tests affectant le rendu des descriptions/avatars ont été couverts et n’introduisent pas de régression détectée par la suite automatique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38d0e300883299426b39be399adc5)