### PR TITLE
Attach uploaded documents to the active folder in Documents view

### DIFF
--- a/apps/web/js/services/analysis-runner.js
+++ b/apps/web/js/services/analysis-runner.js
@@ -816,6 +816,7 @@ export async function runAnalysis(options = {}) {
   }
 
   const triggerType = options.triggerType || "manual";
+  const currentFolderId = String(options.currentFolderId || "").trim() || null;
   const triggerLabel = options.triggerLabel
     || (triggerType === "document-upload" ? "Dépôt de document" : "Lancement manuel");
   const primaryAgentKey = options.agentKey || getPrimaryAnalysisAgent()?.key || "parasismique";
@@ -851,9 +852,14 @@ export async function runAnalysis(options = {}) {
 
       setSystemStatus("running", "En cours d’analyse", "Création du document");
       const currentUser = await getCurrentUser();
+      console.info("[documents-upload] create-record.start", {
+        projectId: backendProjectId,
+        currentFolderId
+      });
 
       const documentRow = await restInsert("documents", {
         project_id: backendProjectId,
+        folder_id: currentFolderId,
         created_by: currentUser?.id || null,
         filename: inputs.pdfFile.name,
         original_filename: inputs.pdfFile.name,
@@ -864,6 +870,11 @@ export async function runAnalysis(options = {}) {
         upload_status: "uploaded",
         document_kind: "source_pdf"
       }, "id,project_id,storage_bucket,storage_path");
+      console.info("[documents-upload] create-record.success", {
+        documentId: String(documentRow?.id || ""),
+        projectId: backendProjectId,
+        currentFolderId
+      });
 
       setSystemStatus("running", "En cours d’analyse", "Création du run");
       await restInsert("analysis_runs", {

--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1978,6 +1978,8 @@ function buildRepoDocumentFromState() {
 
 function triggerAutoAnalysisAfterDirectUpload(root, document = null) {
   const documentName = document?.name || "";
+  const currentFolderId = docsViewState.currentFolderId || null;
+  console.info("[documents-upload] current-folder", { currentFolderId });
   if (!shouldAutoRunAnalysisAfterUpload()) {
     setDocumentsActivity({
       tone: "info",
@@ -2007,6 +2009,7 @@ function triggerAutoAnalysisAfterDirectUpload(root, document = null) {
     triggerType: "document-upload",
     triggerLabel: "Dépôt de document",
     documentName,
+    currentFolderId,
     documentIds: document?.id ? [document.id] : [],
     summary: "Analyse déclenchée automatiquement après dépôt réussi d’un document."
   });
@@ -2029,6 +2032,16 @@ function commitDirectDocument(root) {
 function handleSubmit(root) {
   if (!canSubmitUpload()) return;
   commitDirectDocument(root);
+  loadCurrentDirectory()
+    .then(() => {
+      console.info("[documents-upload] refresh-current-directory", { currentFolderId: docsViewState.currentFolderId || null });
+      renderProjectDocumentsContent(root);
+    })
+    .catch((error) => {
+      console.error("[documents-upload] refresh-current-directory.failed", {
+        error: error instanceof Error ? error.message : String(error || "")
+      });
+    });
 }
 
 function bindDocumentsSplitActions(root) {


### PR DESCRIPTION
### Motivation
- Permettre que les fichiers uploadés depuis l’UI Documents soient rattachés au dossier courant plutôt qu’au seul emplacement racine. 

### Description
- Transmet le `currentFolderId` depuis la vue Documents vers le chemin d’upload/creation en appelant `runAnalysis({ currentFolderId })` (modification dans `apps/web/js/views/project-documents.js`).
- Persiste `folder_id` lors de la création de l’enregistrement `documents` dans `runAnalysis` (modification dans `apps/web/js/services/analysis-runner.js`) en écrivant `folder_id: currentFolderId` ou `null` pour la racine.
- Après un upload/submit, rafraîchit uniquement le dossier courant via `loadCurrentDirectory()` au lieu de recharger toute l’application (UI refresh ciblé dans `project-documents.js`).
- Ajout d’instrumentation temporaire pour débogage: `[documents-upload] current-folder`, `[documents-upload] create-record.start`, `[documents-upload] create-record.success`, et `[documents-upload] refresh-current-directory`, et préservation du `storage_path` existant (aucun changement au chemin Supabase Storage).

### Testing
- Exécuté les tests Node ciblés avec `node --test apps/web/js/services/project-document-selectors.test.mjs apps/web/js/views/project-subjects/project-subjects-description-versions.test.mjs`.
- Tous les tests lancés sont passés: `# tests 13`, `# pass 13`, `# fail 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49164b99c83298aef7df20f88c2d3)