### PR TITLE
Documents: validate/unique folder names, folder-aware uploads/analysis, and UI improvements

### DIFF
--- a/apps/web/js/services/analysis-runner.js
+++ b/apps/web/js/services/analysis-runner.js
@@ -816,6 +816,7 @@ export async function runAnalysis(options = {}) {
   }
 
   const triggerType = options.triggerType || "manual";
+  const currentFolderId = String(options.currentFolderId || "").trim() || null;
   const triggerLabel = options.triggerLabel
     || (triggerType === "document-upload" ? "Dépôt de document" : "Lancement manuel");
   const primaryAgentKey = options.agentKey || getPrimaryAnalysisAgent()?.key || "parasismique";
@@ -851,9 +852,9 @@ export async function runAnalysis(options = {}) {
 
       setSystemStatus("running", "En cours d’analyse", "Création du document");
       const currentUser = await getCurrentUser();
-
       const documentRow = await restInsert("documents", {
         project_id: backendProjectId,
+        folder_id: currentFolderId,
         created_by: currentUser?.id || null,
         filename: inputs.pdfFile.name,
         original_filename: inputs.pdfFile.name,
@@ -864,7 +865,6 @@ export async function runAnalysis(options = {}) {
         upload_status: "uploaded",
         document_kind: "source_pdf"
       }, "id,project_id,storage_bucket,storage_path");
-
       setSystemStatus("running", "En cours d’analyse", "Création du run");
       await restInsert("analysis_runs", {
         id: runId,

--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -917,10 +917,15 @@ export async function createDocumentFolder(projectId = "", parentFolderId = null
   const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
   const normalizedParentFolderId = safeString(parentFolderId || "") || null;
   const normalizedName = safeString(name);
-  if (!normalizedName) throw new Error("Folder name is required.");
+  if (!normalizedName) throw new Error("Le nom du dossier ne peut pas être vide.");
   console.info("[documents-folders] create.start", { projectId: backendProjectId, parentFolderId: normalizedParentFolderId, name: normalizedName });
 
   try {
+    const siblings = await listDocumentFolderChildren(backendProjectId, normalizedParentFolderId);
+    const duplicate = siblings.some((folder) => safeString(folder.name).toLocaleLowerCase("fr-FR") === normalizedName.toLocaleLowerCase("fr-FR"));
+    if (duplicate) {
+      throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
+    }
     return await restInsert("project_document_folders", {
       project_id: backendProjectId,
       parent_folder_id: normalizedParentFolderId,
@@ -929,6 +934,9 @@ export async function createDocumentFolder(projectId = "", parentFolderId = null
       select: "id,project_id,parent_folder_id,name,created_at,updated_at,created_by"
     });
   } catch (error) {
+    if (String(error?.message || "").toLowerCase().includes("duplicate key")) {
+      throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
+    }
     console.error("[documents-folders] failure", { action: "createDocumentFolder", projectId: backendProjectId, parentFolderId: normalizedParentFolderId, error: error instanceof Error ? error.message : String(error || "") });
     throw error;
   }
@@ -939,10 +947,22 @@ export async function renameDocumentFolder(projectId = "", folderId = "", name =
   const normalizedFolderId = safeString(folderId);
   const normalizedName = safeString(name);
   if (!normalizedFolderId) throw new Error("Folder id is required.");
-  if (!normalizedName) throw new Error("Folder name is required.");
+  if (!normalizedName) throw new Error("Le nom du dossier ne peut pas être vide.");
   console.info("[documents-folders] rename.start", { projectId: backendProjectId, folderId: normalizedFolderId, name: normalizedName });
 
   try {
+    const current = await restFetch("project_document_folders", new URLSearchParams({
+      select: "id,parent_folder_id,name,project_id",
+      id: `eq.${normalizedFolderId}`,
+      project_id: `eq.${backendProjectId}`,
+      limit: "1"
+    }));
+    const currentFolder = Array.isArray(current) ? current[0] : null;
+    if (!currentFolder) throw new Error("Dossier introuvable.");
+    const siblings = await listDocumentFolderChildren(backendProjectId, safeString(currentFolder.parent_folder_id || "") || null);
+    const duplicate = siblings.some((folder) => safeString(folder.id) !== normalizedFolderId
+      && safeString(folder.name).toLocaleLowerCase("fr-FR") === normalizedName.toLocaleLowerCase("fr-FR"));
+    if (duplicate) throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
     const updated = await restUpdate("project_document_folders", {
       id: normalizedFolderId,
       project_id: backendProjectId
@@ -956,6 +976,9 @@ export async function renameDocumentFolder(projectId = "", folderId = "", name =
     }
     return updated;
   } catch (error) {
+    if (String(error?.message || "").toLowerCase().includes("duplicate key")) {
+      throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
+    }
     console.error("[documents-folders] failure", { action: "renameDocumentFolder", projectId: backendProjectId, folderId: normalizedFolderId, error: error instanceof Error ? error.message : String(error || "") });
     throw error;
   }
@@ -1033,6 +1056,17 @@ export async function moveDocumentFile(projectId = "", fileId = "", targetFolder
   console.info("[documents-files] move.start", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId });
 
   try {
+    if (normalizedTargetFolderId) {
+      const rows = await restFetch("project_document_folders", new URLSearchParams({
+        select: "id,project_id",
+        id: `eq.${normalizedTargetFolderId}`,
+        project_id: `eq.${backendProjectId}`,
+        limit: "1"
+      }));
+      if (!Array.isArray(rows) || !rows.length) {
+        throw new Error("Dossier cible introuvable.");
+      }
+    }
     const payload = await rpcCall("move_project_document_file", {
       file_id: normalizedFileId,
       target_folder_id: normalizedTargetFolderId

--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1612,6 +1612,10 @@ function renderDocumentsListView() {
   const treeHtml = isRoot ? "" : renderDocumentsSidebarTree();
   const topBar = renderDocumentsTopBar();
   const moveModalHtml = docsViewState.moveModal?.isOpen ? renderMoveFileModal() : "";
+  const emptyTitle = isRoot ? "La racine est vide." : "Ce dossier est vide.";
+  const emptyDescription = isRoot
+    ? "Ajoutez un dossier ou importez un document pour commencer."
+    : "Ajoutez un sous-dossier ou importez un document dans ce dossier.";
   return `
     <section class="project-simple-page project-simple-page--documents">
       <div class="documents-shell documents-shell--project-page documents-layout${isRoot ? " is-root" : ""}" id="projectDocumentScroll" style="--documents-tree-width:${isRoot ? 0 : (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0)}px">
@@ -1627,8 +1631,8 @@ function renderDocumentsListView() {
               bodyHtml,
               state: hasDocuments ? "ready" : "empty",
               emptyHtml: renderDataTableEmptyState({
-                title: "Aucun document n’a encore été déposé.",
-                description: "Ajoutez des documents pour commencer à constituer le dossier du projet."
+                title: emptyTitle,
+                description: emptyDescription
               })
             })}
           </div>
@@ -1978,6 +1982,7 @@ function buildRepoDocumentFromState() {
 
 function triggerAutoAnalysisAfterDirectUpload(root, document = null) {
   const documentName = document?.name || "";
+  const currentFolderId = docsViewState.currentFolderId || null;
   if (!shouldAutoRunAnalysisAfterUpload()) {
     setDocumentsActivity({
       tone: "info",
@@ -2007,6 +2012,7 @@ function triggerAutoAnalysisAfterDirectUpload(root, document = null) {
     triggerType: "document-upload",
     triggerLabel: "Dépôt de document",
     documentName,
+    currentFolderId,
     documentIds: document?.id ? [document.id] : [],
     summary: "Analyse déclenchée automatiquement après dépôt réussi d’un document."
   });
@@ -2029,6 +2035,15 @@ function commitDirectDocument(root) {
 function handleSubmit(root) {
   if (!canSubmitUpload()) return;
   commitDirectDocument(root);
+  loadCurrentDirectory()
+    .then(() => {
+      renderProjectDocumentsContent(root);
+    })
+    .catch((error) => {
+      console.error("[documents-upload] refresh-current-directory.failed", {
+        error: error instanceof Error ? error.message : String(error || "")
+      });
+    });
 }
 
 function bindDocumentsSplitActions(root) {
@@ -2123,13 +2138,22 @@ function bindDocumentsView(root) {
   const addFolderBtn = document.getElementById("documentsAddFolderBtn");
   if (addFolderBtn) {
     addFolderBtn.addEventListener("click", async () => {
-      const name = window.prompt("Nom du dossier ?");
-      if (!name) return;
-      console.info("[documents-view] create-folder.submit", { parentFolderId: docsViewState.currentFolderId || null });
-      await createDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), docsViewState.currentFolderId || null, name);
-      await loadCurrentDirectory();
-      if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "create-folder" });
-      renderProjectDocumentsContent(root);
+      const name = String(window.prompt("Nom du dossier ?") || "").trim();
+      if (!name) {
+        setDocumentsActivity({ tone: "warning", title: "Nom invalide", message: "Le nom du dossier ne peut pas être vide." });
+        renderProjectDocumentsContent(root);
+        return;
+      }
+      try {
+        console.info("[documents-view] create-folder.submit", { parentFolderId: docsViewState.currentFolderId || null });
+        await createDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), docsViewState.currentFolderId || null, name);
+        await loadCurrentDirectory();
+        if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "create-folder" });
+        renderProjectDocumentsContent(root);
+      } catch (error) {
+        setDocumentsActivity({ tone: "error", title: "Création impossible", message: error instanceof Error ? error.message : "Erreur Supabase lors de la création du dossier." });
+        renderProjectDocumentsContent(root);
+      }
     });
   }
 
@@ -2138,13 +2162,22 @@ function bindDocumentsView(root) {
       event.stopPropagation();
       const folderId = btn.getAttribute("data-folder-rename-id") || "";
       const currentName = btn.getAttribute("data-folder-rename-name") || "";
-      const name = window.prompt("Nouveau nom du dossier :", currentName);
-      if (!name) return;
-      console.info("[documents-view] rename-folder.submit", { folderId });
-      await renameDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), folderId, name);
-      await loadCurrentDirectory();
-      if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "rename-folder" });
-      renderProjectDocumentsContent(root);
+      const name = String(window.prompt("Nouveau nom du dossier :", currentName) || "").trim();
+      if (!name) {
+        setDocumentsActivity({ tone: "warning", title: "Nom invalide", message: "Le nom du dossier ne peut pas être vide." });
+        renderProjectDocumentsContent(root);
+        return;
+      }
+      try {
+        console.info("[documents-view] rename-folder.submit", { folderId });
+        await renameDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), folderId, name);
+        await loadCurrentDirectory();
+        if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "rename-folder" });
+        renderProjectDocumentsContent(root);
+      } catch (error) {
+        setDocumentsActivity({ tone: "error", title: "Renommage impossible", message: error instanceof Error ? error.message : "Erreur Supabase lors du renommage du dossier." });
+        renderProjectDocumentsContent(root);
+      }
     });
   });
 


### PR DESCRIPTION
### Motivation

- Prevent invalid or duplicate document folder names and provide clearer French error messages when creating or renaming folders.
- Ensure uploaded documents and automatic analyses record the current folder context so files are created in the intended folder.
- Improve UI feedback when folders are empty and when folder create/rename operations fail.

### Description

- Added a `currentFolderId` option to `runAnalysis` and persist `folder_id` when inserting a `documents` row in `analysis-runner.js` so uploads/analysis are folder-aware.
- Enhanced `createDocumentFolder` and `renameDocumentFolder` in `project-supabase-sync.js` to trim and validate names, check existing sibling folders for case-insensitive duplicates before inserting/updating, and convert DB duplicate-key errors into a friendly message.
- Added target-folder existence validation in `moveDocumentFile` to fail early if the destination folder does not belong to the project.
- Updated UI in `project-documents.js` to show localized empty-state titles/descriptions, trim and validate prompt input for folder creation/rename, surface warning/error activities via `setDocumentsActivity` instead of silent failures, pass `currentFolderId` when auto-triggering `runAnalysis`, and refresh the current directory after uploads or folder operations.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49164b99c83298aef7df20f88c2d3)