### PR TITLE
Fix PDF preview scroll to use document compact behavior

### DIFF
--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -51,7 +51,15 @@ const pdfPreviewController = {
   activeSearchIndex: -1
 };
 
-function logPdfPreviewDebug() {}
+function logPdfPreviewDebug(label, payload = {}) {
+  try {
+    if (window.localStorage?.getItem("debug:project-scroll-policy") !== "1") return;
+  } catch (_) {
+    return;
+  }
+
+  console.info("[documents-pdf-preview]", label, payload);
+}
 
 const docsViewState = {
   mode: "list", // "list" | "upload" | "report-preview" | "pdf-preview"
@@ -2501,6 +2509,19 @@ function renderProjectDocumentsContent(root) {
         : renderDocumentsListView();
 
   document.body.classList.toggle("documents-pdf-sticky-mode", docsViewState.mode === "pdf-preview");
+
+  if (docsViewState.mode === "pdf-preview") {
+    const projectShellBody = document.querySelector(".project-shell__body");
+    const projectShellBodyStyle = projectShellBody ? window.getComputedStyle(projectShellBody) : null;
+    const scrollingElement = document.scrollingElement || document.documentElement || document.body || null;
+    logPdfPreviewDebug("scroll-policy", {
+      bodyClassName: document.body?.className || "",
+      windowScrollY: Number(window.scrollY || 0),
+      documentScrollingElementScrollTop: Number(scrollingElement?.scrollTop || 0),
+      projectShellBodyOverflow: projectShellBodyStyle?.overflow || null,
+      projectShellBodyPosition: projectShellBodyStyle?.position || null
+    });
+  }
 
   bindDocumentsView(root);
 }

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -6596,13 +6596,21 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
   padding:0;
 }
 .documents-pdf-sticky-mode .project-shell__body{
-  position:fixed;
-  top:0;
-  left:0;
-  right:0;
-  bottom:0;
-  overflow:auto;
-  z-index:30;
+  position:relative;
+  top:auto;
+  overflow:visible;
+  z-index:auto;
+}
+body.route--project.documents-pdf-sticky-mode.project-shell-compact #globalHeaderHost,
+body.route--project.documents-pdf-sticky-mode.project-shell-compact .gh-header.gh-header--project{
+  transform:translateY(-100%);
+  opacity:0;
+  pointer-events:none;
+  transition:transform .16s ease, opacity .16s ease;
+}
+body.route--project.documents-pdf-sticky-mode.project-shell-compact .project-shell__body{
+  margin-top:calc(-1 * var(--header-h-compact));
+  padding-top:var(--header-h-compact);
 }
 .documents-pdf-sticky-mode .project-context-header{
   position:static;


### PR DESCRIPTION
### Motivation

- Corriger le comportement du preview PDF qui forçait le scroll interne via `.project-shell__body` en `position: fixed` et breakait la hiérarchie normale de scroll;.
- Faire en sorte que le scroll soit porté par le `document/window` uniquement quand `docsViewState.mode === "pdf-preview"` (scopé via la classe `documents-pdf-sticky-mode`).
- Réutiliser le mode compact existant (`project-shell-compact`) pour masquer le header global en contexte PDF sans introduire de scroll interne ni impacter les autres onglets.

### Description

- Dans `apps/web/style.css` : supprimé le bloc qui mettait `.documents-pdf-sticky-mode .project-shell__body` en `position: fixed`/`overflow:auto` et remplacé par des règles non-intrusives (`position: relative`, `overflow: visible`) pour rester dans le flux document.
- Dans `apps/web/style.css` : ajouté des règles strictement scoppées à `body.route--project.documents-pdf-sticky-mode.project-shell-compact` pour masquer le chrome global/projet avec `transform: translateY(-100%)`, `opacity:0`, `pointer-events:none` et une courte `transition`, et pour remonter visuellement `.project-shell__body` en compact PDF via `margin-top`/`padding-top` (sans position fixed).
- Dans `apps/web/js/views/project-documents.js` : implémenté `logPdfPreviewDebug(...)` activable via `localStorage['debug:project-scroll-policy'] === '1'` et ajouté un point d'instrumentation au rendu PDF qui logge `body` classes, `window.scrollY`, `document.scrollingElement.scrollTop` et le `computedStyle` de `.project-shell__body` pour faciliter le debug de la politique de scroll.
- Aucun changement au système de scroll existant : `clearProjectActiveScrollSource()` est conservé et aucun nouvel écouteur de scroll local n’a été ajouté, garantissant que la source active de scroll reste le document/window.

### Testing

- Exécuté `git diff --check` pour valider les problèmes de diff/whitespace et la vérification a réussi.
- Aucune suite de tests automatisés spécifiques aux fichiers modifiés n’a été exécutée dans ce rollout (instrumentation ajoutée pour aider le debug runtime via `localStorage`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e1af0fbc83299d74a2f753caf526)