### PR TITLE
Fix duplicate descriptionState declaration causing test failure

### DIFF
--- a/apps/web/js/views/project-subjects/project-subjects-table.js
+++ b/apps/web/js/views/project-subjects/project-subjects-table.js
@@ -188,7 +188,6 @@ export function renderFlatSujetRow(sujet, situationId, options = {}) {
     agent: firstNonEmpty(descriptionState?.agent, sujet?.agent, sujet?.raw?.agent, "system"),
     fallback: "System"
   });
-  const descriptionState = getEntityDescriptionState("sujet", sujet.id) || {};
   const authorIdentity = getAuthorIdentity({
     author,
     agent: firstNonEmpty(descriptionState?.agent, sujet?.agent, sujet?.raw?.agent, "system"),


### PR DESCRIPTION
### Motivation
- Corriger l'échec des tests Node causé par une double déclaration de la variable `descriptionState` qui provoquait `SyntaxError: Identifier 'descriptionState' has already been declared` pendant le déploiement.

### Description
- Supprimé la déclaration dupliquée de `descriptionState` dans `renderFlatSujetRow` du fichier `apps/web/js/views/project-subjects/project-subjects-table.js` afin de conserver une seule source de vérité utilisée pour dériver `authorIdentity`.

### Testing
- Exécuté `npm test` localement et la suite automatisée s'est terminée sans échec : `237` tests au total, `232` passés, `0` échoués et `5` ignorés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f390f2c4608329becfdaae75783238)