### PR TITLE
Improve PDF preview scrolling and compact chrome behavior for project documents

### DIFF
--- a/apps/web/js/views/project-documents.js
+++ b/apps/web/js/views/project-documents.js
@@ -1,5 +1,5 @@
 import { store } from "../store.js";
-import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrollPolicy } from "./project-shell-chrome.js";
+import { setProjectViewHeader, clearProjectActiveScrollSource, debugProjectScrollPolicy, resetProjectShellCompactState, bindProjectDocumentChromeCompact } from "./project-shell-chrome.js";
 import {
   bindGhActionButtons,
   initGhActionButton,
@@ -1502,7 +1502,7 @@ function renderPdfPreviewView() {
   const topBar = renderDocumentsTopBar();
   return `
     <section class="project-simple-page project-simple-page--documents">
-      <div class="documents-shell documents-shell--project-page documents-layout${docsViewState.currentFolderId ? "" : " is-root"}" id="projectDocumentScroll" style="--documents-tree-width:${docsViewState.currentFolderId ? (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0) : 0}px">
+      <div class="documents-shell documents-shell--project-page documents-shell--pdf-preview documents-layout${docsViewState.currentFolderId ? "" : " is-root"}" id="projectDocumentScroll" style="--documents-tree-width:${docsViewState.currentFolderId ? (docsViewState.documentTreeOpen ? Math.max(220, Math.min(520, Number(docsViewState.treeWidth || 280))) : 0) : 0}px">
         ${treeHtml}
         <main class="documents-main">
           ${topBar}
@@ -1989,6 +1989,20 @@ async function openPdfPreview(root, documentId) {
 
   setActiveProjectDocument(documentItem.id);
   docsViewState.mode = "pdf-preview";
+  debugProjectScrollPolicy("documents-open-pdf-preview-reset-compact", {
+    beforeBodyClass: document.body?.className || "",
+    beforeScrollY: Number(window.scrollY || 0)
+  });
+  resetProjectShellCompactState({ scrollToTop: false });
+  requestAnimationFrame(() => {
+    if (docsViewState.mode !== "pdf-preview") return;
+    resetProjectShellCompactState({ scrollToTop: false });
+  });
+  debugProjectScrollPolicy("documents-open-pdf-preview-after-reset", {
+    afterBodyClass: document.body?.className || "",
+    afterScrollY: Number(window.scrollY || 0),
+    tabsClass: document.querySelector(".project-tabs")?.className || null
+  });
   docsViewState.pdfPreview = {
     objectUrl: "",
     signedUrl: "",
@@ -2152,6 +2166,17 @@ function bindDocumentsSplitActions(root) {
 
 function bindDocumentsView(root) {
   bindDocumentsSplitActions(root);
+  const documentsShell = root.querySelector(".documents-shell");
+  if (documentsShell) {
+    bindProjectDocumentChromeCompact({
+      scrollEl: document,
+      chromeEl: documentsShell,
+      classHost: document.body,
+      bodyClassName: "documents-local-chrome-compact",
+      compactThreshold: 8,
+      key: docsViewState.mode === "pdf-preview" ? "documents-pdf-shell" : "documents-list-shell"
+    });
+  }
   const treeToggleBtn = document.getElementById("documentsTreeToggleBtn");
   if (treeToggleBtn) {
     treeToggleBtn.addEventListener("click", async () => {
@@ -2513,13 +2538,34 @@ function renderProjectDocumentsContent(root) {
   if (docsViewState.mode === "pdf-preview") {
     const projectShellBody = document.querySelector(".project-shell__body");
     const projectShellBodyStyle = projectShellBody ? window.getComputedStyle(projectShellBody) : null;
+    const topbar = document.querySelector(".documents-topbar");
+    const pdfToolbar = document.querySelector(".documents-report-table__header--pdf-preview");
+    const pdfBody = document.querySelector(".documents-report-table__body--pdf");
+    const treePanel = document.querySelector(".documents-tree__panel");
+    const getNodeStyle = (node) => {
+      if (!node) return null;
+      const computed = window.getComputedStyle(node);
+      return {
+        position: computed.position,
+        top: computed.top,
+        overflow: computed.overflow,
+        overflowX: computed.overflowX,
+        overflowY: computed.overflowY,
+        height: computed.height,
+        maxHeight: computed.maxHeight
+      };
+    };
     const scrollingElement = document.scrollingElement || document.documentElement || document.body || null;
     logPdfPreviewDebug("scroll-policy", {
       bodyClassName: document.body?.className || "",
       windowScrollY: Number(window.scrollY || 0),
       documentScrollingElementScrollTop: Number(scrollingElement?.scrollTop || 0),
       projectShellBodyOverflow: projectShellBodyStyle?.overflow || null,
-      projectShellBodyPosition: projectShellBodyStyle?.position || null
+      projectShellBodyPosition: projectShellBodyStyle?.position || null,
+      documentsTopbar: getNodeStyle(topbar),
+      documentsPdfToolbar: getNodeStyle(pdfToolbar),
+      documentsPdfBody: getNodeStyle(pdfBody),
+      documentsTreePanel: getNodeStyle(treePanel)
     });
   }
 

--- a/apps/web/js/views/project-shell-chrome.js
+++ b/apps/web/js/views/project-shell-chrome.js
@@ -491,6 +491,72 @@ export function clearProjectActiveScrollSource(el = null) {
   debugProjectScrollPolicy("clear-active-scroll-source");
 }
 
+export function resetProjectShellCompactState({ scrollToTop = false } = {}) {
+  refreshProjectShellChromeRefs();
+
+  shellState.cleanupActiveScrollSource?.();
+  shellState.cleanupActiveScrollSource = null;
+  shellState.activeScrollSourceEl = null;
+  shellState.activeScrollSourceResolver = null;
+
+  if (scrollToTop) {
+    try {
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+    } catch (_) {
+      window.scrollTo(0, 0);
+    }
+    if (document.documentElement) document.documentElement.scrollTop = 0;
+    if (document.body) document.body.scrollTop = 0;
+  }
+
+  applyCompactState(false);
+  debugProjectScrollPolicy("reset-project-shell-compact-state", {
+    scrollToTop: scrollToTop === true,
+    bodyClassName: document.body?.className || "",
+    scrollY: Number(window.scrollY || 0)
+  });
+}
+
+export function bindProjectDocumentChromeCompact({
+  scrollEl = document,
+  chromeEl = null,
+  classHost = document.body,
+  bodyClassName = "",
+  compactThreshold = 8,
+  key = "local-document-chrome",
+  onCompactChange = null
+} = {}) {
+  if (!chromeEl) return;
+
+  const isDocumentLike = scrollEl === document || scrollEl === document.documentElement || scrollEl === document.body;
+  const eventTarget = isDocumentLike ? window : scrollEl;
+  const stateTarget = isDocumentLike ? (document.scrollingElement || document.documentElement || document.body) : scrollEl;
+  const safeKey = String(key || "local-document-chrome").replace(/[^a-zA-Z0-9_-]/g, "").toLowerCase();
+  const attr = `data-project-document-chrome-bound-${safeKey}`;
+  const sync = () => {
+    const scrolled = Number(stateTarget?.scrollTop || window.scrollY || 0) > compactThreshold;
+    if (bodyClassName && classHost?.classList) {
+      classHost.classList.toggle(bodyClassName, scrolled);
+    }
+    chromeEl.classList.toggle("project-local-chrome--compact", scrolled);
+    onCompactChange?.(scrolled);
+  };
+
+  chromeEl.__syncProjectDocumentChromeCompact = sync;
+
+  if (chromeEl.getAttribute?.(attr) === "1") {
+    sync();
+    return;
+  }
+
+  chromeEl.setAttribute?.(attr, "1");
+  eventTarget.addEventListener("scroll", sync, { passive: true });
+  window.addEventListener("resize", sync, { passive: true });
+
+  sync();
+  setTimeout(sync, 0);
+}
+
 export function setProjectCompactEnabled(enabled = true) {
   shellState.compactEnabled = enabled !== false;
   if (!shellState.compactEnabled) {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -5921,7 +5921,7 @@ color:var(--text);
 
 .documents-report-table__header--pdf-preview{
   position:sticky;
-  top:0;
+  top:calc(var(--app-top) + var(--documents-pdf-topbar-h, 44px));
   z-index:calc(var(--z-header) - 1);
   justify-content:flex-end;
   padding:10px 16px;
@@ -6011,8 +6011,12 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 }
 
 .documents-report-table__body--pdf{
-  min-height:calc(100vh - 220px);
+  min-height:0;
+  height:calc(100dvh - var(--documents-pdf-topbar-h, 44px) - var(--documents-pdf-toolbar-h, 52px));
   padding:0;
+  overflow:auto;
+  overflow-x:auto;
+  overflow-y:auto;
 }
 
 .documents-report__page-break{
@@ -6062,8 +6066,8 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 
 .documents-pdf-viewer{
   background:var(--panel);
-  overflow:auto;
-  min-height:calc(100vh - 220px);
+  overflow:visible;
+  min-height:100%;
 }
 
 .documents-pdf-viewer__frame{
@@ -6076,9 +6080,9 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 
 .documents-pdf-viewer__canvas-shell{
   position:relative;
-  min-height:calc(100vh - 220px);
+  min-height:100%;
   background:#f6f8fa;
-  overflow:auto;
+  overflow:visible;
 }
 
 .documents-pdf-viewer__canvas-shell.is-dark-mode{
@@ -6095,8 +6099,8 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
   align-items:flex-start;
   gap:24px;
   padding:16px 12px 24px;
-  min-height:calc(100vh - 220px);
-  min-width:100%;
+  min-height:100%;
+  min-width:max-content;
   background:var(--headbg);
 }
 
@@ -6592,9 +6596,6 @@ body.route--project.project-shell-compact .documents-report-table__header--pdf-p
 .documents-tree__file:hover{background:rgba(110,118,129,.16);}
 .documents-tree__file:hover .documents-tree__label{color:#58a6ff;text-decoration:underline;}
 .documents-tree__row,.documents-tree__file{position:relative;}
-.documents-pdf-sticky-mode main#app{
-  padding:0;
-}
 .documents-pdf-sticky-mode .project-shell__body{
   position:relative;
   top:auto;
@@ -6608,19 +6609,55 @@ body.route--project.documents-pdf-sticky-mode.project-shell-compact .gh-header.g
   pointer-events:none;
   transition:transform .16s ease, opacity .16s ease;
 }
-body.route--project.documents-pdf-sticky-mode.project-shell-compact .project-shell__body{
-  margin-top:calc(-1 * var(--header-h-compact));
-  padding-top:var(--header-h-compact);
+.documents-shell--pdf-preview{
+  --documents-pdf-topbar-h:44px;
+  --documents-pdf-toolbar-h:52px;
+  width:100%;
+  max-width:none;
+  overflow:visible;
 }
-.documents-pdf-sticky-mode .project-context-header{
-  position:static;
+.documents-shell--pdf-preview .documents-main{
+  min-width:0;
+  height:auto;
+  max-height:none;
+  overflow:visible;
 }
-.documents-pdf-sticky-mode .gh-header.gh-header--project,
-.documents-pdf-sticky-mode .documents-topbar,
-.documents-pdf-sticky-mode .documents-report-table__header.documents-report-table__header--pdf-preview{
-  position:relative;
-  top:auto;
-  z-index:auto;
+.documents-shell .documents-topbar{
+  position:sticky;
+  top:var(--app-top);
+  z-index:calc(var(--z-header) - 3);
+  background:var(--headbg);
+}
+body.route--project.project-shell-compact .documents-shell .documents-topbar,
+body.documents-local-chrome-compact .documents-shell .documents-topbar,
+.documents-shell.project-local-chrome--compact .documents-topbar{
+  top:0;
+}
+.documents-shell--pdf-preview .documents-report-table__header--pdf-preview{
+  position:sticky;
+  top:calc(var(--app-top) + var(--documents-pdf-topbar-h, 44px));
+  z-index:calc(var(--z-header) - 2);
+  background:var(--headbgtight);
+}
+body.route--project.project-shell-compact .documents-shell--pdf-preview .documents-report-table__header--pdf-preview,
+body.documents-local-chrome-compact .documents-shell--pdf-preview .documents-report-table__header--pdf-preview,
+.documents-shell--pdf-preview.project-local-chrome--compact .documents-report-table__header--pdf-preview{
+  top:var(--documents-pdf-topbar-h, 44px);
+}
+.documents-shell--pdf-preview .documents-report-table__body--pdf{
+  min-height:0;
+  height:calc(100dvh - var(--documents-pdf-topbar-h, 44px) - var(--documents-pdf-toolbar-h, 52px));
+  overflow:auto;
+  overflow-x:auto;
+  overflow-y:auto;
+}
+.documents-shell--pdf-preview .documents-pdf-viewer,
+.documents-shell--pdf-preview .documents-pdf-viewer__canvas-shell{
+  min-height:100%;
+  overflow:visible;
+}
+.documents-shell--pdf-preview .documents-pdf-viewer__pages{
+  min-width:max-content;
 }
 .documents-tree .documents-repo__icon--folder,.documents-tree .octicon-file-directory-fill,.documents-tree .octicon-file-directory-open-fill{fill:rgb(145, 152, 161);color:rgb(145, 152, 161);}
 .documents-tree__resize-handle{position:absolute;top:0;right:-6px;width:12px;height:100%;cursor:col-resize;}


### PR DESCRIPTION
### Motivation

- Fix issues with the project shell compact/header behavior and scrolling when opening PDF previews so the document viewer and toolbar remain correctly positioned and the chrome can be toggled into a compact state per-document. 
- Provide a local compact binding for documents UI to avoid interfering with global project scroll source and to allow resetting compact state when entering the PDF preview.

### Description

- Added `resetProjectShellCompactState` and `bindProjectDocumentChromeCompact` in `views/project-shell-chrome.js` to allow resetting and locally binding a compact chrome behavior for document views, and exported both functions. 
- Updated `views/project-documents.js` to call `resetProjectShellCompactState` when opening a PDF preview and to bind the document chrome compact logic via `bindProjectDocumentChromeCompact` in `bindDocumentsView`. 
- Enhanced debug logging around scroll/compact policy in PDF preview with `debugProjectScrollPolicy` and `logPdfPreviewDebug` calls, and added defensive requestAnimationFrame reset calls. 
- Adjusted PDF preview markup to add `documents-shell--pdf-preview` class and toggle body and host classes for sticky/compact behaviors. 
- Updated CSS (`style.css`) to introduce layout variables `--documents-pdf-topbar-h` and `--documents-pdf-toolbar-h`, make the PDF toolbar sticky below the topbar, and adjust PDF viewer/container sizing and overflow to work with the new compact/sticky behavior.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f598d2cb4483299d4492c4130d3600)