### PR TITLE
Add subissue action button to situation grid and fix dropdown scoping

### DIFF
--- a/apps/web/js/views/project-situation-drilldown.js
+++ b/apps/web/js/views/project-situation-drilldown.js
@@ -24,7 +24,7 @@ export function renderProjectSituationDrilldown(situation, options = {}) {
         <button
           type="button"
           id="${escapeHtml(closeButtonId)}"
-          class="project-situation-drilldown__close"
+          class="project-situation-drilldown__close overlay-chrome__close"
           aria-label="${escapeHtml(closeButtonLabel)}"
           title="${escapeHtml(closeButtonLabel)}"
         >✕</button>

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -254,6 +254,7 @@ export function createProjectSituationsEvents({
 
   function openSituationGridCellDropdown(root, { field = "", anchor = null, subjectId = "", situationId = "" } = {}) {
     if (!anchor) return;
+    const scopeRoot = resolveSituationGridDropdownRoot();
     const state = ensureSituationGridCellDropdownState();
     const host = document.getElementById("subjectMetaDropdownHost");
     closeSituationGridCellDropdown();
@@ -272,7 +273,7 @@ export function createProjectSituationsEvents({
     }));
     if (state.field === "kanban") {
       const opened = openSharedSubjectKanbanDropdown?.({
-        root,
+        root: scopeRoot,
         subjectId: state.subjectId,
         situationId: state.situationId
       });
@@ -281,7 +282,7 @@ export function createProjectSituationsEvents({
     }
 
     const opened = openSharedSubjectMetaDropdown?.({
-      root,
+      root: scopeRoot,
       field: state.field,
       subjectId: state.subjectId,
       anchor,
@@ -1172,7 +1173,8 @@ export function createProjectSituationsEvents({
   }
 
   function bindSituationGridEditableCells(root) {
-    setSituationGridDropdownRoot(root);
+    const scopeRoot = root?.closest?.(".project-shell__content") || root;
+    setSituationGridDropdownRoot(scopeRoot);
     root.querySelectorAll("[data-situation-grid-edit-cell]").forEach((node) => {
       node.addEventListener("click", (event) => {
         const caretNode = event.target instanceof Element
@@ -1194,6 +1196,26 @@ export function createProjectSituationsEvents({
           return;
         }
         openSituationGridCellDropdown(root, { field, anchor: node, subjectId, situationId });
+      });
+    });
+    root.querySelectorAll("[data-action='open-subissue-action-menu'][data-subject-id]").forEach((node) => {
+      node.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const subjectId = String(node.getAttribute("data-subject-id") || "").trim();
+        const situationId = String(node.getAttribute("data-situation-grid-situation-id") || store?.situationsView?.selectedSituationId || "").trim();
+        if (!subjectId) return;
+        const state = ensureSituationGridCellDropdownState();
+        if (state.open && state.field === "subissue-actions" && state.subjectId === subjectId && state.anchor === node) {
+          closeSituationGridCellDropdown();
+          return;
+        }
+        openSituationGridCellDropdown(root, {
+          field: "subissue-actions",
+          anchor: node,
+          subjectId,
+          situationId
+        });
       });
     });
     uiState?.situationGridDropdownAbortController?.abort?.();
@@ -1981,10 +2003,6 @@ export function createProjectSituationsEvents({
         if (!drilldownBody) return;
         drilldownBody.innerHTML = renderProjectSituationDrilldown(selectedSituation, {
           closeButtonId: "projectSituationDrilldownClose"
-        });
-
-        drilldownBody.querySelector("#projectSituationDrilldownClose")?.addEventListener("click", () => {
-          document.getElementById("drilldownClose")?.click();
         });
 
         drilldownBody.querySelector(".project-situation-drilldown__section-action")?.addEventListener("click", () => {

--- a/apps/web/js/views/project-situations/project-situations-view-grid.js
+++ b/apps/web/js/views/project-situations/project-situations-view-grid.js
@@ -112,6 +112,39 @@ function getSituationGridMetaAnchorKey(field = "", subjectId = "") {
   });
 }
 
+function renderSituationGridAddSubissueButton(subjectId = "", situationId = "") {
+  const normalizedSubjectId = normalizeId(subjectId);
+  const normalizedSituationId = normalizeId(situationId);
+  if (!normalizedSubjectId) return "";
+  const anchorKey = buildSubjectMetaAnchorKey({
+    field: "subissue-actions",
+    scope: "situation-grid",
+    scopeHost: "main",
+    subjectId: normalizedSubjectId,
+    instance: "situation-grid-subissue-actions"
+  });
+  return `
+    <button
+      type="button"
+      class="situation-grid__add-subissue-trigger"
+      data-action="open-subissue-action-menu"
+      data-subject-id="${escapeHtml(normalizedSubjectId)}"
+      data-subject-meta-anchor="${escapeHtml(anchorKey)}"
+      data-subject-meta-instance="situation-grid-subissue-actions"
+      data-subject-meta-scope="situation-grid"
+      data-subject-meta-scope-host="main"
+      data-subject-meta-subject-id="${escapeHtml(normalizedSubjectId)}"
+      data-situation-grid-situation-id="${escapeHtml(normalizedSituationId)}"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      aria-label="Ajouter un sous-sujet"
+      title="Ajouter un sous-sujet"
+    >
+      ${svgIcon("plus", { className: "octicon octicon-plus" })}
+    </button>
+  `;
+}
+
 function getSubjectProgress(subject, subjectsById = {}, childrenBySubjectId = {}) {
   const subjectId = normalizeId(subject?.id);
   const childIds = Array.isArray(childrenBySubjectId?.[subjectId]) ? childrenBySubjectId[subjectId] : [];
@@ -498,6 +531,8 @@ export function renderSituationGridView(situation, subjects = [], options = {}) 
             ${renderIssueStateIcon(subject, { isBlocked })}
             <button type="button" class="situation-grid__subject-title" data-open-situation-subject="${escapeHtml(subjectId)}">${escapeHtml(subjectTitle)}</button>
             <span class="situation-grid__subject-id mono">${escapeHtml(identifier)}</span>
+            <span class="situation-grid__title-spacer" aria-hidden="true"></span>
+            ${renderSituationGridAddSubissueButton(subjectId, normalizedSituationId)}
           </div>
         </div>
       `;

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -551,16 +551,7 @@ const projectSubjectDrilldown = createProjectSubjectDrilldownController({
   renderOverlayChromeHead,
   bindOverlayChromeDismiss,
   getDrilldownSelection,
-  promoteActionHtml: `
-    <button
-      class="icon-btn icon-btn--sm js-drilldown-promote-selection"
-      type="button"
-      aria-label="Afficher ce sujet dans le panneau principal"
-      title="Afficher dans le panneau principal"
-    >
-      ${svgIcon("screen-full", { className: "octicon octicon-screen-full" })}
-    </button>
-  `,
+  promoteActionHtml: "",
   openDrilldownFromSituationSelection: openDrilldownFromSituation,
   openDrilldownFromSubjectSelection: openDrilldownFromSubject,
   openDrilldownFromSujetSelection: openDrilldownFromSujet,

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -11323,6 +11323,39 @@ circle.situation-trajectory__hierarchy-link--blocked,
   flex:0 0 auto;
 }
 
+.situation-grid__title-spacer{
+  flex:1 1 auto;
+  min-width:0;
+}
+
+.situation-grid__add-subissue-trigger{
+  width:24px;
+  height:24px;
+  border:1px solid transparent;
+  border-radius:6px;
+  background:transparent;
+  color:var(--fgColor-muted, #8b949e);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .12s ease, color .12s ease, background-color .12s ease, border-color .12s ease;
+}
+
+.situation-grid__row:hover .situation-grid__add-subissue-trigger,
+.situation-grid__row:focus-within .situation-grid__add-subissue-trigger{
+  opacity:1;
+  pointer-events:auto;
+}
+
+.situation-grid__add-subissue-trigger:hover,
+.situation-grid__add-subissue-trigger:focus-visible{
+  color:var(--fgColor-accent, #2f81f7);
+  border-color:var(--borderColor-default, #30363d);
+  background:var(--bgColor-muted, rgba(110,118,129,.1));
+}
+
 .situation-grid__empty-cell{
   width:100%;
   min-height:1px;


### PR DESCRIPTION
### Motivation

- Provide a quick way to add a subissue from the situation grid and surface an action menu for subissue operations. 
- Ensure subject-meta dropdowns open in the correct overlay / content scope so dropdowns render and behave correctly inside embedded shells. 
- Tidy some UI affordances and remove an unused promote action in the subject drilldown chrome.

### Description

- Added `renderSituationGridAddSubissueButton` and inserted the add-subissue trigger into the grid title cell, emitting `data-action="open-subissue-action-menu"` and necessary meta attributes. 
- Implemented event handling in `bindSituationGridEditableCells` to listen for `data-action="open-subissue-action-menu"` clicks and open the situation-grid dropdown with `field: "subissue-actions"`. 
- Scoped dropdown roots by resolving a `scopeRoot` (closest `.project-shell__content`) and passing it into `openSharedSubjectKanbanDropdown` and `openSharedSubjectMetaDropdown`, and set the stored dropdown root from `bindSituationGridEditableCells`. 
- Added a flexible spacer and styles for the new add-subissue button in `style.css` including hover/focus behaviors and visibility on row hover. 
- Small UI changes: added `overlay-chrome__close` class to the drilldown close button and removed the `promoteActionHtml` content in `project-subjects.js` (now an empty string). 
- Removed an obsolete click handler that previously wired the generated drilldown close button to the global drilldown close element.

### Testing

- Ran linter with `npm run lint` which completed without errors. 
- Executed the automated test suite with `npm test` and all tests passed. 
- Built the frontend assets with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75e090e0c83298797779adbd050e7)