### PR TITLE
Remove duplicate `instanceKey` declaration in project-situations-events.js

### DIFF
--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -2223,4 +2223,3 @@ export function createProjectSituationsEvents({
     if (!isPaginationDebugEnabled()) return;
     console.info("[pagination]", { entity, previousPage, nextPage, totalPages });
   }
-    const instanceKey = String(anchor?.dataset?.subjectMetaInstance || "situation-grid").trim() || "situation-grid";


### PR DESCRIPTION
### Motivation
- Remove a redundant `const instanceKey` declaration that could cause a duplicate-declaration error or confusion in `project-situations-events.js`.

### Description
- Delete the extra line declaring `const instanceKey = String(anchor?.dataset?.subjectMetaInstance || "situation-grid").trim() || "situation-grid";` to avoid a redeclaration and clean up the code.

### Testing
- Ran `yarn lint` and `yarn test:web`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76db419208329a0b4785aed3cc734)