### PR TITLE
Remove stray instanceKey assignment in project-situations-events.js

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -2223,4 +2223,3 @@ export function createProjectSituationsEvents({
     if (!isPaginationDebugEnabled()) return;
     console.info("[pagination]", { entity, previousPage, nextPage, totalPages });
   }
-    const instanceKey = String(anchor?.dataset?.subjectMetaInstance || "situation-grid").trim() || "situation-grid";


### PR DESCRIPTION
### Motivation
- A stray top-level `instanceKey` assignment using `anchor?.dataset?.subjectMetaInstance` was present in `apps/web/js/views/project-situations/project-situations-events.js`, which violates an explicit test expectation that the events source must not contain that pattern.

### Description
- Deleted the unintended trailing `const instanceKey = String(anchor?.dataset?.subjectMetaInstance || "situation-grid").trim() || "situation-grid";` line from `apps/web/js/views/project-situations/project-situations-events.js` so instance keys are determined by the existing normalized-field logic instead of reading `subjectMetaInstance` from an anchor.

### Testing
- Ran `node --test apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs` and it passed (`8/8`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76db419208329a0b4785aed3cc734)