### PR TITLE
Add document folders, move RPC and folder UI/sync support

### DIFF
--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -859,6 +859,198 @@ export async function syncProjectDocumentsFromSupabase(options = {}) {
   return nextItems;
 }
 
+function ensureBackendProjectIdOrThrow(projectId = "") {
+  const normalizedProjectId = safeString(projectId);
+  if (!normalizedProjectId) {
+    throw new Error("Project id is required.");
+  }
+
+  return normalizedProjectId;
+}
+
+export async function listDocumentFolders(projectId = "") {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  console.info("[documents-folders] list.start", { projectId: backendProjectId, parentFolderId: null });
+
+  try {
+    const params = new URLSearchParams();
+    params.set("select", "id,project_id,parent_folder_id,name,created_at,updated_at,created_by");
+    params.set("project_id", `eq.${backendProjectId}`);
+    params.set("order", "name.asc");
+    const rows = await restFetch("project_document_folders", params);
+    const items = Array.isArray(rows) ? rows : [];
+    console.info("[documents-folders] list.success", { projectId: backendProjectId, count: items.length, parentFolderId: null });
+    return items;
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "listDocumentFolders", projectId: backendProjectId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function listDocumentFolderChildren(projectId = "", parentFolderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedParentFolderId = safeString(parentFolderId || "") || null;
+  console.info("[documents-folders] list.start", { projectId: backendProjectId, parentFolderId: normalizedParentFolderId });
+
+  try {
+    const params = new URLSearchParams();
+    params.set("select", "id,project_id,parent_folder_id,name,created_at,updated_at,created_by");
+    params.set("project_id", `eq.${backendProjectId}`);
+    if (normalizedParentFolderId) {
+      params.set("parent_folder_id", `eq.${normalizedParentFolderId}`);
+    } else {
+      params.set("parent_folder_id", "is.null");
+    }
+    params.set("order", "name.asc");
+    const rows = await restFetch("project_document_folders", params);
+    const items = Array.isArray(rows) ? rows : [];
+    console.info("[documents-folders] list.success", { projectId: backendProjectId, count: items.length, parentFolderId: normalizedParentFolderId });
+    return items;
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "listDocumentFolderChildren", projectId: backendProjectId, parentFolderId: normalizedParentFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function createDocumentFolder(projectId = "", parentFolderId = null, name = "") {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedParentFolderId = safeString(parentFolderId || "") || null;
+  const normalizedName = safeString(name);
+  if (!normalizedName) throw new Error("Folder name is required.");
+  console.info("[documents-folders] create.start", { projectId: backendProjectId, parentFolderId: normalizedParentFolderId, name: normalizedName });
+
+  try {
+    return await restInsert("project_document_folders", {
+      project_id: backendProjectId,
+      parent_folder_id: normalizedParentFolderId,
+      name: normalizedName
+    }, {
+      select: "id,project_id,parent_folder_id,name,created_at,updated_at,created_by"
+    });
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "createDocumentFolder", projectId: backendProjectId, parentFolderId: normalizedParentFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function renameDocumentFolder(projectId = "", folderId = "", name = "") {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFolderId = safeString(folderId);
+  const normalizedName = safeString(name);
+  if (!normalizedFolderId) throw new Error("Folder id is required.");
+  if (!normalizedName) throw new Error("Folder name is required.");
+  console.info("[documents-folders] rename.start", { projectId: backendProjectId, folderId: normalizedFolderId, name: normalizedName });
+
+  try {
+    const updated = await restUpdate("project_document_folders", {
+      id: normalizedFolderId,
+      project_id: backendProjectId
+    }, {
+      name: normalizedName
+    }, {
+      select: "id,project_id,parent_folder_id,name,created_at,updated_at,created_by"
+    });
+    if (!updated) {
+      throw new Error("Folder not found or update not allowed.");
+    }
+    return updated;
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "renameDocumentFolder", projectId: backendProjectId, folderId: normalizedFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function getDocumentFolderPath(projectId = "", folderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFolderId = safeString(folderId || "") || null;
+  if (!normalizedFolderId) return [];
+
+  const folders = await listDocumentFolders(backendProjectId);
+  const foldersById = new Map(folders.map((folder) => [safeString(folder.id), folder]));
+  const breadcrumb = [];
+  let cursorId = normalizedFolderId;
+
+  while (cursorId) {
+    const folder = foldersById.get(cursorId);
+    if (!folder || safeString(folder.project_id) !== backendProjectId) break;
+    breadcrumb.unshift(folder);
+    const nextCursor = safeString(folder.parent_folder_id || "");
+    if (!nextCursor || nextCursor === cursorId) break;
+    cursorId = nextCursor;
+  }
+
+  return breadcrumb;
+}
+
+export async function listDocumentDirectory(projectId = "", folderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFolderId = safeString(folderId || "") || null;
+  console.info("[documents-folders] list.start", { projectId: backendProjectId, folderId: normalizedFolderId });
+
+  try {
+    const [allFolders, breadcrumb] = await Promise.all([
+      listDocumentFolders(backendProjectId),
+      getDocumentFolderPath(backendProjectId, normalizedFolderId)
+    ]);
+    const currentFolder = normalizedFolderId
+      ? (allFolders.find((folder) => safeString(folder.id) === normalizedFolderId) || null)
+      : null;
+    const folders = allFolders.filter((folder) => safeString(folder.parent_folder_id || "") === safeString(normalizedFolderId || ""));
+
+    const fileParams = new URLSearchParams();
+    fileParams.set("select", "id,project_id,folder_id,filename,original_filename,mime_type,storage_bucket,storage_path,document_kind,upload_status,created_at,updated_at,deleted_at");
+    fileParams.set("project_id", `eq.${backendProjectId}`);
+    fileParams.set("deleted_at", "is.null");
+    if (normalizedFolderId) {
+      fileParams.set("folder_id", `eq.${normalizedFolderId}`);
+    } else {
+      fileParams.set("folder_id", "is.null");
+    }
+    fileParams.set("order", "created_at.desc");
+
+    const fileRows = await restFetch("documents", fileParams);
+    const files = (Array.isArray(fileRows) ? fileRows : []).map(mapDocumentRowToViewModel);
+    console.info("[documents-folders] list.success", { projectId: backendProjectId, folderId: normalizedFolderId, foldersCount: folders.length, filesCount: files.length });
+
+    return {
+      currentFolder,
+      breadcrumb,
+      folders,
+      files
+    };
+  } catch (error) {
+    console.error("[documents-folders] failure", { action: "listDocumentDirectory", projectId: backendProjectId, folderId: normalizedFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
+export async function moveDocumentFile(projectId = "", fileId = "", targetFolderId = null) {
+  const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
+  const normalizedFileId = safeString(fileId);
+  const normalizedTargetFolderId = safeString(targetFolderId || "") || null;
+  if (!normalizedFileId) throw new Error("File id is required.");
+  console.info("[documents-files] move.start", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId });
+
+  try {
+    const payload = await rpcCall("move_project_document_file", {
+      file_id: normalizedFileId,
+      target_folder_id: normalizedTargetFolderId
+    });
+    const moved = Array.isArray(payload) ? (payload[0] || null) : payload;
+    if (!moved) {
+      throw new Error("No row returned by move_project_document_file.");
+    }
+    if (safeString(moved.project_id) !== backendProjectId) {
+      throw new Error("Moved file does not belong to the requested project.");
+    }
+    console.info("[documents-files] move.success", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId });
+    return moved;
+  } catch (error) {
+    console.error("[documents-files] move.failure", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId, error: error instanceof Error ? error.message : String(error || "") });
+    throw error;
+  }
+}
+
 export async function syncProjectActionsFromSupabase(options = {}) {
   const force = Boolean(options.force);
   const frontendProjectId = getFrontendProjectKey();

--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -23,7 +23,7 @@ import {
 } from "../services/analysis-runner.js";
 import { addProjectDocument, decorateDocumentWithPhase, getEnabledProjectPhasesCatalog, getProjectDocumentById, getProjectDocumentPreviewUrl, getProjectDocuments, resolveDocumentRefs, setActiveProjectDocument } from "../services/project-documents-store.js";
 import { getDocumentStatsMap } from "../services/project-document-selectors.js";
-import { syncProjectDocumentsFromSupabase } from "../services/project-supabase-sync.js";
+import { listDocumentDirectory, createDocumentFolder, renameDocumentFolder, syncProjectDocumentsFromSupabase } from "../services/project-supabase-sync.js";
 import { getEffectiveSituationStatus, getEffectiveSujetStatus } from "./project-situations.js";
 import { buildSupabaseAuthHeaders, getSupabaseAnonKey, getSupabaseUrl } from "../../assets/js/auth.js";
 
@@ -77,8 +77,33 @@ const docsViewState = {
     rotation: 0,
     searchQuery: "",
     darkMode: false
-  }
+  },
+  currentFolderId: null,
+  breadcrumb: [],
+  folders: [],
+  files: [],
+  documentTreeOpen: false
 };
+
+function getFolderClosedIconSvg() {
+  return `<svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75Z"></path></svg>`;
+}
+
+function getFolderOpenIconSvg() {
+  return `<svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-file-directory-open-fill" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M.513 1.513A1.75 1.75 0 0 1 1.75 1h3.5c.55 0 1.07.26 1.4.7l.9 1.2a.25.25 0 0 0 .2.1H13a1 1 0 0 1 1 1v.5H2.75a.75.75 0 0 0 0 1.5h11.978a1 1 0 0 1 .994 1.117L15 13.25A1.75 1.75 0 0 1 13.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75c0-.464.184-.91.513-1.237Z"></path></svg>`;
+}
+
+async function loadCurrentDirectory({ forceFolderId } = {}) {
+  const projectId = String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || "").trim();
+  const folderId = forceFolderId === undefined ? docsViewState.currentFolderId : (forceFolderId || null);
+  console.info("[documents-view] load-directory.start", { projectId, folderId });
+  const directory = await listDocumentDirectory(projectId, folderId);
+  docsViewState.currentFolderId = directory?.currentFolder?.id || null;
+  docsViewState.breadcrumb = Array.isArray(directory?.breadcrumb) ? directory.breadcrumb : [];
+  docsViewState.folders = Array.isArray(directory?.folders) ? directory.folders : [];
+  docsViewState.files = Array.isArray(directory?.files) ? directory.files : [];
+  console.info("[documents-view] load-directory.success", { projectId, folderId: docsViewState.currentFolderId, folders: docsViewState.folders.length, files: docsViewState.files.length });
+}
 
 function syncDocumentsSelectedPhase() {
   const enabledPhases = getEnabledProjectPhasesCatalog();
@@ -1089,7 +1114,9 @@ function renderDocumentsToolbar() {
     mainAction: "add-documents"
   });
 
+  const addFolderButton = `<button type="button" class="gh-btn" id="documentsAddFolderBtn">Ajouter un dossier</button>`;
   const rightHtml = [
+    renderProjectTableToolbarGroup({ html: addFolderButton }),
     renderProjectTableToolbarGroup({ html: documentsButton })
   ].join("");
 
@@ -1098,6 +1125,29 @@ function renderDocumentsToolbar() {
     leftHtml: "",
     rightHtml
   });
+}
+
+function renderDocumentsBreadcrumb() {
+  const crumbButtons = [`<button type="button" class="documents-breadcrumb__link" data-breadcrumb-folder-id="">Documents</button>`];
+  docsViewState.breadcrumb.forEach((folder) => {
+    crumbButtons.push(`<span class="documents-breadcrumb__sep">/</span><button type="button" class="documents-breadcrumb__link" data-breadcrumb-folder-id="${escapeHtml(String(folder.id || ""))}">${escapeHtml(String(folder.name || "Dossier"))}</button>`);
+  });
+  crumbButtons.push(`<span class="documents-breadcrumb__sep">/</span>`);
+  return `<div class="documents-breadcrumb">${crumbButtons.join("")}</div>`;
+}
+
+function renderRepoFolderRow(folder) {
+  return `
+    <div class="documents-repo__row documents-repo__row--folder is-clickable" data-folder-id="${escapeHtml(folder.id || "")}" role="button" tabindex="0" aria-label="Ouvrir le dossier">
+      <div class="documents-repo__cell documents-repo__cell--name">
+        <span class="documents-repo__icon documents-repo__icon--folder">${getFolderClosedIconSvg()}</span>
+        <button type="button" class="documents-repo__name documents-repo__name-trigger js-folder-open-trigger" data-folder-id="${escapeHtml(folder.id || "")}">${escapeHtml(folder.name || "Dossier")}</button>
+      </div>
+      <div class="documents-repo__cell documents-repo__cell--message"><div class="documents-repo__message-main">Dossier</div></div>
+      <div class="documents-repo__cell documents-repo__cell--date">${escapeHtml(String(folder.updated_at || folder.created_at || "À l'instant"))}</div>
+      <div class="documents-repo__cell documents-repo__cell--stats"><button type="button" class="gh-btn" data-folder-rename-id="${escapeHtml(folder.id || "")}" data-folder-rename-name="${escapeHtml(folder.name || "")}">Renommer</button></div>
+    </div>
+  `;
 }
 
 
@@ -1150,7 +1200,9 @@ function renderRepoDocumentRow(doc) {
         <div class="documents-repo__message-meta">${escapeHtml(`${decoratedDoc.phaseCode}${decoratedDoc.phaseLabel ? ` - ${decoratedDoc.phaseLabel}` : ""}`)}</div>
       </div>
       <div class="documents-repo__cell documents-repo__cell--date">${escapeHtml(decoratedDoc.updatedAt || "À l'instant")}</div>
-      <div class="documents-repo__cell documents-repo__cell--stats">${renderDocumentStatsCell(decoratedDoc)}</div>
+      <div class="documents-repo__cell documents-repo__cell--stats">
+        <div class="documents-repo__stats-actions">${renderDocumentStatsCell(decoratedDoc)}<button type="button" class="gh-btn" data-document-move-id="${escapeHtml(decoratedDoc.id || "")}">Déplacer</button></div>
+      </div>
     </div>
   `;
 }
@@ -1510,15 +1562,17 @@ function renderPdfPreviewView() {
 }
 
 function renderDocumentsListView() {
-  const documents = getProjectDocuments();
-  const hasDocuments = documents.length > 0;
-  const bodyHtml = documents.map(renderRepoDocumentRow).join("");
+  const folders = Array.isArray(docsViewState.folders) ? docsViewState.folders : [];
+  const documents = Array.isArray(docsViewState.files) ? docsViewState.files : [];
+  const hasDocuments = folders.length + documents.length > 0;
+  const bodyHtml = [...folders.map(renderRepoFolderRow), ...documents.map(renderRepoDocumentRow)].join("");
 
   return `
     <section class="project-simple-page project-simple-page--documents">
       <div class="documents-shell documents-shell--project-page" id="projectDocumentScroll">
           ${renderDocumentsToolbar()}
           ${renderDocumentsActivityBanner()}
+          ${renderDocumentsBreadcrumb()}
 
           ${renderDataTableShell({
             className: "documents-repo data-table-shell--document-scroll",
@@ -1866,6 +1920,56 @@ function bindDocumentsSplitActions(root) {
 
 function bindDocumentsView(root) {
   bindDocumentsSplitActions(root);
+  const addFolderBtn = document.getElementById("documentsAddFolderBtn");
+  if (addFolderBtn) {
+    addFolderBtn.addEventListener("click", async () => {
+      const name = window.prompt("Nom du dossier ?");
+      if (!name) return;
+      console.info("[documents-view] create-folder.submit", { parentFolderId: docsViewState.currentFolderId || null });
+      await createDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), docsViewState.currentFolderId || null, name);
+      await loadCurrentDirectory();
+      renderProjectDocumentsContent(root);
+    });
+  }
+
+  document.querySelectorAll("[data-folder-rename-id]").forEach((btn) => {
+    btn.addEventListener("click", async (event) => {
+      event.stopPropagation();
+      const folderId = btn.getAttribute("data-folder-rename-id") || "";
+      const currentName = btn.getAttribute("data-folder-rename-name") || "";
+      const name = window.prompt("Nouveau nom du dossier :", currentName);
+      if (!name) return;
+      console.info("[documents-view] rename-folder.submit", { folderId });
+      await renameDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), folderId, name);
+      await loadCurrentDirectory();
+      renderProjectDocumentsContent(root);
+    });
+  });
+
+  document.querySelectorAll(".js-folder-open-trigger[data-folder-id]").forEach((trigger) => {
+    const folderId = trigger.getAttribute("data-folder-id") || "";
+    trigger.addEventListener("click", async (event) => {
+      event.preventDefault();
+      console.info("[documents-view] open-folder", { folderId });
+      await loadCurrentDirectory({ forceFolderId: folderId });
+      renderProjectDocumentsContent(root);
+    });
+  });
+
+  document.querySelectorAll("[data-breadcrumb-folder-id]").forEach((crumb) => {
+    crumb.addEventListener("click", async () => {
+      const folderId = crumb.getAttribute("data-breadcrumb-folder-id") || null;
+      console.info("[documents-view] breadcrumb-click", { folderId: folderId || null });
+      await loadCurrentDirectory({ forceFolderId: folderId || null });
+      renderProjectDocumentsContent(root);
+    });
+  });
+
+  document.querySelectorAll("[data-document-move-id]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      console.info("[documents-view] move-file.open", { fileId: btn.getAttribute("data-document-move-id") || "" });
+    });
+  });
 
     const activityCloseBtn = document.getElementById("documentsActivityCloseBtn");
   if (activityCloseBtn) {
@@ -1928,6 +2032,7 @@ function bindDocumentsView(root) {
 
     trigger.addEventListener("click", async (event) => {
       event.preventDefault();
+      console.info("[documents-view] open-file", { documentId });
       await openPdfPreview(root, documentId);
     });
   });
@@ -2029,10 +2134,11 @@ export function renderProjectDocuments(root) {
   root.className = "project-shell__content";
   clearProjectActiveScrollSource();
 
-  renderProjectDocumentsContent(root);
   debugProjectScrollPolicy("render-project-documents", { mode: docsViewState.mode });
-
-  syncProjectDocumentsFromSupabase({ force: true })
+  Promise.all([
+    syncProjectDocumentsFromSupabase({ force: true }),
+    loadCurrentDirectory()
+  ])
     .then(() => {
       if (!root?.isConnected) return;
       renderProjectDocumentsContent(root);

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -6471,6 +6471,32 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-repo__icon--document{
   color:var(--fg);
 }
+.documents-repo__icon--folder{
+  color:#58a6ff;
+}
+.documents-breadcrumb{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin:8px 0 12px;
+  color:var(--muted);
+  font-size:13px;
+  flex-wrap:wrap;
+}
+.documents-breadcrumb__link{
+  appearance:none;
+  border:0;
+  background:none;
+  color:var(--blueLink);
+  padding:0;
+  cursor:pointer;
+  font:inherit;
+}
+.documents-breadcrumb__link:hover,
+.documents-breadcrumb__link:focus-visible{
+  text-decoration:underline;
+}
+.documents-breadcrumb__sep{color:var(--muted);}
 .documents-repo__message-main{
   color:var(--muted);
   font-size:13px;
@@ -6491,6 +6517,12 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
   flex-wrap:wrap;
   gap:6px;
   align-items:center;
+}
+.documents-repo__stats-actions{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  justify-content:space-between;
 }
 .documents-count-badge{
   display:inline-flex;

--- a/supabase/migrations/202606150045_document_folders_and_move_rpc.sql
+++ b/supabase/migrations/202606150045_document_folders_and_move_rpc.sql
@@ -1,0 +1,107 @@
+create table if not exists public.project_document_folders (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  parent_folder_id uuid null,
+  name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  created_by uuid null references auth.users(id),
+  constraint project_document_folders_name_not_blank check (btrim(name) <> ''),
+  constraint project_document_folders_unique_name_per_parent unique nulls not distinct (project_id, parent_folder_id, name),
+  constraint project_document_folders_project_id_id_unique unique (project_id, id),
+  constraint project_document_folders_parent_folder_fkey
+    foreign key (parent_folder_id) references public.project_document_folders(id) on delete cascade,
+  constraint project_document_folders_parent_same_project_fkey
+    foreign key (project_id, parent_folder_id) references public.project_document_folders(project_id, id) on delete cascade
+);
+
+create index if not exists idx_project_document_folders_project_id
+  on public.project_document_folders(project_id);
+
+create index if not exists idx_project_document_folders_parent_folder_id
+  on public.project_document_folders(parent_folder_id);
+
+create index if not exists idx_project_document_folders_project_parent
+  on public.project_document_folders(project_id, parent_folder_id);
+
+drop trigger if exists trg_project_document_folders_updated_at on public.project_document_folders;
+create trigger trg_project_document_folders_updated_at
+before update on public.project_document_folders
+for each row execute function public.set_updated_at();
+
+alter table public.documents
+  add column if not exists folder_id uuid null references public.project_document_folders(id) on delete set null;
+
+create index if not exists idx_documents_folder_id
+  on public.documents(folder_id);
+
+alter table public.project_document_folders enable row level security;
+
+-- Folder access follows the same project owner predicate currently used for documents.
+drop policy if exists project_document_folders_by_project on public.project_document_folders;
+create policy project_document_folders_by_project
+on public.project_document_folders
+for all
+using (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+)
+with check (
+  project_id in (
+    select p.id
+    from public.projects p
+    where p.owner_id = auth.uid()
+  )
+);
+
+create or replace function public.move_project_document_file(
+  file_id uuid,
+  target_folder_id uuid default null
+)
+returns public.documents
+language plpgsql
+security invoker
+as $$
+declare
+  v_document public.documents;
+  v_target_folder public.project_document_folders;
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select d.*
+  into v_document
+  from public.documents d
+  where d.id = file_id;
+
+  if not found then
+    raise exception 'Document file not found: %', file_id;
+  end if;
+
+  if target_folder_id is not null then
+    select f.*
+    into v_target_folder
+    from public.project_document_folders f
+    where f.id = target_folder_id;
+
+    if not found then
+      raise exception 'Target folder not found: %', target_folder_id;
+    end if;
+
+    if v_target_folder.project_id <> v_document.project_id then
+      raise exception 'Target folder belongs to another project';
+    end if;
+  end if;
+
+  update public.documents d
+  set folder_id = target_folder_id
+  where d.id = v_document.id
+  returning * into v_document;
+
+  return v_document;
+end;
+$$;


### PR DESCRIPTION
### Motivation
- Provide folder organization for project documents and allow moving files between folders on the backend.
- Expose CRUD and listing operations for folders and directory listing through the existing Supabase sync service to power a folder UI.
- Surface folder management in the documents view so users can create, rename and navigate folders and prepare move operations.

### Description
- Add a new DB migration that creates `project_document_folders`, adds `folder_id` to `documents`, adds indexes and row-level security, and implements the `move_project_document_file` RPC to relocate files into folders and return the updated `documents` row.
- Implement new service functions in `project-supabase-sync.js` including `ensureBackendProjectIdOrThrow`, `listDocumentFolders`, `listDocumentFolderChildren`, `createDocumentFolder`, `renameDocumentFolder`, `getDocumentFolderPath`, `listDocumentDirectory`, and `moveDocumentFile`, plus logging and validation.
- Update the documents view (`project-documents.js`) to import folder APIs, extend `docsViewState` with folder/directory state, add `loadCurrentDirectory`, breadcrumb rendering, folder row rendering, folder create/rename/open handlers, and integrate directory load with `syncProjectDocumentsFromSupabase` during render.
- Add CSS rules in `style.css` for folder icons, breadcrumb, and layout, and include a small UI change to add a "Ajouter un dossier" button and a document "Déplacer" action button (move UI currently opens a stub log).

### Testing
- No automated tests were added or executed as part of this change; please run the project's CI to exercise the full test suite against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4472039c08329a70fc662fb3fca7d)