### PR TITLE
Add subissue button to grid, integrate overlay-close, and remove promote action

### DIFF
--- a/apps/web/js/views/project-situation-drilldown.js
+++ b/apps/web/js/views/project-situation-drilldown.js
@@ -24,7 +24,7 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
         <button
           type="button"
           id="${escapeHtml(closeButtonId)}"
-          class="project-situation-drilldown__close"
+          class="project-situation-drilldown__close overlay-chrome__close"
           aria-label="${escapeHtml(closeButtonLabel)}"
           title="${escapeHtml(closeButtonLabel)}"
         >✕</button>

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1983,10 +1983,6 @@ export function createProjectSituationsEvents({
           closeButtonId: "projectSituationDrilldownClose"
         });
 
-        drilldownBody.querySelector("#projectSituationDrilldownClose")?.addEventListener("click", () => {
-          document.getElementById("drilldownClose")?.click();
-        });
-
         drilldownBody.querySelector(".project-situation-drilldown__section-action")?.addEventListener("click", () => {
           openEditPanel(root, selectedSituationId);
         });

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -112,6 +112,37 @@ function getSituationGridMetaAnchorKey(field = "", subjectId = "") {
   });
 }
 
+function renderSituationGridAddSubissueButton(subjectId = "") {
+  const normalizedSubjectId = normalizeId(subjectId);
+  if (!normalizedSubjectId) return "";
+  const anchorKey = buildSubjectMetaAnchorKey({
+    field: "subissue-actions",
+    scope: "situation-grid",
+    scopeHost: "main",
+    subjectId: normalizedSubjectId,
+    instance: "situation-grid-subissue-actions"
+  });
+  return `
+    <button
+      type="button"
+      class="situation-grid__add-subissue-trigger"
+      data-action="open-subissue-action-menu"
+      data-subject-id="${escapeHtml(normalizedSubjectId)}"
+      data-subject-meta-anchor="${escapeHtml(anchorKey)}"
+      data-subject-meta-instance="situation-grid-subissue-actions"
+      data-subject-meta-scope="situation-grid"
+      data-subject-meta-scope-host="main"
+      data-subject-meta-subject-id="${escapeHtml(normalizedSubjectId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      aria-label="Ajouter un sous-sujet"
+      title="Ajouter un sous-sujet"
+    >
+      ${svgIcon("plus", { className: "octicon octicon-plus" })}
+    </button>
+  `;
+}
+
 function getSubjectProgress(subject, subjectsById = {}, childrenBySubjectId = {}) {
   const subjectId = normalizeId(subject?.id);
   const childIds = Array.isArray(childrenBySubjectId?.[subjectId]) ? childrenBySubjectId[subjectId] : [];
@@ -498,6 +529,8 @@ export function renderSituationGridView(situation, subjects = [], options = {}) 
             ${renderIssueStateIcon(subject, { isBlocked })}
             <button type="button" class="situation-grid__subject-title" data-open-situation-subject="${escapeHtml(subjectId)}">${escapeHtml(subjectTitle)}</button>
             <span class="situation-grid__subject-id mono">${escapeHtml(identifier)}</span>
+            <span class="situation-grid__title-spacer" aria-hidden="true"></span>
+            ${renderSituationGridAddSubissueButton(subjectId)}
           </div>
         </div>
       `;

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -551,16 +551,7 @@ const projectSubjectDrilldown = createProjectSubjectDrilldownController({
   renderOverlayChromeHead,
   bindOverlayChromeDismiss,
   getDrilldownSelection,
-  promoteActionHtml: `
-    <button
-      class="icon-btn icon-btn--sm js-drilldown-promote-selection"
-      type="button"
-      aria-label="Afficher ce sujet dans le panneau principal"
-      title="Afficher dans le panneau principal"
-    >
-      ${svgIcon("screen-full", { className: "octicon octicon-screen-full" })}
-    </button>
-  `,
+  promoteActionHtml: "",
   openDrilldownFromSituationSelection: openDrilldownFromSituation,
   openDrilldownFromSubjectSelection: openDrilldownFromSubject,
   openDrilldownFromSujetSelection: openDrilldownFromSujet,

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -11323,6 +11323,39 @@ circle.situation-trajectory__hierarchy-link--blocked,
   flex:0 0 auto;
 }
 
+.situation-grid__title-spacer{
+  flex:1 1 auto;
+  min-width:0;
+}
+
+.situation-grid__add-subissue-trigger{
+  width:24px;
+  height:24px;
+  border:1px solid transparent;
+  border-radius:6px;
+  background:transparent;
+  color:var(--fgColor-muted, #8b949e);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .12s ease, color .12s ease, background-color .12s ease, border-color .12s ease;
+}
+
+.situation-grid__row:hover .situation-grid__add-subissue-trigger,
+.situation-grid__row:focus-within .situation-grid__add-subissue-trigger{
+  opacity:1;
+  pointer-events:auto;
+}
+
+.situation-grid__add-subissue-trigger:hover,
+.situation-grid__add-subissue-trigger:focus-visible{
+  color:var(--fgColor-accent, #2f81f7);
+  border-color:var(--borderColor-default, #30363d);
+  background:var(--bgColor-muted, rgba(110,118,129,.1));
+}
+
 .situation-grid__empty-cell{
   width:100%;
   min-height:1px;


### PR DESCRIPTION
### Motivation
- Integrate the drilldown close control with the overlay chrome styling and behavior so it is handled consistently by the overlay system.
- Surface an inline "add subissue" action in the situation grid so users can open the subissue action menu from each subject row.
- Remove the promote action from the subject drilldown chrome to simplify the drilldown header actions.

### Description
- Added `overlay-chrome__close` to the drilldown close button in `project-situation-drilldown.js` and removed the manual click proxy wiring in `project-situations-events.js` so the overlay chrome handles dismissal.
- Implemented `renderSituationGridAddSubissueButton` and inserted it into the grid title cell in `project-situations-view-grid.js`, emitting a button with the appropriate `data-*` attributes to open the subissue action menu.
- Replaced the `promoteActionHtml` markup with an empty string in `project-subjects.js` to remove the promote button from the drilldown header.
- Added CSS rules in `style.css` for `.situation-grid__title-spacer` and `.situation-grid__add-subissue-trigger` including hover/focus behaviors to show the button on row hover.

### Testing
- Ran the JavaScript unit test suite with `npm test`; all tests passed.
- Ran the linter with `npm run lint`; no lint errors remained.
- Performed automated UI snapshot checks for the grid and drilldown components; snapshots updated/validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75e090e0c83298797779adbd050e7)