### PR TITLE
Improve documents tree resize, label truncation, and layout consistency

### DIFF
--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1608,7 +1608,7 @@ function renderDocumentsListView() {
   const moveModalHtml = docsViewState.moveModal?.isOpen ? renderMoveFileModal() : "";
   return `
     <section class="project-simple-page project-simple-page--documents">
-      <div class="documents-shell documents-shell--project-page documents-layout${isRoot ? " is-root" : ""}" id="projectDocumentScroll">
+      <div class="documents-shell documents-shell--project-page documents-layout${isRoot ? " is-root" : ""}" id="projectDocumentScroll" style="--documents-tree-width:${isRoot ? 0 : (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0)}px">
           ${treeHtml}
           <div class="documents-main">
             ${isRoot ? renderDocumentsToolbar() : topBar}
@@ -1659,13 +1659,13 @@ function renderDocumentsSidebarTree() {
     const hasChildren = childFolders.length > 0 || files.length > 0;
     const isExpanded = expandedSet.has(id);
     const caret = hasChildren ? `<button type="button" class="documents-tree__caret" data-tree-toggle-folder-id="${escapeHtml(id)}">${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}</button>` : `<span class="documents-tree__caret-spacer"></span>`;
-    const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="padding-left:${12 + Math.min(depth, 8) * 18}px">${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} ${escapeHtml(folder.name || "Dossier")}</button></div>`;
+    const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="padding-left:${12 + Math.min(depth, 8) * 18}px">${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} <span class="documents-tree__label">${escapeHtml(folder.name || "Dossier")}</span></button></div>`;
     if (!isExpanded) return row;
-    const fileRows = files.map((file) => `<div class="documents-tree__file" style="padding-left:${34 + Math.min(depth + 1, 9) * 18}px">${getDocumentIconSvg()} ${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</div>`).join("");
+    const fileRows = files.map((file) => `<div class="documents-tree__file" style="padding-left:${12 + Math.min(depth + 2, 10) * 24}px">${getDocumentIconSvg()} <span class="documents-tree__label">${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</span></div>`).join("");
     return `${row}${walk(id, depth + 1).join("")}${fileRows}`;
   });
   const opened = !!docsViewState.documentTreeOpen;
-  const treeBody = `<div class="documents-tree__panel"><div class="documents-tree__row${docsViewState.currentFolderId ? "" : " is-active"}"><span class="documents-tree__caret-spacer"></span><button type="button" class="documents-tree__item${docsViewState.currentFolderId ? "" : " is-active"}" data-tree-folder-id="">${getFolderOpenIconSvg()} Racine / Documents</button></div>${walk("").join("")}</div>`;
+  const treeBody = `<div class="documents-tree__panel"><div class="documents-tree__row${docsViewState.currentFolderId ? "" : " is-active"}"><span class="documents-tree__caret-spacer"></span><button type="button" class="documents-tree__item${docsViewState.currentFolderId ? "" : " is-active"}" data-tree-folder-id="">${getFolderOpenIconSvg()} <span class="documents-tree__label">Racine / Documents</span></button></div>${walk("").join("")}</div>`;
   return `
     <aside class="documents-tree${opened ? " is-open" : " is-collapsed"}" style="--documents-tree-width:${Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280)))}px">
       ${treeBody}
@@ -1705,7 +1705,7 @@ function renderMoveFileModal() {
         <header class="documents-move-modal__header"><h3>Déplacer le fichier</h3><button type="button" class="gh-btn" id="documentsMoveModalCloseBtn">Fermer</button></header>
         <div class="documents-move-modal__current">Dossier actuel : <strong>${escapeHtml(sourceLabel)}</strong></div>
         <div class="documents-move-modal__targets">
-          <button type="button" class="documents-move-modal__target${rootSelected ? " is-active" : ""}" data-move-target-folder-id="">${getFolderOpenIconSvg()} Racine / Documents</button>
+          <button type="button" class="documents-move-modal__target${rootSelected ? " is-active" : ""}" data-move-target-folder-id="">${getFolderOpenIconSvg()} <span class="documents-tree__label">Racine / Documents</span></button>
           ${flatten("").join("")}
         </div>
         <footer class="documents-move-modal__actions"><button type="button" class="gh-btn gh-btn--validate" id="documentsMoveModalConfirmBtn">Déplacer ici</button></footer>
@@ -2438,6 +2438,8 @@ export function renderProjectDocuments(root) {
       const onMove = (moveEvent) => {
         const next = Math.max(220, Math.min(520, startWidth + (moveEvent.clientX - startX)));
         docsViewState.treeWidth = next;
+        const shell = document.getElementById("projectDocumentScroll");
+        if (shell) shell.style.setProperty("--documents-tree-width", `${next}px`);
         if (guide) {
           guide.style.display = "block";
           guide.style.left = `${next}px`;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -6569,14 +6569,16 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-tree.is-collapsed .documents-tree__panel,.documents-tree.is-collapsed .documents-tree__resize-handle,.documents-tree.is-collapsed .documents-tree__resize-guide{display:none;}
 .documents-tree__toggle{width:32px;height:32px;border:1px solid var(--border);background:var(--bgElev);color:var(--muted);border-radius:8px;display:inline-flex;align-items:center;justify-content:center;}
 .documents-tree__panel{width:100%;min-height:240px;max-height:var(--documents-content-height, calc(100vh - 180px));overflow:auto;border-right:1px solid var(--border);border-top:0;border-left:0;border-bottom:0;border-radius:0;background:var(--bgElev);padding:8px;display:flex;flex-direction:column;gap:2px;height:var(--documents-content-height, calc(100vh - 180px));}
-.documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;}
+.documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;height:44px;}
 .documents-tree__row.is-active{background:rgba(56,139,253,.15);}
 .documents-tree__row.is-active::before{content:"";position:absolute;left:-6px;top:4px;bottom:4px;width:3px;border-radius:3px;background:#2f81f7;}
 .documents-tree__caret{border:0;background:transparent;color:var(--muted);cursor:pointer;padding:0 4px;}
 .documents-tree__caret-spacer{display:inline-block;width:16px;}
-.documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
+.documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px 8px 0px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
 .documents-tree__item.is-active{color:#58a6ff;}
-.documents-tree__file{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px;padding:4px 0;}
+.documents-tree__file{display:flex;align-items:center;gap:8px;font-size:13px;padding:4px 0;height:44px;min-width:0;}
+.documents-tree__item,.documents-tree__file{min-width:0;}
+.documents-tree__label{display:block;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .documents-tree .documents-repo__icon--folder,.documents-tree .octicon-file-directory-fill,.documents-tree .octicon-file-directory-open-fill{fill:rgb(145, 152, 161);color:rgb(145, 152, 161);}
 .documents-tree__resize-handle{position:absolute;top:0;right:-6px;width:12px;height:100%;cursor:col-resize;}
 .documents-tree__resize-guide{position:absolute;top:0;bottom:0;width:2px;background:#2f81f7;display:none;pointer-events:none;}


### PR DESCRIPTION
### Motivation

- Make the documents sidebar more responsive and visually consistent by enabling live resizing of the tree and preventing label overflow. 
- Improve alignment and spacing for folder and file rows so items remain readable and clickable at different widths.

### Description

- Set a CSS variable for the tree width on the documents container by adding an inline `style` on the `#projectDocumentScroll` element and use it to drive the layout in the grid (`--documents-tree-width`).
- Update the resize pointer handler to update the CSS variable live during dragging (`shell.style.setProperty("--documents-tree-width", ...)`) so the tree resizes without a full rerender until pointer release.
- Wrap folder and file names in a new `.documents-tree__label` element and adjust file indentation calculations to standardize spacing between levels.
- Add CSS changes for consistent row heights and truncation: set `.documents-tree__row` and `.documents-tree__file` heights, tweak `.documents-tree__item` padding, add `min-width:0` and a `.documents-tree__label` rule with `overflow:hidden;text-overflow:ellipsis;white-space:nowrap;`.

### Testing

- Ran the frontend unit test suite with `yarn test` and the test run completed successfully.
- Ran the linter with `yarn lint` and it reported no new issues.
- Built the frontend assets with `yarn build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f475a6b3a88329af6163ea866e4b72)