### PR TITLE
Add interactive documents tree sidebar, make tree items open PDFs and refine PDF preview layout

### DIFF
--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1148,7 +1148,7 @@ function renderDocumentsTopBar() {
         <button type="button" class="documents-tree__toggle" id="documentsTreeToggleBtn">${toggleIcon}</button>
         ${renderDocumentsBreadcrumb()}
       </div>
-      <div class="documents-topbar__right">
+      ${docsViewState.mode === "pdf-preview" ? "" : `<div class="documents-topbar__right">
         <button type="button" class="gh-btn" id="documentsAddFolderBtn">Ajouter un dossier</button>
         ${renderGhActionButton({
           id: "documentsAddAction",
@@ -1157,7 +1157,7 @@ function renderDocumentsTopBar() {
           tone: "primary",
           mainAction: "add-documents"
         })}
-      </div>
+      </div>`}
     </div>
   `;
 }
@@ -1437,11 +1437,15 @@ function renderPdfPreviewView() {
   const previewErrorMessage = String(docsViewState.pdfPreview?.errorMessage || "").trim();
   const hasPdfBytes = docsViewState.pdfPreview?.bytes instanceof Uint8Array && docsViewState.pdfPreview.bytes.byteLength > 0;
 
+  const treeHtml = docsViewState.currentFolderId ? renderDocumentsSidebarTree() : "";
+  const topBar = renderDocumentsTopBar();
   return `
     <section class="project-simple-page project-simple-page--documents">
-      <div class="documents-shell documents-shell--report documents-shell--pdf-preview documents-shell--project-page" id="projectDocumentScroll">
+      <div class="documents-shell documents-shell--project-page documents-layout${docsViewState.currentFolderId ? "" : " is-root"}" id="projectDocumentScroll" style="--documents-tree-width:${docsViewState.currentFolderId ? (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0) : 0}px">
+        ${treeHtml}
+        <div class="documents-main">
+          ${topBar}
           ${renderDocumentsActivityBanner()}
-
           <div class="documents-report">
             <div class="documents-report__path">${escapeHtml(breadcrumb)}</div>
 
@@ -1592,6 +1596,7 @@ function renderPdfPreviewView() {
             </section>
           </div>
         </div>
+      </div>
     </section>
   `;
 }
@@ -1608,7 +1613,7 @@ function renderDocumentsListView() {
   const moveModalHtml = docsViewState.moveModal?.isOpen ? renderMoveFileModal() : "";
   return `
     <section class="project-simple-page project-simple-page--documents">
-      <div class="documents-shell documents-shell--project-page documents-layout${isRoot ? " is-root" : ""}" id="projectDocumentScroll">
+      <div class="documents-shell documents-shell--project-page documents-layout${isRoot ? " is-root" : ""}" id="projectDocumentScroll" style="--documents-tree-width:${isRoot ? 0 : (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0)}px">
           ${treeHtml}
           <div class="documents-main">
             ${isRoot ? renderDocumentsToolbar() : topBar}
@@ -1659,13 +1664,13 @@ function renderDocumentsSidebarTree() {
     const hasChildren = childFolders.length > 0 || files.length > 0;
     const isExpanded = expandedSet.has(id);
     const caret = hasChildren ? `<button type="button" class="documents-tree__caret" data-tree-toggle-folder-id="${escapeHtml(id)}">${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}</button>` : `<span class="documents-tree__caret-spacer"></span>`;
-    const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="padding-left:${12 + Math.min(depth, 8) * 18}px">${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} ${escapeHtml(folder.name || "Dossier")}</button></div>`;
+    const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="--tree-indent:${12 + Math.min(depth, 8) * 18}px;padding-left:${12 + Math.min(depth, 8) * 18}px">${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} <span class="documents-tree__label">${escapeHtml(folder.name || "Dossier")}</span></button></div>`;
     if (!isExpanded) return row;
-    const fileRows = files.map((file) => `<div class="documents-tree__file" style="padding-left:${34 + Math.min(depth + 1, 9) * 18}px">${getDocumentIconSvg()} ${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</div>`).join("");
+    const fileRows = files.map((file) => `<button type="button" class="documents-tree__file" data-tree-document-id="${escapeHtml(String(file?.id || ""))}" style="--tree-indent:${12 + Math.min(depth + 2, 10) * 24}px;padding-left:${12 + Math.min(depth + 2, 10) * 24}px">${getDocumentIconSvg()} <span class="documents-tree__label">${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</span></button>`).join("");
     return `${row}${walk(id, depth + 1).join("")}${fileRows}`;
   });
   const opened = !!docsViewState.documentTreeOpen;
-  const treeBody = `<div class="documents-tree__panel"><div class="documents-tree__row${docsViewState.currentFolderId ? "" : " is-active"}"><span class="documents-tree__caret-spacer"></span><button type="button" class="documents-tree__item${docsViewState.currentFolderId ? "" : " is-active"}" data-tree-folder-id="">${getFolderOpenIconSvg()} Racine / Documents</button></div>${walk("").join("")}</div>`;
+  const treeBody = `<div class="documents-tree__panel"><div class="documents-tree__row${docsViewState.currentFolderId ? "" : " is-active"}"><span class="documents-tree__caret-spacer"></span><button type="button" class="documents-tree__item${docsViewState.currentFolderId ? "" : " is-active"}" data-tree-folder-id="">${getFolderOpenIconSvg()} <span class="documents-tree__label">Racine / Documents</span></button></div>${walk("").join("")}</div>`;
   return `
     <aside class="documents-tree${opened ? " is-open" : " is-collapsed"}" style="--documents-tree-width:${Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280)))}px">
       ${treeBody}
@@ -1705,7 +1710,7 @@ function renderMoveFileModal() {
         <header class="documents-move-modal__header"><h3>Déplacer le fichier</h3><button type="button" class="gh-btn" id="documentsMoveModalCloseBtn">Fermer</button></header>
         <div class="documents-move-modal__current">Dossier actuel : <strong>${escapeHtml(sourceLabel)}</strong></div>
         <div class="documents-move-modal__targets">
-          <button type="button" class="documents-move-modal__target${rootSelected ? " is-active" : ""}" data-move-target-folder-id="">${getFolderOpenIconSvg()} Racine / Documents</button>
+          <button type="button" class="documents-move-modal__target${rootSelected ? " is-active" : ""}" data-move-target-folder-id="">${getFolderOpenIconSvg()} <span class="documents-tree__label">Racine / Documents</span></button>
           ${flatten("").join("")}
         </div>
         <footer class="documents-move-modal__actions"><button type="button" class="gh-btn gh-btn--validate" id="documentsMoveModalConfirmBtn">Déplacer ici</button></footer>
@@ -2064,6 +2069,14 @@ function bindDocumentsView(root) {
       console.info("[documents-tree] select-folder", { folderId: folderId || null });
       await loadCurrentDirectory({ forceFolderId: folderId || null });
       renderProjectDocumentsContent(root);
+    });
+  });
+  document.querySelectorAll("[data-tree-document-id]").forEach((node) => {
+    node.addEventListener("click", async () => {
+      const documentId = String(node.getAttribute("data-tree-document-id") || "").trim();
+      if (!documentId) return;
+      console.info("[documents-view] open-file", { documentId, source: "tree" });
+      await openPdfPreview(root, documentId);
     });
   });
   document.querySelectorAll("[data-tree-toggle-folder-id]").forEach((node) => {
@@ -2438,6 +2451,8 @@ export function renderProjectDocuments(root) {
       const onMove = (moveEvent) => {
         const next = Math.max(220, Math.min(520, startWidth + (moveEvent.clientX - startX)));
         docsViewState.treeWidth = next;
+        const shell = document.getElementById("projectDocumentScroll");
+        if (shell) shell.style.setProperty("--documents-tree-width", `${next}px`);
         if (guide) {
           guide.style.display = "block";
           guide.style.left = `${next}px`;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -6496,13 +6496,17 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
   color:var(--blueLink);
   padding:0;
   cursor:pointer;
-  font:inherit;
+  font-size:16px;
+  line-height:24px;
+  font-weight:400;
 }
 .documents-breadcrumb__link:hover,
 .documents-breadcrumb__link:focus-visible{
   text-decoration:underline;
 }
 .documents-breadcrumb__sep{color:var(--muted);}
+.documents-breadcrumb__link:first-of-type{font-weight:600;}
+.documents-breadcrumb__link:last-of-type{font-weight:600;color:rgb(240, 246, 252);}
 .documents-repo__message-main{
   color:var(--muted);
   font-size:13px;
@@ -6567,16 +6571,23 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-topbar .documents-breadcrumb{margin:0;white-space:nowrap;overflow:auto;}
 .documents-tree{position:relative;width:var(--documents-tree-width);}
 .documents-tree.is-collapsed .documents-tree__panel,.documents-tree.is-collapsed .documents-tree__resize-handle,.documents-tree.is-collapsed .documents-tree__resize-guide{display:none;}
-.documents-tree__toggle{width:32px;height:32px;border:1px solid var(--border);background:var(--bgElev);color:var(--muted);border-radius:8px;display:inline-flex;align-items:center;justify-content:center;}
+.documents-tree__toggle{width:32px;height:32px;border:solid 1px transparent;background:var(--bgElev);color:var(--muted);border-radius:8px;display:inline-flex;align-items:center;justify-content:center;}
 .documents-tree__panel{width:100%;min-height:240px;max-height:var(--documents-content-height, calc(100vh - 180px));overflow:auto;border-right:1px solid var(--border);border-top:0;border-left:0;border-bottom:0;border-radius:0;background:var(--bgElev);padding:8px;display:flex;flex-direction:column;gap:2px;height:var(--documents-content-height, calc(100vh - 180px));}
-.documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;}
+.documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;height:44px;}
 .documents-tree__row.is-active{background:rgba(56,139,253,.15);}
+.documents-tree__row:hover{background:rgba(110,118,129,.16);}
 .documents-tree__row.is-active::before{content:"";position:absolute;left:-6px;top:4px;bottom:4px;width:3px;border-radius:3px;background:#2f81f7;}
 .documents-tree__caret{border:0;background:transparent;color:var(--muted);cursor:pointer;padding:0 4px;}
 .documents-tree__caret-spacer{display:inline-block;width:16px;}
-.documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
+.documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px 8px 0px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
 .documents-tree__item.is-active{color:#58a6ff;}
-.documents-tree__file{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px;padding:4px 0;}
+.documents-tree__file{display:flex;align-items:center;gap:8px;font-size:13px;padding:4px 0;height:44px;min-width:0;border:0;background:transparent;color:var(--text);cursor:pointer;position:relative;border-radius:6px;}
+.documents-tree__item,.documents-tree__file{min-width:0;}
+.documents-tree__label{display:block;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.documents-tree__file:hover{background:rgba(110,118,129,.16);}
+.documents-tree__file:hover .documents-tree__label{color:#58a6ff;text-decoration:underline;}
+.documents-tree__row,.documents-tree__file{position:relative;}
+.documents-tree__row::after,.documents-tree__file::after{content:"";position:absolute;left:calc(var(--tree-indent, 12px) - 10px);top:4px;bottom:4px;width:1px;background:rgba(240,246,252,.24);pointer-events:none;}
 .documents-tree .documents-repo__icon--folder,.documents-tree .octicon-file-directory-fill,.documents-tree .octicon-file-directory-open-fill{fill:rgb(145, 152, 161);color:rgb(145, 152, 161);}
 .documents-tree__resize-handle{position:absolute;top:0;right:-6px;width:12px;height:100%;cursor:col-resize;}
 .documents-tree__resize-guide{position:absolute;top:0;bottom:0;width:2px;background:#2f81f7;display:none;pointer-events:none;}


### PR DESCRIPTION
### Motivation

- Provide a persistent, interactive documents tree/sidebar for navigating project document folders and files. 
- Allow opening PDF files directly from the tree and ensure the PDF preview layout integrates with the tree and topbar state. 
- Improve visual presentation and accessibility of the tree and breadcrumb elements.

### Description

- Render the documents tree sidebar in both list and PDF preview views and wire the layout to a CSS variable `--documents-tree-width` so the shell responds to tree width changes. 
- Convert tree file rows into interactive buttons with `data-tree-document-id` and add an event handler that calls `openPdfPreview` when a tree file is clicked. 
- Hide the top-right actions in the topbar when `docsViewState.mode === "pdf-preview"` and adjust `renderPdfPreviewView` markup to include the tree and main area structure (`.documents-layout`, `.documents-main`). 
- Persist tree expansion state/width and update the resize logic to update the shell width live during pointer moves. 
- Revamp tree and breadcrumb styles in `style.css`: add indentation variables, hover states, sizing/typography tweaks, label spans, and visual refinements for rows, files, caret, and resize handle. 
- Small markup tweaks across tree, breadcrumb, and move-modal to wrap labels in `.documents-tree__label` for truncation and consistent styling.

### Testing

- Ran the automated unit test suite with `yarn test` and all tests passed. 
- Ran the linter with `npm run lint` and the build with `npm run build`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f475a6b3a88329af6163ea866e4b72)