### PR TITLE
Make SVG charts responsive with `viewBox`/`preserveAspectRatio` and add chart CSS

### DIFF
--- a/apps/web/js/utils/svg-line-chart.js
+++ b/apps/web/js/utils/svg-line-chart.js
@@ -146,7 +146,7 @@ export function renderSvgLineChart({
   return `
     <div class="svg-line-chart${interactive ? " svg-line-chart--interactive" : ""}"${interactive ? ` data-chart-model="${chartModel}" data-chart-id="${chartId}"` : ""}>
       <div class="svg-line-chart__frame">
-      <svg class="svg-line-chart__svg" width="${safeWidth}" height="${safeHeight}" role="img" aria-describedby="${descriptionId}"${interactive ? ` data-chart-svg="${chartId}"` : ""}>
+      <svg class="svg-line-chart__svg" viewBox="0 0 ${safeWidth} ${safeHeight}" preserveAspectRatio="xMidYMid meet" role="img" aria-describedby="${descriptionId}"${interactive ? ` data-chart-svg="${chartId}"` : ""}>
         <desc id="${descriptionId}">${escapeHtml(ariaDescription || subtitle || title)}</desc>
         <g transform="translate(${margin.left},${margin.top})">
           ${safeYGrid.show ? `

--- a/apps/web/js/views/project-situations/project-situations-view.js
+++ b/apps/web/js/views/project-situations/project-situations-view.js
@@ -40,7 +40,7 @@ export function createProjectSituationsView({
     return `
       <div class="svg-line-chart">
         <div class="svg-line-chart__frame">
-          <svg class="svg-line-chart__svg" width="${width}" height="${height}" role="img" aria-label="Distribution des sujets">
+          <svg class="svg-line-chart__svg" viewBox="0 0 ${width} ${height}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Distribution des sujets">
             <g transform="translate(${margin.left},${margin.top})">
               <g class="svg-line-chart__grid svg-line-chart__grid--x svg-line-chart__grid--dashed" transform="translate(0,${innerHeight})">
                 ${(Array.isArray(yTicks) ? yTicks : []).map((tick) => {

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -9657,6 +9657,10 @@ body.route--project #situationsDetailsHost .detail-chrome__sticky{
   color:var(--muted);
 }
 
+.project-situation-insights__chart-shell .svg-line-chart__frame > .svg-line-chart__svg{
+  height:auto;
+}
+
 .svg-line-chart__grid .svg-line-chart__tick line{
   stroke:rgba(139,148,158,.28);
   stroke-width:1;


### PR DESCRIPTION
### Motivation

- Replace fixed SVG `width`/`height` attributes with scalable SVGs so charts can resize responsively in fluid layouts.
- Ensure charts inside the project situation insights shell render at the correct height when using responsive SVG sizing.

### Description

- Replace `width="..." height="..."` with `viewBox="0 0 <width> <height>" preserveAspectRatio="xMidYMid meet"` for chart `<svg>` elements in `apps/web/js/utils/svg-line-chart.js` and `apps/web/js/views/project-situations/project-situations-view.js` to enable responsive scaling.
- Add a CSS rule `.project-situation-insights__chart-shell .svg-line-chart__frame > .svg-line-chart__svg { height:auto; }` in `apps/web/style.css` to allow the responsive SVG to determine height correctly inside the insights chart shell.
- Preserve existing ARIA attributes and interactive data attributes; no changes to chart data encoding or drawing logic were made.

### Testing

- Ran the project's JavaScript unit tests via `npm test` and verified the test suite passes.
- Ran the style linter via `npm run lint` and confirmed no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0e5e3ae08329bdb9150ec9384b85)