### PR TITLE
Documents: folder duplicate checks, folder-aware uploads, and enhanced PDF preview zoom/input

### DIFF
--- a/apps/web/js/services/analysis-runner.js
+++ b/apps/web/js/services/analysis-runner.js
@@ -816,6 +816,7 @@ export async function runAnalysis(options = {}) {
   }
 
   const triggerType = options.triggerType || "manual";
+  const currentFolderId = String(options.currentFolderId || "").trim() || null;
   const triggerLabel = options.triggerLabel
     || (triggerType === "document-upload" ? "Dépôt de document" : "Lancement manuel");
   const primaryAgentKey = options.agentKey || getPrimaryAnalysisAgent()?.key || "parasismique";
@@ -851,9 +852,9 @@ export async function runAnalysis(options = {}) {
 
       setSystemStatus("running", "En cours d’analyse", "Création du document");
       const currentUser = await getCurrentUser();
-
       const documentRow = await restInsert("documents", {
         project_id: backendProjectId,
+        folder_id: currentFolderId,
         created_by: currentUser?.id || null,
         filename: inputs.pdfFile.name,
         original_filename: inputs.pdfFile.name,
@@ -864,7 +865,6 @@ export async function runAnalysis(options = {}) {
         upload_status: "uploaded",
         document_kind: "source_pdf"
       }, "id,project_id,storage_bucket,storage_path");
-
       setSystemStatus("running", "En cours d’analyse", "Création du run");
       await restInsert("analysis_runs", {
         id: runId,

--- a/apps/web/js/services/project-supabase-sync.js
+++ b/apps/web/js/services/project-supabase-sync.js
@@ -917,10 +917,15 @@ export async function createDocumentFolder(projectId = "", parentFolderId = null
   const backendProjectId = ensureBackendProjectIdOrThrow(projectId);
   const normalizedParentFolderId = safeString(parentFolderId || "") || null;
   const normalizedName = safeString(name);
-  if (!normalizedName) throw new Error("Folder name is required.");
+  if (!normalizedName) throw new Error("Le nom du dossier ne peut pas être vide.");
   console.info("[documents-folders] create.start", { projectId: backendProjectId, parentFolderId: normalizedParentFolderId, name: normalizedName });
 
   try {
+    const siblings = await listDocumentFolderChildren(backendProjectId, normalizedParentFolderId);
+    const duplicate = siblings.some((folder) => safeString(folder.name).toLocaleLowerCase("fr-FR") === normalizedName.toLocaleLowerCase("fr-FR"));
+    if (duplicate) {
+      throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
+    }
     return await restInsert("project_document_folders", {
       project_id: backendProjectId,
       parent_folder_id: normalizedParentFolderId,
@@ -929,6 +934,9 @@ export async function createDocumentFolder(projectId = "", parentFolderId = null
       select: "id,project_id,parent_folder_id,name,created_at,updated_at,created_by"
     });
   } catch (error) {
+    if (String(error?.message || "").toLowerCase().includes("duplicate key")) {
+      throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
+    }
     console.error("[documents-folders] failure", { action: "createDocumentFolder", projectId: backendProjectId, parentFolderId: normalizedParentFolderId, error: error instanceof Error ? error.message : String(error || "") });
     throw error;
   }
@@ -939,10 +947,22 @@ export async function renameDocumentFolder(projectId = "", folderId = "", name =
   const normalizedFolderId = safeString(folderId);
   const normalizedName = safeString(name);
   if (!normalizedFolderId) throw new Error("Folder id is required.");
-  if (!normalizedName) throw new Error("Folder name is required.");
+  if (!normalizedName) throw new Error("Le nom du dossier ne peut pas être vide.");
   console.info("[documents-folders] rename.start", { projectId: backendProjectId, folderId: normalizedFolderId, name: normalizedName });
 
   try {
+    const current = await restFetch("project_document_folders", new URLSearchParams({
+      select: "id,parent_folder_id,name,project_id",
+      id: `eq.${normalizedFolderId}`,
+      project_id: `eq.${backendProjectId}`,
+      limit: "1"
+    }));
+    const currentFolder = Array.isArray(current) ? current[0] : null;
+    if (!currentFolder) throw new Error("Dossier introuvable.");
+    const siblings = await listDocumentFolderChildren(backendProjectId, safeString(currentFolder.parent_folder_id || "") || null);
+    const duplicate = siblings.some((folder) => safeString(folder.id) !== normalizedFolderId
+      && safeString(folder.name).toLocaleLowerCase("fr-FR") === normalizedName.toLocaleLowerCase("fr-FR"));
+    if (duplicate) throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
     const updated = await restUpdate("project_document_folders", {
       id: normalizedFolderId,
       project_id: backendProjectId
@@ -956,6 +976,9 @@ export async function renameDocumentFolder(projectId = "", folderId = "", name =
     }
     return updated;
   } catch (error) {
+    if (String(error?.message || "").toLowerCase().includes("duplicate key")) {
+      throw new Error("Un dossier avec ce nom existe déjà dans ce dossier parent.");
+    }
     console.error("[documents-folders] failure", { action: "renameDocumentFolder", projectId: backendProjectId, folderId: normalizedFolderId, error: error instanceof Error ? error.message : String(error || "") });
     throw error;
   }
@@ -1033,6 +1056,17 @@ export async function moveDocumentFile(projectId = "", fileId = "", targetFolder
   console.info("[documents-files] move.start", { projectId: backendProjectId, fileId: normalizedFileId, targetFolderId: normalizedTargetFolderId });
 
   try {
+    if (normalizedTargetFolderId) {
+      const rows = await restFetch("project_document_folders", new URLSearchParams({
+        select: "id,project_id",
+        id: `eq.${normalizedTargetFolderId}`,
+        project_id: `eq.${backendProjectId}`,
+        limit: "1"
+      }));
+      if (!Array.isArray(rows) || !rows.length) {
+        throw new Error("Dossier cible introuvable.");
+      }
+    }
     const payload = await rpcCall("move_project_document_file", {
       file_id: normalizedFileId,
       target_folder_id: normalizedTargetFolderId

--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -32,6 +32,9 @@ const SUPABASE_ANON_KEY = getSupabaseAnonKey();
 const PDFJS_CDN_VERSION = "4.4.168";
 const PDFJS_MODULE_URL = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_CDN_VERSION}/build/pdf.min.mjs`;
 const PDFJS_WORKER_MODULE_URL = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_CDN_VERSION}/build/pdf.worker.min.mjs`;
+const PDF_PREVIEW_ZOOM_STEPS = [
+  0.01, 0.0625, 0.0833, 0.125, 0.25, 0.333, 0.5, 0.667, 0.75, 0.79, 1, 1.25, 1.5, 2, 2.38, 3, 4, 6, 8, 12, 16, 24, 32, 64
+];
 
 let pdfJsLibPromise = null;
 let pdfPreviewRenderToken = 0;
@@ -317,7 +320,7 @@ function updatePdfPreviewToolbarState(root = null) {
 
   const zoomNode = activeRoot.querySelector("#documentsPdfZoomValue");
   if (zoomNode) {
-    zoomNode.textContent = formatPdfPreviewZoomPercent(docsViewState.pdfPreview?.zoomLevel || 1);
+    zoomNode.value = formatPdfPreviewZoomPercent(docsViewState.pdfPreview?.zoomLevel || 1);
   }
 
   const darkModeButton = activeRoot.querySelector('[data-pdf-preview-action="toggle-dark-mode"]');
@@ -595,11 +598,35 @@ function bindPdfPreviewControls(root) {
   root.addEventListener("keydown", (event) => {
     const target = event.target;
     if (!(target instanceof HTMLInputElement)) return;
+    if (target.id === "documentsPdfZoomValue" && event.key === "Enter") {
+      event.preventDefault();
+      const parsed = parsePdfZoomInputValue(target.value);
+      if (parsed) {
+        docsViewState.pdfPreview.zoomLevel = parsed;
+        updatePdfPreviewToolbarState(root);
+        schedulePdfPreviewRender(root);
+      } else {
+        updatePdfPreviewToolbarState(root);
+      }
+      return;
+    }
     if (target.id !== "documentsPdfSearchInput") return;
     if (event.key === "Enter") {
       event.preventDefault();
       movePdfPreviewSearchSelection(root, event.shiftKey ? -1 : 1);
     }
+  });
+
+  root.addEventListener("focusout", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.id !== "documentsPdfZoomValue") return;
+    const parsed = parsePdfZoomInputValue(target.value);
+    if (parsed) {
+      docsViewState.pdfPreview.zoomLevel = parsed;
+      schedulePdfPreviewRender(root);
+    }
+    updatePdfPreviewToolbarState(root);
   });
 
   pdfPreviewController.isBound = true;
@@ -837,7 +864,7 @@ async function renderPdfPreviewPages(root) {
       cacheKey,
       reusedCachedDocument: pdfPreviewController.documentCacheKey === cacheKey
     });
-    const zoomLevel = Math.min(3, Math.max(0.5, Number(docsViewState.pdfPreview?.zoomLevel || 1)));
+    const zoomLevel = Math.min(64, Math.max(0.01, Number(docsViewState.pdfPreview?.zoomLevel || 1)));
     const rotation = Number(docsViewState.pdfPreview?.rotation || 0);
     const outputScale = window.devicePixelRatio && window.devicePixelRatio > 1 ? window.devicePixelRatio : 1;
 
@@ -1025,7 +1052,9 @@ function updatePdfPreviewZoom(root, direction = 0) {
     return;
   }
   const currentZoom = Number(docsViewState.pdfPreview?.zoomLevel || 1);
-  const nextZoom = Math.min(3, Math.max(0.5, Number((currentZoom + direction).toFixed(2))));
+  const currentIndex = resolveClosestPdfZoomStepIndex(currentZoom);
+  const nextIndex = Math.min(PDF_PREVIEW_ZOOM_STEPS.length - 1, Math.max(0, currentIndex + (direction >= 0 ? 1 : -1)));
+  const nextZoom = PDF_PREVIEW_ZOOM_STEPS[nextIndex];
   if (Math.abs(nextZoom - currentZoom) < 0.001) {
     logPdfPreviewDebug("zoom ignored: unchanged after clamp", { currentZoom, nextZoom, direction });
     return;
@@ -1033,6 +1062,28 @@ function updatePdfPreviewZoom(root, direction = 0) {
   docsViewState.pdfPreview.zoomLevel = nextZoom;
   logPdfPreviewDebug("zoom updated", { currentZoom, nextZoom, direction });
   schedulePdfPreviewRender(root);
+}
+
+function resolveClosestPdfZoomStepIndex(zoomLevel = 1) {
+  const target = Number(zoomLevel);
+  if (!Number.isFinite(target)) return 10;
+  let bestIndex = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  PDF_PREVIEW_ZOOM_STEPS.forEach((step, index) => {
+    const distance = Math.abs(step - target);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  });
+  return bestIndex;
+}
+
+function parsePdfZoomInputValue(value = "") {
+  const normalized = String(value || "").replace(",", ".").replace("%", "").trim();
+  const numeric = Number(normalized);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.min(64, Math.max(0.01, numeric / 100));
 }
 
 function updatePdfPreviewRotation(root, direction = 0) {
@@ -1484,7 +1535,14 @@ function renderPdfPreviewView() {
                     >
                       ${getPdfZoomOutIconSvg()}
                     </button>
-                    <span class="documents-pdf-viewer__zoom-value" id="documentsPdfZoomValue">${formatPdfPreviewZoomPercent(docsViewState.pdfPreview?.zoomLevel || 1)}</span>
+                    <input
+                      type="text"
+                      class="gh-input documents-pdf-viewer__zoom-value"
+                      id="documentsPdfZoomValue"
+                      inputmode="decimal"
+                      value="${formatPdfPreviewZoomPercent(docsViewState.pdfPreview?.zoomLevel || 1)}"
+                      aria-label="Niveau de zoom du PDF"
+                    />
                     <button
                       type="button"
                       class="gh-btn documents-report-table__icon-btn"
@@ -1612,6 +1670,10 @@ function renderDocumentsListView() {
   const treeHtml = isRoot ? "" : renderDocumentsSidebarTree();
   const topBar = renderDocumentsTopBar();
   const moveModalHtml = docsViewState.moveModal?.isOpen ? renderMoveFileModal() : "";
+  const emptyTitle = isRoot ? "La racine est vide." : "Ce dossier est vide.";
+  const emptyDescription = isRoot
+    ? "Ajoutez un dossier ou importez un document pour commencer."
+    : "Ajoutez un sous-dossier ou importez un document dans ce dossier.";
   return `
     <section class="project-simple-page project-simple-page--documents">
       <div class="documents-shell documents-shell--project-page documents-layout${isRoot ? " is-root" : ""}" id="projectDocumentScroll" style="--documents-tree-width:${isRoot ? 0 : (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0)}px">
@@ -1627,8 +1689,8 @@ function renderDocumentsListView() {
               bodyHtml,
               state: hasDocuments ? "ready" : "empty",
               emptyHtml: renderDataTableEmptyState({
-                title: "Aucun document n’a encore été déposé.",
-                description: "Ajoutez des documents pour commencer à constituer le dossier du projet."
+                title: emptyTitle,
+                description: emptyDescription
               })
             })}
           </div>
@@ -1664,8 +1726,11 @@ function renderDocumentsSidebarTree() {
     const files = filesByFolder.get(id) || [];
     const hasChildren = childFolders.length > 0 || files.length > 0;
     const isExpanded = expandedSet.has(id);
+    const indentDividers = Array.from({ length: Math.max(0, depth) })
+      .map(() => `<span class="documents-tree__divider${isExpanded ? " is-expanded" : ""}" aria-hidden="true"></span>`)
+      .join("");
     const caret = hasChildren ? `<button type="button" class="documents-tree__caret" data-tree-toggle-folder-id="${escapeHtml(id)}">${svgIcon(isExpanded ? "chevron-down" : "chevron-right", { className: isExpanded ? "octicon octicon-chevron-down" : "octicon octicon-chevron-right" })}</button>` : `<span class="documents-tree__caret-spacer"></span>`;
-    const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="--tree-indent:${12 + Math.min(depth, 8) * 18}px;padding-left:${12 + Math.min(depth, 8) * 18}px">${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} <span class="documents-tree__label">${escapeHtml(folder.name || "Dossier")}</span></button></div>`;
+    const row = `<div class="documents-tree__row${active ? " is-active" : ""}" style="--tree-indent:${12 + Math.min(depth, 8) * 18}px"><span class="documents-tree__indent">${indentDividers}</span>${caret}<button type="button" class="documents-tree__item${active ? " is-active" : ""}" data-tree-folder-id="${escapeHtml(id)}">${isExpanded ? getFolderOpenIconSvg() : getFolderClosedIconSvg()} <span class="documents-tree__label">${escapeHtml(folder.name || "Dossier")}</span></button></div>`;
     if (!isExpanded) return row;
     const fileRows = files.map((file) => `<button type="button" class="documents-tree__file" data-tree-document-id="${escapeHtml(String(file?.id || ""))}" style="--tree-indent:${12 + Math.min(depth + 2, 10) * 24}px;padding-left:${12 + Math.min(depth + 2, 10) * 24}px">${getDocumentIconSvg()} <span class="documents-tree__label">${escapeHtml(file?.name || file?.original_filename || file?.filename || "Fichier")}</span></button>`).join("");
     return `${row}${walk(id, depth + 1).join("")}${fileRows}`;
@@ -1978,6 +2043,7 @@ function buildRepoDocumentFromState() {
 
 function triggerAutoAnalysisAfterDirectUpload(root, document = null) {
   const documentName = document?.name || "";
+  const currentFolderId = docsViewState.currentFolderId || null;
   if (!shouldAutoRunAnalysisAfterUpload()) {
     setDocumentsActivity({
       tone: "info",
@@ -2007,6 +2073,7 @@ function triggerAutoAnalysisAfterDirectUpload(root, document = null) {
     triggerType: "document-upload",
     triggerLabel: "Dépôt de document",
     documentName,
+    currentFolderId,
     documentIds: document?.id ? [document.id] : [],
     summary: "Analyse déclenchée automatiquement après dépôt réussi d’un document."
   });
@@ -2029,6 +2096,15 @@ function commitDirectDocument(root) {
 function handleSubmit(root) {
   if (!canSubmitUpload()) return;
   commitDirectDocument(root);
+  loadCurrentDirectory()
+    .then(() => {
+      renderProjectDocumentsContent(root);
+    })
+    .catch((error) => {
+      console.error("[documents-upload] refresh-current-directory.failed", {
+        error: error instanceof Error ? error.message : String(error || "")
+      });
+    });
 }
 
 function bindDocumentsSplitActions(root) {
@@ -2123,13 +2199,22 @@ function bindDocumentsView(root) {
   const addFolderBtn = document.getElementById("documentsAddFolderBtn");
   if (addFolderBtn) {
     addFolderBtn.addEventListener("click", async () => {
-      const name = window.prompt("Nom du dossier ?");
-      if (!name) return;
-      console.info("[documents-view] create-folder.submit", { parentFolderId: docsViewState.currentFolderId || null });
-      await createDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), docsViewState.currentFolderId || null, name);
-      await loadCurrentDirectory();
-      if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "create-folder" });
-      renderProjectDocumentsContent(root);
+      const name = String(window.prompt("Nom du dossier ?") || "").trim();
+      if (!name) {
+        setDocumentsActivity({ tone: "warning", title: "Nom invalide", message: "Le nom du dossier ne peut pas être vide." });
+        renderProjectDocumentsContent(root);
+        return;
+      }
+      try {
+        console.info("[documents-view] create-folder.submit", { parentFolderId: docsViewState.currentFolderId || null });
+        await createDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), docsViewState.currentFolderId || null, name);
+        await loadCurrentDirectory();
+        if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "create-folder" });
+        renderProjectDocumentsContent(root);
+      } catch (error) {
+        setDocumentsActivity({ tone: "error", title: "Création impossible", message: error instanceof Error ? error.message : "Erreur Supabase lors de la création du dossier." });
+        renderProjectDocumentsContent(root);
+      }
     });
   }
 
@@ -2138,13 +2223,22 @@ function bindDocumentsView(root) {
       event.stopPropagation();
       const folderId = btn.getAttribute("data-folder-rename-id") || "";
       const currentName = btn.getAttribute("data-folder-rename-name") || "";
-      const name = window.prompt("Nouveau nom du dossier :", currentName);
-      if (!name) return;
-      console.info("[documents-view] rename-folder.submit", { folderId });
-      await renameDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), folderId, name);
-      await loadCurrentDirectory();
-      if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "rename-folder" });
-      renderProjectDocumentsContent(root);
+      const name = String(window.prompt("Nouveau nom du dossier :", currentName) || "").trim();
+      if (!name) {
+        setDocumentsActivity({ tone: "warning", title: "Nom invalide", message: "Le nom du dossier ne peut pas être vide." });
+        renderProjectDocumentsContent(root);
+        return;
+      }
+      try {
+        console.info("[documents-view] rename-folder.submit", { folderId });
+        await renameDocumentFolder(String(store.currentProject?.backendProjectId || store.currentProject?.id || store.currentProjectId || ""), folderId, name);
+        await loadCurrentDirectory();
+        if (docsViewState.documentTreeOpen) console.info("[documents-tree] refresh-after-mutation", { action: "rename-folder" });
+        renderProjectDocumentsContent(root);
+      } catch (error) {
+        setDocumentsActivity({ tone: "error", title: "Renommage impossible", message: error instanceof Error ? error.message : "Erreur Supabase lors du renommage du dossier." });
+        renderProjectDocumentsContent(root);
+      }
     });
   });
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -5986,7 +5986,7 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 }
 
 .documents-pdf-viewer__search-toolbar{
-  display:flex;
+  display:inline-flex;
   align-items:center;
   gap:8px;
   flex-wrap:wrap;
@@ -6572,13 +6572,16 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-tree{position:relative;width:var(--documents-tree-width);z-index:1;}
 .documents-tree.is-collapsed .documents-tree__panel,.documents-tree.is-collapsed .documents-tree__resize-handle,.documents-tree.is-collapsed .documents-tree__resize-guide{display:none;}
 .documents-tree__toggle{width:32px;height:32px;border:solid 1px transparent;background:var(--bgElev);color:var(--muted);border-radius:8px;display:inline-flex;align-items:center;justify-content:center;}
-.documents-tree__panel{width:100%;min-height:240px;max-height:var(--documents-content-height, calc(100vh - 180px));overflow:auto;border-right:1px solid var(--border);border-top:0;border-left:0;border-bottom:0;border-radius:0;background:var(--bgElev);padding:8px;display:flex;flex-direction:column;gap:2px;height:var(--documents-content-height, calc(100vh - 180px));}
+.documents-tree__panel{width:100%;min-height:240px;max-height:var(--documents-content-height, calc(100vh - 180px));overflow:auto;border-right:1px solid var(--border);border-top:0;border-left:0;border-bottom:0;border-radius:0;background:var(--bgElev);padding:8px;padding-top:16px;display:flex;flex-direction:column;gap:2px;height:var(--documents-content-height, calc(100vh - 180px));}
 .documents-tree__row{display:flex;align-items:center;gap:4px;width:100%;position:relative;border-radius:6px;height:34px;}
 .documents-tree__row.is-active{background:rgba(110, 118, 129, .14);}
 .documents-tree__row:hover{background:rgba(110,118,129,.16);}
 .documents-tree__row.is-active::before{content:"";position:absolute;left:-6px;top:4px;bottom:4px;width:3px;border-radius:3px;background:#2f81f7;}
 .documents-tree__caret{border:0;background:transparent;color:var(--muted);cursor:pointer;padding:0 4px;}
 .documents-tree__caret-spacer{display:inline-block;width:16px;}
+.documents-tree__indent{display:flex;align-items:center;gap:4px;min-width:0;}
+.documents-tree__divider{width:14px;height:16px;border-left:1px solid transparent;border-right:1px solid transparent;display:inline-block;flex:0 0 14px;}
+.documents-tree__divider.is-expanded{border-left-color:#ffff;border-right-color:#ffff;}
 .documents-tree__item{display:flex;align-items:center;gap:8px;padding:8px 12px 8px 0px;border:0;background:transparent;color:var(--text);border-radius:8px;text-align:left;cursor:pointer;width:100%;}
 .documents-tree__item.is-active{color:#58a6ff;}
 .documents-tree__file{display:flex;align-items:center;gap:8px;font-size:13px;padding:4px 0;height:34px;min-width:0;border:0;background:transparent;color:var(--text);cursor:pointer;position:relative;border-radius:6px;}


### PR DESCRIPTION
### Motivation
- Improve document management UX by preventing duplicate folder names, validating folder operations, and associating uploaded documents with folders; and enhance the PDF preview zoom controls for more flexible viewing.

### Description
- Persist the current folder when creating documents during analysis runs by passing `currentFolderId` and setting `folder_id` on the `documents` insert.
- Add duplicate-name prevention and localized error messages to folder creation and renaming in `project-supabase-sync`, including a case-insensitive check (`fr-FR`) against siblings and handling DB duplicate-key errors, and validate target folder existence during file moves.
- Replace the PDF zoom display with an editable input, add a dense `PDF_PREVIEW_ZOOM_STEPS` scale, implement `resolveClosestPdfZoomStepIndex` and `parsePdfZoomInputValue`, support Enter/blur behavior to parse/apply values, extend zoom range to `0.01–64`, and update toolbar/state rendering and keyboard handlers accordingly.
- Improve folder UI/UX in `project-documents` by trimming and validating folder names on create/rename prompts, showing activity banners on success/error, refreshing directory state after uploads and mutations, updating empty-folder messages, and adding visual indentation dividers in the tree.
- Apply CSS changes for the PDF toolbar and document tree layout to support the new input control and indentation visuals.

### Testing
- Ran the web linter via `npm run lint` and the frontend unit test suite via `npm test`, both completed successfully.
- Built the web bundle with `npm run build:web` and performed automated smoke checks on the documents view and PDF preview, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49164b99c83298aef7df20f88c2d3)