### PR TITLE
Handle create/link subissue actions from situation grid cell dropdown

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -1239,6 +1239,42 @@ export function createProjectSituationsEvents({
       const eventTarget = event.target instanceof Element ? event.target : null;
       if (!eventTarget) return;
       const root = resolveSituationGridDropdownRoot();
+      const actionButton = eventTarget.closest("[data-action='open-create-subissue'],[data-action='open-link-existing-subissue']");
+      if (actionButton) {
+        const state = ensureSituationGridCellDropdownState();
+        if (!state.open || String(state.field || "").trim().toLowerCase() !== "subissue-actions") return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (actionButton.matches("[data-action='open-link-existing-subissue']")) {
+          if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") return;
+          if (!store.projectSubjectsView.subjectMetaDropdown || typeof store.projectSubjectsView.subjectMetaDropdown !== "object") return;
+          store.projectSubjectsView.subjectMetaDropdown.subissueActionsView = "existing-subissue";
+          store.projectSubjectsView.subjectMetaDropdown.subissueActionIntent = "link-existing";
+          store.projectSubjectsView.subjectMetaDropdown.query = "";
+          rerender(root);
+          return;
+        }
+        if (!store.situationsView || typeof store.situationsView !== "object") return;
+        const existing = store.situationsView.createSubjectForm && typeof store.situationsView.createSubjectForm === "object"
+          ? store.situationsView.createSubjectForm
+          : {};
+        store.situationsView.createSubjectForm = {
+          ...existing,
+          isOpen: true,
+          title: "",
+          description: "",
+          validationError: "",
+          isSubmitting: false,
+          mode: "subissue",
+          parentSubjectId: String(state.subjectId || "").trim() || null,
+          sourceSubjectId: String(state.subjectId || "").trim() || null,
+          origin: "detail",
+          scopeHost: "main"
+        };
+        closeSituationGridCellDropdown();
+        rerender(root);
+        return;
+      }
       const actionNode = eventTarget.closest(
         "[data-subject-kanban-select],[data-subject-assignee-toggle],[data-subject-label-toggle],[data-objective-select]"
       );
@@ -2223,4 +2259,3 @@ export function createProjectSituationsEvents({
     if (!isPaginationDebugEnabled()) return;
     console.info("[pagination]", { entity, previousPage, nextPage, totalPages });
   }
-    const instanceKey = String(anchor?.dataset?.subjectMetaInstance || "situation-grid").trim() || "situation-grid";


### PR DESCRIPTION
### Motivation

- Allow users to open the create-subissue flow or link an existing subissue directly from the situation grid cell dropdown without closing the dropdown prematurely.
- Ensure store state is updated consistently so the UI can render the appropriate subissue creation or linking views.

### Description

- Added detection for `[data-action='open-create-subissue']` and `[data-action='open-link-existing-subissue']` clicks inside `handleGridDropdownItemClickCapture` and short-circuited processing when those actions are invoked. 
- Implemented logic to set `store.projectSubjectsView.subjectMetaDropdown` for the link-existing flow and to populate `store.situationsView.createSubjectForm` with initial fields for the create-subissue flow, including `mode: "subissue"`, `parentSubjectId`, and UI state keys like `isOpen` and `isSubmitting`.
- Prevented default behavior and stopped propagation for these action clicks, closed the cell dropdown as appropriate with `closeSituationGridCellDropdown`, and forced a UI update via `rerender(root)`.
- Added defensive type checks around `store.projectSubjectsView` and `store.situationsView` access to avoid runtime errors.

### Testing

- Ran the existing frontend JavaScript unit test suite (`yarn test`) and the linter (`yarn lint`), and both completed without failures.
- No new automated tests were added for the dropdown actions in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76db419208329a0b4785aed3cc734)