### PR TITLE
Fix Documents PDF preview scroll and sticky policy

### DIFF
--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1502,7 +1502,7 @@ function renderPdfPreviewView() {
   const topBar = renderDocumentsTopBar();
   return `
     <section class="project-simple-page project-simple-page--documents">
-      <div class="documents-shell documents-shell--project-page documents-layout${docsViewState.currentFolderId ? "" : " is-root"}" id="projectDocumentScroll" style="--documents-tree-width:${docsViewState.currentFolderId ? (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0) : 0}px">
+      <div class="documents-shell documents-shell--project-page documents-shell--pdf-preview documents-layout${docsViewState.currentFolderId ? "" : " is-root"}" id="projectDocumentScroll" style="--documents-tree-width:${docsViewState.currentFolderId ? (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0) : 0}px">
         ${treeHtml}
         <main class="documents-main">
           ${topBar}
@@ -2513,13 +2513,34 @@ function renderProjectDocumentsContent(root) {
   if (docsViewState.mode === "pdf-preview") {
     const projectShellBody = document.querySelector(".project-shell__body");
     const projectShellBodyStyle = projectShellBody ? window.getComputedStyle(projectShellBody) : null;
+    const topbar = document.querySelector(".documents-topbar");
+    const pdfToolbar = document.querySelector(".documents-report-table__header--pdf-preview");
+    const pdfBody = document.querySelector(".documents-report-table__body--pdf");
+    const treePanel = document.querySelector(".documents-tree__panel");
+    const getNodeStyle = (node) => {
+      if (!node) return null;
+      const computed = window.getComputedStyle(node);
+      return {
+        position: computed.position,
+        top: computed.top,
+        overflow: computed.overflow,
+        overflowX: computed.overflowX,
+        overflowY: computed.overflowY,
+        height: computed.height,
+        maxHeight: computed.maxHeight
+      };
+    };
     const scrollingElement = document.scrollingElement || document.documentElement || document.body || null;
     logPdfPreviewDebug("scroll-policy", {
       bodyClassName: document.body?.className || "",
       windowScrollY: Number(window.scrollY || 0),
       documentScrollingElementScrollTop: Number(scrollingElement?.scrollTop || 0),
       projectShellBodyOverflow: projectShellBodyStyle?.overflow || null,
-      projectShellBodyPosition: projectShellBodyStyle?.position || null
+      projectShellBodyPosition: projectShellBodyStyle?.position || null,
+      documentsTopbar: getNodeStyle(topbar),
+      documentsPdfToolbar: getNodeStyle(pdfToolbar),
+      documentsPdfBody: getNodeStyle(pdfBody),
+      documentsTreePanel: getNodeStyle(treePanel)
     });
   }
 

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -5921,7 +5921,7 @@ color:var(--text);
 
 .documents-report-table__header--pdf-preview{
   position:sticky;
-  top:0;
+  top:var(--documents-pdf-topbar-h, 44px);
   z-index:calc(var(--z-header) - 1);
   justify-content:flex-end;
   padding:10px 16px;
@@ -6011,8 +6011,12 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 }
 
 .documents-report-table__body--pdf{
-  min-height:calc(100vh - 220px);
+  min-height:0;
+  height:calc(100dvh - var(--documents-pdf-topbar-h, 44px) - var(--documents-pdf-toolbar-h, 52px));
   padding:0;
+  overflow:auto;
+  overflow-x:auto;
+  overflow-y:auto;
 }
 
 .documents-report__page-break{
@@ -6062,8 +6066,8 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 
 .documents-pdf-viewer{
   background:var(--panel);
-  overflow:auto;
-  min-height:calc(100vh - 220px);
+  overflow:visible;
+  min-height:100%;
 }
 
 .documents-pdf-viewer__frame{
@@ -6076,9 +6080,9 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 
 .documents-pdf-viewer__canvas-shell{
   position:relative;
-  min-height:calc(100vh - 220px);
+  min-height:100%;
   background:#f6f8fa;
-  overflow:auto;
+  overflow:visible;
 }
 
 .documents-pdf-viewer__canvas-shell.is-dark-mode{
@@ -6095,8 +6099,8 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
   align-items:flex-start;
   gap:24px;
   padding:16px 12px 24px;
-  min-height:calc(100vh - 220px);
-  min-width:100%;
+  min-height:100%;
+  min-width:max-content;
   background:var(--headbg);
 }
 
@@ -6594,6 +6598,7 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-tree__row,.documents-tree__file{position:relative;}
 .documents-pdf-sticky-mode main#app{
   padding:0;
+  overflow:visible;
 }
 .documents-pdf-sticky-mode .project-shell__body{
   position:relative;
@@ -6615,12 +6620,69 @@ body.route--project.documents-pdf-sticky-mode.project-shell-compact .project-she
 .documents-pdf-sticky-mode .project-context-header{
   position:static;
 }
-.documents-pdf-sticky-mode .gh-header.gh-header--project,
-.documents-pdf-sticky-mode .documents-topbar,
-.documents-pdf-sticky-mode .documents-report-table__header.documents-report-table__header--pdf-preview{
-  position:relative;
-  top:auto;
-  z-index:auto;
+.documents-pdf-sticky-mode .gh-header.gh-header--project{
+  position:fixed;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview{
+  --documents-pdf-topbar-h:44px;
+  --documents-pdf-toolbar-h:52px;
+  width:100%;
+  max-width:none;
+  margin:0;
+  align-items:start;
+  overflow:visible;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview.documents-layout{
+  grid-template-columns:var(--documents-tree-width, auto) minmax(0, 1fr);
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-main{
+  min-width:0;
+  min-height:0;
+  height:auto;
+  max-height:none;
+  overflow:visible;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-tree{
+  align-self:start;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-tree__panel{
+  position:sticky;
+  top:0;
+  height:calc(100dvh - var(--documents-pdf-tree-offset, 0px));
+  max-height:calc(100dvh - var(--documents-pdf-tree-offset, 0px));
+  overflow:auto;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-topbar{
+  position:sticky;
+  top:0;
+  z-index:calc(var(--z-header) - 3);
+  background:var(--headbg);
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-report-table{
+  display:flex;
+  flex-direction:column;
+  min-height:0;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-report-table__header--pdf-preview{
+  position:sticky;
+  top:var(--documents-pdf-topbar-h, 44px);
+  z-index:calc(var(--z-header) - 2);
+  background:var(--headbgtight);
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-report-table__body--pdf{
+  min-height:0;
+  height:calc(100dvh - var(--documents-pdf-topbar-h, 44px) - var(--documents-pdf-toolbar-h, 52px));
+  overflow:auto;
+  overflow-x:auto;
+  overflow-y:auto;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-pdf-viewer,
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-pdf-viewer__canvas-shell{
+  min-height:100%;
+  overflow:visible;
+}
+.documents-pdf-sticky-mode .documents-shell.documents-shell--pdf-preview .documents-pdf-viewer__pages{
+  min-width:max-content;
 }
 .documents-tree .documents-repo__icon--folder,.documents-tree .octicon-file-directory-fill,.documents-tree .octicon-file-directory-open-fill{fill:rgb(145, 152, 161);color:rgb(145, 152, 161);}
 .documents-tree__resize-handle{position:absolute;top:0;right:-6px;width:12px;height:100%;cursor:col-resize;}


### PR DESCRIPTION
### Motivation
- Corriger le comportement de scroll dans l’onglet Documents quand on affiche un preview PDF pour conserver le scroll principal sur `document/window` et rendre uniquement la zone PDF scrollable verticalement/horizontalement.
- Éviter que les règles existantes remettent en `position:relative` les éléments devant rester sticky (aside, breadcrumb, toolbar PDF) et limiter l’impact aux vues PDF.

### Description
- Ajouté la classe dédiée `documents-shell--pdf-preview` dans `renderPdfPreviewView()` pour cibler strictement le rendu preview PDF sans impacter les autres vues (`apps/web/js/views/project-documents.js`).
- Modifié `apps/web/style.css` pour définir une politique CSS scindée à `body.documents-pdf-sticky-mode` + `.documents-shell--pdf-preview` avec variables CSS (`--documents-pdf-topbar-h`, `--documents-pdf-toolbar-h`) et : le `main#app`/`.project-shell__body` en `overflow:visible`, le layout en grille, l’aside (`.documents-tree__panel`) sticky et confiné à la hauteur viewport, le `topbar` et la `documents-report-table__header--pdf-preview` en `position:sticky` avec offsets, et la `documents-report-table__body--pdf` comme conteneur de scroll (`overflow:auto`, hauteur calculée via `100dvh - vars`).
- Réduit/ retiré les `overflow` concurrents dans le viewer PDF (`.documents-pdf-viewer`, `__canvas-shell`, `__pages`) et mis `min-width:max-content` sur les pages pour permettre le scroll horizontal au zoom.
- Ajouté instrumentation de debug dans `renderProjectDocumentsContent()` pour logger, quand `debug:project-scroll-policy` est activé, les styles calculés (`position/top/overflow/height/maxHeight`) de `.documents-topbar`, `.documents-report-table__header--pdf-preview`, `.documents-report-table__body--pdf` et `.documents-tree__panel`, tout en conservant la mécanique existante `document.body.classList.toggle("documents-pdf-sticky-mode", ...)`.

### Testing
- Aucun test automatisé n’a été ajouté ni exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f598d2cb4483299d4492c4130d3600)