### PR TITLE
Ajuste l’UI de l’onglet Documents (hauteurs, padding et indentation)

### DIFF
--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1661,7 +1661,7 @@ function renderDocumentsSidebarTree() {
     const caret = hasChildren ? `<button type="button" class="documents-tree__caret" data-tree-toggle-folder-id="${escapeHtml(id)}">${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}</button>` : `<span class="documents-tree__caret-spacer"></span>`;
     const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="padding-left:${12 + Math.min(depth, 8) * 18}px">${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} ${escapeHtml(folder.name || "Dossier")}</button></div>`;
     if (!isExpanded) return row;
-    const fileRows = files.map((file) => `<div class="documents-tree__file" style="padding-left:${34 + Math.min(depth + 1, 9) * 18}px">${getDocumentIconSvg()} ${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</div>`).join("");
+    const fileRows = files.map((file) => `<div class="documents-tree__file" style="padding-left:${12 + Math.min(depth + 1, 9) * 24}px">${getDocumentIconSvg()} ${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</div>`).join("");
     return `${row}${walk(id, depth + 1).join("")}${fileRows}`;
   });
   const opened = !!docsViewState.documentTreeOpen;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -6569,14 +6569,14 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-tree.is-collapsed .documents-tree__panel,.documents-tree.is-collapsed .documents-tree__resize-handle,.documents-tree.is-collapsed .documents-tree__resize-guide{display:none;}
 .documents-tree__toggle{width:32px;height:32px;border:1px solid var(--border);background:var(--bgElev);color:var(--muted);border-radius:8px;display:inline-flex;align-items:center;justify-content:center;}
 .documents-tree__panel{width:100%;min-height:240px;max-height:var(--documents-content-height, calc(100vh - 180px));overflow:auto;border-right:1px solid var(--border);border-top:0;border-left:0;border-bottom:0;border-radius:0;background:var(--bgElev);padding:8px;display:flex;flex-direction:column;gap:2px;height:var(--documents-content-height, calc(100vh - 180px));}
-.documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;}
+.documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;height:44px;}
 .documents-tree__row.is-active{background:rgba(56,139,253,.15);}
 .documents-tree__row.is-active::before{content:"";position:absolute;left:-6px;top:4px;bottom:4px;width:3px;border-radius:3px;background:#2f81f7;}
 .documents-tree__caret{border:0;background:transparent;color:var(--muted);cursor:pointer;padding:0 4px;}
 .documents-tree__caret-spacer{display:inline-block;width:16px;}
-.documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
+.documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px 8px 0px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
 .documents-tree__item.is-active{color:#58a6ff;}
-.documents-tree__file{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px;padding:4px 0;}
+.documents-tree__file{display:flex;align-items:center;gap:8px;font-size:13px;padding:4px 0;height:44px;}
 .documents-tree .documents-repo__icon--folder,.documents-tree .octicon-file-directory-fill,.documents-tree .octicon-file-directory-open-fill{fill:rgb(145, 152, 161);color:rgb(145, 152, 161);}
 .documents-tree__resize-handle{position:absolute;top:0;right:-6px;width:12px;height:100%;cursor:col-resize;}
 .documents-tree__resize-guide{position:absolute;top:0;bottom:0;width:2px;background:#2f81f7;display:none;pointer-events:none;}


### PR DESCRIPTION
### Motivation
- Harmoniser la hauteur des lignes et l’alignement des éléments dans l’arborescence Documents pour un rendu visuel cohérent et un espacement prévisible entre dossiers et fichiers.

### Description
- Ajoute `height:44px` à `.documents-tree__row` dans `apps/web/style.css` pour fixer la hauteur des lignes.
- Met à jour `.documents-tree__item` avec `padding: 8px 12px 8px 0px` dans `apps/web/style.css` pour ajuster le padding droit/gauche demandé.
- Met à jour `.documents-tree__file` dans `apps/web/style.css` pour appliquer `height:44px`, `font-size:13px` et retirer la couleur `var(--muted)`.
- Réajuste le calcul du `padding-left` des fichiers dans `apps/web/js/views/project-documents.js` pour utiliser la formule `padding-left = 24px * step + 12px` implémentée comme `12 + Math.min(depth + 1, 9) * 24`.

### Testing
- Aucun test automatisé spécifique n’a été exécuté pour ces modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f475a6b3a88329af6163ea866e4b72)