### PR TITLE
fix(situations): remove non-functional fullscreen button from drilldown header

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -350,15 +350,6 @@ export function createProjectSituationsView({
                     <button type="button" class="gh-btn gh-action__main gh-btn--default gh-btn--md" data-open-situation-insights>
                       ${svgIcon("graph", { className: "octicon octicon-graph" })}<span>Indicateurs</span>
                     </button>
-                    <button
-                      type="button"
-                      class="gh-btn gh-action__main gh-btn--default gh-btn--md"
-                      data-open-situation-drilldown
-                      aria-label="Étendre la barre latérale"
-                      title="Étendre la barre latérale"
-                    >
-                      ${svgIcon("sidebar-expand", { className: "octicon octicon-sidebar-expand" })}
-                    </button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Corriger un défaut UX en retirant l’icône de plein écran affichée dans le drilldown de l’onglet `Situations` alors que ce mode n’est implémenté que pour l’onglet `Sujets`.

### Description
- Supprime le bouton avec l’attribut `data-open-situation-drilldown` (icône `sidebar-expand`) depuis `apps/web/js/views/project-situations/project-situations-view.js` dans l’en-tête du détail de situation, en laissant le bouton `data-open-situation-insights` et les métadonnées inchangés.

### Testing
- Vérifié le diff avec `git diff -- apps/web/js/views/project-situations/project-situations-view.js` et appliqué le changement via `git commit -m "fix(situations): remove non-functional fullscreen button from drilldown header"`, les commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75b859a6c8329be52f5bf12b6aa9b)