### PR TITLE
Fix subissue-actions dropdown in Situations grid by reusing shared subject flows

### DIFF
--- a/apps/web/js/views/project-situations.js
+++ b/apps/web/js/views/project-situations.js
@@ -55,7 +55,9 @@ import {
   setSharedSubjectKanbanDropdownQuery,
   toggleSubjectAssigneeFromSharedDropdown,
   toggleSubjectLabelFromSharedDropdown,
-  toggleSubjectObjectiveFromSharedDropdown
+  toggleSubjectObjectiveFromSharedDropdown,
+  openSharedCreateSubissueModal,
+  linkExistingSubjectAsSubissueFromSharedDropdown
 } from "./project-subjects.js";
 
 const { uiState, ensureSituationsViewState } = createProjectSituationsState({ store });

--- a/apps/web/js/views/project-situations/project-situations-events.js
+++ b/apps/web/js/views/project-situations/project-situations-events.js
@@ -111,6 +111,8 @@ export function createProjectSituationsEvents({
   toggleSubjectAssigneeFromSharedDropdown,
   toggleSubjectLabelFromSharedDropdown,
   toggleSubjectObjectiveFromSharedDropdown,
+  openSharedCreateSubissueModal,
+  linkExistingSubjectAsSubissueFromSharedDropdown,
   setSituationGridKanbanStatus,
   setSituationGridSubjectParent,
   reorderSituationGridSubjectChildren,
@@ -295,6 +297,16 @@ export function createProjectSituationsEvents({
       instanceKey,
       openedFrom: "situation-grid"
     });
+    if (opened && state.field === "subissue-actions" && store?.projectSubjectsView?.subjectMetaDropdown) {
+      const dropdown = store.projectSubjectsView.subjectMetaDropdown;
+      dropdown.subissueActionsView = "menu";
+      dropdown.query = "";
+      dropdown.activeKey = "";
+      dropdown.subissueActionSubjectId = state.subjectId;
+      dropdown.subissueActionScopeHost = "main";
+      dropdown.subissueActionIntent = "";
+      setSharedSubjectMetaDropdownQuery?.("", scopeRoot);
+    }
     if (!opened) closeSituationGridCellDropdown();
   }
 
@@ -1246,35 +1258,42 @@ export function createProjectSituationsEvents({
         event.preventDefault();
         event.stopPropagation();
         if (actionButton.matches("[data-action='open-link-existing-subissue']")) {
-          if (!store.projectSubjectsView || typeof store.projectSubjectsView !== "object") return;
-          if (!store.projectSubjectsView.subjectMetaDropdown || typeof store.projectSubjectsView.subjectMetaDropdown !== "object") return;
-          store.projectSubjectsView.subjectMetaDropdown.subissueActionsView = "existing-subissue";
-          store.projectSubjectsView.subjectMetaDropdown.subissueActionIntent = "link-existing";
-          store.projectSubjectsView.subjectMetaDropdown.query = "";
-          rerender(root);
+          const dropdown = store?.projectSubjectsView?.subjectMetaDropdown;
+          if (!dropdown || typeof dropdown !== "object") return;
+          dropdown.subissueActionsView = "existing-subissue";
+          dropdown.subissueActionIntent = "link-existing";
+          dropdown.subissueActionSubjectId = String(state.subjectId || "").trim();
+          dropdown.subissueActionScopeHost = "main";
+          dropdown.query = "";
+          dropdown.activeKey = "";
+          setSharedSubjectMetaDropdownQuery?.("", root);
           return;
         }
-        if (!store.situationsView || typeof store.situationsView !== "object") return;
-        const existing = store.situationsView.createSubjectForm && typeof store.situationsView.createSubjectForm === "object"
-          ? store.situationsView.createSubjectForm
-          : {};
-        store.situationsView.createSubjectForm = {
-          ...existing,
-          isOpen: true,
-          title: "",
-          description: "",
-          validationError: "",
-          isSubmitting: false,
-          mode: "subissue",
-          parentSubjectId: String(state.subjectId || "").trim() || null,
-          sourceSubjectId: String(state.subjectId || "").trim() || null,
-          origin: "detail",
-          scopeHost: "main"
-        };
+        closeSituationGridCellDropdown();
+        openSharedCreateSubissueModal?.({
+          parentSubjectId: state.subjectId,
+          sourceSubjectId: state.subjectId,
+          scopeHost: "main",
+          root
+        });
+        return;
+      }
+      const subissueExistingEntry = eventTarget.closest("[data-subject-subissue-existing-entry]");
+      if (subissueExistingEntry) {
+        const state = ensureSituationGridCellDropdownState();
+        if (!state.open || String(state.field || "").trim().toLowerCase() !== "subissue-actions") return;
+        const childSubjectId = String(subissueExistingEntry.getAttribute("data-subject-subissue-existing-entry") || "").trim();
+        const parentSubjectId = String(state.subjectId || store?.projectSubjectsView?.subjectMetaDropdown?.subissueActionSubjectId || "").trim();
+        if (!parentSubjectId || !childSubjectId || parentSubjectId === childSubjectId) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const linked = linkExistingSubjectAsSubissueFromSharedDropdown?.({ parentSubjectId, childSubjectId, root });
+        if (!linked) return;
         closeSituationGridCellDropdown();
         rerender(root);
         return;
       }
+
       const actionNode = eventTarget.closest(
         "[data-subject-kanban-select],[data-subject-assignee-toggle],[data-subject-label-toggle],[data-objective-select]"
       );

--- a/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
+++ b/apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs
@@ -96,3 +96,14 @@ test("les indicateurs de drop de la grille situation utilisent une ligne plus é
   assert.match(styleSource, /\.situation-grid \.subissues-sortable-row\.is-subissue-dragging::after\{bottom:0;\}/);
   assert.match(styleSource, /\.subject-status-blocked-indicator \.octicon-blocked\{[\s\S]*background:var\(--bg\);/);
 });
+
+test("les actions sous-sujet de la grille réutilisent les flux partagés", () => {
+  assert.match(eventsSource, /dropdown\.subissueActionsView = "menu";/);
+  assert.match(eventsSource, /dropdown\.subissueActionSubjectId = state\.subjectId;/);
+  assert.match(eventsSource, /openSharedCreateSubissueModal\?\.\(\{/);
+  assert.doesNotMatch(eventsSource, /store\.situationsView\.createSubjectForm = \{/);
+  assert.match(eventsSource, /dropdown\.subissueActionsView = "existing-subissue";/);
+  assert.match(eventsSource, /dropdown\.subissueActionSubjectId = String\(state\.subjectId \|\| ""\)\.trim\(\);/);
+  assert.match(eventsSource, /const subissueExistingEntry = eventTarget\.closest\("\[data-subject-subissue-existing-entry\]"\);/);
+  assert.match(eventsSource, /linkExistingSubjectAsSubissueFromSharedDropdown\?\.\(\{ parentSubjectId, childSubjectId, root \}\);/);
+});

--- a/apps/web/js/views/project-subjects.js
+++ b/apps/web/js/views/project-subjects.js
@@ -894,6 +894,7 @@ const getDraftSubjectSelection = (...args) => projectSubjectsView.getDraftSubjec
 const buildDefaultDraftSubjectMeta = (...args) => projectSubjectsView.buildDefaultDraftSubjectMeta(...args);
 const resetCreateSubjectForm = (...args) => projectSubjectsView.resetCreateSubjectForm(...args);
 const openCreateSubjectForm = (...args) => projectSubjectsView.openCreateSubjectForm(...args);
+const rerenderCreateSubissueModal = (...args) => projectSubjectsView.rerenderCreateSubissueModal?.(...args);
 const getCustomSubjects = (...args) => projectSubjectsView.getCustomSubjects(...args);
 const createSubjectFromDraft = (...args) => projectSubjectsView.createSubjectFromDraft(...args);
 const normalizeSujetKanbanStatus = (...args) => projectSubjectsView.normalizeSujetKanbanStatus(...args);
@@ -1023,6 +1024,44 @@ export function toggleSubjectLabelFromSharedDropdown(...args) {
 
 export function toggleSubjectObjectiveFromSharedDropdown(...args) {
   return toggleSubjectObjective(...args);
+}
+
+export function linkExistingSubjectAsSubissueFromSharedDropdown({
+  parentSubjectId = "",
+  childSubjectId = "",
+  root = document
+} = {}) {
+  const normalizedParentSubjectId = String(parentSubjectId || "").trim();
+  const normalizedChildSubjectId = String(childSubjectId || "").trim();
+  if (!normalizedParentSubjectId || !normalizedChildSubjectId || normalizedParentSubjectId === normalizedChildSubjectId) return false;
+  const linked = setSubjectParent(normalizedChildSubjectId, normalizedParentSubjectId, { root, skipRerender: true });
+  if (!linked) return false;
+  closeSubjectMetaDropdown();
+  renderSubjectMetaDropdownHost(root);
+  syncSubjectMetaDropdownPosition(root);
+  rerenderCreateSubissueModal?.();
+  rerenderPanels?.();
+  return true;
+}
+
+export function openSharedCreateSubissueModal({
+  parentSubjectId = "",
+  sourceSubjectId = "",
+  scopeHost = "main",
+  root = document
+} = {}) {
+  const normalizedParentSubjectId = String(parentSubjectId || "").trim();
+  if (!normalizedParentSubjectId) return false;
+  projectSubjectsView.openCreateSubjectForm({
+    mode: "subissue",
+    parentSubjectId: normalizedParentSubjectId,
+    sourceSubjectId: String(sourceSubjectId || normalizedParentSubjectId).trim() || normalizedParentSubjectId,
+    origin: "detail",
+    scopeHost
+  });
+  projectSubjectsView.rerenderCreateSubissueModal?.();
+  void root;
+  return true;
 }
 
 let collaboratorsHydrationInFlight = null;

--- a/apps/web/js/views/project-subjects/project-subjects-view.js
+++ b/apps/web/js/views/project-subjects/project-subjects-view.js
@@ -3841,6 +3841,7 @@ function getObjectiveById(objectiveId) {
     buildDefaultDraftSubjectMeta,
     resetCreateSubjectForm,
     openCreateSubjectForm,
+    rerenderCreateSubissueModal,
     getCustomSubjects,
     createSubjectFromDraft,
     normalizeSujetKanbanStatus,


### PR DESCRIPTION
### Motivation
- The Situations grid opened the shared `subissue-actions` dropdown but handled the two actions (`Créer un sous-sujet` / `Ajouter un sujet existant`) with local, partial logic that did not trigger the shared modal or correctly wire the existing-subject link flow.
- The goal is to reuse the existing subject detail flows (shared dropdown + `subjectCreateSubissueModal`) to avoid duplicated state mutations and make the grid behave like the detail view.

### Description
- Expose `rerenderCreateSubissueModal` from `apps/web/js/views/project-subjects/project-subjects-view.js` so external code can re-render the existing subissue modal. (no change to detail view rendering itself). 
- Add two public helpers in `apps/web/js/views/project-subjects.js`: `openSharedCreateSubissueModal({...})` to open the existing subissue creation flow, and `linkExistingSubjectAsSubissueFromSharedDropdown({...})` to link an existing subject as subissue while using `skipRerender` and reusing the shared dropdown/modal rendering. 
- Wire these helpers into Situations by importing them in `apps/web/js/views/project-situations.js` and passing them into `createProjectSituationsEvents`. 
- Update `apps/web/js/views/project-situations/project-situations-events.js` to: initialize and preserve the `subissue-actions` context on dropdown open, route the `open-create-subissue` action through `openSharedCreateSubissueModal` (removing the direct mutation of `store.situationsView.createSubjectForm`), set the dropdown into `existing-subissue` with full context for `open-link-existing-subissue`, and handle clicks on `[data-subject-subissue-existing-entry]` to call `linkExistingSubjectAsSubissueFromSharedDropdown` and then close/rerender the grid. 
- Add assertions in `apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs` to validate the new shared-flow integration and the existing-entry click handling.

### Testing
- Ran the focused unit test file `node --test apps/web/js/views/project-situations/project-situations-grid-dropdown.test.mjs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7730480488329bc3d142e29b1d960)