### PR TITLE
Add project document folders, move RPC and frontend folder APIs

### DIFF
--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -859,6 +859,198 @@ export async function syncProjectDocumentsFromSupabase(options = {}) {
   return nextItems;
 }
 
+function ensureBackendProjectIdOrThrow(projectId = "") {
+  const normalizedProjectId = safeString(projectId);
+  if (!normalizedProjectId) {
+    throw new Error("Project id is required.");
+  }
+
+  return normalizedProjectId;
+}
+
+export async function listDocumentFolders(projectId = "") {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  console.info("[documents-folders] list.start", { projectId: backendProjectId, parentFolderId: null });
+
+  try {
+    const params = new URLSearchParams();
+    params.set("select", "id,project_id,parent_folder_id,name,created_at,updated_at,created_by");
+    params.set("project_id", `eq.${backendProjectId}`);
+    params.set("order", "name.asc");
+    const rows = await restFetch("project_document_folders", params);
+    const items = Array.isArray(rows) ? rows : [];
+    console.info("[documents-folders] list.success", { projectId: backendProjectId, count: items.length, parentFolderId: null });
+    return items;
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "listDocumentFolders", projectId: backendProjectId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function listDocumentFolderChildren(projectId = "", parentFolderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedParentFolderId = safeString(parentFolderId || "") || null;
+  console.info("[documents-folders] list.start", { projectId: backendProjectId, parentFolderId: normalizedParentFolderId });
+
+  try {
+    const params = new URLSearchParams();
+    params.set("select", "id,project_id,parent_folder_id,name,created_at,updated_at,created_by");
+    params.set("project_id", `eq.${backendProjectId}`);
+    if (normalizedParentFolderId) {
+      params.set("parent_folder_id", `eq.${normalizedParentFolderId}`);
+    } else {
+      params.set("parent_folder_id", "is.null");
+    }
+    params.set("order", "name.asc");
+    const rows = await restFetch("project_document_folders", params);
+    const items = Array.isArray(rows) ? rows : [];
+    console.info("[documents-folders] list.success", { projectId: backendProjectId, count: items.length, parentFolderId: normalizedParentFolderId });
+    return items;
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "listDocumentFolderChildren", projectId: backendProjectId, parentFolderId: normalizedParentFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function createDocumentFolder(projectId = "", parentFolderId = null, name = "") {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedParentFolderId = safeString(parentFolderId || "") || null;
+  const normalizedName = safeString(name);
+  if (!normalizedName) throw new Error("Folder name is required.");
+  console.info("[documents-folders] create.start", { projectId: backendProjectId, parentFolderId: normalizedParentFolderId, name: normalizedName });
+
+  try {
+    return await restInsert("project_document_folders", {
+      project_id: backendProjectId,
+      parent_folder_id: normalizedParentFolderId,
+      name: normalizedName
+    }, {
+      select: "id,project_id,parent_folder_id,name,created_at,updated_at,created_by"
+    });
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "createDocumentFolder", projectId: backendProjectId, parentFolderId: normalizedParentFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function renameDocumentFolder(projectId = "", folderId = "", name = "") {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFolderId = safeString(folderId);
+  const normalizedName = safeString(name);
+  if (!normalizedFolderId) throw new Error("Folder id is required.");
+  if (!normalizedName) throw new Error("Folder name is required.");
+  console.info("[documents-folders] rename.start", { projectId: backendProjectId, folderId: normalizedFolderId, name: normalizedName });
+
+  try {
+    const updated = await restUpdate("project_document_folders", {
+      id: normalizedFolderId,
+      project_id: backendProjectId
+    }, {
+      name: normalizedName
+    }, {
+      select: "id,project_id,parent_folder_id,name,created_at,updated_at,created_by"
+    });
+    if (!updated) {
+      throw new Error("Folder not found or update not allowed.");
+    }
+    return updated;
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "renameDocumentFolder", projectId: backendProjectId, folderId: normalizedFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function getDocumentFolderPath(projectId = "", folderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFolderId = safeString(folderId || "") || null;
+  if (!normalizedFolderId) return [];
+
+  const folders = await listDocumentFolders(backendProjectId);
+  const foldersById = new Map(folders.map((folder) => [safeString(folder.id), folder]));
+  const breadcrumb = [];
+  let cursorId = normalizedFolderId;
+
+  while (cursorId) {
+    const folder = foldersById.get(cursorId);
+    if (!folder || safeString(folder.project_id) !== backendProjectId) break;
+    breadcrumb.unshift(folder);
+    const nextCursor = safeString(folder.parent_folder_id || "");
+    if (!nextCursor || nextCursor === cursorId) break;
+    cursorId = nextCursor;
+  }
+
+  return breadcrumb;
+}
+
+export async function listDocumentDirectory(projectId = "", folderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFolderId = safeString(folderId || "") || null;
+  console.info("[documents-folders] list.start", { projectId: backendProjectId, folderId: normalizedFolderId });
+
+  try {
+    const [allFolders, breadcrumb] = await Promise.all([
+      listDocumentFolders(backendProjectId),
+      getDocumentFolderPath(backendProjectId, normalizedFolderId)
+    ]);
+    const currentFolder = normalizedFolderId
+      ? (allFolders.find((folder) => safeString(folder.id) === normalizedFolderId) || null)
+      : null;
+    const folders = allFolders.filter((folder) => safeString(folder.parent_folder_id || "") === safeString(normalizedFolderId || ""));
+
+    const fileParams = new URLSearchParams();
+    fileParams.set("select", "id,project_id,folder_id,filename,original_filename,mime_type,storage_bucket,storage_path,document_kind,upload_status,created_at,updated_at,deleted_at");
+    fileParams.set("project_id", `eq.${backendProjectId}`);
+    fileParams.set("deleted_at", "is.null");
+    if (normalizedFolderId) {
+      fileParams.set("folder_id", `eq.${normalizedFolderId}`);
+    } else {
+      fileParams.set("folder_id", "is.null");
+    }
+    fileParams.set("order", "created_at.desc");
+
+    const fileRows = await restFetch("documents", fileParams);
+    const files = (Array.isArray(fileRows) ? fileRows : []).map(mapDocumentRowToViewModel);
+    console.info("[documents-folders] list.success", { projectId: backendProjectId, folderId: normalizedFolderId, foldersCount: folders.length, filesCount: files.length });
+
+    return {
+      currentFolder,
+      breadcrumb,
+      folders,
+      files
+    };
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "listDocumentDirectory", projectId: backendProjectId, folderId: normalizedFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function moveDocumentFile(projectId = "", fileId = "", targetFolderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFileId = safeString(fileId);
+  const normalizedTargetFolderId = safeString(targetFolderId || "") || null;
+  if (!normalizedFileId) throw new Error("File id is required.");
+  console.info("[documents-files] move.start", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId });
+
+  try {
+    const payload = await rpcCall("move_project_document_file", {
+      file_id: normalizedFileId,
+      target_folder_id: normalizedTargetFolderId
+    });
+    const moved = Array.isArray(payload) ? (payload[0] || null) : payload;
+    if (!moved) {
+      throw new Error("No row returned by move_project_document_file.");
+    }
+    if (safeString(moved.project_id) !== backendProjectId) {
+      throw new Error("Moved file does not belong to the requested project.");
+    }
+    console.info("[documents-files] move.success", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId });
+    return moved;
+  } catch (error) {
+    console.error("[documents-files] move.failure", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
 export async function syncProjectActionsFromSupabase(options = {}) {
   const force = Boolean(options.force);
   const frontendProjectId = getFrontendProjectKey();

--- a/supabase/migrations/202606150045_document_folders_and_move_rpc.sql
+++ b/supabase/migrations/202606150045_document_folders_and_move_rpc.sql
@@ -1,0 +1,107 @@
+create table if not exists public.project_document_folders (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  parent_folder_id uuid null,
+  name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid null references auth.users(id),
+  constraint project_document_folders_name_not_blank check (btrim(name) <> ''),
+  constraint project_document_folders_unique_name_per_parent unique nulls not distinct (project_id, parent_folder_id, name),
+  constraint project_document_folders_project_id_id_unique unique (project_id, id),
+  constraint project_document_folders_parent_folder_fkey
+    foreign key (parent_folder_id) references public.project_document_folders(id) on delete cascade,
+  constraint project_document_folders_parent_same_project_fkey
+    foreign key (project_id, parent_folder_id) references public.project_document_folders(project_id, id) on delete cascade
+);
+
+create index if not exists idx_project_document_folders_project_id
+  on public.project_document_folders(project_id);
+
+create index if not exists idx_project_document_folders_parent_folder_id
+  on public.project_document_folders(parent_folder_id);
+
+create index if not exists idx_project_document_folders_project_parent
+  on public.project_document_folders(project_id, parent_folder_id);
+
+drop trigger if exists trg_project_document_folders_updated_at on public.project_document_folders;
+create trigger trg_project_document_folders_updated_at
+before update on public.project_document_folders
+for each row execute function public.set_updated_at();
+
+alter table public.documents
+  add column if not exists folder_id uuid null references public.project_document_folders(id) on delete set null;
+
+create index if not exists idx_documents_folder_id
+  on public.documents(folder_id);
+
+alter table public.project_document_folders enable row level security;
+
+-- Folder access follows the same project owner predicate currently used for documents.
+drop policy if exists project_document_folders_by_project on public.project_document_folders;
+create policy project_document_folders_by_project
+on public.project_document_folders
+for all
+using (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+)
+with check (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+);
+
+create or replace function public.move_project_document_file(
+  file_id uuid,
+  target_folder_id uuid default null
+)
+returns public.documents
+language plpgsql
+security invoker
+as $$
+declare
+  v_document public.documents;
+  v_target_folder public.project_document_folders;
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select d.*
+  into v_document
+  from public.documents d
+  where d.id = file_id;
+
+  if not found then
+    raise exception 'Document file not found: %', file_id;
+  end if;
+
+  if target_folder_id is not null then
+    select f.*
+    into v_target_folder
+    from public.project_document_folders f
+    where f.id = target_folder_id;
+
+    if not found then
+      raise exception 'Target folder not found: %', target_folder_id;
+    end if;
+
+    if v_target_folder.project_id <> v_document.project_id then
+      raise exception 'Target folder belongs to another project';
+    end if;
+  end if;
+
+  update public.documents d
+  set folder_id = target_folder_id
+  where d.id = v_document.id
+  returning * into v_document;
+
+  return v_document;
+end;
+$$;


### PR DESCRIPTION
### Motivation

- Introduce a folder model for project documents to support hierarchical organization and file moves.  
- Provide backend enforcement and an RPC to safely move files between folders while preserving project ownership constraints.  

### Description

- Add a Supabase migration `202606150045_document_folders_and_move_rpc.sql` that creates `project_document_folders` with constraints, indexes, RLS policy, and adds a nullable `folder_id` column to `documents` with an index.  
- Implement a `move_project_document_file` PL/pgSQL function that validates auth, existence, and project membership, then updates `documents.folder_id` and returns the updated row.  
- Add frontend service APIs in `apps/web/js/services/project-supabase-sync.js` including `ensureBackendProjectIdOrThrow`, `listDocumentFolders`, `listDocumentFolderChildren`, `createDocumentFolder`, `renameDocumentFolder`, `getDocumentFolderPath`, `listDocumentDirectory`, and `moveDocumentFile` with input validation, logging, and calls to `restFetch`, `restInsert`, `restUpdate`, and `rpcCall`.  

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4472039c08329a70fc662fb3fca7d)